### PR TITLE
fix: generate_profile_url crash when login

### DIFF
--- a/src/schema/core.clj
+++ b/src/schema/core.clj
@@ -5,11 +5,17 @@
   in non-debug environments.
 
   `value` is first transformed via `malli.core/schema` to make sure we fail fast
-  and only register valid schemas."
+  and only register valid schemas.
+
+  Pass raw schema `value` instead of schema instance when it's `:function` schema
+  https://github.com/status-im/status-mobile/pull/18364#issuecomment-1875543794"
   [sym value]
   `(if ^boolean js/goog.DEBUG
      (try
-       (malli.core/=> ~sym (malli.core/schema ~value))
+       (let [schema-instance# (malli.core/schema ~value)]
+         (if (and (seq ~value) (= :function (first ~value)))
+           (malli.core/=> ~sym ~value)
+           (malli.core/=> ~sym schema-instance#)))
        (catch js/Error e#
          (taoensso.timbre/error "Failed to instrument function"
                                 {:symbol ~sym :error e#})

--- a/src/status_im/common/universal_links.cljs
+++ b/src/status_im/common/universal_links.cljs
@@ -200,24 +200,23 @@
               (handle-url url))))
 
 (defn generate-profile-url
-  ([cofx] (generate-profile-url cofx nil))
-  ([{:keys [db]} [{:keys [public-key cb]}]]
-   (let [profile-public-key (get-in db [:profile/profile :public-key])
-         profile?           (or (not public-key) (= public-key profile-public-key))
-         ens-name?          (if profile?
-                              (get-in db [:profile/profile :ens-name?])
-                              (get-in db [:contacts/contacts public-key :ens-name]))
-         public-key         (if profile? profile-public-key public-key)]
-     (when public-key
-       {:json-rpc/call
-        [{:method     (if ens-name? "wakuext_shareUserURLWithENS" "wakuext_shareUserURLWithData")
-          :params     [public-key]
-          :on-success (fn [url]
-                        (rf/dispatch [:universal-links/save-profile-url public-key url])
-                        (when (fn? cb) (cb)))
-          :on-error   #(log/error "failed to wakuext_shareUserURLWithData"
-                                  {:error      %
-                                   :public-key public-key})}]}))))
+  [{:keys [db]} [{:keys [public-key cb]}]]
+  (let [profile-public-key (get-in db [:profile/profile :public-key])
+        profile?           (or (not public-key) (= public-key profile-public-key))
+        ens-name?          (if profile?
+                             (get-in db [:profile/profile :ens-name?])
+                             (get-in db [:contacts/contacts public-key :ens-name]))
+        public-key         (if profile? profile-public-key public-key)]
+    (when public-key
+      {:json-rpc/call
+       [{:method     (if ens-name? "wakuext_shareUserURLWithENS" "wakuext_shareUserURLWithData")
+         :params     [public-key]
+         :on-success (fn [url]
+                       (rf/dispatch [:universal-links/save-profile-url public-key url])
+                       (when (fn? cb) (cb)))
+         :on-error   #(log/error "failed to wakuext_shareUserURLWithData"
+                                 {:error      %
+                                  :public-key public-key})}]})))
 
 (schema/=> generate-profile-url
   [:=>

--- a/src/status_im/common/universal_links_test.cljs
+++ b/src/status_im/common/universal_links_test.cljs
@@ -12,7 +12,7 @@
   (testing "the user is not logged in"
     (testing "it stores the url for later processing"
       (is (match? {:db {:universal-links/url "some-url"}}
-             (links/handle-url {:db {}} "some-url")))))
+                  (links/handle-url {:db {}} "some-url")))))
   (testing "the user is logged in"
     (let [db {:profile/profile     {:public-key "pk"}
               :app-state           "active"
@@ -22,8 +22,8 @@
                           [:db :universal-links/url]))))
       (testing "Handle a custom string"
         (is (match? (get-in (links/handle-url {:db db} "https://status.app/u#statuse2e")
-                       [:router/handle-uri :uri])
-               "https://status.app/u#statuse2e"))))))
+                            [:router/handle-uri :uri])
+                    "https://status.app/u#statuse2e"))))))
 
 (deftest url-event-listener
   (testing "the url is not nil"

--- a/src/status_im/common/universal_links_test.cljs
+++ b/src/status_im/common/universal_links_test.cljs
@@ -5,10 +5,13 @@
     [re-frame.core :as re-frame]
     [status-im.common.universal-links :as links]))
 
+(def pubkey
+  "0x04fbce10971e1cd7253b98c7b7e54de3729ca57ce41a2bfb0d1c4e0a26f72c4b6913c3487fa1b4bb86125770f1743fb4459da05c1cbe31d938814cfaf36e252073")
+
 (deftest handle-url-test
   (testing "the user is not logged in"
     (testing "it stores the url for later processing"
-      (is (= {:db {:universal-links/url "some-url"}}
+      (is (match? {:db {:universal-links/url "some-url"}}
              (links/handle-url {:db {}} "some-url")))))
   (testing "the user is logged in"
     (let [db {:profile/profile     {:public-key "pk"}
@@ -18,7 +21,7 @@
         (is (nil? (get-in (links/handle-url {:db db} "some-url")
                           [:db :universal-links/url]))))
       (testing "Handle a custom string"
-        (is (= (get-in (links/handle-url {:db db} "https://status.app/u#statuse2e")
+        (is (match? (get-in (links/handle-url {:db db} "https://status.app/u#statuse2e")
                        [:router/handle-uri :uri])
                "https://status.app/u#statuse2e"))))))
 
@@ -28,77 +31,58 @@
       (let [actual (atom nil)]
         (with-redefs [re-frame/dispatch #(reset! actual %)]
           (links/url-event-listener #js {:url "some-url"})
-          (is (= [:universal-links/handle-url "some-url"] @actual))))))
+          (is (match? [:universal-links/handle-url "some-url"] @actual))))))
   (testing "the url is nil"
     (testing "it does not dispatches the url"
       (let [actual (atom nil)]
         (with-redefs [re-frame/dispatch #(reset! actual %)]
           (links/url-event-listener #js {})
-          (is (= nil @actual)))))))
+          (is (match? nil @actual)))))))
 
 (deftest generate-profile-url
   (testing "user has ens name"
     (testing "it calls the ens rpc method with ens name as param"
-      (let [pubkey "pubkey"
-            db     {:profile/profile {:ens-name? true :public-key pubkey}}
-            rst    (links/generate-profile-url {:db db})]
-        (are [result expected] (= result expected)
+      (let [db  {:profile/profile {:ens-name? true :public-key pubkey}}
+            rst (links/generate-profile-url {:db db} [])]
+        (are [result expected] (match? result expected)
          "wakuext_shareUserURLWithENS" (-> rst :json-rpc/call first :method)
          pubkey                        (-> rst :json-rpc/call first :params first)))))
   (testing "user has no ens name"
     (testing "it calls the ens rpc method with public keyas param"
-      (let [pubkey "pubkey"
-            db     {:profile/profile {:public-key pubkey}}
-            rst    (links/generate-profile-url {:db db})]
-        (are [result expected] (= result expected)
+      (let [db  {:profile/profile {:public-key pubkey}}
+            rst (links/generate-profile-url {:db db} [])]
+        (are [result expected] (match? result expected)
          "wakuext_shareUserURLWithData" (-> rst :json-rpc/call first :method)
          pubkey                         (-> rst :json-rpc/call first :params first)))))
   (testing "contact has ens name"
     (testing "it calls the ens rpc method with ens name as param"
-      (let [pubkey "pubkey"
-            ens    "ensname.eth"
-            db     {:contacts/contacts {pubkey {:ens-name ens}}}
-            rst    (links/generate-profile-url {:db db} [{:public-key pubkey}])]
-        (are [result expected] (= result expected)
+      (let [ens "ensname.eth"
+            db  {:contacts/contacts {pubkey {:ens-name ens}}}
+            rst (links/generate-profile-url {:db db} [{:public-key pubkey}])]
+        (are [result expected] (match? result expected)
          "wakuext_shareUserURLWithENS" (-> rst :json-rpc/call first :method)
          pubkey                        (-> rst :json-rpc/call first :params first)))))
   (testing "contact has no ens name"
     (testing "it calls the ens rpc method with public keyas param"
-      (let [pubkey "pubkey"
-            db     {:contacts/contacts {pubkey {:public-key pubkey}}}
-            rst    (links/generate-profile-url {:db db} [{:public-key pubkey}])]
-        (are [result expected] (= result expected)
+      (let [db  {:contacts/contacts {pubkey {:public-key pubkey}}}
+            rst (links/generate-profile-url {:db db} [{:public-key pubkey}])]
+        (are [result expected] (match? result expected)
          "wakuext_shareUserURLWithData" (-> rst :json-rpc/call first :method)
          pubkey                         (-> rst :json-rpc/call first :params first))))))
 
 (deftest save-profile-url
   (testing "given a contact public key and profile url"
     (testing "it updates the contact in db"
-      (let [pubkey "pubkey"
-            url    "url"
-            db     {:contacts/contacts {pubkey {:public-key pubkey}}}
-            rst    (links/save-profile-url {:db db} [pubkey url])]
-        (is (= (get-in rst [:db :contacts/contacts pubkey :universal-profile-url]) url)))))
+      (let [url "url"
+            db  {:contacts/contacts {pubkey {:public-key pubkey}}}
+            rst (links/save-profile-url {:db db} [pubkey url])]
+        (is (match? (get-in rst [:db :contacts/contacts pubkey :universal-profile-url]) url)))))
   (testing "given a user public key and profile url"
     (testing "it updates the user profile in db"
-      (let [pubkey "pubkey"
-            url    "url"
-            db     {:profile/profile {:public-key pubkey}}
-            rst    (links/save-profile-url {:db db} [pubkey url])]
-        (is (= (get-in rst [:db :profile/profile :universal-profile-url]) url)))))
-  (testing "given a invalid url"
-    (testing "it returns the db untouched"
-      (let [pubkey "pubkey"
-            url    "url"
-            db     {:profile/profile {:public-key pubkey}}
-            rst    (links/save-profile-url {:db db} ["invalid pubkey" url])]
-        (is (= (:db rst) db)))))
-  (testing "given a nil as url"
-    (testing "it returns nil"
-      (let [pubkey "pubkey"
-            db     {:profile/profile {:public-key pubkey}}
-            rst    (links/save-profile-url {:db db} ["invalid pubkey"])]
-        (is (nil? rst))))))
+      (let [url "url"
+            db  {:profile/profile {:public-key pubkey}}
+            rst (links/save-profile-url {:db db} [pubkey url])]
+        (is (match? (get-in rst [:db :profile/profile :universal-profile-url]) url))))))
 
 (deftest universal-link-test
   (testing "universal-link?"

--- a/src/status_im/contexts/chat/messages/link_preview/events.cljs
+++ b/src/status_im/contexts/chat/messages/link_preview/events.cljs
@@ -80,9 +80,10 @@
     [:cofx :schema.re-frame/cofx]
     [:args
      [:schema [:catn [:community-id [:? :string]]]]]]
-   [:map
-    [:db map?]
-    [:json-rpc/call :schema.common/rpc-call]]])
+   [:maybe
+    [:map
+     [:db map?]
+     [:json-rpc/call :schema.common/rpc-call]]]])
 
 (rf/reg-event-fx :chat.ui/fetch-community fetch-community)
 
@@ -124,9 +125,10 @@
     [:cofx :schema.re-frame/cofx]
     [:args
      [:schema [:catn [:community-id [:? :string]]]]]]
-   [:map
-    [:db map?]
-    [:json-rpc/call :schema.common/rpc-call]]])
+   [:maybe
+    [:map
+     [:db map?]
+     [:json-rpc/call :schema.common/rpc-call]]]])
 
 (rf/reg-event-fx :chat.ui/spectate-community spectate-community)
 

--- a/src/status_im/contexts/chat/messages/link_preview/events_test.cljs
+++ b/src/status_im/contexts/chat/messages/link_preview/events_test.cljs
@@ -17,11 +17,11 @@
                                          :TryDatabase     true
                                          :WaitForResponse true}]}]}
              (sut/fetch-community {} ["community-id"])))))
-  (t/testing "with nil community id"
+  (t/testing "with no community id"
     (t/testing "do nothing"
       (t/is (match?
              nil
-             (sut/fetch-community {} nil))))))
+             (sut/fetch-community {} []))))))
 
 (t/deftest community-failed-to-resolve
   (t/testing "given a community id"


### PR DESCRIPTION
fixes #18331

### Summary

update the function to have fixed arity

### Review notes
I'm not sure if this is the reason
I checked `.shadow-cljs/builds/mobile/dev/ana/status_im/common/universal_links.cljs.cache.transit.json` and `generate_profile_url.cljs$core$IFn$_invoke$arity$2 ` is definitely defined
But I do come across the crash today

### Testing notes
<!-- (Optional) -->
I don't think it's possible to test this. It might be only a debug build thing.

status: ready <!-- Can be ready or wip -->