### PR TITLE
fix: min pwd length for ::multiaccounts.db/password

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -117,7 +117,7 @@
 (def ^:const profile-pictures-visibility-everyone 2)
 (def ^:const profile-pictures-visibility-none 3)
 
-(def ^:const min-password-length 6)
+(def ^:const min-password-length 10)
 (def ^:const max-group-chat-participants 20)
 (def ^:const default-number-of-messages 20)
 (def ^:const default-number-of-pin-messages 3)


### PR DESCRIPTION
fixes #18393

### UPDATE

This PR is blocked as we do not not have a decision yet about upgrading from the old Status app to a new one. See the comment [here](https://github.com/status-im/status-mobile/pull/18425#issuecomment-1885063577).

### Summary

it's used in status-im.common.standard-authentication.enter-password
to decide if confirm button should be disabled

#### Areas that maybe impacted
legacy add new wallet view (not used anymore?)
places where we enter user's password: login, biometrics settings, creating wallet accounts etc


status: ready <!-- Can be ready or wip -->