### PR TITLE
fix improper use of current-chat-id and rename subs

### DIFF
--- a/src/legacy/status_im/ui/screens/chat/group.cljs
+++ b/src/legacy/status_im/ui/screens/chat/group.cljs
@@ -12,7 +12,7 @@
 (def message-max-length 100)
 
 (defn request-membership
-  [{:keys [state introduction-message] :as invitation}]
+  [{:keys [state introduction-message] :as invitation} chat-id]
   (let [{:keys [message retry?]} @(re-frame/subscribe [:chats/current-chat-membership])
         message-length           (count message)]
     [react/view {:margin-horizontal 16 :margin-top 10}
@@ -47,7 +47,7 @@
         [react/text (i18n/label :t/introduce-yourself)]
         [quo/text-input
          {:placeholder         (i18n/label :t/message)
-          :on-change-text      #(re-frame/dispatch [:group-chats.ui/update-membership-message %])
+          :on-change-text      #(re-frame/dispatch [:group-chats.ui/update-membership-message % chat-id])
           :max-length          (if platform/android?
                                  message-max-length
                                  (when (>= message-length message-max-length)
@@ -63,4 +63,4 @@
   [chat-id invitation-admin]
   (letsubs [invitations [:group-chat/invitations-by-chat-id chat-id]]
     (when invitation-admin
-      [request-membership (first invitations)])))
+      [request-membership (first invitations) chat-id])))

--- a/src/status_im/common/home/actions/view.cljs
+++ b/src/status_im/common/home/actions/view.cljs
@@ -349,7 +349,7 @@
   [chat-id]
   (entry {:icon                :i/members
           :label               (i18n/label :t/group-details)
-          :on-press            #(hide-sheet-and-dispatch [:show-group-chat-profile chat-id])
+          :on-press            #(hide-sheet-and-dispatch [:navigate-to :group-chat-profile chat-id])
           :danger?             false
           :accessibility-label :group-details
           :sub-label           nil

--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -20,31 +20,20 @@
     :icon-only?          true
     :container-style     {:margin-left 20}
     :accessibility-label :back-button
-    :on-press            (fn []
-                           (rf/dispatch [:navigate-back])
-                           (rf/dispatch [:chat/close]))}
+    :on-press            #(rf/dispatch [:navigate-back])}
    :i/arrow-left])
 
 (defn options-button
-  []
-  (let [group (rf/sub [:chats/current-chat])]
-    [quo/button
-     {:type                :grey
-      :size                32
-      :icon-only?          true
-      :container-style     {:margin-right 20}
-      :accessibility-label :options-button
-      :on-press            #(rf/dispatch [:show-bottom-sheet
-                                          {:content (fn [] [actions/group-details-actions group])}])}
-     :i/options]))
-
-(defn top-buttons
-  []
-  [rn/view
-   {:style {:flex-direction     :row
-            :padding-horizontal 20
-            :justify-content    :space-between}}
-   [back-button] [options-button]])
+  [group]
+  [quo/button
+   {:type                :grey
+    :size                32
+    :icon-only?          true
+    :container-style     {:margin-right 20}
+    :accessibility-label :options-button
+    :on-press            #(rf/dispatch [:show-bottom-sheet
+                                        {:content (fn [] [actions/group-details-actions group])}])}
+   :i/options])
 
 (defn count-container
   [amount accessibility-label]
@@ -100,7 +89,8 @@
   []
   (let [selected-participants      (rf/sub [:group-chat/selected-participants])
         deselected-members         (rf/sub [:group-chat/deselected-members])
-        {:keys [admins] :as group} (rf/sub [:chats/current-chat])
+        chat-id                    (rf/sub [:get-screen-params :group-chat-profile])
+        {:keys [admins] :as group} (rf/sub [:chats/chat-by-id chat-id])
         admin?                     (get admins (rf/sub [:multiaccount/public-key]))]
     [rn/view {:flex 1 :margin-top 20}
      [rn/touchable-opacity
@@ -130,9 +120,9 @@
                                (rf/dispatch [:navigate-back])
                                (js/setTimeout (fn []
                                                 (rf/dispatch
-                                                 [:group-chats.ui/remove-members-pressed]))
+                                                 [:group-chats.ui/remove-members-pressed chat-id]))
                                               500)
-                               (rf/dispatch [:group-chats.ui/add-members-pressed]))
+                               (rf/dispatch [:group-chats.ui/add-members-pressed chat-id]))
         :disabled?           (and (zero? (count selected-participants))
                                   (zero? (count deselected-members)))}
        (i18n/label :t/save)]]]))
@@ -151,84 +141,79 @@
                         :on-press show-profile-actions}})
      item]))
 
-(defn f-group-details
-  []
-  (fn []
-    (rn/use-effect (fn []
-                     #(rf/dispatch [:chat/close])))
-    (let [{:keys [admins chat-id chat-name color public?
-                  muted contacts]} (rf/sub [:chats/current-chat])
-          members                  (rf/sub [:contacts/group-members-sections])
-          pinned-messages          (rf/sub [:chats/pinned chat-id])
-          current-pk               (rf/sub [:multiaccount/public-key])
-          admin?                   (get admins current-pk)]
-      [rn/view
-       {:style {:flex             1
-                :background-color (colors/theme-colors colors/white colors/neutral-95)}}
-       [quo/header
-        {:left-component  [back-button]
-         :right-component [options-button]
-         :background      (colors/theme-colors colors/white colors/neutral-95)}]
-       [rn/view
-        {:style {:flex-direction     :row
-                 :margin-top         24
-                 :padding-horizontal 20}}
-        [quo/group-avatar
-         {:customization-color color
-          :size                :size-32}]
-        [quo/text
-         {:weight :semi-bold
-          :size   :heading-1
-          :style  {:margin-horizontal 8}} chat-name]
-        [rn/view {:style {:margin-top 8}}
-         [quo/icon (if public? :i/world :i/privacy)
-          {:size 20 :color (colors/theme-colors colors/neutral-50 colors/neutral-40)}]]]
-       [rn/view {:style (style/actions-view)}
-        [rn/touchable-opacity
-         {:style               (style/action-container color)
-          :accessibility-label :pinned-messages
-          :on-press            (fn []
-                                 (rf/dispatch [:dismiss-keyboard])
-                                 (rf/dispatch [:pin-message/show-pins-bottom-sheet chat-id]))}
-         [rn/view
-          {:style {:flex-direction  :row
-                   :justify-content :space-between}}
-          [quo/icon :i/pin {:size 20 :color (colors/theme-colors colors/neutral-100 colors/white)}]
-          [count-container (count pinned-messages) :pinned-count]]
-         [quo/text {:style {:margin-top 16} :size :paragraph-1 :weight :medium}
-          (i18n/label :t/pinned-messages)]]
-        [rn/touchable-opacity
-         {:style               (style/action-container color)
-          :accessibility-label :toggle-mute
-          :on-press            #(rf/dispatch [:chat.ui/mute chat-id (not muted)
-                                              (when-not muted constants/mute-till-unmuted)])}
-         [quo/icon (if muted :i/muted :i/activity-center)
-          {:size 20 :color (colors/theme-colors colors/neutral-100 colors/white)}]
-         [quo/text {:style {:margin-top 16} :size :paragraph-1 :weight :medium}
-          (i18n/label (if muted :unmute-group :mute-group))]]
-        [rn/touchable-opacity
-         {:style               (style/action-container color)
-          :accessibility-label :manage-members
-          :on-press            (fn []
-                                 (rf/dispatch [:group/clear-added-participants])
-                                 (rf/dispatch [:group/clear-removed-members])
-                                 (rf/dispatch [:open-modal :group-add-manage-members]))}
-         [rn/view
-          {:style {:flex-direction  :row
-                   :justify-content :space-between}}
-          [quo/icon :i/add-user {:size 20 :color (colors/theme-colors colors/neutral-100 colors/white)}]
-          [count-container (count contacts) :members-count]]
-         [quo/text {:style {:margin-top 16} :size :paragraph-1 :weight :medium}
-          (i18n/label (if admin? :t/manage-members :t/add-members))]]]
-       [rn/section-list
-        {:key-fn                         :title
-         :sticky-section-headers-enabled false
-         :sections                       members
-         :render-section-header-fn       contacts-section-header
-         :render-data                    {:chat-id chat-id
-                                          :admin?  admin?}
-         :render-fn                      contact-item-render}]])))
-
 (defn group-details
   []
-  [:f> f-group-details])
+  (let [chat-id         (rf/sub [:get-screen-params :group-chat-profile])
+        {:keys [admins chat-id chat-name color public?
+                muted contacts]
+         :as   group}   (rf/sub [:chats/chat-by-id chat-id])
+        members         (rf/sub [:contacts/group-members-sections chat-id])
+        pinned-messages (rf/sub [:chats/pinned chat-id])
+        current-pk      (rf/sub [:multiaccount/public-key])
+        admin?          (get admins current-pk)]
+    [rn/view
+     {:style {:flex             1
+              :background-color (colors/theme-colors colors/white colors/neutral-95)}}
+     [quo/header
+      {:left-component  [back-button]
+       :right-component [options-button group]
+       :background      (colors/theme-colors colors/white colors/neutral-95)}]
+     [rn/view
+      {:style {:flex-direction     :row
+               :margin-top         24
+               :padding-horizontal 20}}
+      [quo/group-avatar
+       {:customization-color color
+        :size                :size-32}]
+      [quo/text
+       {:weight :semi-bold
+        :size   :heading-1
+        :style  {:margin-horizontal 8}} chat-name]
+      [rn/view {:style {:margin-top 8}}
+       [quo/icon (if public? :i/world :i/privacy)
+        {:size 20 :color (colors/theme-colors colors/neutral-50 colors/neutral-40)}]]]
+     [rn/view {:style (style/actions-view)}
+      [rn/touchable-opacity
+       {:style               (style/action-container color)
+        :accessibility-label :pinned-messages
+        :on-press            (fn []
+                               (rf/dispatch [:dismiss-keyboard])
+                               (rf/dispatch [:pin-message/show-pins-bottom-sheet chat-id]))}
+       [rn/view
+        {:style {:flex-direction  :row
+                 :justify-content :space-between}}
+        [quo/icon :i/pin {:size 20 :color (colors/theme-colors colors/neutral-100 colors/white)}]
+        [count-container (count pinned-messages) :pinned-count]]
+       [quo/text {:style {:margin-top 16} :size :paragraph-1 :weight :medium}
+        (i18n/label :t/pinned-messages)]]
+      [rn/touchable-opacity
+       {:style               (style/action-container color)
+        :accessibility-label :toggle-mute
+        :on-press            #(rf/dispatch [:chat.ui/mute chat-id (not muted)
+                                            (when-not muted constants/mute-till-unmuted)])}
+       [quo/icon (if muted :i/muted :i/activity-center)
+        {:size 20 :color (colors/theme-colors colors/neutral-100 colors/white)}]
+       [quo/text {:style {:margin-top 16} :size :paragraph-1 :weight :medium}
+        (i18n/label (if muted :unmute-group :mute-group))]]
+      [rn/touchable-opacity
+       {:style               (style/action-container color)
+        :accessibility-label :manage-members
+        :on-press            (fn []
+                               (rf/dispatch [:group/clear-added-participants])
+                               (rf/dispatch [:group/clear-removed-members])
+                               (rf/dispatch [:open-modal :group-add-manage-members chat-id]))}
+       [rn/view
+        {:style {:flex-direction  :row
+                 :justify-content :space-between}}
+        [quo/icon :i/add-user {:size 20 :color (colors/theme-colors colors/neutral-100 colors/white)}]
+        [count-container (count contacts) :members-count]]
+       [quo/text {:style {:margin-top 16} :size :paragraph-1 :weight :medium}
+        (i18n/label (if admin? :t/manage-members :t/add-members))]]]
+     [rn/section-list
+      {:key-fn                         :title
+       :sticky-section-headers-enabled false
+       :sections                       members
+       :render-section-header-fn       contacts-section-header
+       :render-data                    {:chat-id chat-id
+                                        :admin?  admin?}
+       :render-fn                      contact-item-render}]]))

--- a/src/status_im/contexts/chat/home/view.cljs
+++ b/src/status_im/contexts/chat/home/view.cljs
@@ -48,7 +48,7 @@
 
 (defn chats
   [{:keys [theme selected-tab set-scroll-ref scroll-shared-value]}]
-  (let [unfiltered-items (rf/sub [:chats-stack-items])
+  (let [unfiltered-items (rf/sub [:chats/chats-stack-items])
         items            (filter-and-sort-items-by-tab selected-tab unfiltered-items)]
     (if (empty? items)
       [common.empty-state/view

--- a/src/status_im/contexts/chat/messenger/menus/pinned_messages/view.cljs
+++ b/src/status_im/contexts/chat/messenger/menus/pinned_messages/view.cljs
@@ -46,7 +46,7 @@
   [chat-id]
   (let [pinned                 (rf/sub [:chats/pinned-sorted-list chat-id])
         render-data            (rf/sub [:chats/current-chat-message-list-view-context :in-pinned-view])
-        current-chat           (rf/sub [:chat-by-id chat-id])
+        current-chat           (rf/sub [:chats/chat-by-id chat-id])
         {:keys [community-id]} current-chat
         community              (rf/sub [:communities/community community-id])
         community-images       (rf/sub [:community/images community-id])]

--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -137,7 +137,7 @@
   [chat-id cover-bg-color]
   (let [latest-pin-text                      (rf/sub [:chats/last-pinned-message-text chat-id])
         pins-count                           (rf/sub [:chats/pin-messages-count chat-id])
-        {:keys [muted muted-till chat-type]} (rf/sub [:chat-by-id chat-id])
+        {:keys [muted muted-till chat-type]} (rf/sub [:chats/chat-by-id chat-id])
         community-channel?                   (= constants/community-chat-type chat-type)
         muted?                               (and muted (some? muted-till))
         mute-chat-label                      (if community-channel? :t/mute-channel :t/mute-chat)

--- a/src/status_im/contexts/communities/actions/chat/view.cljs
+++ b/src/status_im/contexts/communities/actions/chat/view.cljs
@@ -109,7 +109,7 @@
 
 (defn actions
   [{:keys [locked? chat-id]} inside-chat?]
-  (let [{:keys [muted muted-till chat-type]} (rf/sub [:chat-by-id chat-id])]
+  (let [{:keys [muted muted-till chat-type]} (rf/sub [:chats/chat-by-id chat-id])]
     (cond
       locked?
       [quo/action-drawer

--- a/src/status_im/subs/chats.cljs
+++ b/src/status_im/subs/chats.cljs
@@ -12,7 +12,7 @@
 (def memo-chats-stack-items (atom nil))
 
 (re-frame/reg-sub
- :chats-stack-items
+ :chats/chats-stack-items
  :<- [:chats/home-list-chats]
  :<- [:view-id]
  :<- [:home-items-show-number]
@@ -102,7 +102,7 @@
            active-chats)))
 
 (re-frame/reg-sub
- :chat-by-id
+ :chats/chat-by-id
  :<- [:chats/chats]
  (fn [chats [_ chat-id]]
    (get chats chat-id)))
@@ -110,35 +110,35 @@
 (re-frame/reg-sub
  :chats/synced-from
  (fn [[_ chat-id] _]
-   (re-frame/subscribe [:chat-by-id chat-id]))
+   (re-frame/subscribe [:chats/chat-by-id chat-id]))
  (fn [{:keys [synced-from]}]
    synced-from))
 
 (re-frame/reg-sub
  :chats/muted
  (fn [[_ chat-id] _]
-   (re-frame/subscribe [:chat-by-id chat-id]))
+   (re-frame/subscribe [:chats/chat-by-id chat-id]))
  (fn [{:keys [muted]}]
    muted))
 
 (re-frame/reg-sub
  :chats/chat-type
  (fn [[_ chat-id] _]
-   (re-frame/subscribe [:chat-by-id chat-id]))
+   (re-frame/subscribe [:chats/chat-by-id chat-id]))
  (fn [{:keys [chat-type]}]
    chat-type))
 
 (re-frame/reg-sub
  :chats/joined
  (fn [[_ chat-id] _]
-   (re-frame/subscribe [:chat-by-id chat-id]))
+   (re-frame/subscribe [:chats/chat-by-id chat-id]))
  (fn [{:keys [joined]}]
    joined))
 
 (re-frame/reg-sub
  :chats/synced-to-and-from
  (fn [[_ chat-id] _]
-   (re-frame/subscribe [:chat-by-id chat-id]))
+   (re-frame/subscribe [:chats/chat-by-id chat-id]))
  (fn [chat]
    (select-keys chat [:synced-to :synced-from])))
 
@@ -395,7 +395,7 @@
 (re-frame/reg-sub
  :group-chat/inviter-info
  (fn [[_ chat-id] _]
-   [(re-frame/subscribe [:chat-by-id chat-id])
+   [(re-frame/subscribe [:chats/chat-by-id chat-id])
     (re-frame/subscribe [:multiaccount/public-key])])
  (fn [[chat my-public-key]]
    {:member?    (group-chats.db/member? my-public-key chat)

--- a/src/status_im/subs/contact.cljs
+++ b/src/status_im/subs/contact.cljs
@@ -270,11 +270,12 @@
 
 (re-frame/reg-sub
  :contacts/contacts-by-chat
- (fn [[_ _ chat-id] _]
+ (fn [[_ chat-id]]
    [(re-frame/subscribe [:chats/chat chat-id])
-    (re-frame/subscribe [:contacts/contacts])])
- (fn [[chat all-contacts] [_ query-fn]]
-   (contact.db/query-chat-contacts chat all-contacts query-fn)))
+    (re-frame/subscribe [:contacts/contacts])
+    (re-frame/subscribe [:profile/profile])])
+ (fn [[{:keys [contacts admins]} all-contacts current-multiaccount]]
+   (contact.db/get-all-contacts-in-group-chat contacts admins all-contacts current-multiaccount)))
 
 (re-frame/reg-sub
  :contacts/contact-by-address
@@ -316,8 +317,9 @@
 
 (re-frame/reg-sub
  :contacts/group-members-sections
- :<- [:contacts/current-chat-contacts]
- (fn [members]
+ (fn [[_ chat-id]]
+   [(re-frame/subscribe [:contacts/contacts-by-chat chat-id])])
+ (fn [[members]]
    (let [admins  (filter :admin? members)
          online  (filter #(and (not (:admin? %)) (:online? %)) members)
          offline (filter #(and (not (:admin? %)) (not (:online? %))) members)]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/18391

### Summary

- Removes use `:current-chat-id` just for checking group details
- Removes use of anonymous function in functional component
- Fixes names of subscriptions

### Testing
Please make sure management of group is working fine (removing, adding of members etc.)

status: ready
