### PR TITLE
Communities: Share Selective Account

### DIFF
--- a/src/quo/components/wallet/account_permissions/view.cljs
+++ b/src/quo/components/wallet/account_permissions/view.cljs
@@ -29,6 +29,7 @@
       [:checked? {:optional true} [:maybe :boolean]]
       [:disabled? {:optional true} [:maybe :boolean]]
       [:on-change {:optional true} [:maybe fn?]]
+      [:container-style {:optional true} [:maybe :map]]
       [:theme :schema.common/theme]]]]
    :any])
 
@@ -58,11 +59,11 @@
 
 (defn- view-internal
   [{:keys
-    [checked? disabled? on-change token-details keycard? theme]
+    [checked? disabled? on-change token-details keycard? theme container-style]
     {:keys
      [name address emoji customization-color]} :account}]
   [rn/view
-   {:style               (style/container theme)
+   {:style               (merge (style/container theme) container-style)
     :accessibility-label :wallet-account-permissions}
    [rn/view {:style style/row1}
     [account-avatar/view

--- a/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
@@ -10,19 +10,29 @@
     [utils.re-frame :as rf]))
 
 (defn- join-community-and-navigate-back
-  [id]
+  [id addresses-for-permissions]
   (rf/dispatch [:password-authentication/show
                 {:content (fn [] [password-authentication/view])}
                 {:label    (i18n/label :t/join-open-community)
                  :on-press #(rf/dispatch [:communities/request-to-join
-                                          {:community-id id :password %}])}])
+                                          {:community-id        id
+                                           :password            %
+                                           :addresses-to-reveal addresses-for-permissions}])}])
   (rf/dispatch [:navigate-back]))
 
-(defn view
+(defn f-view-internal
   []
   (let [{id :community-id}          (rf/sub [:get-screen-params])
         {:keys [name color images]} (rf/sub [:communities/community id])
-        accounts                    (rf/sub [:wallet/accounts-with-customization-color])]
+        accounts                    (rf/sub [:wallet/accounts-with-customization-color])
+        addresses-for-permissions   (rf/sub [:communities/addresses-for-permissions])
+        selected-accounts           (filter #(contains? addresses-for-permissions
+                                                        (:address %))
+                                            accounts)]
+    (rn/use-effect (fn []
+                     (rf/dispatch [:communities/set-addresses-for-permissions
+                                   (set (map :address accounts))]))
+                   [])
     [rn/view {:style style/container}
      [quo/page-nav
       {:text-align          :left
@@ -53,7 +63,7 @@
                       :action            :arrow
                       :label             :preview
                       :label-props       {:type :accounts
-                                          :data accounts}
+                                          :data selected-accounts}
                       :description-props {:text (i18n/label :t/all-addresses)}}
                      {:title             (i18n/label :t/for-airdrops)
                       :on-press          #(rf/dispatch [:open-modal :airdrop-addresses
@@ -77,4 +87,8 @@
         :track-text          (i18n/label :t/slide-to-request-to-join)
         :track-icon          :i/face-id
         :customization-color color
-        :on-complete         #(join-community-and-navigate-back id)}]]]))
+        :on-complete         #(join-community-and-navigate-back id addresses-for-permissions)}]]]))
+
+(defn view
+  []
+  [:f> f-view-internal])

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/style.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/style.cljs
@@ -1,22 +1,15 @@
-(ns status-im.contexts.communities.actions.addresses-for-permissions.style
-  (:require [quo.foundations.colors :as colors]))
+(ns status-im.contexts.communities.actions.addresses-for-permissions.style)
 
 (def container {:flex 1})
-
-(def account-item-container
-  {:font-size          30
-   :border-radius      16
-   :flex-direction     :row
-   :border-width       1
-   :height             56
-   :padding-horizontal 12
-   :align-items        :center
-   :margin-bottom      8
-   :gap                8
-   :border-color       colors/neutral-90})
 
 (def buttons
   {:flex-direction     :row
    :gap                12
    :padding-horizontal 20
    :padding-vertical   12})
+
+(def error-message
+  {:flex-direction  :row
+   :gap             4
+   :justify-content :center
+   :margin-bottom   8})

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -1,55 +1,76 @@
 (ns status-im.contexts.communities.actions.addresses-for-permissions.view
   (:require [quo.core :as quo]
+            [quo.foundations.colors :as colors]
             [react-native.core :as rn]
+            [reagent.core :as reagent]
             [status-im.common.not-implemented :as not-implemented]
             [status-im.contexts.communities.actions.addresses-for-permissions.style :as style]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
 (defn- account-item
-  [item]
-  [rn/view
-   {:style style/account-item-container}
-   [quo/account-avatar (assoc item :size 32)]
-   [rn/view
-    [quo/text
-     {:size   :paragraph-1
-      :weight :semi-bold}
-     (:name item)]
-    [quo/address-text
-     {:address (:address item)
-      :format  :short}]]])
+  [item _ _ selected-addresses]
+  [quo/account-permissions
+   {:account         {:name                (:name item)
+                      :address             (:address item)
+                      :emoji               (:emoji item)
+                      :customization-color (:customization-color item)}
+    :token-details   []
+    :checked?        (contains? @selected-addresses (:address item))
+    :on-change       (fn [checked?]
+                       (if checked?
+                         (swap! selected-addresses conj (:address item))
+                         (swap! selected-addresses disj (:address item))))
+    :container-style {:margin-bottom 8}}])
 
 (defn view
   []
   (let [{id :community-id}          (rf/sub [:get-screen-params])
         {:keys [name color images]} (rf/sub [:communities/community id])
-        accounts                    (rf/sub [:wallet/accounts-with-customization-color])]
-    [rn/safe-area-view {:style style/container}
+        accounts                    (rf/sub [:wallet/accounts-with-customization-color])
+        selected-addresses          (reagent/atom (rf/sub [:communities/addresses-for-permissions]))]
+    (fn []
+      [rn/safe-area-view {:style style/container}
+       [quo/drawer-top
+        {:type                :context-tag
+         :title               (i18n/label :t/addresses-for-permissions)
+         :community-name      name
+         :button-icon         :i/info
+         :on-button-press     not-implemented/alert
+         :community-logo      (get-in images [:thumbnail :uri])
+         :customization-color color}]
 
-     [quo/drawer-top
-      {:type                :context-tag
-       :title               (i18n/label :t/addresses-for-permissions)
-       :community-name      name
-       :button-icon         :i/info
-       :on-button-press     not-implemented/alert
-       :community-logo      (get-in images [:thumbnail :uri])
-       :customization-color color}]
+       [rn/flat-list
+        {:render-fn               account-item
+         :render-data             selected-addresses
+         :content-container-style {:padding 20}
+         :key-fn                  :address
+         :data                    accounts}]
 
-     [rn/flat-list
-      {:render-fn               account-item
-       :content-container-style {:padding 20}
-       :key-fn                  :address
-       :data                    accounts}]
+       (when (empty? @selected-addresses)
+         [rn/view
+          {:style style/error-message}
+          [quo/icon
+           :i/info
+           {:color colors/danger-50
+            :size  16}]
+          [quo/text
+           {:size  :paragraph-2
+            :style {:color colors/danger-50}}
+           (i18n/label :t/no-addresses-selected)]])
 
-     [rn/view {:style style/buttons}
-      [quo/button
-       {:type            :grey
-        :container-style {:flex 1}
-        :on-press        #(rf/dispatch [:navigate-back])}
-       (i18n/label :t/cancel)]
-      [quo/button
-       {:container-style     {:flex 1}
-        :customization-color color
-        :on-press            #(rf/dispatch [:navigate-back])}
-       (i18n/label :t/confirm-changes)]]]))
+       [rn/view {:style style/buttons}
+        [quo/button
+         {:type            :grey
+          :container-style {:flex 1}
+          :on-press        #(rf/dispatch [:navigate-back])}
+         (i18n/label :t/cancel)]
+        [quo/button
+         {:container-style     {:flex 1}
+          :customization-color color
+          :disabled?           (empty? @selected-addresses)
+          :on-press            (fn []
+                                 (rf/dispatch [:communities/set-addresses-for-permissions
+                                               @selected-addresses])
+                                 (rf/dispatch [:navigate-back]))}
+         (i18n/label :t/confirm-changes)]]])))

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -184,3 +184,7 @@
                      :params     []
                      :on-success #(rf/dispatch [:communities/fetched-collapsed-categories-success %])
                      :on-error   #(log/error "failed to fetch collapsed community categories" %)}]}))
+
+(rf/reg-event-fx :communities/set-addresses-for-permissions
+ (fn [{:keys [db]} [addresses]]
+   {:db (assoc-in db [:communities/addresses-for-permissions] addresses)}))

--- a/src/status_im/contexts/communities/overview/events.cljs
+++ b/src/status_im/contexts/communities/overview/events.cljs
@@ -63,9 +63,10 @@
                                                   err))}]}))))
 
 (defn request-to-join
-  [{:keys [db]} [{:keys [community-id password]}]]
-  (let [pub-key             (get-in db [:profile/profile :public-key])
-        addresses-to-reveal []]
+  [{:keys [db]}
+   [{:keys [community-id password addresses-to-reveal]
+     :or   {addresses-to-reveal []}}]]
+  (let [pub-key (get-in db [:profile/profile :public-key])]
     {:fx [[:json-rpc/call
            [{:method     "wakuext_generateJoiningCommunityRequestsForSigning"
              :params     [pub-key community-id addresses-to-reveal]

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -145,6 +145,7 @@
 (reg-root-key-sub :communities/collapsed-categories :communities/collapsed-categories)
 (reg-root-key-sub :communities/selected-tab :communities/selected-tab)
 (reg-root-key-sub :contract-communities :contract-communities)
+(reg-root-key-sub :communities/addresses-for-permissions :communities/addresses-for-permissions)
 
 ;;activity center
 (reg-root-key-sub :activity-center :activity-center)

--- a/translations/en.json
+++ b/translations/en.json
@@ -179,6 +179,7 @@
     "community-rules": "Community rules",
     "address-to-share": "Addresses to share",
     "addresses-for-permissions": "Addresses for permissions",
+    "no-addresses-selected": "At least 1 address must be shared with community",
     "confirm-changes": "Confirm changes",
     "airdrop-addresses": "Address for airdrops",
     "join-as-a-member": "Join as a Member",


### PR DESCRIPTION
fixes #18010

This PR enables selectively sharing addresses when joining a community.

Screen Recording:

https://github.com/status-im/status-mobile/assets/19279756/3eb6ccf8-5df2-4c8b-8ddd-6d6fbd069cb4


### Test Note
- To test this, change the `community-accounts-selection-enabled?` flag in `src/status_im2/config.cljs` to `true`.
- Select only the primary Ethereum account to join if you have multiple wallet accounts. Refer: https://github.com/status-im/status-mobile/issues/18308

> This feature is currently under a flag not enabled in the development branch, so these changes do not require manual QA.