### PR TITLE
#[16978] Select collectible to send

### DIFF
--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -16,7 +16,11 @@
     [rn/view {:style {:flex 1}}
      (case selected-tab
        :assets       [assets/view]
-       :collectibles [collectibles/view {:collectibles collectible-list}]
+       :collectibles [collectibles/view
+                      {:collectibles         collectible-list
+                       :on-collectible-press (fn [id]
+                                               (rf/dispatch [:wallet/get-collectible-details id])
+                                               (rf/dispatch [:navigate-to :wallet-collectible]))}]
        :activity     [activity/view]
        :permissions  [empty-tab/view
                       {:title        (i18n/label :t/no-permissions)

--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -7,18 +7,20 @@
     [status-im.contexts.wallet.common.activity-tab.view :as activity]
     [status-im.contexts.wallet.common.collectibles-tab.view :as collectibles]
     [status-im.contexts.wallet.common.empty-tab.view :as empty-tab]
-    [utils.i18n :as i18n]))
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (defn view
   [{:keys [selected-tab]}]
-  [rn/view {:style {:flex 1}}
-   (case selected-tab
-     :assets       [assets/view]
-     :collectibles [collectibles/view]
-     :activity     [activity/view]
-     :permissions  [empty-tab/view
-                    {:title        (i18n/label :t/no-permissions)
-                     :description  (i18n/label :t/no-collectibles-description)
-                     :placeholder? true}]
-     :dapps        [dapps/view]
-     [about/view])])
+  (let [collectible-list (rf/sub [:wallet/current-viewing-account-collectibles])]
+    [rn/view {:style {:flex 1}}
+     (case selected-tab
+       :assets       [assets/view]
+       :collectibles [collectibles/view {:collectibles collectible-list}]
+       :activity     [activity/view]
+       :permissions  [empty-tab/view
+                      {:title        (i18n/label :t/no-permissions)
+                       :description  (i18n/label :t/no-collectibles-description)
+                       :placeholder? true}]
+       :dapps        [dapps/view]
+       [about/view])]))

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -9,25 +9,30 @@
 
 (defn- view-internal
   [{:keys [theme collectibles filtered? on-collectible-press]}]
-  (cond
-    (and filtered? (empty? collectibles))
-    [rn/view]
+  (let [no-results-match-query? (and filtered? (empty? collectibles))]
+    (cond
+      no-results-match-query?
+      [rn/view {:style {:flex 1 :justify-content :center}}
+       [quo/empty-state
+        {:title       (i18n/label :t/nothing-found)
+         :description (i18n/label :t/try-to-search-something-else)
+         :image       (resources/get-themed-image :no-collectibles theme)}]]
 
-    (empty? collectibles)
-    [empty-tab/view
-     {:title       (i18n/label :t/no-collectibles)
-      :description (i18n/label :t/no-collectibles-description)
-      :image       (resources/get-themed-image :no-collectibles theme)}]
+      (empty? collectibles)
+      [empty-tab/view
+       {:title       (i18n/label :t/no-collectibles)
+        :description (i18n/label :t/no-collectibles-description)
+        :image       (resources/get-themed-image :no-collectibles theme)}]
 
-    :else
-    [rn/flat-list
-     {:data                    collectibles
-      :style                   {:flex 1}
-      :content-container-style {:align-items :center}
-      :num-columns             2
-      :render-fn               (fn [{:keys [preview-url id]}]
-                                 [quo/collectible
-                                  {:images   [preview-url]
-                                   :on-press #(on-collectible-press id)}])}]))
+      :else
+      [rn/flat-list
+       {:data                    collectibles
+        :style                   {:flex 1}
+        :content-container-style {:align-items :center}
+        :num-columns             2
+        :render-fn               (fn [{:keys [preview-url id]}]
+                                   [quo/collectible
+                                    {:images   [preview-url]
+                                     :on-press #(on-collectible-press id)}])}])))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -1,11 +1,11 @@
 (ns status-im.contexts.wallet.common.collectibles-tab.view
   (:require
-   [quo.core :as quo]
-   [quo.theme]
-   [react-native.core :as rn]
-   [status-im.common.resources :as resources]
-   [status-im.contexts.wallet.common.empty-tab.view :as empty-tab]
-   [utils.i18n :as i18n]))
+    [quo.core :as quo]
+    [quo.theme]
+    [react-native.core :as rn]
+    [status-im.common.resources :as resources]
+    [status-im.contexts.wallet.common.empty-tab.view :as empty-tab]
+    [utils.i18n :as i18n]))
 
 (defn- view-internal
   [{:keys [theme collectibles filtered? on-collectible-press]}]

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -5,11 +5,10 @@
     [react-native.core :as rn]
     [status-im.common.resources :as resources]
     [status-im.contexts.wallet.common.empty-tab.view :as empty-tab]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+    [utils.i18n :as i18n]))
 
 (defn- view-internal
-  [{:keys [theme collectibles filtered?]}]
+  [{:keys [theme collectibles filtered? on-collectible-press]}]
   (cond
     (and filtered? (empty? collectibles))
     [rn/view]
@@ -29,10 +28,6 @@
       :render-fn               (fn [{:keys [preview-url id]}]
                                  [quo/collectible
                                   {:images   [preview-url]
-                                   :on-press (fn []
-                                               (rf/dispatch [:wallet/get-collectible-details id])
-                                               (rf/dispatch
-                                                [:navigate-to
-                                                 :wallet-collectible]))}])}]))
+                                   :on-press #(on-collectible-press id)}])}]))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -9,28 +9,30 @@
     [utils.re-frame :as rf]))
 
 (defn- view-internal
-  [{:keys [theme]}]
-  (let [specific-address (rf/sub [:wallet/current-viewing-account-address])
-        collectible-list (if specific-address
-                           (rf/sub [:wallet/collectibles-per-account specific-address])
-                           (rf/sub [:wallet/all-collectibles]))]
-    (if (empty? collectible-list)
-      [empty-tab/view
-       {:title       (i18n/label :t/no-collectibles)
-        :description (i18n/label :t/no-collectibles-description)
-        :image       (resources/get-themed-image :no-collectibles theme)}]
-      [rn/flat-list
-       {:data                    collectible-list
-        :style                   {:flex 1}
-        :content-container-style {:align-items :center}
-        :num-columns             2
-        :render-fn               (fn [{:keys [preview-url id]}]
-                                   [quo/collectible
-                                    {:images   [preview-url]
-                                     :on-press (fn []
-                                                 (rf/dispatch [:wallet/get-collectible-details id])
-                                                 (rf/dispatch
-                                                  [:navigate-to
-                                                   :wallet-collectible]))}])}])))
+  [{:keys [theme collectibles filtered?]}]
+  (cond
+    (and filtered? (empty? collectibles))
+    [rn/view]
+
+    (empty? collectibles)
+    [empty-tab/view
+     {:title       (i18n/label :t/no-collectibles)
+      :description (i18n/label :t/no-collectibles-description)
+      :image       (resources/get-themed-image :no-collectibles theme)}]
+
+    :else
+    [rn/flat-list
+     {:data                    collectibles
+      :style                   {:flex 1}
+      :content-container-style {:align-items :center}
+      :num-columns             2
+      :render-fn               (fn [{:keys [preview-url id]}]
+                                 [quo/collectible
+                                  {:images   [preview-url]
+                                   :on-press (fn []
+                                               (rf/dispatch [:wallet/get-collectible-details id])
+                                               (rf/dispatch
+                                                [:navigate-to
+                                                 :wallet-collectible]))}])}]))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -1,11 +1,11 @@
 (ns status-im.contexts.wallet.common.collectibles-tab.view
   (:require
-    [quo.core :as quo]
-    [quo.theme]
-    [react-native.core :as rn]
-    [status-im.common.resources :as resources]
-    [status-im.contexts.wallet.common.empty-tab.view :as empty-tab]
-    [utils.i18n :as i18n]))
+   [quo.core :as quo]
+   [quo.theme]
+   [react-native.core :as rn]
+   [status-im.common.resources :as resources]
+   [status-im.contexts.wallet.common.empty-tab.view :as empty-tab]
+   [utils.i18n :as i18n]))
 
 (defn- view-internal
   [{:keys [theme collectibles filtered? on-collectible-press]}]

--- a/src/status_im/contexts/wallet/home/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/view.cljs
@@ -13,5 +13,8 @@
     [rn/view {:style style/container}
      (case selected-tab
        :assets       [assets/view]
-       :collectibles [collectibles/view {:collectibles collectible-list}]
+       :collectibles [collectibles/view {:collectibles         collectible-list
+                                         :on-collectible-press (fn [id]
+                                                                 (rf/dispatch [:wallet/get-collectible-details id])
+                                                                 (rf/dispatch [:navigate-to :wallet-collectible]))}]
        [activity/view])]))

--- a/src/status_im/contexts/wallet/home/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/view.cljs
@@ -4,12 +4,14 @@
     [status-im.contexts.wallet.common.activity-tab.view :as activity]
     [status-im.contexts.wallet.common.collectibles-tab.view :as collectibles]
     [status-im.contexts.wallet.home.tabs.assets.view :as assets]
-    [status-im.contexts.wallet.home.tabs.style :as style]))
+    [status-im.contexts.wallet.home.tabs.style :as style]
+    [utils.re-frame :as rf]))
 
 (defn view
   [{:keys [selected-tab]}]
-  [rn/view {:style style/container}
-   (case selected-tab
-     :assets       [assets/view]
-     :collectibles [collectibles/view]
-     [activity/view])])
+  (let [collectible-list (rf/sub [:wallet/all-collectibles])]
+    [rn/view {:style style/container}
+     (case selected-tab
+       :assets       [assets/view]
+       :collectibles [collectibles/view {:collectibles collectible-list}]
+       [activity/view])]))

--- a/src/status_im/contexts/wallet/home/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/view.cljs
@@ -13,8 +13,9 @@
     [rn/view {:style style/container}
      (case selected-tab
        :assets       [assets/view]
-       :collectibles [collectibles/view {:collectibles         collectible-list
-                                         :on-collectible-press (fn [id]
-                                                                 (rf/dispatch [:wallet/get-collectible-details id])
-                                                                 (rf/dispatch [:navigate-to :wallet-collectible]))}]
+       :collectibles [collectibles/view
+                      {:collectibles         collectible-list
+                       :on-collectible-press (fn [id]
+                                               (rf/dispatch [:wallet/get-collectible-details id])
+                                               (rf/dispatch [:navigate-to :wallet-collectible]))}]
        [activity/view])]))

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -1,16 +1,16 @@
 (ns status-im.contexts.wallet.send.select-asset.view
   (:require
-   [clojure.string :as string]
-   [quo.core :as quo]
-   [quo.theme :as quo.theme]
-   [react-native.core :as rn]
-   [reagent.core :as reagent]
-   [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
-   [status-im.contexts.wallet.common.utils :as utils]
-   [status-im.contexts.wallet.common.collectibles-tab.view :as collectibles-tab]
-   [status-im.contexts.wallet.send.select-asset.style :as style]
-   [utils.i18n :as i18n]
-   [utils.re-frame :as rf]))
+    [clojure.string :as string]
+    [quo.core :as quo]
+    [quo.theme :as quo.theme]
+    [react-native.core :as rn]
+    [reagent.core :as reagent]
+    [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
+    [status-im.contexts.wallet.common.collectibles-tab.view :as collectibles-tab]
+    [status-im.contexts.wallet.common.utils :as utils]
+    [status-im.contexts.wallet.send.select-asset.style :as style]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (def tabs-data
   [{:id :tab/assets :label (i18n/label :t/assets) :accessibility-label :assets-tab}

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -61,11 +61,14 @@
 
 (defn collectibles-grid
   [search-text]
-  (let [collectibles-filtered (rf/sub [:wallet/current-viewing-account-collectibles-filtered
-                                       search-text])]
+  (let [collectibles (rf/sub [:wallet/current-viewing-account-collectibles-filtered search-text])]
     [collectibles-tab/view
-     {:collectibles collectibles-filtered
-      :filtered?    true}]))
+     {:collectibles         collectibles
+      :filtered?            true
+      :on-collectible-press (fn [collectible-id]
+                              (js/alert (str "Collectible to send: \n"
+                                             collectible-id
+                                             "\nNavigation not implemented yet")))}]))
 
 (defn- tab-view
   [search-text selected-tab on-change-text]

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -1,15 +1,16 @@
 (ns status-im.contexts.wallet.send.select-asset.view
   (:require
-    [quo.core :as quo]
-    [quo.theme :as quo.theme]
-    [react-native.core :as rn]
-    [reagent.core :as reagent]
-    [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
-    [status-im.contexts.wallet.common.utils :as utils]
-    [status-im.contexts.wallet.common.collectibles-tab.view :as collectibles-tab]
-    [status-im.contexts.wallet.send.select-asset.style :as style]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+   [clojure.string :as string]
+   [quo.core :as quo]
+   [quo.theme :as quo.theme]
+   [react-native.core :as rn]
+   [reagent.core :as reagent]
+   [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
+   [status-im.contexts.wallet.common.utils :as utils]
+   [status-im.contexts.wallet.common.collectibles-tab.view :as collectibles-tab]
+   [status-im.contexts.wallet.send.select-asset.style :as style]
+   [utils.i18n :as i18n]
+   [utils.re-frame :as rf]))
 
 (def tabs-data
   [{:id :tab/assets :label (i18n/label :t/assets) :accessibility-label :assets-tab}
@@ -61,10 +62,11 @@
 
 (defn collectibles-grid
   [search-text]
-  (let [collectibles (rf/sub [:wallet/current-viewing-account-collectibles-filtered search-text])]
+  (let [collectibles      (rf/sub [:wallet/current-viewing-account-collectibles-filtered search-text])
+        search-performed? (not (string/blank? search-text))]
     [collectibles-tab/view
      {:collectibles         collectibles
-      :filtered?            true
+      :filtered?            search-performed?
       :on-collectible-press (fn [collectible-id]
                               (js/alert (str "Collectible to send: \n"
                                              collectible-id

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -32,6 +32,17 @@
         (add-collectibles-preview-url))))
 
 (re-frame/reg-sub
+ :wallet/current-viewing-account-collectibles-filtered
+ :<- [:wallet/current-viewing-account-collectibles]
+ (fn [current-account-collectibles [_ search-text]]
+   (let [search-text-lower-case (string/lower-case search-text)]
+     (filter (fn [{{collection-name :name}  :collection-data
+                   {collectible-name :name} :collectible-data}]
+               (or (string/includes? (string/lower-case collection-name) search-text-lower-case)
+                   (string/includes? (string/lower-case collectible-name) search-text-lower-case)))
+             current-account-collectibles))))
+
+(re-frame/reg-sub
  :wallet/last-collectible-details
  :<- [:wallet]
  (fn [wallet]

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -10,15 +10,17 @@
     animation-url
     image-url))
 
+(defn add-collectibles-preview-url
+  [collectibles]
+  (map (fn [{:keys [collectible-data] :as collectible}]
+         (assoc collectible :preview-url (preview-url collectible-data)))
+       collectibles))
+
 (re-frame/reg-sub
- :wallet/collectibles-per-account
- :<- [:wallet]
- (fn [wallet [_ address]]
-   (as-> wallet $
-     (get-in $ [:accounts address :collectibles])
-     (map (fn [{:keys [collectible-data] :as collectible}]
-            (assoc collectible :preview-url (preview-url collectible-data)))
-          $))))
+ :wallet/current-viewing-account-collectibles
+ :<- [:wallet/current-viewing-account]
+ (fn [current-account]
+   (-> current-account :collectibles add-collectibles-preview-url)))
 
 (re-frame/reg-sub
  :wallet/all-collectibles
@@ -27,8 +29,7 @@
    (->> wallet
         :accounts
         (mapcat (comp :collectibles val))
-        (map (fn [{:keys [collectible-data] :as collectible}]
-               (assoc collectible :preview-url (preview-url collectible-data)))))))
+        (add-collectibles-preview-url))))
 
 (re-frame/reg-sub
  :wallet/last-collectible-details

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -124,10 +124,10 @@
  :<- [:wallet/balances]
  :<- [:profile/currency-symbol]
  (fn [[accounts current-viewing-account-address balances currency-symbol]]
-   (let [current-viewing-account (utils/get-account-by-address accounts current-viewing-account-address)
-         balance                 (get balances current-viewing-account-address)
-         formatted-balance       (utils/prettify-balance currency-symbol balance)]
-     (-> current-viewing-account
+   (let [balance           (get balances current-viewing-account-address)
+         formatted-balance (utils/prettify-balance currency-symbol balance)]
+     (-> accounts
+         (utils/get-account-by-address current-viewing-account-address)
          (assoc :balance           balance
                 :formatted-balance formatted-balance)))))
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -1793,6 +1793,8 @@
     "community-info-not-found": "Community information not found",
     "community-info": "Community info",
     "not-found": "Not found",
+    "nothing-found": "Nothing found",
+    "try-to-search-something-else": "Try to search something else",
     "activity": "Activity",
     "reject-and-delete": "Reject and delete",
     "accept-and-add": "Accept and add",


### PR DESCRIPTION
fixes #16978

### Summary

This PR shows the list of the collectibles to send and implements filtering capabilities:

<img src="https://github.com/status-im/status-mobile/assets/90291778/c3de6093-5097-46e4-9706-31a99d6f86db"
height=600>

[figma link](https://www.figma.com/file/HKncH4wnDwZDAhc4AryK8Y/Wallet-for-Mobile?type=design&node-id=7111-517487&mode=design&t=kkyZAvnrCAKVS32n-0)

### Testing notes
You will need an account owning some collectibles, otherwise you will see an empty screen component.

### Steps to test

- Open Status
- Navigate to wallet tab 
- Pick an account owning collectibles -> Send
- Pick an account to send in `My accounts`
- Select `Collectibles` tab

Now the existing collectibles are shown, or the empty-state component if there are no collectibles.
Also you are able to filter by the collectible name or collectible's collection name.

status: ready
