### PR TITLE
fix: route not found when attempting to transfer assets to own accounts

### DIFF
--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -301,6 +301,10 @@
      (background-timer/clear-timeout current-timeout)
      {:db (assoc db :wallet/local-suggestions [] :wallet/valid-ens-or-address? false)})))
 
+(rf/reg-event-fx :wallet/clean-account-selection
+ (fn [{:keys [db]}]
+   {:db (update-in db [:wallet :ui :send] dissoc :send-account-address)}))
+
 (rf/reg-event-fx :wallet/get-address-details-success
  (fn [{:keys [db]} [{:keys [hasActivity]}]]
    {:db (assoc-in db

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -14,10 +14,6 @@
 
    {:db (assoc-in db [:wallet :ui :send :select-address-tab] tab)}))
 
-(rf/reg-event-fx :wallet/select-send-account-address
- (fn [{:keys [db]} [address]]
-   {:db (assoc db [:wallet :ui :send :send-account-address] address)}))
-
 (rf/reg-event-fx :wallet/suggested-routes-success
  (fn [{:keys [db]} [suggested-routes timestamp]]
    (when (= (get-in db [:wallet :ui :send :suggested-routes-call-timestamp]) timestamp)
@@ -44,9 +40,18 @@
             (update-in [:wallet :ui :send] dissoc :route)
             (update-in [:wallet :ui :send] dissoc :loading-suggested-routes?))}))
 
+(rf/reg-event-fx :wallet/select-send-account-address
+ (fn [{:keys [db]} [{:keys [address stack-id]}]]
+   {:db (-> db
+            (assoc-in [:wallet :ui :send :send-account-address] address)
+            (update-in [:wallet :ui :send] dissoc :to-address))
+    :fx [[:navigate-to-within-stack [:wallet-select-asset stack-id]]]}))
+
 (rf/reg-event-fx :wallet/select-send-address
  (fn [{:keys [db]} [{:keys [address stack-id]}]]
-   {:db (assoc-in db [:wallet :ui :send :to-address] address)
+   {:db (-> db
+            (assoc-in [:wallet :ui :send :to-address] address)
+            (update-in [:wallet :ui :send] dissoc :send-account-address))
     :fx [[:navigate-to-within-stack [:wallet-select-asset stack-id]]]}))
 
 (rf/reg-event-fx :wallet/send-select-token
@@ -63,7 +68,8 @@
  (fn [{:keys [db now]} [amount]]
    (let [wallet-address          (get-in db [:wallet :current-viewing-account-address])
          token                   (get-in db [:wallet :ui :send :token])
-         to-address              (get-in db [:wallet :ui :send :to-address])
+         account-address         (get-in db [:wallet :ui :send :send-account-address])
+         to-address              (or account-address (get-in db [:wallet :ui :send :to-address]))
          token-decimal           (:decimals token)
          token-id                (:symbol token)
          network-preferences     []

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -12,10 +12,9 @@
   [{:keys [color address] :as account}]
   [quo/account-item
    {:account-props (assoc account :customization-color color)
-    :on-press      (fn []
-                     (rf/dispatch [:wallet/select-send-account-address address])
-                     (rf/dispatch [:navigate-to-within-stack
-                                   [:wallet-select-asset :wallet-select-address]]))}])
+    :on-press      #(rf/dispatch [:wallet/select-send-account-address
+                                  {:address  address
+                                   :stack-id :wallet-select-address}])}])
 
 (defn my-accounts
   [theme]

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -117,6 +117,7 @@
   (let [on-close       (fn []
                          (rf/dispatch [:wallet/clean-scanned-address])
                          (rf/dispatch [:wallet/clean-local-suggestions])
+                         (rf/dispatch [:wallet/clean-account-selection])
                          (rf/dispatch [:wallet/select-address-tab nil])
                          (rf/dispatch [:navigate-back]))
         on-change-tab  #(rf/dispatch [:wallet/select-address-tab %])
@@ -128,7 +129,8 @@
         (rn/use-effect (fn []
                          (fn []
                            (rf/dispatch [:wallet/clean-scanned-address])
-                           (rf/dispatch [:wallet/clean-local-suggestions]))))
+                           (rf/dispatch [:wallet/clean-local-suggestions])
+                           (rf/dispatch [:wallet/clean-account-selection]))))
         [floating-button-page/view
          {:header [account-switcher/view
                    {:on-press      on-close


### PR DESCRIPTION
fixes #18232 

### Summary

This PR fixes routes not being fetched when attemping to send assets to an account from My Accounts tab.

- Refactor `:wallet/select-send-account-address` event to dissoc `:to-address` from db, and assoc `:send-account-address`, also moved navigation to an effect
- Refactor `:wallet/select-send-address` event to dissoc `:send-account-address` from db, and assoc `:to-address`
- In `:wallet/get-suggested-routes` event, use `:send-account-address` or `:to-address` as the sending address parameter (previously `:send-account-address` was being ignored and caused `getSuggestedRoutes` endpoint to instantly fail)

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in
- Go to wallet
- Be sure the user has an additional account, create a new one if not
- Go to Tap on send from an account with funds
- Tap on My Accounts tab and select an account from the logged user
- Select ETH asset
- Input some valid amount
- Check routes are loading successfully 

status: ready