### PR TITLE
Wallet: select-send-address event

### DIFF
--- a/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/.clj-kondo/taoensso/encore/config.edn
+++ b/.clj-kondo/taoensso/encore/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:analyze-call {taoensso.encore/defalias taoensso.encore/defalias}}}

--- a/.clj-kondo/taoensso/encore/taoensso/encore.clj
+++ b/.clj-kondo/taoensso/encore/taoensso/encore.clj
@@ -1,0 +1,16 @@
+(ns taoensso.encore
+  (:require
+   [clj-kondo.hooks-api :as hooks]))
+
+(defn defalias [{:keys [node]}]
+  (let [[sym-raw src-raw] (rest (:children node))
+        src (if src-raw src-raw sym-raw)
+        sym (if src-raw
+              sym-raw
+              (symbol (name (hooks/sexpr src))))]
+    {:node (with-meta
+             (hooks/list-node
+               [(hooks/token-node 'def)
+                (hooks/token-node (hooks/sexpr sym))
+                (hooks/token-node (hooks/sexpr src))])
+             (meta src))}))

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -47,10 +47,11 @@
             (update-in [:wallet :ui :send] dissoc :to-address))
     :fx [[:navigate-to-within-stack [:wallet-select-asset stack-id]]]}))
 
+(rf/reg-event-fx :wallet/select-send-address
 (fn [{:keys [db]} [{:keys [address token stack-id]}]]
   {:db (assoc-in db [:wallet :ui :send :to-address] address)
    :fx [[:navigate-to-within-stack
-         (if token [:wallet-send-input-amount stack-id] [:wallet-select-asset stack-id])]]})
+         (if token [:wallet-send-input-amount stack-id] [:wallet-select-asset stack-id])]]}))
 
 (rf/reg-event-fx :wallet/send-select-token
  (fn [{:keys [db]} [{:keys [token stack-id]}]]

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -48,10 +48,10 @@
     :fx [[:navigate-to-within-stack [:wallet-select-asset stack-id]]]}))
 
 (rf/reg-event-fx :wallet/select-send-address
-(fn [{:keys [db]} [{:keys [address token stack-id]}]]
-  {:db (assoc-in db [:wallet :ui :send :to-address] address)
-   :fx [[:navigate-to-within-stack
-         (if token [:wallet-send-input-amount stack-id] [:wallet-select-asset stack-id])]]}))
+ (fn [{:keys [db]} [{:keys [address token stack-id]}]]
+   {:db (assoc-in db [:wallet :ui :send :to-address] address)
+    :fx [[:navigate-to-within-stack
+          (if token [:wallet-send-input-amount stack-id] [:wallet-select-asset stack-id])]]}))
 
 (rf/reg-event-fx :wallet/send-select-token
  (fn [{:keys [db]} [{:keys [token stack-id]}]]


### PR DESCRIPTION
This PR adds back the `:wallet/select-send-address` that seems to have been accidentally removed in previous commit