### PR TITLE
ci: upgrade CI hosts to Xcode 15.1

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -5,7 +5,7 @@ library 'status-jenkins-lib@v1.8.4'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'macos && arm64 && nix-2.14 && xcode-14.3' }
+  agent { label 'macos && arm64 && nix-2.14 && xcode-15.1' }
 
   parameters {
     string(

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -69,7 +69,7 @@ in {
   yarn = super.yarn.override { nodejs = super.nodejs-18_x; };
   openjdk = super.openjdk11_headless;
   xcodeWrapper = super.xcodeenv.composeXcodeWrapper {
-    version = "14.0";
+    version = "15.0";
     allowHigher = true;
   };
   go = super.go_1_19;

--- a/nix/status-go/mobile/default.nix
+++ b/nix/status-go/mobile/default.nix
@@ -19,7 +19,7 @@
 
   ios = {targets ? [ "ios/arm64" "iossimulator/amd64"]}: callPackage ./build.nix {
     platform = "ios";
-    platformVersion = "8.0";
+    platformVersion = "11.0";
     outputFileName = "Statusgo.xcframework";
     inherit meta source goBuildLdFlags targets;
   };


### PR DESCRIPTION
Hosts are also upgrade to macOS 14.2.1.

- https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes
- https://developer.apple.com/documentation/xcode-release-notes/xcode-15_0_1-release-notes
- https://developer.apple.com/documentation/xcode-release-notes/xcode-15_1-release-notes

Infra change:

- [`infra-role-bootstrap-macos#8db6aa78`](https://github.com/status-im/infra-role-bootstrap-macos/commit/8db6aa78) - xcode: upgrade from 14.3 to 15.1