### PR TITLE
fix: boost checksum issue due to jfrog

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -793,7 +793,7 @@ CHECKOUT OPTIONS:
     :submodules: true
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 64032b9e9b938fda23325e68a3771f0fabf414dc
   BVLinearGradient: 612a04ff38e8480291f3379ee5b5a2c571f03fe0
   CryptoSwift: c4f2debceb38bf44c80659afe009f71e23e4a082
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54

--- a/nix/deps/nodejs-patched/default.nix
+++ b/nix/deps/nodejs-patched/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation {
     "patchBuildIdPhase"
     "patchKeyChainPhase"
     "patchGlogPhase"
+    "patchBoostPodSpec"
     "installPhase"
   ];
 
@@ -75,6 +76,14 @@ stdenv.mkDerivation {
     substituteInPlace ./node_modules/react-native/scripts/ios-configure-glog.sh \
     --replace 'export CC="' '#export CC="' \
     --replace 'export CXX="' '#export CXX="'
+  '';
+
+  # to fix pod checksum issue : https://github.com/facebook/react-native/issues/42180
+  # TODO remove this patch after upgrading to react-native 0.73.2
+  patchBoostPodSpec = ''
+   substituteInPlace ./node_modules/react-native/third-party-podspecs/boost.podspec \
+      --replace 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2' \
+      'https://sourceforge.net/projects/boost/files/boost/1.76.0/boost_1_76_0.tar.bz2' \
   '';
 
   # The ELF types are incompatible with the host platform, so let's not even try


### PR DESCRIPTION
I tried doing a clean pod install and was faced with this : 

```
Installing Yoga (1.14.0)
Installing boost (1.76.0)

[!] Error installing boost
Verification checksum was incorrect, expected 
f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41, got 
5e89103d9b70bba5c91a794126b169cb67654be2051f90cf7c22ba6893ede0ff
```

related issue in react-native repo : https://github.com/facebook/react-native/issues/42180 

In this PR we patch the pod specs provided by react native to rely on `sourceforge` instead `jfrog` to get boost.

#### Platforms
- iOS

status: ready
