### PR TITLE
fixed spacing between the header and illustration on biometrics page

### DIFF
--- a/src/status_im/contexts/onboarding/enable_biometrics/style.cljs
+++ b/src/status_im/contexts/onboarding/enable_biometrics/style.cljs
@@ -2,6 +2,10 @@
 
 (def default-margin 20)
 
+(def title-container
+  {:margin-horizontal 20
+   :padding-vertical  12})
+
 (defn page-container
   [insets]
   {:flex            1
@@ -10,8 +14,10 @@
 
 (defn page-illustration
   [width]
-  {:flex  1
-   :width width})
+  {:flex           1
+   :padding-top    12
+   :padding-bottom 10
+   :width          width})
 
 (defn buttons
   [insets]

--- a/src/status_im/contexts/onboarding/enable_biometrics/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_biometrics/view.cljs
@@ -16,7 +16,7 @@
 (defn page-title
   []
   [quo/text-combinations
-   {:container-style                 {:margin-top 12 :margin-horizontal 20}
+   {:container-style                 style/title-container
     :title                           (i18n/label :t/enable-biometrics)
     :title-accessibility-label       :enable-biometrics-title
     :description                     (i18n/label :t/use-biometrics)
@@ -51,9 +51,12 @@
 (defn enable-biometrics-parallax
   []
   (let [stretch (if rn/small-screen? 25 40)]
-    [parallax/video
-     {:layers  (:biometrics resources/parallax-video)
-      :stretch stretch}]))
+    [rn/view
+     {:position :absolute
+      :top      12}
+     [parallax/video
+      {:layers  (:biometrics resources/parallax-video)
+       :stretch stretch}]]))
 
 (defn enable-biometrics-simple
   []


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/17500

### Summary
Updates the vertical padding for the `text-combinations` component as used in the biometric screen and also adds a padding-top to the parallax video container on this screen. 

I also noticed on develop this screen does not have the page-nav but thats not the case with the designs. I wonder if its just a bug or its on purpose?. 

Android Before & After

<img src="https://github.com/status-im/status-mobile/assets/28704507/cddb2b48-26e3-400a-a9a8-c5801d2c9a31" width="325">

<img src="https://github.com/status-im/status-mobile/assets/28704507/59721dc0-ade9-4278-be52-005104f9b32c" width="325">

iOS Before & After

<img src="https://github.com/status-im/status-mobile/assets/28704507/ff37169a-1c6c-43cd-ae61-7acfdb0720cf" width="325">

<img src="https://github.com/status-im/status-mobile/assets/28704507/d9313090-511a-4d7c-8e07-b1f64c3ec7b1" width="325">

Figma

<img src="https://github.com/status-im/status-mobile/assets/28704507/aa64c89a-6af7-450e-bf02-c9138e613269" width=325>

