### PR TITLE
fix: increase numbered keyboard touchable area

### DIFF
--- a/src/quo/components/numbered_keyboard/keyboard_key/view.cljs
+++ b/src/quo/components/numbered_keyboard/keyboard_key/view.cljs
@@ -26,6 +26,7 @@
                                    (on-press label)))
           :on-press-in         #(reset! pressed? true)
           :on-press-out        #(reset! pressed? false)
+          :hit-slop            {:top 8 :bottom 8 :left 25 :right 25}
           :style               (style/container background-color)}
          (case type
            :key             [icons/icon


### PR DESCRIPTION
fixes #18205

### Summary

This PR increases touchable area of keys in numebered keyboard to improve responsiveness of touches

#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Log in
- Open wallet, go to send tokens
- Select a token, reach to input amount screen
- Verify responsiveness of touches in numbered keyboard

status: ready