### PR TITLE
fix: android shadow

### DIFF
--- a/src/quo/foundations/shadows.cljs
+++ b/src/quo/foundations/shadows.cljs
@@ -6,13 +6,14 @@
     [react-native.platform :as platform]
     [utils.number]))
 
-
-(def ^:private shadowOpacityCoefficient 5)
-(def ^:private shadowRadiusCoefficient 0.8)
-
 (defn- get-shadow-color
+  "Calculates the shadow color based on a given color and opacity, with an optional coefficient.
+  - Arity [color opacity]: Uses a default coefficient value of 5 (empirically determined) to compute the shadow color.
+  - Arity [color opacity coefficient]: Uses the specified coefficient to compute the shadow color.
+  On Android platforms, the shadow color's alpha is adjusted based on the product of opacity and
+  coefficient, constrained between 0 and 1. Returns a map with :shadow-color and :shadow-opacity keys."
   ([color opacity]
-   (get-shadow-color color opacity shadowOpacityCoefficient))
+   (get-shadow-color color opacity 5))
   ([color opacity coefficient]
    {:shadow-color   (if platform/android?
                       (colors/alpha color (utils.number/value-in-range (* opacity coefficient) 0 1))
@@ -20,8 +21,12 @@
     :shadow-opacity opacity}))
 
 (defn- get-shadow-radius
+  "Computes shadow radius and elevation properties based on a given radius, with an optional coefficient.
+  - Arity [radius]: Uses a default coefficient of 0.8 (empirically determined) to compute the elevation.
+  - Arity [radius coefficient]: Uses the specified coefficient to compute the elevation.
+  Returns a map with :elevation, computed as the product of radius and coefficient, and :shadow-radius keys."
   ([radius]
-   (get-shadow-radius radius shadowRadiusCoefficient))
+   (get-shadow-radius radius 0.8))
   ([radius coefficient]
    {:elevation     (* radius coefficient)
     :shadow-radius radius}))

--- a/src/quo/foundations/shadows.cljs
+++ b/src/quo/foundations/shadows.cljs
@@ -6,6 +6,10 @@
     [react-native.platform :as platform]
     [utils.number]))
 
+;; Set radius coefficient based on Android Version.
+;; A good way to know is to check if shadow color is supported i.e API level 28 (Android 9) above
+(def ^:private shadow-radius-coefficient (if platform/is-shadow-color-supported? 0.8 0.1))
+
 (defn- get-shadow-color
   "Calculates the shadow color based on a given color and opacity, with an optional coefficient.
   - Arity [color opacity]: Uses a default coefficient value of 5 (empirically determined) to compute the shadow color.
@@ -22,11 +26,11 @@
 
 (defn- get-shadow-radius
   "Computes shadow radius and elevation properties based on a given radius, with an optional coefficient.
-  - Arity [radius]: Uses a default coefficient of 0.8 (empirically determined) to compute the elevation.
+  - Arity [radius]: Uses a default coefficient of 0.8 for API level 28 and above and 0.1 otherwise (empirically determined) to compute the elevation.
   - Arity [radius coefficient]: Uses the specified coefficient to compute the elevation.
   Returns a map with :elevation, computed as the product of radius and coefficient, and :shadow-radius keys."
   ([radius]
-   (get-shadow-radius radius 0.8))
+   (get-shadow-radius radius shadow-radius-coefficient))
   ([radius coefficient]
    {:elevation     (* radius coefficient)
     :shadow-radius radius}))

--- a/src/quo/foundations/shadows.cljs
+++ b/src/quo/foundations/shadows.cljs
@@ -3,28 +3,28 @@
   (:require
     [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
-    [react-native.platform :as platform]))
+    [react-native.platform :as platform]
+    [utils.number]))
 
-(defn clamp
-  [value min-val max-val]
-  (max min-val (min max-val value)))
 
-(defn get-shadow-color
+(def ^:private shadowOpacityCoefficient 5)
+(def ^:private shadowRadiusCoefficient 0.8)
+
+(defn- get-shadow-color
   ([color opacity]
-   (get-shadow-color color opacity 5))
+   (get-shadow-color color opacity shadowOpacityCoefficient))
   ([color opacity coefficient]
    {:shadow-color   (if platform/android?
-                      (colors/alpha color (clamp (* opacity coefficient) 0 1))
+                      (colors/alpha color (utils.number/value-in-range (* opacity coefficient) 0 1))
                       color)
     :shadow-opacity opacity}))
 
-(defn get-shadow-radius
+(defn- get-shadow-radius
   ([radius]
-   (get-shadow-radius radius 0.8))
+   (get-shadow-radius radius shadowRadiusCoefficient))
   ([radius coefficient]
    {:elevation     (* radius coefficient)
     :shadow-radius radius}))
-
 
 (def ^:private shadows
   (let [dark-normal           {1 (merge {:shadow-offset {:width 0 :height 4}}
@@ -56,8 +56,7 @@
                                         (get-shadow-radius 16))
                                4 (merge {:shadow-offset {:width 0 :height 16}}
                                         (get-shadow-color colors/neutral-100 0.16)
-                                        (get-shadow-radius 16))
-                              }
+                                        (get-shadow-radius 16))}
         light-normal-inverted (-> light-normal
                                   (update-in [:soft :shadow-offset :height] -)
                                   (update-in [:medium :shadow-offset :height] -)

--- a/src/quo/foundations/shadows.cljs
+++ b/src/quo/foundations/shadows.cljs
@@ -5,60 +5,59 @@
     [quo.theme :as quo.theme]
     [react-native.platform :as platform]))
 
+(defn clamp
+  [value min-val max-val]
+  (max min-val (min max-val value)))
+
+(defn get-shadow-color
+  ([color opacity]
+   (get-shadow-color color opacity 5))
+  ([color opacity coefficient]
+   {:shadow-color   (if platform/android?
+                      (colors/alpha color (clamp (* opacity coefficient) 0 1))
+                      color)
+    :shadow-opacity opacity}))
+
+(defn get-shadow-radius
+  ([radius]
+   (get-shadow-radius radius 0.8))
+  ([radius coefficient]
+   {:elevation     (* radius coefficient)
+    :shadow-radius radius}))
+
+
 (def ^:private shadows
-  (let [dark-normal           {1 {:shadow-color   (when platform/ios?
-                                                    (colors/alpha colors/neutral-100 0.5))
-                                  :shadow-offset  {:width 0 :height 4}
-                                  :elevation      3
-                                  :shadow-opacity 1
-                                  :shadow-radius  20}
-                               2 {:shadow-color   (when platform/ios?
-                                                    (colors/alpha colors/neutral-100 0.64))
-                                  :shadow-offset  {:width 0 :height 4}
-                                  :elevation      4
-                                  :shadow-opacity 1
-                                  :shadow-radius  20}
-                               3 {:shadow-color   (when platform/ios?
-                                                    (colors/alpha colors/neutral-100 0.64))
-                                  :shadow-offset  {:width 0 :height 12}
-                                  :elevation      8
-                                  :shadow-opacity 1
-                                  :shadow-radius  20}
-                               4 {:shadow-color   (when platform/ios?
-                                                    (colors/alpha colors/neutral-100 0.72))
-                                  :shadow-offset  {:width 0 :height 16}
-                                  :shadow-opacity 1
-                                  :shadow-radius  20
-                                  :elevation      15}}
+  (let [dark-normal           {1 (merge {:shadow-offset {:width 0 :height 4}}
+                                        (get-shadow-color colors/neutral-100 0.5)
+                                        (get-shadow-radius 20))
+                               2 (merge {:shadow-offset {:width 0 :height 4}}
+                                        (get-shadow-color colors/neutral-100 0.64)
+                                        (get-shadow-radius 20))
+                               3 (merge {:shadow-offset {:width 0 :height 12}}
+                                        (get-shadow-color colors/neutral-100 0.64)
+                                        (get-shadow-radius 20))
+                               4 (merge {:shadow-offset {:width 0 :height 16}}
+                                        (get-shadow-color colors/neutral-100 0.72)
+                                        (get-shadow-radius 20))}
         dark-normal-inverted  (-> dark-normal
                                   (update-in [:soft :shadow-offset :height] -)
                                   (update-in [:medium :shadow-offset :height] -)
                                   (update-in [:intense :shadow-offset :height] -)
                                   (update-in [:strong :shadow-offset :height] -))
-        light-normal          {1 {:shadow-color   (when platform/ios?
-                                                    (colors/alpha colors/neutral-100 0.04))
-                                  :shadow-offset  {:width 0 :height 4}
-                                  :elevation      1
-                                  :shadow-opacity 1
-                                  :shadow-radius  16}
-                               2 {:shadow-color   (when platform/ios?
-                                                    (colors/alpha colors/neutral-100 0.08))
-                                  :shadow-offset  {:width 0 :height 4}
-                                  :elevation      6
-                                  :shadow-opacity 1
-                                  :shadow-radius  16}
-                               3 {:shadow-color   (when platform/ios?
-                                                    (colors/alpha colors/neutral-100 0.12))
-                                  :shadow-offset  {:width 0 :height 12}
-                                  :elevation      8
-                                  :shadow-opacity 1
-                                  :shadow-radius  16}
-                               4 {:shadow-color   (when platform/ios?
-                                                    (colors/alpha colors/neutral-100 0.16))
-                                  :shadow-offset  {:width 0 :height 16}
-                                  :shadow-opacity 1
-                                  :shadow-radius  16
-                                  :elevation      13}}
+        light-normal          {1 (merge {:shadow-offset {:width 0 :height 4}}
+                                        (get-shadow-color colors/neutral-100 0.04)
+                                        (get-shadow-radius 16))
+
+                               2 (merge {:shadow-offset {:width 0 :height 4}}
+                                        (get-shadow-color colors/neutral-100 0.08)
+                                        (get-shadow-radius 16))
+                               3 (merge {:shadow-offset {:width 0 :height 12}}
+                                        (get-shadow-color colors/neutral-100 0.12)
+                                        (get-shadow-radius 16))
+                               4 (merge {:shadow-offset {:width 0 :height 16}}
+                                        (get-shadow-color colors/neutral-100 0.16)
+                                        (get-shadow-radius 16))
+                              }
         light-normal-inverted (-> light-normal
                                   (update-in [:soft :shadow-offset :height] -)
                                   (update-in [:medium :shadow-offset :height] -)

--- a/src/react_native/platform.cljs
+++ b/src/react_native/platform.cljs
@@ -14,3 +14,5 @@
 (def low-device? (and android? (< version 29)))
 
 (def is-below-android-13? (and android? (< version 33)))
+
+(def is-shadow-color-supported? (and android? (> version 27)))


### PR DESCRIPTION
Hi guys, I am trying this method to get Android shadows as close to Figma as possible. Unfortunately we might not be able to get the exact same shadows as on Figma because of the way shadows work on Android, but we can generally get close.

I created a function for getting the Android shadow elevation based on the `shadowBlur` as seen on Figma. For the `shadowColor` and `shadowOpacity`, I have found out that applying the `opacity` via the alpha channel in the colour produces a more desirable result.

Here are some examples:

**Before**: 

<img width="462" alt="Screenshot 2024-01-15 at 13 03 55" src="https://github.com/status-im/status-mobile/assets/45393944/89f51a6c-c365-4223-a26d-6af61861a27d">
<img width="542" alt="Screenshot 2024-01-15 at 13 03 50" src="https://github.com/status-im/status-mobile/assets/45393944/492c6b0a-4bf9-465c-9b84-c4738163cc95">
<img width="462" alt="Screenshot 2024-01-15 at 13 03 24" src="https://github.com/status-im/status-mobile/assets/45393944/fd43eb58-a497-4481-8876-8e73752cc314">
<img width="542" alt="Screenshot 2024-01-15 at 13 03 16" src="https://github.com/status-im/status-mobile/assets/45393944/f9671de8-dc66-4421-b56f-aa10b2784e01">


**After:** 

<img width="462" alt="Screenshot 2024-01-15 at 13 06 58" src="https://github.com/status-im/status-mobile/assets/45393944/a04f9fd2-8e19-4a0d-bb4b-4af1a607fb68">
<img width="542" alt="Screenshot 2024-01-15 at 13 06 53" src="https://github.com/status-im/status-mobile/assets/45393944/33a08ecb-c487-4138-a76c-7a96bf355b0e">
<img width="462" alt="Screenshot 2024-01-15 at 13 06 39" src="https://github.com/status-im/status-mobile/assets/45393944/14ab998b-c40c-4ebc-8107-f8b69c7fd979">
<img width="542" alt="Screenshot 2024-01-15 at 13 06 37" src="https://github.com/status-im/status-mobile/assets/45393944/e5042d20-0e4c-43cc-8089-a27b409918f9">


The after results are not as pronounced as before and are somewhat closer to iOS. 

**Known Issue:** This doesn't work on Android 8.1