### PR TITLE
fix: random local `make run-ios` failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,8 +279,9 @@ run-android: ##@run Build Android APK and start it on the device
 	npx react-native run-android --appIdSuffix debug
 
 SIMULATOR=iPhone 13
+# TODO: fix IOS_STATUS_GO_TARGETS to be either amd64 or arm64 when RN is upgraded
 run-ios: export TARGET := ios
-run-ios: export IOS_STATUS_GO_TARGETS := iossimulator/amd64
+run-ios: export IOS_STATUS_GO_TARGETS := ios/arm64,iossimulator/amd64
 run-ios: ##@run Build iOS app and start it in a simulator/device
 ifneq ("$(SIMULATOR)", "")
 	npx react-native run-ios --simulator="$(SIMULATOR)" | xcbeautify
@@ -291,8 +292,9 @@ endif
 show-ios-devices: ##@other shows connected ios device and its name
 	xcrun xctrace list devices
 
+# TODO: fix IOS_STATUS_GO_TARGETS to be either amd64 or arm64 when RN is upgraded
 run-ios-device: export TARGET := ios
-run-ios-device: export IOS_STATUS_GO_TARGETS := ios/arm64
+run-ios-device: export IOS_STATUS_GO_TARGETS := ios/arm64,iossimulator/amd64
 run-ios-device: ##@run iOS app and start it on a connected device by its name
 ifndef DEVICE_NAME
 	$(error Usage: make run-ios-device DEVICE_NAME=your-device-name)


### PR DESCRIPTION
fixes #18443

### Review notes

Maybe this issue happens because of `Xcode` Upgrade to `15.x `
OR
Maybe this issue happens because if `MacOS` Upgrade to `Sonoma`
But we explicitly specify both targets `amd` and `arm` to ensure that the build does not fail.
When testing locally this made sure that builds did not randomly fail.
However local `iOS` builds will be slower.
Better to be slow than to fail randomly.

#### Platforms
- iOS

status: ready
