### PR TITLE
fix: fix navigation after creating an account or watch only account

### DIFF
--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -35,13 +35,7 @@
  (fn [{:keys [db]} [address]]
    {:db (assoc-in db [:wallet :current-viewing-account-address] address)
     :fx [[:dispatch [:hide-bottom-sheet]]
-         [:dispatch-later
-          [{:dispatch [:navigate-back]
-            :ms       100}
-           {:dispatch [:navigate-back]
-            :ms       100}
-           {:dispatch [:navigate-to :wallet-accounts address]
-            :ms       300}]]
+         [:dispatch [:navigate-to :wallet-accounts address]]
          [:dispatch [:wallet/show-account-created-toast address]]]}))
 
 (rf/reg-event-fx :wallet/switch-current-viewing-account
@@ -51,7 +45,7 @@
 (rf/reg-event-fx :wallet/close-account-page
  (fn [{:keys [db]}]
    {:db (update db :wallet dissoc :current-viewing-account-address)
-    :fx [[:dispatch [:navigate-back]]]}))
+    :fx [[:dispatch [:pop-to-root :shell-stack]]]}))
 
 (rf/reg-event-fx
  :wallet/get-accounts-success

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -280,7 +280,10 @@
      :component emoji-picker/view}
 
     {:name      :wallet-accounts
-     :options   {:insets {:top? true}}
+     :options   {:insets             {:top? true}
+                 :popGesture         false
+                 :hardwareBackButton {:dismissModalOnPress false
+                                      :popStackOnPress     false}}
      :component wallet-accounts/view}
 
     {:name      :wallet-edit-account


### PR DESCRIPTION
fixes #18323

### Summary

This PR fixes navigation when creating an account or watch only account 

https://github.com/status-im/status-mobile/assets/18485527/0030c2a5-e15e-4dce-879d-34b63338ae16

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in
- Go to wallet
- Tap on + button to display bottom sheet
- Create an account or add a watch only account
- Check we are not navigating back anymore and navigation is correct

status: ready