### PR TITLE
[#18362] Add support Reanimated inline styles

### DIFF
--- a/src/quo/components/buttons/slide_button/style.cljs
+++ b/src/quo/components/buttons/slide_button/style.cljs
@@ -1,8 +1,7 @@
 (ns quo.components.buttons.slide-button.style
   (:require
     [quo.components.buttons.slide-button.constants :as constants]
-    [quo.components.buttons.slide-button.utils :as utils]
-    [react-native.reanimated :as reanimated]))
+    [quo.components.buttons.slide-button.utils :as utils]))
 
 (def absolute-fill
   {:position :absolute
@@ -13,28 +12,25 @@
 
 (defn thumb-container
   [{:keys [interpolate-track thumb-size customization-color theme]}]
-  (reanimated/apply-animations-to-style
-   {:transform [{:translate-x (interpolate-track :track-clamp)}]}
+  [{:transform [{:translate-x (interpolate-track :track-clamp)}]}
    {:background-color (utils/main-color customization-color theme)
     :border-radius    12
     :height           thumb-size
     :width            thumb-size
     :align-items      :center
     :overflow         :hidden
-    :justify-content  :center}))
+    :justify-content  :center}])
 
 (defn arrow-icon-container
   [interpolate-track]
-  (reanimated/apply-animations-to-style
-   {:transform [{:translate-x (interpolate-track :arrow-icon-position)}]}
-   {:flex            1
-    :align-items     :center
-    :justify-content :center}))
+  {:transform       [{:translate-x (interpolate-track :arrow-icon-position)}]
+   :flex            1
+   :align-items     :center
+   :justify-content :center})
 
 (defn action-icon
   [interpolate-track size]
-  (reanimated/apply-animations-to-style
-   {:transform [{:translate-x (interpolate-track :action-icon-position)}]}
+  [{:transform [{:translate-x (interpolate-track :action-icon-position)}]}
    {:height          size
     :width           size
     :position        :absolute
@@ -42,7 +38,7 @@
     :left            0
     :top             0
     :flex-direction  :row
-    :justify-content :space-around}))
+    :justify-content :space-around}])
 
 (defn track
   [{:keys [disabled? customization-color height blur?]}]
@@ -57,9 +53,8 @@
 
 (defn track-cover
   [interpolate-track]
-  (reanimated/apply-animations-to-style
-   {:left (interpolate-track :track-cover)}
-   (assoc absolute-fill :overflow :hidden)))
+  [{:left (interpolate-track :track-cover)}
+   (assoc absolute-fill :overflow :hidden)])
 
 (defn track-cover-text-container
   [track-width]

--- a/src/react_native/reanimated.cljs
+++ b/src/react_native/reanimated.cljs
@@ -46,9 +46,11 @@
   []
   (let [current-component (reagent/current-component)
         reagent-props     (reagent/props current-component)
-        external-props    (oops/gobj-get current-component "props")
         children          (reagent/children current-component)
         updated-props     (update reagent-props :style transforms/styles-with-vectors)
+        ;; Some components add JS props to their children (such as TouchableWithoutFeedback), to make
+        ;; this component fully compatible we are passing those props to the inner component (`view*`).
+        external-props    (oops/gobj-get current-component "props")
         all-props         (transforms/copy-js-obj-to-map external-props updated-props #(not= % "argv"))]
     (into [view* all-props] children)))
 

--- a/src/react_native/reanimated.cljs
+++ b/src/react_native/reanimated.cljs
@@ -22,8 +22,10 @@
                      useAnimatedScrollHandler
                      runOnJS)]
     ["react-native-redash" :refer (withPause)]
+    [oops.core :as oops]
     [react-native.flat-list :as rn-flat-list]
     [reagent.core :as reagent]
+    [utils.transforms :as transforms]
     [utils.worklets.core :as worklets.core]))
 
 (def enable-layout-animations enableLayoutAnimations)
@@ -38,7 +40,18 @@
 ;; Animated Components
 (def create-animated-component (comp reagent/adapt-react-class (.-createAnimatedComponent reanimated)))
 
-(def view (reagent/adapt-react-class (.-View reanimated)))
+(def ^:private view* (reagent/adapt-react-class (.-View reanimated)))
+
+(defn view
+  []
+  (let [current-component (reagent/current-component)
+        reagent-props     (reagent/props current-component)
+        external-props    (oops/gobj-get current-component "props")
+        children          (reagent/children current-component)
+        updated-props     (update reagent-props :style transforms/styles-with-vectors)
+        all-props         (transforms/copy-js-obj-to-map external-props updated-props #(not= % "argv"))]
+    (into [view* all-props] children)))
+
 (def text (reagent/adapt-react-class (.-Text reanimated)))
 (def scroll-view (reagent/adapt-react-class (.-ScrollView reanimated)))
 (def image (reagent/adapt-react-class (.-Image reanimated)))

--- a/src/status_im/contexts/chat/messenger/composer/images/view.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/images/view.cljs
@@ -36,9 +36,9 @@
                                          (if (seq images) constants/images-container-height 0)))
                    [images])
     [reanimated/view
-     {:style (reanimated/apply-animations-to-style {:height height}
-                                                   {:margin-horizontal -20
-                                                    :z-index           1})}
+     {:style {:height            height
+              :margin-horizontal -20
+              :z-index           1}}
      [gesture/flat-list
       {:key-fn                            first
        :render-fn                         (fn [item]

--- a/src/status_im/contexts/chat/messenger/messages/content/album/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/album/view.cljs
@@ -22,6 +22,7 @@
 (defn album-message
   [{:keys [albumize?] :as message} context on-long-press message-container-data]
   (let [shared-element-id (rf/sub [:shared-element-id])
+        media-server-port (rf/sub [:mediaserver/port])
         first-image       (first (:album message))
         album-style       (if (> (:image-width first-image) (:image-height first-image))
                             :landscape
@@ -57,8 +58,7 @@
                                                :index    index}])}
               [fast-image/fast-image
                {:style     (style/image dimensions index portrait? images-count)
-                :source    {:uri (url/replace-port (:image (:content item))
-                                                   (rf/sub [:mediaserver/port]))}
+                :source    {:uri (url/replace-port (:image (:content item)) media-server-port)}
                 :native-ID (when (and (= shared-element-id (:message-id item))
                                       (< index constants/max-album-photos))
                              :shared-element)}]

--- a/src/status_im/contexts/profile/settings/header/style.cljs
+++ b/src/status_im/contexts/profile/settings/header/style.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.profile.settings.header.style
-  (:require [quo.foundations.colors :as colors]
-            [react-native.reanimated :as reanimated]))
+  (:require [quo.foundations.colors :as colors]))
 
 (defn header-view
   [customization-color theme]
@@ -30,19 +29,17 @@
 
 (defn radius-container
   [opacity-animation]
-  (reanimated/apply-animations-to-style
-   {:opacity opacity-animation}
-   {:flex-direction  :row
-    :justify-content :space-between}))
+  {:opacity         opacity-animation
+   :flex-direction  :row
+   :justify-content :space-between})
 
 (defn avatar-container
   [theme scale-animation top-margin-animation side-margin-animation]
-  (reanimated/apply-animations-to-style
-   {:transform     [{:scale scale-animation}]
+  [{:transform     [{:scale scale-animation}]
     :margin-top    top-margin-animation
     :margin-left   side-margin-animation
     :margin-bottom side-margin-animation}
    {:align-items   :flex-start
     :border-width  4
     :border-color  (colors/theme-colors colors/border-avatar-light colors/neutral-80-opa-80 theme)
-    :border-radius 100}))
+    :border-radius 100}])

--- a/src/status_im/contexts/shell/jump_to/components/bottom_tabs/style.cljs
+++ b/src/status_im/contexts/shell/jump_to/components/bottom_tabs/style.cljs
@@ -2,13 +2,11 @@
   (:require
     [quo.foundations.colors :as colors]
     [react-native.platform :as platform]
-    [react-native.reanimated :as reanimated]
     [status-im.contexts.shell.jump-to.utils :as utils]))
 
 (defn bottom-tabs-container
   [pass-through? height]
-  (reanimated/apply-animations-to-style
-   {:height height}
+  [{:height height}
    {:background-color    (if pass-through? :transparent colors/neutral-100)
     :flex                1
     :align-items         :center
@@ -18,7 +16,7 @@
     :right               0
     :left                0
     :overflow            :hidden
-    :accessibility-label :bottom-tabs-container}))
+    :accessibility-label :bottom-tabs-container}])
 
 (defn bottom-tabs
   []
@@ -30,11 +28,10 @@
 
 (defn bottom-tabs-blur-overlay
   [height]
-  (reanimated/apply-animations-to-style
-   {:height height}
+  [{:height height}
    {:position         :absolute
     :left             0
     :right            0
     :bottom           0
     :height           (utils/bottom-tabs-container-height)
-    :background-color colors/neutral-100-opa-70-blur}))
+    :background-color colors/neutral-100-opa-70-blur}])

--- a/src/utils/transforms.cljs
+++ b/src/utils/transforms.cljs
@@ -1,7 +1,10 @@
 (ns utils.transforms
   (:refer-clojure :exclude [js->clj])
   (:require
-    [cljs-bean.core :as clj-bean]))
+    [cljs-bean.core :as clj-bean]
+    [oops.core :as oops]
+    [reagent.impl.template]
+    [reagent.impl.util]))
 
 (defn js->clj [data] (cljs.core/js->clj data :keywordize-keys true))
 
@@ -21,3 +24,37 @@
   [json]
   (when-not (= json "undefined")
     (try (.parse js/JSON json) (catch js/Error _ (when (string? json) json)))))
+
+;; Functions took from reagent and modified to also transform vectors contained in styles
+
+(def ^:private js-val? reagent.impl.util/js-val?)
+(def ^:private named? reagent.impl.util/named?)
+(def ^:private cached-prop-name reagent.impl.template/cached-prop-name)
+(declare styles-with-vectors)
+
+(defn ^:private kv-conv
+  [o k v]
+  (doto o
+    (oops/gobj-set (cached-prop-name k) (styles-with-vectors v))))
+
+(defn styles-with-vectors
+  [x]
+  (cond (js-val? x) x
+        (named? x)  (name x)
+        (map? x)    (reduce-kv kv-conv #js {} x)
+        (vector? x) (to-array (map styles-with-vectors x))
+        (coll? x)   (clj->js x)
+        (ifn? x)    (fn [& args]
+                      (apply x args))
+        :else       (clj->js x)))
+
+(defn copy-js-obj-to-map
+  "Copy `obj` keys and values into `m` if `(pred obj-key)` is satisfied."
+  [obj m pred]
+  (persistent!
+   (reduce (fn [acc js-prop]
+             (if (pred js-prop)
+               (assoc! acc js-prop (oops/gobj-get obj js-prop))
+               acc))
+           (transient m)
+           (js-keys obj))))

--- a/src/utils/transforms.cljs
+++ b/src/utils/transforms.cljs
@@ -3,8 +3,8 @@
   (:require
     [cljs-bean.core :as clj-bean]
     [oops.core :as oops]
-    [reagent.impl.template]
-    [reagent.impl.util]))
+    [reagent.impl.template :as reagent.template]
+    [reagent.impl.util :as reagent.util]))
 
 (defn js->clj [data] (cljs.core/js->clj data :keywordize-keys true))
 
@@ -25,28 +25,30 @@
   (when-not (= json "undefined")
     (try (.parse js/JSON json) (catch js/Error _ (when (string? json) json)))))
 
-;; Functions took from reagent and modified to also transform vectors contained in styles
-
-(def ^:private js-val? reagent.impl.util/js-val?)
-(def ^:private named? reagent.impl.util/named?)
-(def ^:private cached-prop-name reagent.impl.template/cached-prop-name)
 (declare styles-with-vectors)
 
-(defn ^:private kv-conv
-  [o k v]
-  (doto o
-    (oops/gobj-set (cached-prop-name k) (styles-with-vectors v))))
+(defn ^:private convert-keys-and-values
+  "Takes a JS Object a key and a value.
+   Transforms the key from a Clojure style prop to a JS style prop, using the reagent cache.
+   Performs a mutual recursion transformation on the value using `styles-with-vectors`.
+
+   Based on `reagent.impl.template/kv-conv`."
+  [obj k v]
+  (doto obj
+    (oops/gobj-set (reagent.template/cached-prop-name k) (styles-with-vectors v))))
 
 (defn styles-with-vectors
+  "Takes a Clojure style map or a Clojure vector of style maps and returns a JS Object
+   valid to use as React Native styles.
+   The transformation is done by performing mutual recursive calls with `convert-keys-and-values`.
+
+   Based on `reagent.impl.template/convert-prop-value`."
   [x]
-  (cond (js-val? x) x
-        (named? x)  (name x)
-        (map? x)    (reduce-kv kv-conv #js {} x)
-        (vector? x) (to-array (map styles-with-vectors x))
-        (coll? x)   (clj->js x)
-        (ifn? x)    (fn [& args]
-                      (apply x args))
-        :else       (clj->js x)))
+  (cond (reagent.util/js-val? x) x
+        (reagent.util/named? x)  (name x)
+        (map? x)                 (reduce-kv convert-keys-and-values #js {} x)
+        (vector? x)              (to-array (mapv styles-with-vectors x))
+        :else                    (clj->js x)))
 
 (defn copy-js-obj-to-map
   "Copy `obj` keys and values into `m` if `(pred obj-key)` is satisfied."


### PR DESCRIPTION
fixes #18362

### Summary

Recently we upgraded Reanimated to `3.x` so inline styles are now supported, it means, for just passing shared-values to our style maps, we no longer need the `use-animated-style` hook :smile: 

This will simplify our code and we won't need to deal with the limitations of that hook, such as:
- Not being able to conditionally use it
```clojure
;; E.g.
(if something?
  (use-animated-style {,,,})
  {,,,})
```
- As a convention, should call it it at the beginning of the render function's body (not followed by many of our components :laughing:).

- Must be used in a functional component
... etc

We get that feature "for free" within Reanimated 3.x, however, it's highly desirable to also support the use of vectors to pass styles to reanimated views since in some cases it's needed - our function `apply-animations-to-style` solved the problem by passing two maps, one with shared-values and other with regular styles-.

:star2:  **So this PR adds support for that vector syntax!** :star2: 

### How to use it

I have modified some components in the codebase, they work as an example, so please check the diff in this PR.

Some simplified examples:
```clojure
;; Before
(defn f-bottom-tabs []
  (let [style (reanimated/apply-animations-to-style ; <- internal use of `use-animated-style`
               {:height (:bottom-tabs-height shared-values)}
               {:position         :absolute
                :left             0
                :right            0
                :bottom           0
                :height           50
                :background-color :red})]
    (when pass-through?
      [reanimated/blur-view (blur-overlay-params style)])))

;; Now:
(defn f-bottom-tabs []
  (let [style [{:height (:bottom-tabs-height shared-values)} ; <- no need of `apply-animations-to-style`
               {:position         :absolute                  ; just a vector `[]`
                :left             0
                :right            0
                :bottom           0
                :height           50
                :background-color :red}]]
    (when pass-through?
      [reanimated/blur-view (blur-overlay-params style)])))
```

```clojure
;; Before
(defn f-view []
  (let [scroll-y          (reanimated/use-shared-value 0)
        opacity-animation (reanimated/interpolate scroll-y [0 45 50] [1 1 0])]
    [reanimated/view {:style (reanimated/apply-animations-to-style ; <- internal use of `use-animated-style`
                              {:opacity opacity-animation}
                              {:flex-direction  :row
                               :justify-content :space-between})}]))

;; Now
(defn f-view []
  (let [scroll-y          (reanimated/use-shared-value 0)
        opacity-animation (reanimated/interpolate scroll-y [0 45 50] [1 1 0])]
    [reanimated/view {:style {:opacity         opacity-animation ; Just the map, no need of a function :)
                              :flex-direction  :row
                              :justify-content :space-between}}]))

;; Another valid option is using a vector:
[reanimated/view {:style [{:opacity opacity-animation}
                          {:flex-direction  :row
                           :justify-content :space-between}]}]

;; We can even split our styles any number of desired maps, so this API is very flexible
[reanimated/view {:style [{:opacity opacity-animation}
                          {:flex-direction :row}
                          {:justify-content :space-between}]}]
```


### Q&A

#### Do we need to update previous usages?

No, this change shouldn't break existing code

#### Is now `use-animated-style` useless?

No, in some complex components we will still need it, Reanimated presents inline styles [here](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation#defining-a-shared-value), and the the use of use-animated-style [here](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/animating-styles-and-props#animating-styles), so please read them. If you are unsure, I'd suggest implementing the component as before and then trying to use the new approach.

#### What about performance!? :angry: 

Reagent doesn't support the vector syntax for styles, and transforming many keys is expensive, I tried various solutions, such as using `csk` + `cske` and trying to write an in-house solution, I was getting `~2ms` to `~5ms` because of the kebab-case to camelCase transformation, that's too much, and we are using `reanimated/view` too much (and in the future will be even more).

Then I decided to have at least the same performance as Reagent, so used its `template` and `utils` functions and slightly modified to support the vector syntax.

Reagent has a cache of transformed keys, so once a key is transformed, it's stored and following ones are just recovered, that's fast! ... and also gave me a hint to improve our key transformations (cc: @status-im/wallet-mobile-devs  while getting hundreds or thousands of collectibles :eyes: )

At the end, the whole component takes ~0.1ms  to ~0.6ms (just used `time`, not `criterium`), but take into consideration this is a dev build, before optimizations made by Google Closure compiler:

![image](https://github.com/status-im/status-mobile/assets/90291778/251181c5-c95f-43ce-a85b-77d70f3b3310)

So we shouldn't worry about it, additionally, these transformed styles are converted to JS objects, so Reagent doesn't need to transform them again :smile: .


### Steps to test

The updated components were:
- Buttons > Slide button:

  ![image](https://github.com/status-im/status-mobile/assets/90291778/f57d4a2b-7fb0-4c58-87f2-3f5a7c4cf1b0)


- The Avatar in the settings header:

  ![image](https://github.com/status-im/status-mobile/assets/90291778/a77c9bb7-986b-4d95-90e0-10f9b2da952a)


- The bottom tabs to navigate:

  ![image](https://github.com/status-im/status-mobile/assets/90291778/705af494-26c0-4e91-93b7-851e7a944a96)

So they should behave exactly as before.


status: ready
