### PR TITLE
🔗 Enable explorer links in wallet->about

### DIFF
--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -19,6 +19,9 @@
 
 (def mainnet-rpc-url (str "https://eth-archival.gateway.pokt.network/v1/lb/" POKT_TOKEN))
 (def goerli-rpc-url (str "https://goerli-archival.gateway.pokt.network/v1/lb/" POKT_TOKEN))
+(def mainnet-chain-explorer-link "https://etherscan.io/address/")
+(def optimism-mainnet-chain-explorer-link "https://optimistic.etherscan.io/address/")
+(def arbitrum-mainnet-chain-explorer-link "https://arbiscan.io/address/")
 (def opensea-api-key OPENSEA_API_KEY)
 (def bootnodes-settings-enabled? (enabled? (get-config :BOOTNODES_SETTINGS_ENABLED "1")))
 (def mailserver-confirmations-enabled? (enabled? (get-config :MAILSERVER_CONFIRMATIONS_ENABLED)))
@@ -91,7 +94,7 @@
 
 (def mainnet-networks
   [{:id                  "mainnet_rpc"
-    :chain-explorer-link "https://etherscan.io/address/"
+    :chain-explorer-link mainnet-chain-explorer-link
     :name                "Mainnet with upstream RPC"
     :config              {:NetworkId      (chain/chain-keyword->chain-id :mainnet)
                           :DataDir        "/ethereum/mainnet_rpc"

--- a/src/status_im/contexts/wallet/account/tabs/about/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/about/view.cljs
@@ -5,6 +5,7 @@
     [react-native.core :as rn]
     [react-native.platform :as platform]
     [react-native.share :as share]
+    [status-im.config :as config]
     [status-im.contexts.profile.utils :as profile.utils]
     [status-im.contexts.wallet.account.tabs.about.style :as style]
     [utils.i18n :as i18n]
@@ -18,15 +19,27 @@
      [[{:icon                :i/link
         :accessibility-label :view-on-eth
         :label               (i18n/label :t/view-on-eth)
-        :right-icon          :i/external}
+        :right-icon          :i/external
+        :on-press            #(rf/dispatch
+                               [:wallet/navigate-to-chain-explorer-from-bottom-sheet
+                                config/mainnet-chain-explorer-link
+                                address])}
        {:icon                :i/link
         :accessibility-label :view-on-opt
         :label               (i18n/label :t/view-on-opt)
-        :right-icon          :i/external}
+        :right-icon          :i/external
+        :on-press            #(rf/dispatch
+                               [:wallet/navigate-to-chain-explorer-from-bottom-sheet
+                                config/optimism-mainnet-chain-explorer-link
+                                address])}
        {:icon                :i/link
         :accessibility-label :view-on-arb
         :label               (i18n/label :t/view-on-arb)
-        :right-icon          :i/external}
+        :right-icon          :i/external
+        :on-press            #(rf/dispatch
+                               [:wallet/navigate-to-chain-explorer-from-bottom-sheet
+                                config/arbitrum-mainnet-chain-explorer-link
+                                address])}
        {:icon                :i/copy
         :accessibility-label :copy-address
         :label               (i18n/label :t/copy-address)

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -321,3 +321,9 @@
             :on-error   #(log/info "failed to get address details"
                                    {:error %
                                     :event :wallet/get-address-details})}]]]}))
+
+(rf/reg-event-fx
+ :wallet/navigate-to-chain-explorer-from-bottom-sheet
+ (fn [_ [explorer-link address]]
+   {:fx [[:dispatch [:hide-bottom-sheet]]
+         [:dispatch [:browser.ui/open-url (str explorer-link "/" address)]]]}))

--- a/src/utils/ethereum/chain.cljs
+++ b/src/utils/ethereum/chain.cljs
@@ -11,7 +11,9 @@
    :bsc         {:id   BSC-mainnet-chain-id
                  :name "BSC"}
    :bsc-testnet {:id   BSC-testnet-chain-id
-                 :name "BSC tetnet"}})
+                 :name "BSC testnet"}
+   :arbitrum    {:id 42161 :name "Arbitrum"}
+   :optimism    {:id 10 :name "Optimism"}})
 
 (defn chain-id->chain-keyword
   [i]


### PR DESCRIPTION
fixes #18377 

### Summary
Open explorer link on Eth, Arb and Opti mainnet.

[🎥 View screen recording](https://github.com/status-im/status-mobile/assets/1925158/0b5cfd5c-8f9a-4d88-94b4-a6d89abad31b)

### Testing notes
1. Goto wallet tab
2. Click on a wallet to view wallet details
3. Scroll tabs, then click on "About" tab
4. Click on the address
5. A bottom sheet will open with options to View on Eth, View on Arb etc
6. Clicking the option should close the bottom sheet, and open the explorer link in the browser

#### Platforms
- Android
- iOS

##### Functional
- wallet / transactions

status: ready
