### PR TITLE
Add lastOpenedAt key to communities

### DIFF
--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -48,7 +48,8 @@
                         :tokenPermissions            :token-permissions
                         :communityTokensMetadata     :tokens-metadata
                         :introMessage                :intro-message
-                        :muteTill                    :muted-till})
+                        :muteTill                    :muted-till
+                        :lastOpenedAt                :last-opened-at})
       (update :admin-settings
               set/rename-keys
               {:pinMessageAllMembersEnabled :pin-message-all-members-enabled?})
@@ -168,6 +169,13 @@
                   (assoc-in acc [communityId categoryId] true))
                 {}
                 categories))}))
+
+(rf/reg-event-fx :communities/update-last-opened-at
+ (fn [_ [community-id]]
+   {:json-rpc/call [{:method     "wakuext_updateLastOpenedAt"
+                     :params     [community-id]
+                     :on-success #(rf/dispatch [:communities/handle-community (first (:communities %))])
+                     :on-error   #(log/error (str "failed to update last opened at for community " %))}]}))
 
 (rf/reg-event-fx :community/fetch
  (fn [_]

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -172,7 +172,7 @@
 
 (rf/reg-event-fx :communities/update-last-opened-at
  (fn [_ [community-id]]
-   {:json-rpc/call [{:method     "wakuext_updateLastOpenedAt"
+   {:json-rpc/call [{:method     "wakuext_communityUpdateLastOpenedAt"
                      :params     [community-id]
                      :on-success #(rf/dispatch [:communities/handle-community (first (:communities %))])
                      :on-error   #(log/error (str "failed to update last opened at for community " %))}]}))

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -374,10 +374,11 @@
       (rf/dispatch [:activity-center.notifications/dismiss-community-overview id]))
     [community-scroll-page community pending?]))
 
-(defn overview
+(defn internal-overview
   [id]
   (let [id                  (or id (rf/sub [:get-screen-params :community-overview]))
         customization-color (rf/sub [:profile/customization-color])]
+    (rn/use-effect #(rf/dispatch [:communities/update-last-opened-at id]) [id])
     [rn/view {:style style/community-overview-container}
      [community-card-page-view id]
      [quo/floating-shell-button
@@ -385,3 +386,5 @@
                  :customization-color customization-color
                  :label               (i18n/label :t/jump-to)}}
       style/floating-shell-button]]))
+
+(defn overview [id] [:f> internal-overview id])

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "4479",
-    "commit-sha1": "f619b2e71a9bd1efa9acb075cf7b5fd34b81e2e3",
-    "src-sha256": "0w4ayk21ws88vkrm2py87ri5gwkhxk462nvnaszgnf5spa1sxh4w"
+    "commit-sha1": "5d5a8edc1697df8879ab587a8e89436907373581",
+    "src-sha256": "1629dm4bjnl39fhxh6hgvs3wjv0m0c0a717f3xnprfjxn0vhpq5z"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.171.39",
-    "commit-sha1": "debfe1cab368140b16d2383efc68007d3c28a4ef",
-    "src-sha256": "0cbj3796qz69ylwcvdw5jsl1cdyrcfk81d7shjkakvjh59rv5sjk"
+    "version": "4479",
+    "commit-sha1": "f619b2e71a9bd1efa9acb075cf7b5fd34b81e2e3",
+    "src-sha256": "0w4ayk21ws88vkrm2py87ri5gwkhxk462nvnaszgnf5spa1sxh4w"
 }


### PR DESCRIPTION
Required for #17337

Adds the last opened at key to communities to know when was a community last opened (This is done currently for overview pages, Internal links not tested yet.)

status: ready
