### PR TITLE
Fix: incorrect props passed to RN's style prop

### DIFF
--- a/src/status_im/contexts/onboarding/common/background/view.cljs
+++ b/src/status_im/contexts/onboarding/common/background/view.cljs
@@ -27,11 +27,11 @@
 (defn background-image
   [content-width]
   [rn/image
-   {:style  {:resize-mode   :stretch
-             :resize-method :scale
-             :margin-top    32
-             :width         content-width}
-    :source (resources/get-image :onboarding-illustration)}])
+   {:resize-mode   :stretch
+    :resize-method :scale
+    :style         {:margin-top 32
+                    :width      content-width}
+    :source        (resources/get-image :onboarding-illustration)}])
 
 (defonce progress (atom nil))
 (defonce paused? (atom nil))

--- a/src/status_im/contexts/onboarding/intro/style.cljs
+++ b/src/status_im/contexts/onboarding/intro/style.cljs
@@ -12,12 +12,8 @@
    :flex-wrap :wrap})
 
 (def plain-text
-  {:size   :paragraph-2
-   :weight :regular
-   :color  colors/white-opa-70})
+  {:color colors/white-opa-70})
 
 (def highlighted-text
-  {:flex   1
-   :size   :paragraph-2
-   :weight :regular
-   :color  colors/white})
+  {:flex  1
+   :color colors/white})

--- a/src/status_im/contexts/onboarding/intro/view.cljs
+++ b/src/status_im/contexts/onboarding/intro/view.cljs
@@ -34,17 +34,20 @@
                            :heading             (i18n/label :t/new-to-status)
                            :accessibility-label :new-to-status-button}}
     [quo/text
-     {:style style/plain-text}
+     {:size   :paragraph-2
+      :weight :regular
+      :style  style/plain-text}
      (i18n/label :t/you-already-use-status)]
-    [quo/text
-     {:style style/text-container}
+    [quo/text {:style style/text-container}
      [quo/text
-      {:style style/plain-text}
+      {:size   :paragraph-2
+       :weight :regular
+       :style  style/plain-text}
       (i18n/label :t/by-continuing-you-accept)]
      [quo/text
-      {:on-press #(debounce/dispatch-and-chill
-                   [:open-modal :privacy-policy]
-                   1000)
+      {:on-press #(debounce/dispatch-and-chill [:open-modal :privacy-policy] 1000)
+       :size     :paragraph-2
+       :weight   :regular
        :style    style/highlighted-text}
       (i18n/label :t/terms-of-service)]]]
    [overlay/view]])


### PR DESCRIPTION
## Summary

Fix 3 errors in the onboarding screen about unsupported props passed to the `style` prop.

```
ERROR  Warning: Failed prop type: Invalid props.style key `resizeMethod` supplied to `Image`.

2x
ERROR  Warning: Failed prop type: Invalid props.style key `size` supplied to `Text`.
```

### Review notes

Related guideline:
https://github.com/status-im/status-mobile/blob/563f1c588d1cdac31629da009a1c894133038d2d/doc/new-guidelines.md#dont-define-properties-in-styles-ns

### Steps to test

Not much changed here. Just e2e tests and my own manual tests should be enough.

status: ready
