### PR TITLE
fix: wrong navigation bar color in transparent screens

### DIFF
--- a/src/status_im/navigation/options.cljs
+++ b/src/status_im/navigation/options.cljs
@@ -86,12 +86,7 @@
     :theme                  :dark
     :layout                 {:componentBackgroundColor :transparent
                              :orientation              ["portrait"]
-                             :backgroundColor          :transparent}}
-   (if platform/android?
-     {:statusBar {:backgroundColor :transparent
-                  :style           :light
-                  :drawBehind      true}}
-     {:statusBar {:style :light}})))
+                             :backgroundColor          :transparent}}))
 
 (def sheet-options
   {:layout                 {:componentBackgroundColor :transparent

--- a/src/status_im/navigation/options.cljs
+++ b/src/status_im/navigation/options.cljs
@@ -81,6 +81,7 @@
 
 (def transparent-screen-options
   (merge
+   (statusbar-and-navbar-root)
    {:modalPresentationStyle :overCurrentContext
     :theme                  :dark
     :layout                 {:componentBackgroundColor :transparent

--- a/src/status_im/navigation/options.cljs
+++ b/src/status_im/navigation/options.cljs
@@ -101,7 +101,7 @@
                              {})})
 
 (def dark-screen
-  (merge (statusbar true)
+  (merge (statusbar-and-navbar-root)
          {:theme  :dark
           :layout {:componentBackgroundColor colors/neutral-95
                    :orientation              ["portrait"]

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -270,9 +270,11 @@
      :component sign-in/view}
 
     {:name      :syncing-progress
-     :options   {:theme      :dark
-                 :layout     options/onboarding-layout
-                 :popGesture false}
+     :options   (merge
+                 (options/statusbar-and-navbar-root)
+                 {:theme      :dark
+                  :layout     options/onboarding-layout
+                  :popGesture false})
      :component syncing-devices/view}
 
     {:name      :syncing-progress-intro

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -119,7 +119,7 @@
      :component lightbox/lightbox}
 
     {:name      :photo-selector
-     :options   {:sheet? true}
+     :options   (merge {:sheet? true} (options/statusbar-and-navbar-root))
      :component photo-selector/photo-selector}
 
     {:name      :camera-screen
@@ -202,14 +202,17 @@
      :component create-password/create-password}
 
     {:name      :enable-biometrics
-     :options   {:theme                  :dark
-                 :layout                 options/onboarding-transparent-layout
-                 :animations             (merge transitions/new-to-status-modal-animations
-                                                transitions/push-animations-for-transparent-background)
-                 :popGesture             false
-                 :modalPresentationStyle :overCurrentContext
-                 :hardwareBackButton     {:dismissModalOnPress false
-                                          :popStackOnPress     false}}
+     :options   (merge
+                 (options/statusbar-and-navbar-root)
+                 {:theme                  :dark
+                  :layout                 options/onboarding-transparent-layout
+                  :animations             (merge
+                                           transitions/new-to-status-modal-animations
+                                           transitions/push-animations-for-transparent-background)
+                  :popGesture             false
+                  :modalPresentationStyle :overCurrentContext
+                  :hardwareBackButton     {:dismissModalOnPress false
+                                           :popStackOnPress     false}})
      :component enable-biometrics/view}
 
     {:name      :generating-keys
@@ -229,11 +232,14 @@
      :component enter-seed-phrase/enter-seed-phrase}
 
     {:name      :enable-notifications
-     :options   {:theme                  :dark
-                 :layout                 options/onboarding-transparent-layout
-                 :animations             (merge transitions/new-to-status-modal-animations
-                                                transitions/push-animations-for-transparent-background)
-                 :modalPresentationStyle :overCurrentContext}
+     :options   (merge
+                 (options/statusbar-and-navbar-root)
+                 {:theme                  :dark
+                  :layout                 options/onboarding-transparent-layout
+                  :animations             (merge
+                                           transitions/new-to-status-modal-animations
+                                           transitions/push-animations-for-transparent-background)
+                  :modalPresentationStyle :overCurrentContext})
      :component enable-notifications/view}
 
     {:name      :identifiers
@@ -281,9 +287,11 @@
      :component syncing-results/view}
 
     {:name      :welcome
-     :options   {:theme      :dark
-                 :layout     options/onboarding-transparent-layout
-                 :animations transitions/push-animations-for-transparent-background}
+     :options   (merge
+                 (options/statusbar-and-navbar-root)
+                 {:theme      :dark
+                  :layout     options/onboarding-transparent-layout
+                  :animations transitions/push-animations-for-transparent-background})
      :component welcome/view}
 
     {:name      :emoji-picker


### PR DESCRIPTION
fixes #18450 

### Summary
Opening 'Jump to' leads to the wrong navigation color

### Testing notes
You can see the video of this case in #17636 

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

status: ready <!-- Can be ready or wip -->
