### PR TITLE
[#18280] Fix token images not being displayed

### DIFF
--- a/src/quo/components/utilities/token/loader.cljs
+++ b/src/quo/components/utilities/token/loader.cljs
@@ -3,12 +3,13 @@
   (:require [clojure.string :as string]))
 
 (def ^:private tokens (loader/resolve-tokens))
+(def ^:private safe-lower-case (comp string/lower-case str))
 
 (defn- get-token-image*
   [token]
   (let [token-symbol (cond-> token
                        (keyword? token) name
-                       :always          (comp string/lower-case str))]
+                       :always          safe-lower-case)]
     (get tokens token-symbol)))
 
 (def get-token-image (memoize get-token-image*))


### PR DESCRIPTION
fixes #18280

### Summary

Fixes the problem of token images not being displayed:

![image](https://github.com/status-im/status-mobile/assets/90291778/ba88396b-2873-4e99-a722-5409ac5ad82c)

And also is able to receive `nil` values, cc: @J-Son89

#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Go to wallet tab
- Test token images are displayed as before

status: ready
