### PR TITLE
fix: handle deep link too early when onboarding

### DIFF
--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -143,7 +143,7 @@
   {:events [:messenger-started]}
   [{:keys [db] :as cofx} {:keys [mailservers] :as response}]
   (log/info "Messenger started")
-  (let [new-account? (get db :onboarding-2/new-account?)]
+  (let [new-account? (get db :onboarding/new-account?)]
     (rf/merge cofx
               {:db            (-> db
                                   (assoc :messenger/started? true)


### PR DESCRIPTION
-------

fixes #18074

### Summary

there's a `(get db :onboarding-2/new-account?)` in  https://github.com/status-im/status-mobile/blob/e7f685fee3f11ea097e618279382aef7f1495cc9/src/status_im/contexts/profile/login/events.cljs#L144

updated to `(get db :onboarding/new-account?)`
so that handle deep link won't be triggerd until user press the button an the end of the onboarding flow

status: ready <!-- Can be ready or wip -->