### PR TITLE
PR to upgrade `react-native-webview` library to `13.6.3`

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -340,7 +340,7 @@ PODS:
     - React
   - react-native-transparent-video (0.1.0):
     - React-Core
-  - react-native-webview (13.3.1):
+  - react-native-webview (13.6.3):
     - React-Core
   - React-NativeModulesApple (0.72.5):
     - React-callinvoker
@@ -838,7 +838,7 @@ SPEC CHECKSUMS:
   react-native-status: 21f75d492fd311dc111303da38a7a2b23a8a8466
   react-native-status-keycard: f1c1227b2d5984c10fb44db68e4bfd2937f31e98
   react-native-transparent-video: e484ad11ace8e5f62516e2c5e15efd3cb4df24b0
-  react-native-webview: c2b70afb1d910cdd8810375aecc6c2894e2ba061
+  react-native-webview: 88293a0f23eca8465c0433c023ec632930e644d0
   React-NativeModulesApple: c6529c637f2e886aab44c48d66cabef2d4fd1138
   React-perflogger: cd8886513f68e1c135a1e79d20575c6489641597
   React-RCTActionSheet: 726d2615ca62a77ce3e2c13d87f65379cdc73498

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-native-svg": "13.10.0",
     "react-native-touch-id": "^4.4.1",
     "react-native-transparent-video": "git+https://github.com/status-im/react-native-transparent-video.git#refs/tags/0.1.1",
-    "react-native-webview": "13.3.1",
+    "react-native-webview": "13.6.3",
     "react-syntax-highlighter": "^15.5.0",
     "rn-emoji-keyboard": "0.7.0",
     "tdigest": "^0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8386,10 +8386,10 @@ react-native-touch-id@^4.4.1:
   version "0.1.0"
   resolved "git+https://github.com/status-im/react-native-transparent-video.git#1327fc622f7521269f66299c3aca610494c76fe1"
 
-react-native-webview@13.3.1:
-  version "13.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.3.1.tgz#b368c3fb6a28c81e8ffe74208c899c95ee633ce7"
-  integrity sha512-jTRC7bZB1gedAbZGGzQUnsaU+avZcZrKLT8g+RR0bsGW80tUOvwezwznKvQ+m1xXOpGFTD1B3+AazUP7+jy4mg==
+react-native-webview@13.6.3:
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.6.3.tgz#f3d26e942ef5cc5a07547f2e47903aa81a68e25e"
+  integrity sha512-IApO0JSj0uAWsBGKWagyfgDYoX29piiMYLmkHtRjKeL1rIVjLoR/bMe7KJ/0X47y86b//a6u3cYQtphyay+F2A==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
### Summary

We need to upgrade `react-native-webview` as a pre-requisite for upgrading `react-native` to `0.73.x`
else we face this issue while building iOS : https://github.com/react-native-webview/react-native-webview/issues/3233

### Testing notes
 `react-native-webview` is currently used in legacy code and primarily for our browser implementation.

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
- browser

##### Functional
- dapps / app browsing

status: ready
