### PR TITLE
Wallet: loading routes

### DIFF
--- a/src/quo/components/utilities/token/loader.cljs
+++ b/src/quo/components/utilities/token/loader.cljs
@@ -8,7 +8,7 @@
   [token]
   (let [token-symbol (cond-> token
                        (keyword? token) name
-                       :always          (comp string/lower-case str))]
+                       :always          string/lower-case)]
     (get tokens token-symbol)))
 
 (def get-token-image (memoize get-token-image*))

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -138,8 +138,10 @@
            :on-change-text  (fn [text]
                               (handle-on-change text))}]
          [routes/view
-          {:amount amount
-           :route  route}]
+          {:amount      amount
+           :route       route
+           :input-value @input-value
+           :networks    (:networks token)}]
          [quo/bottom-actions
           {:actions          :1-action
            :button-one-label (i18n/label :t/confirm)

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -7,8 +7,8 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn loaded-routes
-  [{:keys [amount from-network to-network]}]
+(defn routes
+  [{:keys [amount from-network to-network status]}]
   [rn/view {:style style/routes-container}
    [rn/view {:style style/routes-header-container}
     [quo/section-label
@@ -21,7 +21,7 @@
     [quo/network-bridge
      {:amount  amount
       :network from-network
-      :status  :default}]
+      :status  status}]
     [quo/network-link
      {:shape           :linear
       :source          from-network
@@ -30,11 +30,11 @@
     [quo/network-bridge
      {:amount          amount
       :network         to-network
-      :status          :default
+      :status          status
       :container-style {:right 12}}]]])
 
 (defn view
-  [{:keys [amount route]}]
+  [{:keys [amount route networks input-value]}]
   (let [loading-suggested-routes? (rf/sub [:wallet/wallet-send-loading-suggested-routes?])
         from-network              (utils/id->network (get-in route [:From :chainId]))
         to-network                (utils/id->network (get-in route [:To :chainId]))]
@@ -42,12 +42,14 @@
      {:content-container-style {:flex-grow       1
                                 :align-items     :center
                                 :justify-content :center}}
-     (cond loading-suggested-routes?
-           [quo/text "Loading routes"]
-           (and (not loading-suggested-routes?) route)
-           [loaded-routes
-            {:amount       amount
-             :from-network from-network
-             :to-network   to-network}]
-           (and (not loading-suggested-routes?) (nil? route))
-           [quo/text "Route not found"])]))
+     (when (not (empty? input-value))
+       (if (and (not loading-suggested-routes?) route)
+         [routes
+          {:amount       amount
+           :status       :default
+           :from-network from-network
+           :to-network   to-network}]
+         [routes
+          {:status       :loading
+           :from-network (:network-name (nth (seq networks) 1))
+           :to-network   (:network-name (nth (seq networks) 1))}]))]))

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -2,10 +2,12 @@
   (:require
     [quo.core :as quo]
     [react-native.core :as rn]
+    [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.send.routes.style :as style]
-    [utils.i18n :as i18n]))
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
-(defn view
+(defn loaded-routes
   [{:keys [amount from-network to-network]}]
   [rn/view {:style style/routes-container}
    [rn/view {:style style/routes-header-container}
@@ -30,3 +32,22 @@
       :network         to-network
       :status          :default
       :container-style {:right 12}}]]])
+
+(defn view
+  [{:keys [amount route]}]
+  (let [loading-suggested-routes? (rf/sub [:wallet/wallet-send-loading-suggested-routes?])
+        from-network              (utils/id->network (get-in route [:From :chainId]))
+        to-network                (utils/id->network (get-in route [:To :chainId]))]
+    [rn/scroll-view
+     {:content-container-style {:flex-grow       1
+                                :align-items     :center
+                                :justify-content :center}}
+     (cond loading-suggested-routes?
+           [quo/text "Loading routes"]
+           (and (not loading-suggested-routes?) route)
+           [loaded-routes
+            {:amount       amount
+             :from-network from-network
+             :to-network   to-network}]
+           (and (not loading-suggested-routes?) (nil? route))
+           [quo/text "Route not found"])]))

--- a/src/status_im/contexts/wallet/send/select_address/style.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/style.cljs
@@ -17,5 +17,5 @@
 
 (def button
   {:justify-self      :flex-end
-   :margin-bottom     46
+   :margin-bottom     20
    :margin-horizontal 20})

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -325,7 +325,8 @@
 
     {:name      :wallet-send-input-amount
      :options   {:modalPresentationStyle :overCurrentContext
-                 :insets                 {:top? true}}
+                 :insets                 {:top?    true
+                                          :bottom? true}}
      :component wallet-send-input-amount/view}
 
     {:name      :wallet-select-address


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/18278

This PR implements loading routes UI in wallet send flow.

**A few points that needs consideration**:

The loading routes UI assumes that we know in advance what are the possible routes, but that's not the case. We first need to fetch the routes then display them. 

Currently, we display the best route only. I have noticed that the best route is usually the first network after mainnet, so in this PR I am assuming this will be the best route while in loading state. But is there a way to know/calculate these routes in advance. Especially that later on we want to display all the possible routes, not just the best route.

On Desktop app, it only displays a loading indicator while loading the routes, so maybe on mobile we should do the same?

[Designs](https://www.figma.com/file/HKncH4wnDwZDAhc4AryK8Y/Wallet-for-Mobile?type=design&node-id=7701-161558&mode=design&t=lrVlN0JvTYungt1N-4)

Demo:
https://github.com/status-im/status-mobile/assets/29354102/2d3510f7-6d3a-4816-a29c-d7bb2b79bb8e

