### PR TITLE
fixed dark border around the community logo 

### DIFF
--- a/src/status_im/common/scroll_page/style.cljs
+++ b/src/status_im/common/scroll_page/style.cljs
@@ -58,15 +58,16 @@
 (def picture-border-width 4)
 
 (defn display-picture-container
-  [animation]
+  [animation theme]
   (reanimated/apply-animations-to-style
    {:transform [{:scale animation}]}
-   {:border-radius picture-diameter
-    :border-width  picture-border-width
-    :border-color  (colors/theme-colors colors/white colors/neutral-95)
-    :position      :absolute
-    :top           (- (+ picture-radius picture-border-width))
-    :left          (+ (/ picture-radius 2) picture-border-width)}))
+   {:border-radius    picture-diameter
+    :border-width     picture-border-width
+    :border-color     (colors/theme-colors colors/white colors/neutral-95 theme)
+    :background-color (colors/theme-colors colors/white colors/neutral-95 theme)
+    :position         :absolute
+    :top              (- (+ picture-radius picture-border-width))
+    :left             (+ (/ picture-radius 2) picture-border-width)}))
 
 (defn display-picture
   [theme]

--- a/src/status_im/common/scroll_page/view.cljs
+++ b/src/status_im/common/scroll_page/view.cljs
@@ -89,7 +89,7 @@
                       js/undefined)
                    [scroll-height])
     [reanimated/view
-     {:style (style/display-picture-container animation)}
+     {:style (style/display-picture-container animation theme)}
      [rn/image
       {:source cover
        :style  (style/display-picture theme)}]]))


### PR DESCRIPTION
This PR removes the dark border around the community logo on communities page. The bug is only reproducible when the user has not yet joined the community

fixes https://github.com/status-im/status-mobile/issues/17565

Before & After screen shots
<img width="654" alt="Screenshot 2023-12-28 at 12 49 44" src="https://github.com/status-im/status-mobile/assets/28704507/8d08ce66-3686-4dba-9e96-e4053b77c1f4">
