### PR TITLE
feat(wallet): add ability to send a token

### DIFF
--- a/src/quo/components/utilities/token/view.cljs
+++ b/src/quo/components/utilities/token/view.cljs
@@ -37,13 +37,14 @@
 (def ^:private b64-png-image-prefix "data:image/png;base64,")
 
 (defn temp-empty-symbol
-  [token size]
+  [token size style]
   [rn/view
-   {:style (token-style {:justify-content :center
-                         :align-items     :center
-                         :border-radius   20
-                         :border-width    1
-                         :border-color    :grey}
+   {:style (token-style (merge {:justify-content :center
+                                :align-items     :center
+                                :border-radius   20
+                                :border-width    1
+                                :border-color    :grey}
+                               style)
                         size)}
    [quo/text {:style {:color :grey}}
     (some-> token
@@ -73,6 +74,6 @@
       [rn/image
        {:style  (token-style style size)
         :source source}]
-      [temp-empty-symbol token size])))
+      [temp-empty-symbol token size style])))
 
 (def view (schema/instrument #'view-internal ?schema))

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -25,11 +25,11 @@
                  size
                  theme
                  blur?
-                 container-style]}]
-      [rn/view {:style {:flex 1}}
+                 container-style]
+          :or   {container-style {:flex 1}}}]
+      [rn/view {:style container-style}
        [quo/slide-button
         {:size                size
-         :container-style     container-style
          :customization-color customization-color
          :on-reset            (when @reset-slider? #(reset! reset-slider? false))
          :on-complete         #(authorize/authorize {:on-close              on-close

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -1,4 +1,4 @@
-(ns status-im.common.data-store.wallet
+(ns status-im.contexts.wallet.data-store
   (:require
     [clojure.set :as set]
     [clojure.string :as string]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -1,20 +1,20 @@
 (ns status-im.contexts.wallet.events
   (:require
-   [camel-snake-kebab.core :as csk]
-   [camel-snake-kebab.extras :as cske]
-   [clojure.string :as string]
-   [react-native.background-timer :as background-timer]
-   [status-im.contexts.wallet.data-store :as data-store]
-   [status-im.contexts.wallet.events.collectibles]
-   [status-im.contexts.wallet.item-types :as item-types]
-   [status-im.contexts.wallet.temp :as temp]
-   [taoensso.timbre :as log]
-   [utils.ethereum.chain :as chain]
-   [utils.ethereum.eip.eip55 :as eip55]
-   [utils.i18n :as i18n]
-   [utils.money :as money]
-   [utils.number]
-   [utils.re-frame :as rf]))
+    [camel-snake-kebab.core :as csk]
+    [camel-snake-kebab.extras :as cske]
+    [clojure.string :as string]
+    [react-native.background-timer :as background-timer]
+    [status-im.contexts.wallet.data-store :as data-store]
+    [status-im.contexts.wallet.events.collectibles]
+    [status-im.contexts.wallet.item-types :as item-types]
+    [status-im.contexts.wallet.temp :as temp]
+    [taoensso.timbre :as log]
+    [utils.ethereum.chain :as chain]
+    [utils.ethereum.eip.eip55 :as eip55]
+    [utils.i18n :as i18n]
+    [utils.money :as money]
+    [utils.number]
+    [utils.re-frame :as rf]))
 
 (rf/reg-event-fx :wallet/show-account-created-toast
  (fn [{:keys [db]} [address]]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -1,20 +1,20 @@
 (ns status-im.contexts.wallet.events
   (:require
-    [camel-snake-kebab.core :as csk]
-    [camel-snake-kebab.extras :as cske]
-    [clojure.string :as string]
-    [react-native.background-timer :as background-timer]
-    [status-im.common.data-store.wallet :as data-store]
-    [status-im.contexts.wallet.events.collectibles]
-    [status-im.contexts.wallet.item-types :as item-types]
-    [status-im.contexts.wallet.temp :as temp]
-    [taoensso.timbre :as log]
-    [utils.ethereum.chain :as chain]
-    [utils.ethereum.eip.eip55 :as eip55]
-    [utils.i18n :as i18n]
-    [utils.money :as money]
-    [utils.number]
-    [utils.re-frame :as rf]))
+   [camel-snake-kebab.core :as csk]
+   [camel-snake-kebab.extras :as cske]
+   [clojure.string :as string]
+   [react-native.background-timer :as background-timer]
+   [status-im.contexts.wallet.data-store :as data-store]
+   [status-im.contexts.wallet.events.collectibles]
+   [status-im.contexts.wallet.item-types :as item-types]
+   [status-im.contexts.wallet.temp :as temp]
+   [taoensso.timbre :as log]
+   [utils.ethereum.chain :as chain]
+   [utils.ethereum.eip.eip55 :as eip55]
+   [utils.i18n :as i18n]
+   [utils.money :as money]
+   [utils.number]
+   [utils.re-frame :as rf]))
 
 (rf/reg-event-fx :wallet/show-account-created-toast
  (fn [{:keys [db]} [address]]

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -1,6 +1,9 @@
 (ns status-im.contexts.wallet.send.events
   (:require
+    [camel-snake-kebab.core :as csk]
+    [camel-snake-kebab.extras :as cske]
     [status-im.constants :as constants]
+    [status-im.contexts.wallet.send.utils :as send-utils]
     [taoensso.timbre :as log]
     [utils.money :as money]
     [utils.number]
@@ -8,6 +11,7 @@
 
 (rf/reg-event-fx :wallet/select-address-tab
  (fn [{:keys [db]} [tab]]
+
    {:db (assoc-in db [:wallet :ui :send :select-address-tab] tab)}))
 
 (rf/reg-event-fx :wallet/select-send-account-address
@@ -17,10 +21,14 @@
 (rf/reg-event-fx :wallet/suggested-routes-success
  (fn [{:keys [db]} [suggested-routes timestamp]]
    (when (= (get-in db [:wallet :ui :send :suggested-routes-call-timestamp]) timestamp)
-     {:db (-> db
-              (assoc-in [:wallet :ui :send :suggested-routes] suggested-routes)
-              (assoc-in [:wallet :ui :send :route] (first (:Best suggested-routes)))
-              (assoc-in [:wallet :ui :send :loading-suggested-routes?] false))})))
+     (let [suggested-routes-data (cske/transform-keys csk/->kebab-case suggested-routes)
+           chosen-route          (->> suggested-routes-data
+                                      :best
+                                      first)]
+       {:db (-> db
+                (assoc-in [:wallet :ui :send :suggested-routes] suggested-routes-data)
+                (assoc-in [:wallet :ui :send :route] chosen-route)
+                (assoc-in [:wallet :ui :send :loading-suggested-routes?] false))}))))
 
 (rf/reg-event-fx :wallet/suggested-routes-error
  (fn [{:keys [db]} [_error]]
@@ -47,8 +55,9 @@
     :fx [[:navigate-to-within-stack [:wallet-send-input-amount stack-id]]]}))
 
 (rf/reg-event-fx :wallet/send-select-amount
- (fn [{:keys [db]} [{:keys [amount]}]]
-   {:db (assoc-in db [:wallet :ui :send :amount] amount)}))
+ (fn [{:keys [db]} [{:keys [amount stack-id]}]]
+   {:db (assoc-in db [:wallet :ui :send :amount] amount)
+    :fx [[:navigate-to-within-stack [:wallet-transaction-confirmation stack-id]]]}))
 
 (rf/reg-event-fx :wallet/get-suggested-routes
  (fn [{:keys [db now]} [amount]]
@@ -59,7 +68,7 @@
          token-id                (:symbol token)
          network-preferences     []
          gas-rates               constants/gas-rate-medium
-         amount-in               (money/amount-in-hex amount token-decimal)
+         amount-in               (send-utils/amount-in-hex amount token-decimal)
          from-address            wallet-address
          disabled-from-chain-ids []
          disabled-to-chain-ids   []
@@ -88,3 +97,69 @@
                                                 {:event  :wallet/get-suggested-routes
                                                  :error  error
                                                  :params request-params}))}]})))
+
+(rf/reg-event-fx :wallet/add-authorized-transaction
+ (fn [{:keys [db]} [transaction]]
+   (let [transaction-hashes (:hashes transaction)
+         chain-id           (key (first transaction-hashes))
+         tx-id              (first (val (first transaction-hashes)))
+         transaction-detes  {:status   :pending
+                             :id       (:id transaction)
+                             :chain-id chain-id}]
+     {:db (assoc-in db [:wallet :transactions tx-id] transaction-detes)
+      :fx [[:dispatch [:navigate-to :wallet-transaction-progress]]]})))
+
+(defn- transaction-bridge
+  [{:keys [from-address to-address route]}]
+  (let [{:keys [from bridge-name amount-out gas-amount gas-fees]}           route
+        {:keys [gas-price max-fee-per-gas-medium max-priority-fee-per-gas]} gas-fees]
+    [{:BridgeName bridge-name
+      :ChainID    (:chain-id from)
+      :TransferTx {:From                 from-address
+                   :To                   to-address
+                   :Gas                  (money/to-hex gas-amount)
+                   :GasPrice             (money/to-hex (money/->wei :gwei gas-price))
+                   :Value                amount-out
+                   :Nonce                nil
+                   :MaxFeePerGas         (money/to-hex (money/->wei :gwei max-fee-per-gas-medium))
+                   :MaxPriorityFeePerGas (money/to-hex (money/->wei :gwei max-priority-fee-per-gas))
+                   :Input                ""
+                   :Data                 "0x"}}]))
+
+(defn- multi-transaction-command
+  [{:keys [from-address to-address from-asset to-asset amount-out transfer-type]
+    :or   {transfer-type constants/send-type-transfer}}]
+  {:fromAddress from-address
+   :toAddress   to-address
+   :fromAsset   from-asset
+   :toAsset     to-asset
+   :fromAmount  amount-out
+   :type        transfer-type})
+
+(rf/reg-event-fx :wallet/send-transaction
+ (fn [{:keys [db]} [sha3-pwd]]
+   (let [route          (get-in db [:wallet :ui :send :route])
+         from-address   (get-in db [:wallet :current-viewing-account-address])
+         to-address     (get-in db [:wallet :ui :send :to-address])
+         token          (get-in db [:wallet :ui :send :token])
+         token-id       (:symbol token)
+         request-params [(multi-transaction-command {:from-address from-address
+                                                     :to-address   to-address
+                                                     :from-asset   token-id
+                                                     :to-asset     token-id
+                                                     :amount-out   (:amount-out route)})
+                         (transaction-bridge {:to-address   to-address
+                                              :from-address from-address
+                                              :route        route})
+                         sha3-pwd]]
+     {:json-rpc/call [{:method     "wallet_createMultiTransaction"
+                       :params     request-params
+                       :on-success (fn [result]
+                                     (rf/dispatch [:hide-bottom-sheet])
+                                     (rf/dispatch [:wallet/add-authorized-transaction result]))
+                       :on-error   (fn [error]
+                                     (log/error "failed to send transaction"
+                                                {:event  :wallet/send-transaction
+                                                 :error  error
+                                                 :params request-params}))}]})))
+

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/style.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/style.cljs
@@ -1,13 +1,9 @@
 (ns status-im.contexts.wallet.send.transaction-confirmation.style
   (:require [quo.foundations.colors :as colors]))
 
-(defn container
-  [margin-top]
-  {:position :absolute
-   :top      margin-top
-   :right    0
-   :left     0
-   :bottom   0})
+(def detail-item
+  {:flex   1
+   :height 36})
 
 (def content-container
   {:padding-top        12
@@ -29,11 +25,9 @@
    :border-width       1
    :border-color       (colors/theme-colors colors/neutral-10 colors/neutral-90 theme)})
 
-(def slide-button-container
-  {:position :absolute
-   :right    20
-   :left     20
-   :bottom   20})
+(def details-title-container
+  {:padding-horizontal 20
+   :padding-bottom     16})
 
 (defn section-label
   [theme]

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -1,17 +1,18 @@
 (ns status-im.contexts.wallet.send.transaction-confirmation.view
   (:require
+    [legacy.status-im.utils.utils :as utils]
     [quo.core :as quo]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
-    [reagent.core :as reagent]
-    [status-im.common.resources :as resources]
+    [status-im.common.floating-button-page.view :as floating-button-page]
+    [status-im.common.standard-authentication.core :as standard-auth]
     [status-im.contexts.wallet.send.transaction-confirmation.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
 (defn- transaction-title
-  []
+  [{:keys [token-symbol amount account to-address]}]
   [rn/view {:style style/content-container}
    [rn/view {:style {:flex-direction :row}}
     [quo/text
@@ -21,7 +22,8 @@
       :accessibility-label :send-label}
      (i18n/label :t/send)]
     [quo/summary-tag
-     {:label        "150 ETH"
+     {:token        token-symbol
+      :label        (str amount " " token-symbol)
       :type         :token
       :image-source :eth}]]
    [rn/view
@@ -34,10 +36,10 @@
       :accessibility-label :send-label}
      (i18n/label :t/from)]
     [quo/summary-tag
-     {:label               "Collectibles vault"
+     {:label               (:name account)
       :type                :account
-      :emoji               "🍑"
-      :customization-color :purple}]]
+      :emoji               (:emoji account)
+      :customization-color (:color account)}]]
    [rn/view
     {:style {:flex-direction :row
              :margin-top     4}}
@@ -48,13 +50,11 @@
       :accessibility-label :send-label}
      (i18n/label :t/to)]
     [quo/summary-tag
-     {:label               "Mark Libot"
-      :type                :user
-      :image-source        (resources/get-mock-image :user-picture-male4)
-      :customization-color :magenta}]]])
+     {:type  :address
+      :label (utils/get-shortened-address to-address)}]]])
 
-(defn- transaction-from
-  [status-account-props theme]
+(defn- user-summary
+  [{:keys [amount account-props theme label accessibility-label summary-type]}]
   [rn/view
    {:style {:padding-horizontal 20
             :padding-bottom     16}}
@@ -62,134 +62,134 @@
     {:size                :paragraph-2
      :weight              :medium
      :style               (style/section-label theme)
-     :accessibility-label :summary-from-label}
-    (i18n/label :t/from-capitalized)]
+     :accessibility-label accessibility-label}
+    label]
    [quo/summary-info
-    {:type          :status-account
+    {:type          summary-type
      :networks?     true
-     :values        {:ethereum 150
-                     :optimism 50
-                     :arbitrum 25}
-     :account-props status-account-props}]])
-
-(defn- transaction-to
-  [user-props theme]
-  [rn/view
-   {:style {:padding-horizontal 20
-            :padding-bottom     16}}
-   [quo/text
-    {:size                :paragraph-2
-     :weight              :medium
-     :style               (style/section-label theme)
-     :accessibility-label :summary-from-label}
-    (i18n/label :t/to-capitalized)]
-   [quo/summary-info
-    {:type          :user
-     :networks?     true
-     :values        {:ethereum 150
-                     :optimism 50
-                     :arbitrum 25}
-     :account-props user-props}]])
+     :values        {:ethereum amount}
+     :account-props account-props}]])
 
 (defn- transaction-details
-  [theme]
-  [rn/view
-   {:style {:padding-horizontal 20
-            :padding-bottom     16}}
-   [quo/text
-    {:size                :paragraph-2
-     :weight              :medium
-     :style               (style/section-label theme)
-     :accessibility-label :summary-from-label}
-    (i18n/label :t/details)]
-   [rn/view
-    {:style (style/details-container theme)}
-    [quo/data-item
-     {:container-style {:flex   1
-                        :height 36}
-      :blur?           false
-      :description     :default
-      :icon-right?     false
-      :card?           false
-      :label           :none
-      :status          :default
-      :size            :small
-      :title           (i18n/label :t/est-time)
-      :subtitle        "3-5 min"}]
-    [quo/data-item
-     {:container-style {:flex   1
-                        :height 36}
-      :blur?           false
-      :description     :default
-      :icon-right?     false
-      :card?           false
-      :label           :none
-      :status          :default
-      :size            :small
-      :title           (i18n/label :t/max-fees)
-      :subtitle        "€188,70"}]
-    [quo/data-item
-     {:container-style {:flex   1
-                        :height 36}
-      :blur?           false
-      :description     :default
-      :icon-right?     false
-      :card?           false
-      :label           :none
-      :status          :default
-      :size            :small
-      :title           (i18n/label :t/user-gets {:name "Mark"})
-      :subtitle        "149.99 ETH"}]]])
+  [{:keys [estimated-time-min max-fees token amount to-address theme]}]
+  (let [currency-symbol (rf/sub [:profile/currency-symbol])]
+    [rn/view
+     {:style style/details-title-container}
+     [quo/text
+      {:size                :paragraph-2
+       :weight              :medium
+       :style               (style/section-label theme)
+       :accessibility-label :summary-from-label}
+      (i18n/label :t/details)]
+     [rn/view
+      {:style (style/details-container theme)}
+      [quo/data-item
+       {:container-style style/detail-item
+        :blur?           false
+        :description     :default
+        :icon-right?     false
+        :card?           false
+        :label           :none
+        :status          :default
+        :size            :small
+        :title           (i18n/label :t/est-time)
+        :subtitle        (i18n/label :t/time-in-mins {:minutes (str estimated-time-min)})}]
+      [quo/data-item
+       {:container-style style/detail-item
+        :blur?           false
+        :description     :default
+        :icon-right?     false
+        :card?           false
+        :label           :none
+        :status          :default
+        :size            :small
+        :title           (i18n/label :t/max-fees)
+        :subtitle        (i18n/label :t/amount-with-currency-symbol
+                                     {:amount (str max-fees)
+                                      :symbol currency-symbol})}]
+      [quo/data-item
+       {:container-style style/detail-item
+        :blur?           false
+        :description     :default
+        :icon-right?     false
+        :card?           false
+        :label           :none
+        :status          :default
+        :size            :small
+        :title           (i18n/label :t/user-gets {:name (utils/get-shortened-address to-address)})
+        :subtitle        (str amount " " (:symbol token))}]]]))
 
-(defn- f-view-internal
+(defn- view-internal
   [_]
-  (let [reset-slider?        (reagent/atom false)
-        margin-top           (safe-area/get-top)
-        biometric-auth?      true
-        on-close             #(rf/dispatch [:navigate-back-within-stack :wallet-select-asset])
-        status-account-props {:customization-color :purple
-                              :size                32
-                              :emoji               "🍑"
-                              :type                :default
-                              :name                "Collectibles vault"
-                              :address             "0x0ah...78b"}
-        user-props           {:full-name           "M L"
-                              :status-indicator?   false
-                              :size                :small
-                              :ring-background     (resources/get-mock-image :ring)
-                              :customization-color :blue
-                              :name                "Mark Libot"
-                              :address             "0x0ah...78b"
-                              :status-account      (merge status-account-props
-                                                          {:size  16
-                                                           :name  "New house"
-                                                           :emoji "🍔"})}]
+  (let [on-close              #(rf/dispatch [:navigate-back-within-stack :wallet-select-asset])
+        send-transaction-data (rf/sub [:wallet/wallet-send])
+        token                 (:token send-transaction-data)
+        token-symbol          (:symbol token)
+        amount                (:amount send-transaction-data)
+        route                 (:route send-transaction-data)
+        estimated-time-min    (:estimated-time route)
+        max-fees              "-"
+        to-address            (:to-address send-transaction-data)
+        account               (rf/sub [:wallet/current-viewing-account])
+        account-color         (:color account)
+        from-account-props    {:customization-color account-color
+                               :size                32
+                               :emoji               (:emoji account)
+                               :type                :default
+                               :name                (:name account)
+                               :address             (utils/get-shortened-address (:address account))}
+        user-props            {:full-name to-address
+                               :address   (utils/get-shortened-address to-address)}]
+    (prn route)
+
     (fn [{:keys [theme]}]
       [rn/view {:style {:flex 1}}
-       [quo/gradient-cover {:customization-color :purple}]
-       [rn/view {:style (style/container margin-top)}
-        [quo/page-nav
-         {:icon-name           :i/arrow-left
-          :on-press            on-close
-          :accessibility-label :top-bar
-          :right-side          [{:icon-name           :i/advanced
-                                 :on-press            (fn callback [] nil)
-                                 :accessibility-label "Advanced"}]}]
-        [transaction-title]
-        [transaction-from status-account-props theme]
-        [transaction-to user-props theme]
-        [transaction-details theme]
-        [rn/view {:style style/slide-button-container}
-         [quo/slide-button
-          {:size                :size/s-48
-           :customization-color :purple
-           :on-reset            (when @reset-slider? #(reset! reset-slider? false))
-           :on-complete         #(js/alert "Not implemented yet")
-           :track-icon          (if biometric-auth? :i/face-id :password)
-           :track-text          (i18n/label :t/slide-to-send)}]]]])))
-
-(defn view-internal
-  [props]
-  [:f> f-view-internal props])
+       [floating-button-page/view
+        {:header              [quo/page-nav
+                               {:icon-name           :i/arrow-left
+                                :on-press            on-close
+                                :margin-top          (safe-area/get-top)
+                                :background          :blur
+                                :accessibility-label :top-bar
+                                :right-side          [{:icon-name           :i/advanced
+                                                       :on-press            #(js/alert
+                                                                              "to be implemented")
+                                                       :accessibility-label :advanced-options}]}]
+         :footer              [standard-auth/slide-button
+                               {:size                :size-48
+                                :track-text          (i18n/label :t/slide-to-send)
+                                :container-style     {:z-index 2}
+                                :customization-color account-color
+                                :on-auth-success     #(rf/dispatch [:wallet/send-transaction %])
+                                :auth-button-label   (i18n/label :t/confirm)}]
+         :gradient-cover?     true
+         :customization-color (:color account)}
+        [rn/view
+         [transaction-title
+          {:token-symbol token-symbol
+           :amount       amount
+           :account      account
+           :to-address   to-address}]
+         [user-summary
+          {:amount              amount
+           :summary-type        :status-account
+           :accessibility-label :summary-from-label
+           :label               (i18n/label :t/from-capitalized)
+           :account-props       from-account-props
+           :theme               theme}]
+         [user-summary
+          {:amount              amount
+           :summary-type        :account
+           :accessibility-label :summary-to-label
+           :label               (i18n/label :t/to-capitalized)
+           :account-props       user-props
+           :theme               theme}]
+         [transaction-details
+          {:estimated-time-min estimated-time-min
+           :max-fees           max-fees
+           :token              token
+           :amount             amount
+           :to-address         to-address
+           :theme              theme}]]]])))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/send/transaction_progress/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_progress/view.cljs
@@ -20,7 +20,10 @@
 
 (defn view
   []
-  (let [status          (reagent/atom :sending)
+  (let [current-address (rf/sub [:wallet/current-viewing-account-address])
+        leave-page      (fn []
+                          (rf/dispatch [:navigate-to :wallet-accounts current-address]))
+        status          (reagent/atom :sending)
         {:keys [color]} (rf/sub [:wallet/current-viewing-account])]
     [floating-button-page/view
      {:header              [quo/page-nav
@@ -28,11 +31,11 @@
                              :background          :blur
                              :icon-name           :i/close
                              :margin-top          (safe-area/get-top)
-                             :on-press            #(rf/dispatch [:navigate-back])
+                             :on-press            leave-page
                              :accessibility-label :top-bar}]
       :footer              [quo/button
                             {:customization-color color
-                             :on-press            #(rf/dispatch [:navigate-back])}
+                             :on-press            leave-page}
                             (i18n/label :t/done)]
       :customization-color color
       :gradient-cover?     true}

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -1,0 +1,6 @@
+(ns status-im.contexts.wallet.send.utils
+  (:require [utils.money :as money]))
+
+(defn amount-in-hex
+  [amount token-decimal]
+  (money/to-hex (money/mul (money/bignumber amount) (money/from-decimal token-decimal))))

--- a/src/status_im/contexts/wallet/send/utils_test.cljs
+++ b/src/status_im/contexts/wallet/send/utils_test.cljs
@@ -1,0 +1,10 @@
+(ns status-im.contexts.wallet.send.utils-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [status-im.contexts.wallet.send.utils :as utils]))
+
+(deftest test-amount-in-hex
+  (testing "Test amount-in-hex function"
+    (let [amount  1
+          decimal 18]
+      (is (= (utils/amount-in-hex amount decimal)
+             "0xde0b6b3a7640000")))))

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -338,7 +338,6 @@
      :component wallet-select-asset/view}
 
     {:name      :wallet-transaction-confirmation
-     :options   {:insets {:bottom? true}}
      :component wallet-transaction-confirmation/view}
 
     {:name      :wallet-transaction-progress

--- a/src/status_im/subs/wallet/send.cljs
+++ b/src/status_im/subs/wallet/send.cljs
@@ -8,3 +8,8 @@
  :<- [:wallet/ui]
  (fn [ui]
    (get-in ui [:send :select-address-tab])))
+
+(rf/reg-sub
+ :wallet/wallet-send
+ :<- [:wallet/ui]
+ :-> :send)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -30,11 +30,6 @@
  :-> :ui)
 
 (rf/reg-sub
- :wallet/wallet-send
- :<- [:wallet/ui]
- :-> :send)
-
-(rf/reg-sub
  :wallet/tokens-loading?
  :<- [:wallet/ui]
  :-> :tokens-loading?)

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -247,6 +247,3 @@
   [:=> [:cat [:maybe :int]]
    [:maybe :string]])
 
-(defn amount-in-hex
-  [amount token-decimal]
-  (to-hex (mul (bignumber amount) (from-decimal token-decimal))))

--- a/translations/en.json
+++ b/translations/en.json
@@ -2447,5 +2447,7 @@
     "no-relevant-tokens": "No relevant tokens",
     "from-label": "From",
     "to-label": "To",
-    "oops-wrong-word": "Oops! Wrong word"
+    "oops-wrong-word": "Oops! Wrong word",
+    "time-in-mins": "{{minutes}} min",
+    "amount-with-currency-symbol": "{{symbol}} {{amount}}"
 }


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/18005

This pr adds the integration with Status Go to send a transaction.


Testing Notes:
This pr is adding the happy path for sending a token. 
To send a token this is the flow. 
- On test net or prod
- go to wallet
- go to an account, hit "send" button.
- enter an address using the input box or the scanner (don't select your own accounts via the my-accounts tab)
- choose an amount in crypto less than the amount in your account to allow for gas etc.
- continue to confirmation page
- authorize and sign the transaction
- should then navigate to transaction progress page

This is only for the mainnet transactions (including testnet), support for other Optimism & Arbitrum will be added in addtional pr's.

* Transaction Confirmation page is missing a few UI details, such as gas, time of transaction etc. I will create a follow up issue to implement these completely. 

* Transaction progress page is only initial state of it, there is no expected functionality there as this will be handled in a separate issue. For now the button on that page will navigate to the account-page.
This navigation should also end up with the Transactions tab active on the send page, this is beyond the scope of this pr. The main focus is to be able to send any token 

The slide button on the transaction confirmation page is not sitting right. This is a common component and I would prefer to handle this issue as I don't want to block this pr because of that. The send flows are high priority for 1.27 and this issue can be handled in isolation 👍 

Design Review:
Quo Component - Tags -> Summary Tag was also revisited as it was missng some designs. It would be good to check this component is looking alright here 👍 

https://github.com/status-im/status-mobile/assets/22799766/1248954a-4be4-4e5d-8c3d-fa1b0b5775e6

