### PR TITLE
Wallet - Initialize event, refactor networks data and bug fix

### DIFF
--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -90,11 +90,10 @@
                        (assoc :chats/loading?           true
                               :networks/current-network current-network
                               :networks/networks        (merge networks config/default-networks-by-id)
-                              :profile/profile          (merge profile-overview settings))
-                       (assoc-in [:wallet :ui :tokens-loading?] true))
-               :fx [[:dispatch [:wallet/get-ethereum-chains]]
-                    [:dispatch [:universal-links/generate-profile-url]]
-                    [:dispatch [:community/fetch]]]}
+                              :profile/profile          (merge profile-overview settings)))
+               :fx [[:dispatch [:universal-links/generate-profile-url]]
+                    [:dispatch [:community/fetch]]
+                    [:dispatch [:wallet/initialize]]]}
               (notifications/load-preferences)
               (data-store.chats/fetch-chats-preview
                {:on-success
@@ -125,8 +124,7 @@
                                                             :on-error   #(log/error
                                                                           "failed to start messenger")}]
               :check-eip1559-activation                   {:network-id network-id}
-              :effects.profile/enable-local-notifications nil
-              :dispatch-n                                 [[:wallet/get-accounts]]}
+              :effects.profile/enable-local-notifications nil}
        (not (:universal-links/handling db))
        (assoc :effects.chat/open-last-chat (get-in db [:profile/profile :key-uid]))
        notifications-enabled?

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -64,7 +64,7 @@
       (update-vals #(cske/transform-keys csk/->kebab-case %))
       (update-vals #(mapv rpc->balances-per-chain %))))
 
-(defn <-rpc
+(defn rpc->network
   [network]
   (-> network
       (set/rename-keys

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -13,10 +13,11 @@
 (defn- show-save-account-toast
   [updated-key]
   (let [message (case updated-key
-                  :name                     :t/edit-wallet-account-name-updated-message
-                  :color                    :t/edit-wallet-account-colour-updated-message
-                  :emoji                    :t/edit-wallet-account-emoji-updated-message
-                  :prod-preferred-chain-ids :t/edit-wallet-network-preferences-updated-message
+                  :name                       :t/edit-wallet-account-name-updated-message
+                  :color                      :t/edit-wallet-account-colour-updated-message
+                  :emoji                      :t/edit-wallet-account-emoji-updated-message
+                  (:prod-preferred-chain-ids
+                   :test-preferred-chain-ids) :t/edit-wallet-network-preferences-updated-message
                   nil)]
     (rf/dispatch [:toasts/upsert
                   {:id   :edit-account
@@ -50,11 +51,15 @@
                                               :new-value   @edited-account-name}))]
     (fn []
       (let [{:keys [name emoji address color watch-only?]
-             :as   account}  (rf/sub [:wallet/current-viewing-account])
-            network-details  (rf/sub [:wallet/network-preference-details])
-            account-name     (or @edited-account-name name)
-            button-disabled? (or (nil? @edited-account-name)
-                                 (= name @edited-account-name))]
+             :as   account}         (rf/sub [:wallet/current-viewing-account])
+            network-details         (rf/sub [:wallet/network-preference-details])
+            test-networks-enabled?  (rf/sub [:profile/test-networks-enabled?])
+            network-preferences-key (if test-networks-enabled?
+                                      :test-preferred-chain-ids
+                                      :prod-preferred-chain-ids)
+            account-name            (or @edited-account-name name)
+            button-disabled?        (or (nil? @edited-account-name)
+                                        (= name @edited-account-name))]
         [create-or-edit-account/view
          {:page-nav-right-side [{:icon-name :i/delete
                                  :on-press  #(js/alert "Delete account: to be implemented")}]
@@ -95,7 +100,7 @@
                                                                 (rf/dispatch [:hide-bottom-sheet])
                                                                 (save-account
                                                                  {:account     account
-                                                                  :updated-key :prod-preferred-chain-ids
+                                                                  :updated-key network-preferences-key
                                                                   :new-value   chain-ids}))
                                                  :watch-only? watch-only?}])}]))
            :container-style style/data-item}]]))))

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -195,13 +195,13 @@
    (let [network-data
          {:test (map #(->> %
                            :Test
-                           data-store/<-rpc)
+                           data-store/rpc->network)
                      data)
           :prod (map #(->> %
                            :Prod
-                           data-store/<-rpc)
+                           data-store/rpc->network)
                      data)}]
-     {:db (assoc db :wallet/networks network-data)})))
+     {:db (assoc-in db [:wallet :networks] network-data)})))
 
 (rf/reg-event-fx :wallet/find-ens
  (fn [{:keys [db]} [input contacts chain-id cb]]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -327,3 +327,7 @@
  (fn [_ [explorer-link address]]
    {:fx [[:dispatch [:hide-bottom-sheet]]
          [:dispatch [:browser.ui/open-url (str explorer-link "/" address)]]]}))
+
+(rf/reg-event-fx :wallet/initialize
+ (fn []
+   {:fx [[:dispatch-n [[:wallet/get-ethereum-chains] [:wallet/get-accounts]]]]}))

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -106,7 +106,6 @@
  (fn [profile]
    (:test-networks-enabled? profile)))
 
-
 (re-frame/reg-sub
  :multiaccount/contact
  :<- [:profile/profile]

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -154,7 +154,6 @@
 (reg-root-key-sub :wallet :wallet)
 (reg-root-key-sub :wallet/scanned-address :wallet/scanned-address)
 (reg-root-key-sub :wallet/create-account :wallet/create-account)
-(reg-root-key-sub :wallet/networks :wallet/networks)
 (reg-root-key-sub :wallet/local-suggestions :wallet/local-suggestions)
 (reg-root-key-sub :wallet/valid-ens-or-address? :wallet/valid-ens-or-address?)
 

--- a/src/status_im/subs/wallet/networks.cljs
+++ b/src/status_im/subs/wallet/networks.cljs
@@ -4,10 +4,16 @@
             [status-im.constants :as constants]))
 
 (re-frame/reg-sub
- :wallet/filtered-networks-by-mode
+ :wallet/networks
+ :<- [:wallet]
+ :-> :networks)
+
+(re-frame/reg-sub
+ :wallet/networks-by-mode
  :<- [:wallet/networks]
- (fn [networks [_ test?]]
-   (get networks (if test? :test :prod))))
+ :<- [:profile/test-networks-enabled?]
+ (fn [[networks test-networks-enabled?]]
+   (get networks (if test-networks-enabled? :test :prod))))
 
 (def mainnet-network-details
   {:source       (resources/get-network constants/mainnet-network-name)
@@ -32,7 +38,7 @@
 
 (re-frame/reg-sub
  :wallet/network-details
- :<- [:wallet/filtered-networks-by-mode false]
+ :<- [:wallet/networks-by-mode]
  (fn [networks]
    (->> networks
         (keep

--- a/src/status_im/subs/wallet/networks_test.cljs
+++ b/src/status_im/subs/wallet/networks_test.cljs
@@ -37,7 +37,7 @@
 (h/deftest-sub :wallet/network-details
   [sub-name]
   (testing "returns data with prod"
-    (swap! rf-db/app-db assoc :wallet/networks network-data)
+    (swap! rf-db/app-db assoc-in [:wallet :networks] network-data)
     (is (= [{:network-name :ethereum
              :short-name   "eth"
              :chain-id     1

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -54,11 +54,6 @@
  :-> :token)
 
 (rf/reg-sub
- :wallet/wallet-send-amount
- :<- [:wallet/wallet-send]
- :-> :amount)
-
-(rf/reg-sub
  :wallet/wallet-send-loading-suggested-routes?
  :<- [:wallet/wallet-send]
  :-> :loading-suggested-routes?)
@@ -77,15 +72,13 @@
  :wallet/accounts
  :<- [:wallet]
  :<- [:wallet/network-details]
- (fn [[wallet network-details]]
-   ;; TODO(@rende11): `testnet?` value would be relevant after this implementation,
-   ;; https://github.com/status-im/status-mobile/issues/17826
-   (let [testnet? false]
-     (->> wallet
-          :accounts
-          vals
-          (map #(assoc-network-preferences-names network-details % testnet?))
-          (sort-by :position)))))
+ :<- [:profile/test-networks-enabled?]
+ (fn [[wallet network-details test-networks-enabled?]]
+   (->> wallet
+        :accounts
+        vals
+        (map #(assoc-network-preferences-names network-details % test-networks-enabled?))
+        (sort-by :position))))
 
 (rf/reg-sub
  :wallet/addresses

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -54,6 +54,11 @@
  :-> :token)
 
 (rf/reg-sub
+ :wallet/wallet-send-amount
+ :<- [:wallet/wallet-send]
+ :-> :amount)
+
+(rf/reg-sub
  :wallet/wallet-send-loading-suggested-routes?
  :<- [:wallet/wallet-send]
  :-> :loading-suggested-routes?)

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -167,7 +167,7 @@
     (swap! rf-db/app-db
       #(-> %
            (assoc-in [:wallet :accounts] accounts)
-           (assoc :wallet/networks network-data)))
+           (assoc-in [:wallet :networks] network-data)))
     (is
      (=
       (list {:path                      "m/44'/60'/0'/0/0"
@@ -252,7 +252,7 @@
       #(-> %
            (assoc-in [:wallet :accounts] accounts)
            (assoc-in [:wallet :current-viewing-account-address] "0x1")
-           (assoc :wallet/networks network-data)))
+           (assoc-in [:wallet :networks] network-data)))
 
     (let [result (rf/sub [sub-name])]
       (is
@@ -310,7 +310,7 @@
       #(-> %
            (assoc-in [:wallet :accounts] accounts)
            (assoc-in [:wallet :current-viewing-account-address] "0x2")
-           (assoc :wallet/networks network-data)))
+           (assoc-in [:wallet :networks] network-data)))
     (is
      (= (list
          {:path                      "m/44'/60'/0'/0/0"
@@ -365,7 +365,7 @@
     (swap! rf-db/app-db
       #(-> %
            (assoc-in [:wallet :accounts] accounts)
-           (assoc :wallet/networks network-data)))
+           (assoc-in [:wallet :networks] network-data)))
     (is
      (= (list
          {:path                      "m/44'/60'/0'/0/0"
@@ -421,7 +421,7 @@
       #(-> %
            (assoc-in [:wallet :accounts] accounts)
            (assoc-in [:wallet :current-viewing-account-address] "0x1")
-           (assoc :wallet/networks network-data)))
+           (assoc-in [:wallet :networks] network-data)))
     (is
      (match? [{:short-name       "eth"
                :network-name     :ethereum


### PR DESCRIPTION
fixes #17985
fixes #18368

### Summary

This PR:
 - Introduces new event `:wallet/initialize` to group events that need to be called on login
 - Refactors wallet networks to use the nested structure in re-frame
 - Fixes a bug when updating the testnet network preferences of an account the production network preferences update

### Platforms

- Android
- iOS

### Steps to test

Please do a quick test of the wallet, as this PR does a minor refactor.

#### To test the bug fix

1. Open the Status app
2. Switch to Test net mode
3. Navigate to the Wallet tab
4. Update the network preferences of any account with any network
8. Switch back to live
9. Check the network preferences of the account you have updated
10. Verify the production network preferences are not updated

status: ready 
