### PR TITLE
Wallet: crypto max decimals

### DIFF
--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -37,6 +37,24 @@
        (map (comp :raw-balance val))
        (reduce money/add)))
 
+(defn calc-max-crypto-decimals
+  [value]
+  (let [str-representation (str value)
+        decimal-part       (second (clojure.string/split str-representation #"\."))
+        count              (count (take-while #(= \0 %) decimal-part))]
+    (if-let [first-non-zero-digit (first (filter #(not (= \0 %)) decimal-part))]
+      (if (= \1 first-non-zero-digit)
+        (inc count)
+        count)
+      count)))
+
+(defn prettify-crypto
+  [market-values-per-currency token-units]
+  (let [price          (get-in market-values-per-currency [:usd :price])
+        one-cent-value (/ 0.01 price)
+        count          (calc-max-crypto-decimals one-cent-value)]
+    (.toFixed token-units count)))
+
 (defn total-token-units-in-all-chains
   [{:keys [balances-per-chain decimals] :as _token}]
   (-> balances-per-chain

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -55,7 +55,8 @@
         (inc max-decimals)
         max-decimals))))
 
-(defn prettify-crypto
+(defn get-standard-crypto-format
+  "For full details: https://github.com/status-im/status-mobile/issues/18225"
   [{:keys [market-values-per-currency]} token-units]
   (let [price          (get-in market-values-per-currency [:usd :price])
         one-cent-value (/ 0.01 price)

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -59,10 +59,10 @@
   "For full details: https://github.com/status-im/status-mobile/issues/18225"
   [{:keys [market-values-per-currency]} token-units]
   (let [price          (get-in market-values-per-currency [:usd :price])
-        one-cent-value (/ 0.01 price)
+        one-cent-value (if (pos? price) (/ 0.01 price) 0)
         count          (calc-max-crypto-decimals one-cent-value)]
     (if (< token-units one-cent-value)
-      (str "<" one-cent-value)
+      (str "<" (.toFixed one-cent-value count))
       (.toFixed token-units count))))
 
 (defn total-token-units-in-all-chains

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -14,9 +14,9 @@
   (let [valid-balance? (and balance
                             (or (number? balance) (.-toFixed balance)))]
     (as-> balance $
-          (if valid-balance? $ 0)
-          (.toFixed $ 2)
-          (str currency-symbol $))))
+      (if valid-balance? $ 0)
+      (.toFixed $ 2)
+      (str currency-symbol $))))
 
 (defn get-derivation-path
   [number-of-accounts]
@@ -103,8 +103,8 @@
 (defn calculate-balance-for-token
   [token]
   (money/bignumber
-    (money/mul (total-token-units-in-all-chains token)
-               (-> token :market-values-per-currency :usd :price))))
+   (money/mul (total-token-units-in-all-chains token)
+              (-> token :market-values-per-currency :usd :price))))
 
 (defn calculate-balance
   [tokens-in-account]

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -48,8 +48,8 @@
   (let [str-representation (str value)
         decimal-part       (second (clojure.string/split str-representation #"\."))
         exponent           (extract-exponent str-representation)
-        count              (count (take-while #(= \0 %) decimal-part))
-        max-decimals       (or exponent count)]
+        zeroes-count       (count (take-while #(= \0 %) decimal-part))
+        max-decimals       (or exponent zeroes-count)]
     (let [first-non-zero-digit (first (filter #(not (= \0 %)) decimal-part))]
       (if (= \1 first-non-zero-digit)
         (inc max-decimals)

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -61,7 +61,9 @@
   (let [price          (get-in market-values-per-currency [:usd :price])
         one-cent-value (/ 0.01 price)
         count          (calc-max-crypto-decimals one-cent-value)]
-    (.toFixed token-units count)))
+    (if (< token-units one-cent-value)
+      (str "<" one-cent-value)
+      (.toFixed token-units count))))
 
 (defn total-token-units-in-all-chains
   [{:keys [balances-per-chain decimals] :as _token}]

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -45,25 +45,25 @@
 
 (defn calc-max-crypto-decimals
   [value]
-  (let [str-representation (str value)
-        decimal-part       (second (clojure.string/split str-representation #"\."))
-        exponent           (extract-exponent str-representation)
-        zeroes-count       (count (take-while #(= \0 %) decimal-part))
-        max-decimals       (or exponent zeroes-count)]
-    (let [first-non-zero-digit (first (filter #(not (= \0 %)) decimal-part))]
-      (if (= \1 first-non-zero-digit)
-        (inc max-decimals)
-        max-decimals))))
+  (let [str-representation   (str value)
+        decimal-part         (second (clojure.string/split str-representation #"\."))
+        exponent             (extract-exponent str-representation)
+        zeroes-count         (count (take-while #(= \0 %) decimal-part))
+        max-decimals         (or exponent zeroes-count)
+        first-non-zero-digit (first (filter #(not (= \0 %)) decimal-part))]
+    (if (= \1 first-non-zero-digit)
+      (inc max-decimals)
+      max-decimals)))
 
 (defn get-standard-crypto-format
   "For full details: https://github.com/status-im/status-mobile/issues/18225"
   [{:keys [market-values-per-currency]} token-units]
   (let [price          (get-in market-values-per-currency [:usd :price])
         one-cent-value (if (pos? price) (/ 0.01 price) 0)
-        count          (calc-max-crypto-decimals one-cent-value)]
+        decimals-count (calc-max-crypto-decimals one-cent-value)]
     (if (< token-units one-cent-value)
-      (str "<" (.toFixed one-cent-value count))
-      (.toFixed token-units count))))
+      (str "<" (.toFixed one-cent-value decimals-count))
+      (.toFixed token-units decimals-count))))
 
 (defn total-token-units-in-all-chains
   [{:keys [balances-per-chain decimals] :as _token}]

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -16,3 +16,18 @@
 
       (is (= (utils/get-wallet-qr wallet-singlechain)
              "x000")))))
+
+(deftest test-extract-exponent
+  (testing "extract-exponent function"
+    (is (= (utils/extract-exponent "123.456") nil))
+    (is (= (utils/extract-exponent "2.5e-2") "2"))
+    (is (= (utils/extract-exponent "4.567e-10") "10"))))
+
+(deftest test-calc-max-crypto-decimals
+  (testing "calc-max-crypto-decimals function"
+    (is (= (utils/calc-max-crypto-decimals 0.00323) 2))
+    (is (= (utils/calc-max-crypto-decimals 0.00123) 3))
+    (is (= (utils/calc-max-crypto-decimals 0.00000423) 5))
+    (is (= (utils/calc-max-crypto-decimals 1.23e-6) 6))
+    (is (= (utils/calc-max-crypto-decimals 1.13e-6) 7))))
+

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -28,6 +28,6 @@
     (is (= (utils/calc-max-crypto-decimals 0.00323) 2))
     (is (= (utils/calc-max-crypto-decimals 0.00123) 3))
     (is (= (utils/calc-max-crypto-decimals 0.00000423) 5))
-    (is (= (utils/calc-max-crypto-decimals 1.23e-6) 6))
-    (is (= (utils/calc-max-crypto-decimals 1.13e-6) 7))))
+    (is (= (utils/calc-max-crypto-decimals 2.23e-6) 5))
+    (is (= (utils/calc-max-crypto-decimals 1.13e-6) 6))))
 

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -163,6 +163,17 @@
  (fn [accounts]
    (remove #(:watch-only? %) accounts)))
 
+(defn count-trailing-zeroes
+  [num]
+  (let [str-representation (str num)
+        decimal-part       (second (clojure.string/split str-representation #"\."))
+        count              (count (take-while #(= \0 %) decimal-part))]
+    (if-let [first-non-zero-digit (first (filter #(not (= \0 %)) decimal-part))]
+      (if (= \1 first-non-zero-digit)
+        (inc count)
+        count)
+      count)))
+
 (defn- calc-token-value
   [{:keys [market-values-per-currency] :as token} color currency currency-symbol]
   (let [token-units                 (utils/total-token-units-in-all-chains token)
@@ -180,7 +191,7 @@
                             (neg? change-pct-24hour) :negative
                             :else                    :empty)
      :customization-color color
-     :values              {:crypto-value token-units
+     :values              {:crypto-value (utils/prettify-crypto market-values-per-currency token-units)
                            :fiat-value   (utils/prettify-balance currency-symbol fiat-value)}}))
 
 (rf/reg-sub

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -171,7 +171,11 @@
                                          currency
                                          (get market-values-per-currency
                                               constants/profile-default-currency))
-        {:keys [change-pct-24hour]} market-values]
+        {:keys [change-pct-24hour]} market-values
+        crypto-value (utils/get-standard-crypto-format token token-units)
+        fiat-value   (if (string/includes? crypto-value "<")
+                       "<$0.01"
+                       (utils/prettify-balance currency-symbol fiat-value))]
     {:token               (:symbol token)
      :token-name          (:name token)
      :state               :default
@@ -180,8 +184,8 @@
                             (neg? change-pct-24hour) :negative
                             :else                    :empty)
      :customization-color color
-     :values              {:crypto-value (utils/get-standard-crypto-format token token-units)
-                           :fiat-value   (utils/prettify-balance currency-symbol fiat-value)}}))
+     :values              {:crypto-value crypto-value
+                           :fiat-value   fiat-value}}))
 
 (rf/reg-sub
  :wallet/account-token-values

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -180,7 +180,7 @@
                             (neg? change-pct-24hour) :negative
                             :else                    :empty)
      :customization-color color
-     :values              {:crypto-value (utils/prettify-crypto token token-units)
+     :values              {:crypto-value (utils/get-standard-crypto-format token token-units)
                            :fiat-value   (utils/prettify-balance currency-symbol fiat-value)}}))
 
 (rf/reg-sub

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -163,17 +163,6 @@
  (fn [accounts]
    (remove #(:watch-only? %) accounts)))
 
-(defn count-trailing-zeroes
-  [num]
-  (let [str-representation (str num)
-        decimal-part       (second (clojure.string/split str-representation #"\."))
-        count              (count (take-while #(= \0 %) decimal-part))]
-    (if-let [first-non-zero-digit (first (filter #(not (= \0 %)) decimal-part))]
-      (if (= \1 first-non-zero-digit)
-        (inc count)
-        count)
-      count)))
-
 (defn- calc-token-value
   [{:keys [market-values-per-currency] :as token} color currency currency-symbol]
   (let [token-units                 (utils/total-token-units-in-all-chains token)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -191,7 +191,7 @@
                             (neg? change-pct-24hour) :negative
                             :else                    :empty)
      :customization-color color
-     :values              {:crypto-value (utils/prettify-crypto market-values-per-currency token-units)
+     :values              {:crypto-value (utils/prettify-crypto token token-units)
                            :fiat-value   (utils/prettify-balance currency-symbol fiat-value)}}))
 
 (rf/reg-sub

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -172,10 +172,10 @@
                                          (get market-values-per-currency
                                               constants/profile-default-currency))
         {:keys [change-pct-24hour]} market-values
-        crypto-value (utils/get-standard-crypto-format token token-units)
-        fiat-value   (if (string/includes? crypto-value "<")
-                       "<$0.01"
-                       (utils/prettify-balance currency-symbol fiat-value))]
+        crypto-value                (utils/get-standard-crypto-format token token-units)
+        fiat-value                  (if (string/includes? crypto-value "<")
+                                      "<$0.01"
+                                      (utils/prettify-balance currency-symbol fiat-value))]
     {:token               (:symbol token)
      :token-name          (:name token)
      :state               :default


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/18244

This PR implements max possible decimals for crypto values.

**Before**:
![Screenshot_20231221_125543_Status Debug](https://github.com/status-im/status-mobile/assets/29354102/20a5b8ea-6f25-466e-9c5b-46075a29875d)

**After**:
![Screenshot_20231221_125559_Status Debug](https://github.com/status-im/status-mobile/assets/29354102/9a3a74c0-21cc-4809-adb9-44039ef683e9)
