### PR TITLE
fix: don't show trace message when default is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ run-android: ##@run Build Android APK and start it on the device
 SIMULATOR=iPhone 13
 # TODO: fix IOS_STATUS_GO_TARGETS to be either amd64 or arm64 when RN is upgraded
 run-ios: export TARGET := ios
-run-ios: export IOS_STATUS_GO_TARGETS := ios/arm64,iossimulator/amd64
+run-ios: export IOS_STATUS_GO_TARGETS := ios/arm64;iossimulator/amd64
 run-ios: ##@run Build iOS app and start it in a simulator/device
 ifneq ("$(SIMULATOR)", "")
 	npx react-native run-ios --simulator="$(SIMULATOR)" | xcbeautify
@@ -294,7 +294,7 @@ show-ios-devices: ##@other shows connected ios device and its name
 
 # TODO: fix IOS_STATUS_GO_TARGETS to be either amd64 or arm64 when RN is upgraded
 run-ios-device: export TARGET := ios
-run-ios-device: export IOS_STATUS_GO_TARGETS := ios/arm64,iossimulator/amd64
+run-ios-device: export IOS_STATUS_GO_TARGETS := ios/arm64;iossimulator/amd64
 run-ios-device: ##@run iOS app and start it on a connected device by its name
 ifndef DEVICE_NAME
 	$(error Usage: make run-ios-device DEVICE_NAME=your-device-name)

--- a/nix/lib/getEnvWithDefault.nix
+++ b/nix/lib/getEnvWithDefault.nix
@@ -3,6 +3,6 @@ name: default: let
   logEnvOverride = value:
     builtins.trace "getEnvWithDefault ${name} (default: ${toString default}): ${value}" value;
 in
-  if envOverride != ""
+  if envOverride != "" && envOverride != default
   then logEnvOverride envOverride
   else default


### PR DESCRIPTION
`getEnvWithDefault.nix` prints a trace message in console when a default value is not set. 

In this PR we add a check to see if default value matches the value of that env var.
Otherwise we get log messages like these when running `make run-ios`

```
trace: getEnvWithDefault IOS_STATUS_GO_TARGETS 
(default: ios/arm64;iossimulator/amd64): ios/arm64;iossimulator/amd64
trace: getEnvWithDefault IOS_STATUS_GO_TARGETS 
(default: ios/arm64;iossimulator/amd64): ios/arm64;iossimulator/amd64
```

We also fix a tiny mistake in `make run-ios` status-go target by updating the delimiter to be a semi-colon instead of a comma.

status: ready
