### PR TITLE
Add lastOpenedAt and JoinedAt for communities

### DIFF
--- a/src/legacy/status_im/data_store/communities.cljs
+++ b/src/legacy/status_im/data_store/communities.cljs
@@ -57,7 +57,9 @@
                         :tokenPermissions            :token-permissions
                         :communityTokensMetadata     :tokens-metadata
                         :introMessage                :intro-message
-                        :muteTill                    :muted-till})
+                        :muteTill                    :muted-till
+                        :lastOpenedAt                :last-opened-at
+                        :joinedAt                    :joined-at})
       (update :admin-settings
               set/rename-keys
               {:pinMessageAllMembersEnabled :pin-message-all-members-enabled?})

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -424,3 +424,14 @@
  (fn [{:keys [db]} [community-id]]
    (when (get-in db [:communities community-id])
      {:db (update-in db [:communities community-id] dissoc :fetching-revealed-accounts)})))
+(rf/reg-event-fx :communities/set-addresses-for-permissions
+ (fn [{:keys [db]} [addresses]]
+   {:db (assoc-in db [:communities/addresses-for-permissions] addresses)}))
+
+(rf/reg-event-fx :communities/update-last-opened-at
+ (fn [_ [community-id]]
+   {:json-rpc/call [{:method     "wakuext_communityUpdateLastOpenedAt"
+                     :params     [community-id]
+                     :on-success #(rf/dispatch [:communities/handle-community (first (:communities %))])
+                     :on-error   #(log/error (str "failed to update last opened at for community "
+                                                  %))}]}))

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -434,10 +434,11 @@
  (fn [_ [community-id]]
    {:json-rpc/call [{:method     "wakuext_communityUpdateLastOpenedAt"
                      :params     [community-id]
-                     :on-success #(rf/dispatch [:communities/update-last-opened-at-success community-id %])
+                     :on-success #(rf/dispatch [:communities/update-last-opened-at-success community-id
+                                                %])
                      :on-error   #(log/error (str "failed to update last opened at for community "
                                                   %))}]}))
 
 (rf/reg-event-fx :communities/update-last-opened-at-success
-                 (fn [{:keys [db]} [community-id last-opened-at]]
-                   {:db (assoc-in db [:communities community-id :last-opened-at] last-opened-at)}))
+ (fn [{:keys [db]} [community-id last-opened-at]]
+   {:db (assoc-in db [:communities community-id :last-opened-at] last-opened-at)}))

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -426,9 +426,6 @@
  (fn [{:keys [db]} [community-id]]
    (when (get-in db [:communities community-id])
      {:db (update-in db [:communities community-id] dissoc :fetching-revealed-accounts)})))
-(rf/reg-event-fx :communities/set-addresses-for-permissions
- (fn [{:keys [db]} [addresses]]
-   {:db (assoc-in db [:communities/addresses-for-permissions] addresses)}))
 
 (rf/reg-event-fx :communities/update-last-opened-at
  (fn [_ [community-id]]

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -383,7 +383,7 @@
         (rf/dispatch [:activity-center.notifications/dismiss-community-overview id]))
       [community-scroll-page community pending?])))
 
-(defn internal-overview
+(defn overview
   [id]
   (let [id                  (or id (rf/sub [:get-screen-params :community-overview]))
         customization-color (rf/sub [:profile/customization-color])]
@@ -394,5 +394,3 @@
                  :customization-color customization-color
                  :label               (i18n/label :t/jump-to)}}
       style/floating-shell-button]]))
-
-(defn overview [id] [:f> internal-overview id])

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -387,7 +387,6 @@
   [id]
   (let [id                  (or id (rf/sub [:get-screen-params :community-overview]))
         customization-color (rf/sub [:profile/customization-color])]
-    (rn/use-effect #(rf/dispatch [:communities/update-last-opened-at id]) [id])
     [rn/view {:style style/community-overview-container}
      [community-card-page-view id]
      [quo/floating-shell-button

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -383,10 +383,11 @@
         (rf/dispatch [:activity-center.notifications/dismiss-community-overview id]))
       [community-scroll-page community pending?])))
 
-(defn overview
+(defn internal-overview
   [id]
   (let [id                  (or id (rf/sub [:get-screen-params :community-overview]))
         customization-color (rf/sub [:profile/customization-color])]
+    (rn/use-effect #(rf/dispatch [:communities/update-last-opened-at id]) [id])
     [rn/view {:style style/community-overview-container}
      [community-card-page-view id]
      [quo/floating-shell-button
@@ -394,3 +395,5 @@
                  :customization-color customization-color
                  :label               (i18n/label :t/jump-to)}}
       style/floating-shell-button]]))
+
+(defn overview [id] [:f> internal-overview id])

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.172.6",
-    "commit-sha1": "6e30fbb211b0e0bb1e7966cce4e215c4080aac5c",
-    "src-sha256": "1k3hg2m25qvgvqxmy8im3xhjwvdyvaq49yks92642h9rw494nb94"
+    "version": "v0.172.8",
+    "commit-sha1": "436d22985661322ffda4eb44c1a160e6804f3823",
+    "src-sha256": "1y3l469k2085qaml7dmaky1rlanl4phq2p6yyk97074yw839jzj1"
 }


### PR DESCRIPTION
Required for https://github.com/status-im/status-mobile/issues/17337

### Summary

Adds last-opened-at and joined-at for communities to help with their sorting
QA notes: This won't require QA review as the PR that's going to use these attributes is still WIP


status: ready <!-- Can be ready or wip -->
