### PR TITLE
Add `xcbeautify` to iOS shell and to `make run-ios`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,9 +283,9 @@ run-ios: export TARGET := ios
 run-ios: export IOS_STATUS_GO_TARGETS := iossimulator/amd64
 run-ios: ##@run Build iOS app and start it in a simulator/device
 ifneq ("$(SIMULATOR)", "")
-	npx react-native run-ios --simulator="$(SIMULATOR)"
+	npx react-native run-ios --simulator="$(SIMULATOR)" | xcbeautify
 else
-	npx react-native run-ios
+	npx react-native run-ios | xcbeautify
 endif
 
 show-ios-devices: ##@other shows connected ios device and its name

--- a/nix/mobile/ios/default.nix
+++ b/nix/mobile/ios/default.nix
@@ -21,6 +21,7 @@ in {
       xcodeWrapper watchman procps
       flock # used in nix/scripts/node_modules.sh
       ios-deploy # used in 'make run-ios-device'
+      xcbeautify # used in 'make run-ios'
     ];
 
     # WARNING: Executes shellHook in reverse order.

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -96,4 +96,5 @@ in {
   aapt2 = callPackage ./pkgs/aapt2 { };
   patchMavenSources = callPackage ./pkgs/patch-maven-srcs { };
   goMavenResolver = callPackage ./pkgs/go-maven-resolver { };
+  xcbeautify = callPackage ./pkgs/xcbeautify { };
 }

--- a/nix/pkgs/xcbeautify/default.nix
+++ b/nix/pkgs/xcbeautify/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, unzip, lib }:
+
+let
+  inherit (lib) getAttr;
+in
+stdenv.mkDerivation rec {
+  pname = "xcbeautify";
+  version = "1.1.1";
+  arch = if stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64";
+
+  src = fetchurl {
+    url = "https://github.com/tuist/xcbeautify/releases/download/${version}/xcbeautify-${version}-${arch}-apple-macosx.zip";
+    sha256 = getAttr arch {
+            arm64 = "sha256-VaZBWZNx5iZxjpsVbKQA4wVsigjlhArDCsQXY/RBDx4=";
+            x86_64 = "sha256-Q1t4nHQu05mPqNRmL0KQukGRAHdkQHM7H24ar0isQTo=";
+        };
+    };
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  installPhase = ''
+    install -D xcbeautify $out/bin/xcbeautify
+  '';
+
+  meta = with lib; {
+    description = "A little beautifier tool for xcodebuild";
+    homepage = "https://github.com/tuist/xcbeautify";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+  };
+}


### PR DESCRIPTION
I can't remember the number of times I have had to ask developers to run `make run-ios | xcbeautify` when debugging iOS build failures and they do not have `xcbeautify` installed on their environment.

`xcbeautify` helps make `xcodebuild` output more readable and to identify problems quickly.

This PR adds `xcbeautify` to iOS shell and to  `make run-ios` so that we get readable output by default.

status: ready 

