### PR TITLE
Run integration tests separately from unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,26 +335,68 @@ shadow-server: export TARGET := clojure
 shadow-server:##@ Start shadow-cljs in server mode for watching
 	yarn shadow-cljs server
 
-test-watch: export TARGET := clojure
-test-watch: ##@ Watch tests and re-run no changes to cljs files
-	yarn install
-	nodemon --exec 'yarn shadow-cljs compile mocks && yarn shadow-cljs compile test && node --require ./test-resources/override.js target/test/test.js' -e cljs
-
-test-watch-for-repl: export TARGET := clojure
-test-watch-for-repl: ##@ Watch tests and support REPL connections
-	yarn install
-	rm -f target/test/test.js
-	concurrently --kill-others --prefix-colors 'auto' --names 'build,repl' \
-		'yarn shadow-cljs compile mocks && yarn shadow-cljs watch test --verbose' \
-		'until [ -f ./target/test/test.js ] ; do sleep 1 ; done ; node --require ./test-resources/override.js ./target/test/test.js --repl'
-
 test: export TARGET := clojure
-test: ##@test Run tests once in NodeJS
-	# Here we create the gyp bindings for nodejs
+test: export SHADOW_OUTPUT_TO := target/test/test.js
+test: export SHADOW_NS_REGEXP := .*-test$$
+test: ##@test Run all Clojure tests
 	yarn install
 	yarn shadow-cljs compile mocks && \
 	yarn shadow-cljs compile test && \
 	node --require ./test-resources/override.js target/test/test.js
+
+test-watch: export TARGET := clojure
+test-watch: export SHADOW_OUTPUT_TO := target/test/test.js
+test-watch: export SHADOW_NS_REGEXP := .*-test$$
+test-watch: ##@test Watch all Clojure tests and re-run when files change
+	yarn install
+	yarn shadow-cljs compile mocks && \
+	nodemon --exec 'yarn shadow-cljs compile test && node --require ./test-resources/override.js target/test/test.js' -e cljs
+
+test-watch-for-repl: export TARGET := clojure
+test-watch-for-repl: export SHADOW_OUTPUT_TO := target/test/test.js
+test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connections
+	yarn install
+	rm -f target/test/test.js
+	yarn shadow-cljs compile mocks && \
+	concurrently --kill-others --prefix-colors 'auto' --names 'build,repl' \
+		'yarn shadow-cljs watch test --verbose' \
+		'until [ -f ./target/test/test.js ] ; do sleep 1 ; done ; node --require ./test-resources/override.js ./target/test/test.js --repl'
+
+unit-test: export TARGET := clojure
+unit-test: export SHADOW_OUTPUT_TO := target/unit_test/test.js
+unit-test: export SHADOW_NS_REGEXP := ^(?!status-im\.integration-test).*-test$$
+unit-test: ##@test Run unit tests
+	# Here we create the gyp bindings for nodejs
+	yarn install
+	yarn shadow-cljs compile mocks && \
+	yarn shadow-cljs compile test && \
+	node --require ./test-resources/override.js target/unit_test/test.js
+
+unit-test-watch: export TARGET := clojure
+unit-test-watch: export SHADOW_OUTPUT_TO := target/unit_test/test.js
+unit-test-watch: export SHADOW_NS_REGEXP := ^(?!status-im\.integration-test).*-test$$
+unit-test-watch: ##@test Watch unit tests and re-run when files change
+	yarn install
+	yarn shadow-cljs compile mocks && \
+	nodemon --exec 'yarn shadow-cljs compile test && node --require ./test-resources/override.js target/unit_test/test.js' -e cljs
+
+integration-test: export TARGET := clojure
+integration-test: export SHADOW_OUTPUT_TO := target/integration_test/test.js
+integration-test: export SHADOW_NS_REGEXP := ^status-im\.integration-test.*$$
+integration-test: ##@test Run integration tests
+	# Here we create the gyp bindings for nodejs
+	yarn install
+	yarn shadow-cljs compile mocks && \
+	yarn shadow-cljs compile test && \
+	node --require ./test-resources/override.js target/integration_test/test.js
+
+integration-test-watch: export TARGET := clojure
+integration-test-watch: export SHADOW_OUTPUT_TO := target/integration_test/test.js
+integration-test-watch: export SHADOW_NS_REGEXP := ^status-im\.integration-test.*$$
+integration-test-watch: ##@test Watch integration tests and re-run when files change
+	yarn install
+	yarn shadow-cljs compile mocks && \
+	nodemon --exec 'yarn shadow-cljs compile test && node --require ./test-resources/override.js target/integration_test/test.js' -e cljs
 
 android-test: jsbundle
 android-test: export TARGET := android

--- a/Makefile
+++ b/Makefile
@@ -335,68 +335,63 @@ shadow-server: export TARGET := clojure
 shadow-server:##@ Start shadow-cljs in server mode for watching
 	yarn shadow-cljs server
 
+_clojure-test:
+	yarn install && \
+	yarn shadow-cljs compile mocks && \
+	yarn shadow-cljs compile test && \
+	node --require ./test-resources/override.js "$$SHADOW_OUTPUT_TO"
+
+_clojure-test-watch:
+	yarn install && \
+	yarn shadow-cljs compile mocks && \
+	nodemon --exec "yarn shadow-cljs compile test && node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO" -e cljs
+
 test: export TARGET := clojure
 test: export SHADOW_OUTPUT_TO := target/test/test.js
 test: export SHADOW_NS_REGEXP := .*-test$$
 test: ##@test Run all Clojure tests
-	yarn install
-	yarn shadow-cljs compile mocks && \
-	yarn shadow-cljs compile test && \
-	node --require ./test-resources/override.js target/test/test.js
+test: _clojure-test
 
 test-watch: export TARGET := clojure
 test-watch: export SHADOW_OUTPUT_TO := target/test/test.js
 test-watch: export SHADOW_NS_REGEXP := .*-test$$
 test-watch: ##@test Watch all Clojure tests and re-run when files change
-	yarn install
-	yarn shadow-cljs compile mocks && \
-	nodemon --exec 'yarn shadow-cljs compile test && node --require ./test-resources/override.js target/test/test.js' -e cljs
+test-watch: _clojure-test-watch
 
 test-watch-for-repl: export TARGET := clojure
 test-watch-for-repl: export SHADOW_OUTPUT_TO := target/test/test.js
+test-watch-for-repl: export SHADOW_NS_REGEXP := .*-test$$
 test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connections
 	yarn install
 	rm -f target/test/test.js
 	yarn shadow-cljs compile mocks && \
 	concurrently --kill-others --prefix-colors 'auto' --names 'build,repl' \
 		'yarn shadow-cljs watch test --verbose' \
-		'until [ -f ./target/test/test.js ] ; do sleep 1 ; done ; node --require ./test-resources/override.js ./target/test/test.js --repl'
+		"until [ -f $$SHADOW_OUTPUT_TO ] ; do sleep 1 ; done ; node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO --repl"
 
 unit-test: export TARGET := clojure
 unit-test: export SHADOW_OUTPUT_TO := target/unit_test/test.js
 unit-test: export SHADOW_NS_REGEXP := ^(?!status-im\.integration-test).*-test$$
 unit-test: ##@test Run unit tests
-	# Here we create the gyp bindings for nodejs
-	yarn install
-	yarn shadow-cljs compile mocks && \
-	yarn shadow-cljs compile test && \
-	node --require ./test-resources/override.js target/unit_test/test.js
+unit-test: _clojure-test
 
 unit-test-watch: export TARGET := clojure
 unit-test-watch: export SHADOW_OUTPUT_TO := target/unit_test/test.js
 unit-test-watch: export SHADOW_NS_REGEXP := ^(?!status-im\.integration-test).*-test$$
 unit-test-watch: ##@test Watch unit tests and re-run when files change
-	yarn install
-	yarn shadow-cljs compile mocks && \
-	nodemon --exec 'yarn shadow-cljs compile test && node --require ./test-resources/override.js target/unit_test/test.js' -e cljs
+unit-test-watch: _clojure-test-watch
 
 integration-test: export TARGET := clojure
 integration-test: export SHADOW_OUTPUT_TO := target/integration_test/test.js
 integration-test: export SHADOW_NS_REGEXP := ^status-im\.integration-test.*$$
 integration-test: ##@test Run integration tests
-	# Here we create the gyp bindings for nodejs
-	yarn install
-	yarn shadow-cljs compile mocks && \
-	yarn shadow-cljs compile test && \
-	node --require ./test-resources/override.js target/integration_test/test.js
+integration-test: _clojure-test
 
 integration-test-watch: export TARGET := clojure
 integration-test-watch: export SHADOW_OUTPUT_TO := target/integration_test/test.js
 integration-test-watch: export SHADOW_NS_REGEXP := ^status-im\.integration-test.*$$
 integration-test-watch: ##@test Watch integration tests and re-run when files change
-	yarn install
-	yarn shadow-cljs compile mocks && \
-	nodemon --exec 'yarn shadow-cljs compile test && node --require ./test-resources/override.js target/integration_test/test.js' -e cljs
+integration-test-watch: _clojure-test-watch
 
 android-test: jsbundle
 android-test: export TARGET := android

--- a/Makefile
+++ b/Makefile
@@ -335,30 +335,29 @@ shadow-server: export TARGET := clojure
 shadow-server:##@ Start shadow-cljs in server mode for watching
 	yarn shadow-cljs server
 
+_clojure-test: export TARGET := clojure
 _clojure-test:
 	yarn install && \
 	yarn shadow-cljs compile mocks && \
 	yarn shadow-cljs compile test && \
 	node --require ./test-resources/override.js "$$SHADOW_OUTPUT_TO"
 
+_clojure-test-watch: export TARGET := clojure
 _clojure-test-watch:
 	yarn install && \
 	yarn shadow-cljs compile mocks && \
 	nodemon --exec "yarn shadow-cljs compile test && node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO" -e cljs
 
-test: export TARGET := clojure
 test: export SHADOW_OUTPUT_TO := target/test/test.js
 test: export SHADOW_NS_REGEXP := .*-test$$
 test: ##@test Run all Clojure tests
 test: _clojure-test
 
-test-watch: export TARGET := clojure
 test-watch: export SHADOW_OUTPUT_TO := target/test/test.js
 test-watch: export SHADOW_NS_REGEXP := .*-test$$
 test-watch: ##@test Watch all Clojure tests and re-run when files change
 test-watch: _clojure-test-watch
 
-test-watch-for-repl: export TARGET := clojure
 test-watch-for-repl: export SHADOW_OUTPUT_TO := target/test/test.js
 test-watch-for-repl: export SHADOW_NS_REGEXP := .*-test$$
 test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connections
@@ -369,25 +368,21 @@ test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connection
 		'yarn shadow-cljs watch test --verbose' \
 		"until [ -f $$SHADOW_OUTPUT_TO ] ; do sleep 1 ; done ; node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO --repl"
 
-unit-test: export TARGET := clojure
 unit-test: export SHADOW_OUTPUT_TO := target/unit_test/test.js
 unit-test: export SHADOW_NS_REGEXP := ^(?!status-im\.integration-test).*-test$$
 unit-test: ##@test Run unit tests
 unit-test: _clojure-test
 
-unit-test-watch: export TARGET := clojure
 unit-test-watch: export SHADOW_OUTPUT_TO := target/unit_test/test.js
 unit-test-watch: export SHADOW_NS_REGEXP := ^(?!status-im\.integration-test).*-test$$
 unit-test-watch: ##@test Watch unit tests and re-run when files change
 unit-test-watch: _clojure-test-watch
 
-integration-test: export TARGET := clojure
 integration-test: export SHADOW_OUTPUT_TO := target/integration_test/test.js
 integration-test: export SHADOW_NS_REGEXP := ^status-im\.integration-test.*$$
 integration-test: ##@test Run integration tests
 integration-test: _clojure-test
 
-integration-test-watch: export TARGET := clojure
 integration-test-watch: export SHADOW_OUTPUT_TO := target/integration_test/test.js
 integration-test-watch: export SHADOW_NS_REGEXP := ^status-im\.integration-test.*$$
 integration-test-watch: ##@test Watch integration tests and re-run when files change

--- a/Makefile
+++ b/Makefile
@@ -335,28 +335,24 @@ shadow-server: export TARGET := clojure
 shadow-server:##@ Start shadow-cljs in server mode for watching
 	yarn shadow-cljs server
 
-_clojure-test: export TARGET := clojure
-_clojure-test:
+_test-clojure: export TARGET := clojure
+_test-clojure: export WATCH ?= false
+_test-clojure:
+ifeq ($(WATCH), true)
+	yarn install && \
+	yarn shadow-cljs compile mocks && \
+	nodemon --exec "yarn shadow-cljs compile test && node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO" -e cljs
+else
 	yarn install && \
 	yarn shadow-cljs compile mocks && \
 	yarn shadow-cljs compile test && \
 	node --require ./test-resources/override.js "$$SHADOW_OUTPUT_TO"
-
-_clojure-test-watch: export TARGET := clojure
-_clojure-test-watch:
-	yarn install && \
-	yarn shadow-cljs compile mocks && \
-	nodemon --exec "yarn shadow-cljs compile test && node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO" -e cljs
+endif
 
 test: export SHADOW_OUTPUT_TO := target/test/test.js
 test: export SHADOW_NS_REGEXP := .*-test$$
 test: ##@test Run all Clojure tests
-test: _clojure-test
-
-test-watch: export SHADOW_OUTPUT_TO := target/test/test.js
-test-watch: export SHADOW_NS_REGEXP := .*-test$$
-test-watch: ##@test Watch all Clojure tests and re-run when files change
-test-watch: _clojure-test-watch
+test: _test-clojure
 
 test-watch-for-repl: export SHADOW_OUTPUT_TO := target/test/test.js
 test-watch-for-repl: export SHADOW_NS_REGEXP := .*-test$$
@@ -368,25 +364,15 @@ test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connection
 		'yarn shadow-cljs watch test --verbose' \
 		"until [ -f $$SHADOW_OUTPUT_TO ] ; do sleep 1 ; done ; node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO --repl"
 
-unit-test: export SHADOW_OUTPUT_TO := target/unit_test/test.js
-unit-test: export SHADOW_NS_REGEXP := ^(?!status-im\.integration-test).*-test$$
-unit-test: ##@test Run unit tests
-unit-test: _clojure-test
+test-unit: export SHADOW_OUTPUT_TO := target/unit_test/test.js
+test-unit: export SHADOW_NS_REGEXP := ^(?!status-im\.integration-test).*-test$$
+test-unit: ##@test Run unit tests
+test-unit: _test-clojure
 
-unit-test-watch: export SHADOW_OUTPUT_TO := target/unit_test/test.js
-unit-test-watch: export SHADOW_NS_REGEXP := ^(?!status-im\.integration-test).*-test$$
-unit-test-watch: ##@test Watch unit tests and re-run when files change
-unit-test-watch: _clojure-test-watch
-
-integration-test: export SHADOW_OUTPUT_TO := target/integration_test/test.js
-integration-test: export SHADOW_NS_REGEXP := ^status-im\.integration-test.*$$
-integration-test: ##@test Run integration tests
-integration-test: _clojure-test
-
-integration-test-watch: export SHADOW_OUTPUT_TO := target/integration_test/test.js
-integration-test-watch: export SHADOW_NS_REGEXP := ^status-im\.integration-test.*$$
-integration-test-watch: ##@test Watch integration tests and re-run when files change
-integration-test-watch: _clojure-test-watch
+test-integration: export SHADOW_OUTPUT_TO := target/integration_test/test.js
+test-integration: export SHADOW_NS_REGEXP := ^status-im\.integration-test.*$$
+test-integration: ##@test Run integration tests
+test-integration: _test-clojure
 
 android-test: jsbundle
 android-test: export TARGET := android

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -52,14 +52,22 @@ pipeline {
             """
           }
         }
-        stage('Tests') {
+        stage('Unit Tests') {
           steps {
             sh """#!/bin/bash
               set -eo pipefail
-              make test 2>&1 | tee -a ${LOG_FILE}
+              make unit-test 2>&1 | tee -a ${LOG_FILE}
             """
           }
         }
+      }
+    }
+    stage('Integration Tests') {
+      steps {
+        sh """#!/bin/bash
+          set -eo pipefail
+          make integration-test 2>&1 | tee -a ${LOG_FILE}
+        """
       }
     }
     stage('Component Tests') {

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -56,7 +56,7 @@ pipeline {
           steps {
             sh """#!/bin/bash
               set -eo pipefail
-              make unit-test 2>&1 | tee -a ${LOG_FILE}
+              make test-unit 2>&1 | tee -a ${LOG_FILE}
             """
           }
         }
@@ -66,7 +66,7 @@ pipeline {
       steps {
         sh """#!/bin/bash
           set -eo pipefail
-          make integration-test 2>&1 | tee -a ${LOG_FILE}
+          make test-integration 2>&1 | tee -a ${LOG_FILE}
         """
       }
     }

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -5,7 +5,7 @@
 To run tests:
 
 ```
-   make test
+make test
 ```
 
 
@@ -13,10 +13,10 @@ To run tests:
 Also test watcher can be launched. It will re-run the entire test suite when any file is modified
 
 ```
-   make test-watch
+make test WATCH=true
 ```
 
-Developers can also manually change the shadow-cljs option `:ns-regex` to control which namespaces the test runner should pick. 
+Developers can also manually change the shadow-cljs option `:ns-regex` to control which namespaces the test runner should pick.
 
 ## Testing with REPL
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -108,13 +108,13 @@
   ;; produced by the target :mocks below and redefines node require
   ;; function to use the mocks instead of the rn libraries
   :test
-  {:output-to "target/test/test.js"
+  {:output-to #shadow/env "SHADOW_OUTPUT_TO"
    :output-dir "target/test"
    :optimizations :simple
    :target :node-test
    :dev {:devtools {:preloads [status-im.setup.schema-preload]}}
    ;; Uncomment line below to `make test-watch` a specific file
-   ;; :ns-regexp "status-im.subs.messages-test$"
+   :ns-regexp #shadow/env "SHADOW_NS_REGEXP"
    :main legacy.status-im.test-runner/main
    ;; set :ui-driven to true to let shadow-cljs inject node-repl
    :ui-driven true


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/18112

## Summary

Run Clojure integration tests separately from unit tests in the CI.

### Why?

1. Our integration tests generate a lot more log and noise than unit tests. When a unit or integration test fails, it's harder for the developer to spot what failed. Having separate steps in the pipeline makes this process easier.
2. During development, some devs run unit and integration tests using `make test-watch`, which re-runs the slow integration tests alongside unit tests. The dev can control the namespace regex that decides which test namespaces to run, but there's no easy way to watch only unit tests or only integration tests.

### Changelog:

- `make test` still exists, so if you have been using it, as well as `make test-watch`, they should all work exactly the same.
- `[Changed]` As part of the check stage, Jenkins will run `Lint` and `Unit Tests` in parallel. `Integration Tests` run later because running them at the same time as `Unit Tests` caused errors (see https://ci.status.im/blue/organizations/jenkins/status-mobile%2Fprs%2Ftests/detail/PR-18304/2/pipeline).
- `[Added]` `make unit-test` and `make unit-test-watch` run unit tests only. Watching all unit tests is faster now because we ignore integration tests and we only compile shadow-cljs `:mock` target once. We are at approximately 10-15s to re-run all unit tests after saving a watched file, depending on your hardware. If you change `mocks.js_dependencies.cljs`, you must re-run the make target.
- `[Added]` `make integration-test` and `make integration-test-watch` run integration tests only. These are much slower than the unit tests.

Original idea from @J-Son89 :+1:

#### Areas that may be impacted

Most definitely nothing for production code.

### Steps to test

Of course the Jenkins output since we're changing the pipeline, but you can also run the new make targets locally to check.

status: ready
