### PR TITLE
PR to add `form-data` package for DIWAI uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "create-react-class": "^15.6.2",
     "emojilib": "^2.4.0",
     "eth-phishing-detect": "^1.2.0",
+    "form-data": "^4.0.0",
     "functional-red-black-tree": "^1.0.1",
     "i18n-js": "^3.3.0",
     "jsc-android": "^250231.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5464,6 +5464,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"


### PR DESCRIPTION
This PR adds `form-data` npm package which is needed by DIAWI upload script for iOS IPA.
We had this package in our codebase due to it being a dependency of jest.

However when jest package is updated and cleanup happens in https://github.com/status-im/status-mobile/pull/18276
this package gets removed and iOS uploads that depend on it fail.

fixes #18289

status: ready
