### PR TITLE
[Fix] Currency on recovered profile

### DIFF
--- a/src/legacy/status_im/data_store/settings.cljs
+++ b/src/legacy/status_im/data_store/settings.cljs
@@ -51,3 +51,9 @@
       (visibility-status-updates/<-rpc-settings)
       (set/rename-keys {:compressedKey :compressed-key
                         :emojiHash     :emoji-hash})))
+
+(defn rpc->setting-value
+  [{:keys [name] :as setting}]
+  (condp = name
+    :currency (update setting :value keyword)
+    setting))

--- a/src/status_im/contexts/profile/events.cljs
+++ b/src/status_im/contexts/profile/events.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.profile.events
   (:require
+    [legacy.status-im.data-store.settings :as data-store.settings]
     [native-module.core :as native-module]
     [re-frame.core :as re-frame]
     [status-im.contexts.profile.edit.name.events]
@@ -52,8 +53,10 @@
 
 (rf/defn update-setting-from-backup
   {:events [:profile/update-setting-from-backup]}
-  [{:keys [db]} {{:keys [name value]} :backedUpSettings}]
-  {:db (assoc-in db [:profile/profile (keyword name)] value)})
+  [{:keys [db]} {:keys [backedUpSettings]}]
+  (let [setting              (update backedUpSettings :name keyword)
+        {:keys [name value]} (data-store.settings/rpc->setting-value setting)]
+    {:db (assoc-in db [:profile/profile name] value)}))
 
 (rf/defn update-profile-from-backup
   {:events [:profile/update-profile-from-backup]}


### PR DESCRIPTION
fixes #18199

### Summary

This PR fixes the currency symbol not shown on the recovered profile.

### Review Notes

The bug is caused by to assoc setting value without data sanitization.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Recover any profile created before 14.12.2023
- Verify the currency symbol is shown on the Wallet

status: ready 
