### PR TITLE
Fix: add back missing clj-kondo config files

### DIFF
--- a/.zprintrc
+++ b/.zprintrc
@@ -1,26 +1,26 @@
 ;; -*- mode: clojure -*-
 ;; vi: ft=clojure
-{:width     105
- :style     [;; community style
-             ;; https://github.com/kkinnear/zprint/blob/main/doc/reference.md#community
-             :community
+{:width 105
+ :remove {:fn-force-nl #{:noarg1-body}}
 
-             ;; no comma in map
-             :no-comma
+ :style
+ [;; community style https://github.com/kkinnear/zprint/blob/main/doc/reference.md#community
+  :community
 
-             :custom-justify
+  ;; no comma in map
+  :no-comma
 
-             ;; respect all newlines
-             ;; https://github.com/kkinnear/zprint/blob/main/doc/reference.md#respect-nl
-             :respect-nl
+  :custom-justify
 
-             ;; respect blank line
-             ;; https://github.com/kkinnear/zprint/blob/main/doc/reference.md#respect-bl
-             :respect-bl
+  ;; respect all newlines https://github.com/kkinnear/zprint/blob/main/doc/reference.md#respect-nl
+  :respect-nl
 
-             ;; hang multiline left-hand-thing
-             ;; https://github.com/kkinnear/zprint/issues/273
-             :multi-lhs-hang]
+  ;; respect blank line https://github.com/kkinnear/zprint/blob/main/doc/reference.md#respect-bl
+  :respect-bl
+
+  ;; hang multiline left-hand-thing https://github.com/kkinnear/zprint/issues/273
+  :multi-lhs-hang]
+
  :fn-map
  {"reg-sub"         :arg1-pair
   "h/describe"      :arg1-body
@@ -50,9 +50,9 @@
   "assoc-some"      "assoc"
   "conj-when"       "conj"
   "conj-some"       "conj"}
- :remove    {:fn-force-nl #{:noarg1-body}}
+
  :style-map
- {:no-comma       {:map {:comma? false}}
+ {:no-comma {:map {:comma? false}}
   :custom-justify
   {:doc     "Justify everything using pre-1.1.2 approach"
    :binding {:justify? true :justify {:max-variance 1000}}

--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ lint-fix: ##@test Run code style checks and fix issues
 	ALL_CLOJURE_FILES=$(call find_all_clojure_files) && \
 	zprint '{:search-config? true}' -sw $$ALL_CLOJURE_FILES && \
 	zprint '{:search-config? true}' -sw $$ALL_CLOJURE_FILES && \
-	clojure-lsp --ns-exclude-regex ".*/src/status_im/core\.cljs|.*/src/test_helpers/component_tests_preload\.cljs$$" clean-ns && \
+	clojure-lsp --ns-exclude-regex ".*/\.clj-kondo/.*|.*/src/status_im/core\.cljs|.*/src/test_helpers/component_tests_preload\.cljs$$" clean-ns && \
 	sh scripts/lint/trailing-newline.sh --fix && \
 	node_modules/.bin/prettier --write .
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/17947

### Summary

This PR should fix our issues with auto-generated clj-kondo config files. The code in develop is actually correct, we just forgot to add back some files.

- [x] To be extra precise, we now exclude `.clj-kondo/*` from being processed by `clojure-lsp clean-ns`.
- [x] Formatted the `.zprintrc` file. Whenever I touched that file it was completely reformatted by zprint because I have Emacs configured to format after saving.

### For reviewers

Please, confirm running `make lint-fix` in your machine doesn't make the stage dirty.

### Steps to test

Nothing to test.

status: ready