### PR TITLE
Wallet - Add token filter and prices fallback for fiat amount calculation

### DIFF
--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -90,10 +90,13 @@
 (defn total-token-fiat-value
   "Returns the total token fiat value taking into account all token's chains."
   [currency {:keys [market-values-per-currency] :as token}]
-  (let [price                     (get-in market-values-per-currency
-                                          [currency :price]
-                                          (get-in market-values-per-currency
-                                                  [constants/profile-default-currency :price]))
+  (let [price                     (or (get-in market-values-per-currency
+                                              [currency :price])
+                                      (get-in market-values-per-currency
+                                              [constants/profile-default-currency :price])
+                                      ;; NOTE: adding fallback value (zero) in case prices are
+                                      ;; unavailable and to prevent crash on calculating fiat value
+                                      0)
         total-units-in-all-chains (total-token-units-in-all-chains token)]
     (money/crypto->fiat total-units-in-all-chains price)))
 

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -57,11 +57,18 @@
       (update :balances-per-chain update-vals #(update % :raw-balance money/bignumber))
       (update :balances-per-chain update-keys (comp utils.number/parse-int name))))
 
+(defn- remove-tokens-with-empty-values
+  [tokens]
+  (remove
+   #(or (string/blank? (:symbol %)) (string/blank? (:name %)))
+   tokens))
+
 (defn rpc->tokens
   [tokens]
   (-> tokens
       (update-keys name)
       (update-vals #(cske/transform-keys csk/->kebab-case %))
+      (update-vals remove-tokens-with-empty-values)
       (update-vals #(mapv rpc->balances-per-chain %))))
 
 (defn rpc->network


### PR DESCRIPTION
fixes #18355

### Summary

This PR:
- Adds a filter to remove tokens with no name or symbol to prevent displaying tokens with no data
- Adds a fallback value (zero) for token fiat value calculation and to prevent crash on token price calculation

### Review notes

Regarding fallback value, we can improve the UI/UX by showing a warning icon next to the token name that the prices are unavailable. That's something that requires design development, probably for later.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the Wallet tab
- Verify the token and token prices are displayed without any crash

status: ready 
