### PR TITLE
Wallet - Refresh tokens and prices

### DIFF
--- a/src/legacy/status_im/ethereum/subscriptions.cljs
+++ b/src/legacy/status_im/ethereum/subscriptions.cljs
@@ -89,4 +89,5 @@
     "wallet-get-collectibles-details-done"     {:fx [[:dispatch
                                                       [:wallet/get-collectible-details-done
                                                        event]]]}
+    "wallet-tick-reload"                       {:fx [[:dispatch [:wallet/reload]]]}
     (log/debug ::unknown-wallet-event :type type :event event)))

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -327,9 +327,21 @@
    {:fx [[:dispatch [:hide-bottom-sheet]]
          [:dispatch [:browser.ui/open-url (str explorer-link "/" address)]]]}))
 
+(rf/reg-event-fx :wallet/reload
+ (fn [_]
+   {:fx [[:dispatch-n [[:wallet/get-wallet-token]]]]}))
+
+(rf/reg-event-fx :wallet/start-wallet
+ (fn [_]
+   {:fx [[:json-rpc/call
+          [{:method   "wallet_startWallet"
+            :on-error #(log/info "failed to start wallet"
+                                 {:error %
+                                  :event :wallet/start-wallet})}]]]}))
+
 (rf/reg-event-fx :wallet/initialize
  (fn []
-   {:fx [[:dispatch-n [[:wallet/get-ethereum-chains] [:wallet/get-accounts]]]]}))
+   {:fx [[:dispatch-n [[:wallet/start-wallet] [:wallet/get-ethereum-chains] [:wallet/get-accounts]]]]}))
 
 (rf/reg-event-fx :wallet/share-account
  (fn [_ [{:keys [content title]}]]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -341,7 +341,9 @@
 
 (rf/reg-event-fx :wallet/initialize
  (fn []
-   {:fx [[:dispatch-n [[:wallet/start-wallet] [:wallet/get-ethereum-chains] [:wallet/get-accounts]]]]}))
+   {:fx [[:dispatch [:wallet/start-wallet]]
+         [:dispatch [:wallet/get-ethereum-chains]]
+         [:dispatch [:wallet/get-accounts]]]}))
 
 (rf/reg-event-fx :wallet/share-account
  (fn [_ [{:keys [content title]}]]


### PR DESCRIPTION
fixes #18423

### Summary

This PR adds 
 - RPC call for start wallet which will signal the client to refresh data (tokens, prices, ...etc) every 10 minutes
 - Refreshes tokens and prices every 10 minutes on receiving the *`wallet-tick-reload`* signal


### Platforms

- Android
- iOS

### Steps to test

#### Prerequisite: The wallet account should hold some tokens

- Open Status
- Navigate to the Wallet tab
- Verify the token and prices are updated every 10 minutes

status: ready
