### PR TITLE
ci: fix android-e2e nightly builds

### DIFF
--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -35,9 +35,9 @@ let
 
 
   envFileName =
-    if androidAbiInclude == "x86"                  then ".env.e2e"
-    else if (elem buildType ["release" "nightly"]) then ".env.${buildType}"
-    else if (elem buildType ["pr" "manual"])       then ".env.jenkins"
+    if (elem androidAbiInclude ["x86" "x86_64" "x86;x86_64"]) then ".env.e2e"
+    else if (elem buildType ["release" "nightly"])            then ".env.${buildType}"
+    else if (elem buildType ["pr" "manual"])                  then ".env.jenkins"
     else ".env";
 
   # There are only two types of Gradle build targets: pr and release


### PR DESCRIPTION
Android E2E builds are failing:
https://ci.status.im/job/status-mobile/job/platforms/job/android-e2e/