### PR TITLE
[#18410] - Fix summary-tag style

### DIFF
--- a/src/quo/components/tags/summary_tag/style.cljs
+++ b/src/quo/components/tags/summary_tag/style.cljs
@@ -21,7 +21,12 @@
 (def collectible-image
   {:width         24
    :height        24
-   :border-radius 10})
+   :border-radius 8})
+
+(def network
+  {:width         24
+   :height        24
+   :border-radius 12})
 
 (def token-image
   {:border-radius 12})

--- a/src/quo/components/tags/summary_tag/view.cljs
+++ b/src/quo/components/tags/summary_tag/view.cljs
@@ -22,7 +22,7 @@
     :network
     [rn/image
      {:source image-source
-      :style  style/token-image}]
+      :style  style/network}]
     :saved-address
     [wallet-user-avatar/wallet-user-avatar
      {:full-name           label

--- a/src/status_im/contexts/preview/quo/tags/summary_tag.cljs
+++ b/src/status_im/contexts/preview/quo/tags/summary_tag.cljs
@@ -55,9 +55,7 @@
 
 (defn view
   []
-  (let [state (reagent/atom
-               (merge {:type :token}
-                      (data :token)))]
+  (let [state (reagent/atom (assoc (data :token) :type :token))]
     (fn []
       [preview/preview-container
        {:state      state


### PR DESCRIPTION
fixes #18410

### Summary

Just a style correction

### Steps to test

- Open Status
- Quo preview -> tags -> summary-tag
- Pick the Network and Collectible variants.

### Before and after screenshots comparison

| Figma | now  | before |
|--|--|--|
| <img src=https://github.com/status-im/status-mobile/assets/90291778/ed2fae20-d755-454f-b9ca-c512236c2051 width=240>| <img src=https://github.com/status-im/status-mobile/assets/90291778/7160efd1-9c7d-483e-a493-3eb8679b7a73 width=240> | <img src=https://github.com/status-im/status-mobile/assets/90291778/6049c8af-a251-4b2b-a077-009e97dbb57e width=240> |
| <img src=https://github.com/status-im/status-mobile/assets/90291778/deb8132c-73e5-4550-89b4-7480067a42d3 width=240> | <img src=https://github.com/status-im/status-mobile/assets/90291778/91d50349-8d88-49ed-887b-a3d1549e635c width=240> |<img src=https://github.com/status-im/status-mobile/assets/90291778/a96c918b-4990-4d52-84ff-ac91ea70f414 width=240> |

status: ready <!-- Can be ready or wip -->
