### PR TITLE
fix: fix height on account card component

### DIFF
--- a/src/quo/components/wallet/account_card/style.cljs
+++ b/src/quo/components/wallet/account_card/style.cljs
@@ -11,8 +11,9 @@
     colors/white))
 
 (defn card
-  [{:keys [customization-color type theme pressed?]}]
-  {:width              162
+  [{:keys [customization-color type theme pressed? metrics?]}]
+  {:width              161
+   :height             (if metrics? 88 68)
    :background-color   (when (not= :watch-only type)
                          (colors/theme-colors
                           (colors/resolve-color customization-color

--- a/src/quo/components/wallet/account_card/view.cljs
+++ b/src/quo/components/wallet/account_card/view.cljs
@@ -21,7 +21,8 @@
       :style               (style/card {:customization-color customization-color
                                         :type                type
                                         :theme               theme
-                                        :pressed?            false})}
+                                        :pressed?            false
+                                        :metrics?            metrics?})}
      [rn/view {:style style/loader-container}
       [rn/view
        {:style (assoc (style/loader-view {:width       16
@@ -113,7 +114,8 @@
             :style        (style/card {:customization-color customization-color
                                        :type                type
                                        :theme               theme
-                                       :pressed?            @pressed?})
+                                       :pressed?            @pressed?
+                                       :metrics?            metrics?})
             :on-press     on-press}
            (when (and customization-color (and (not watch-only?) (not missing-keypair?)))
              [customization-colors/overlay


### PR DESCRIPTION
fixes #18178

### Summary

This PR fixes the height in account card component which should fix the UI bug described in the issue, also a small modification on the width (161 instead of 162 to comply with Figma component specs)

#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Login
- Go to new wallet
- Verify account cards are displayed correctly even in small resolution devices

status: ready