### PR TITLE
Communities: Share airdrop address

### DIFF
--- a/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
@@ -10,25 +10,21 @@
     [utils.re-frame :as rf]))
 
 (defn- join-community-and-navigate-back
-  [id addresses-for-permissions]
+  [id]
   (rf/dispatch [:password-authentication/show
                 {:content (fn [] [password-authentication/view])}
                 {:label    (i18n/label :t/join-open-community)
-                 :on-press #(rf/dispatch [:communities/request-to-join
-                                          {:community-id        id
-                                           :password            %
-                                           :addresses-to-reveal addresses-for-permissions}])}])
+                 :on-press #(rf/dispatch [:communities/request-to-join-with-addresses
+                                          {:community-id id
+                                           :password     %}])}])
   (rf/dispatch [:navigate-back]))
 
 (defn f-view-internal
   []
-  (let [{id :community-id}            (rf/sub [:get-screen-params])
-        {:keys [name color images]}   (rf/sub [:communities/community id])
-        accounts                      (rf/sub [:wallet/accounts-with-customization-color])
-        selected-permission-addresses (rf/sub [:communities/selected-permission-addresses])
-        selected-accounts             (filter #(contains? selected-permission-addresses
-                                                          (:address %))
-                                              accounts)]
+  (let [{id :community-id}          (rf/sub [:get-screen-params])
+        {:keys [name color images]} (rf/sub [:communities/community id])
+        airdrop-account             (rf/sub [:communities/airdrop-account])
+        selected-accounts           (rf/sub [:communities/selected-permission-accounts])]
     (rn/use-effect (fn []
                      (rf/dispatch [:communities/initialize-permission-addresses]))
                    [])
@@ -71,8 +67,8 @@
                       :action            :arrow
                       :label             :preview
                       :label-props       {:type :accounts
-                                          :data [(first accounts)]}
-                      :description-props {:text (-> accounts first :name)}}]}]
+                                          :data [airdrop-account]}
+                      :description-props {:text (:name airdrop-account)}}]}]
        [quo/text
         {:style               style/section-title
          :accessibility-label :community-rules-title
@@ -86,7 +82,7 @@
         :track-text          (i18n/label :t/slide-to-request-to-join)
         :track-icon          :i/face-id
         :customization-color color
-        :on-complete         #(join-community-and-navigate-back id selected-permission-addresses)}]]]))
+        :on-complete         #(join-community-and-navigate-back id)}]]]))
 
 (defn view
   []

--- a/src/status_im/contexts/communities/actions/airdrop_addresses/style.cljs
+++ b/src/status_im/contexts/communities/actions/airdrop_addresses/style.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.communities.actions.airdrop-addresses.style)
 
 (def account-list-container
-  {:flex           1
-   :padding-top    12
-   :padding-bottom 8})
+  {:padding-horizontal 8
+   :padding-bottom     8})

--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -4,11 +4,14 @@
             [status-im.contexts.communities.events :as events]))
 
 (deftest initialize-permission-addresses-test
-  (let [initial-db  {:db {:wallet {:accounts {"0x1" {:address "0x1"}
-                                              "0x2" {:address "0x2"}}}}}
+  (let [initial-db  {:db {:wallet {:accounts {"0x1" {:address  "0x1"
+                                                     :position 0}
+                                              "0x2" {:address  "0x2"
+                                                     :position 1}}}}}
         expected-db {:db (assoc (:db initial-db)
                                 :communities/previous-permission-addresses #{"0x1" "0x2"}
-                                :communities/selected-permission-addresses #{"0x1" "0x2"})}]
+                                :communities/selected-permission-addresses #{"0x1" "0x2"}
+                                :communities/airdrop-address               "0x1")}]
     (is (match? expected-db (events/initialize-permission-addresses initial-db)))))
 
 (deftest toggle-selected-permission-address-test
@@ -17,3 +20,33 @@
                 (events/toggle-selected-permission-address initial-db ["0x2"])))
     (is (match? {:db {:communities/selected-permission-addresses #{"0x1" "0x2" "0x3"}}}
                 (events/toggle-selected-permission-address initial-db ["0x3"])))))
+
+(deftest update-previous-permission-addresses-test
+  (let [wallet {:accounts {"0x1" {:address  "0x1"
+                                  :position 0}
+                           "0x2" {:address  "0x2"
+                                  :position 1}
+                           "0x3" {:address  "0x3"
+                                  :position 2}}}]
+    (let [initial-db  {:db {:wallet                                    wallet
+                            :communities/previous-permission-addresses #{"0x1" "0x2"}
+                            :communities/selected-permission-addresses #{"0x1" "0x2" "0x3"}
+                            :communities/airdrop-address               "0x1"}}
+          expected-db {:db {:wallet                                    wallet
+                            :communities/previous-permission-addresses #{"0x1" "0x2" "0x3"}
+                            :communities/selected-permission-addresses #{"0x1" "0x2" "0x3"}
+                            :communities/airdrop-address               "0x1"}}]
+      (is
+       (match? expected-db
+               (events/update-previous-permission-addresses initial-db))))
+    (let [initial-db  {:db {:wallet                                    wallet
+                            :communities/previous-permission-addresses #{"0x1" "0x2"}
+                            :communities/selected-permission-addresses #{"0x2" "0x3"}
+                            :communities/airdrop-address               "0x1"}}
+          expected-db {:db {:wallet                                    wallet
+                            :communities/previous-permission-addresses #{"0x2" "0x3"}
+                            :communities/selected-permission-addresses #{"0x2" "0x3"}
+                            :communities/airdrop-address               "0x2"}}]
+      (is
+       (match? expected-db
+               (events/update-previous-permission-addresses initial-db))))))

--- a/src/status_im/contexts/communities/overview/events.cljs
+++ b/src/status_im/contexts/communities/overview/events.cljs
@@ -64,12 +64,11 @@
 
 (defn request-to-join
   [{:keys [db]}
-   [{:keys [community-id password addresses-to-reveal]
-     :or   {addresses-to-reveal []}}]]
+   [{:keys [community-id password]}]]
   (let [pub-key (get-in db [:profile/profile :public-key])]
     {:fx [[:json-rpc/call
            [{:method     "wakuext_generateJoiningCommunityRequestsForSigning"
-             :params     [pub-key community-id addresses-to-reveal]
+             :params     [pub-key community-id []]
              :on-success [:communities/sign-data community-id password]
              :on-error   [:communities/requested-to-join-error community-id]}]]]}))
 
@@ -116,9 +115,6 @@
            :params      [{:communityId       community-id
                           :signatures        signatures
                           :addressesToReveal addresses-to-reveal
-                          ;; NOTE: At least one airdrop address is required.
-                          ;; This is a temporary solution while the address
-                          ;; selection feature is not implemented in mobile.
                           :airdropAddress    (first addresses-to-reveal)}]
            :js-response true
            :on-success  [:communities/requested-to-join]
@@ -145,3 +141,43 @@
                                :event        :communities/toggle-collapsed-category
                                :category-id  category-id
                                :collapse?    collapse?})}]}))
+
+(defn request-to-join-with-signatures-and-addresses
+  [{:keys [db]} [community-id signatures]]
+  (let [airdrop-address     (get-in db [:communities/airdrop-address])
+        addresses-to-reveal (get-in db [:communities/selected-permission-addresses])]
+    {:fx [[:json-rpc/call
+           [{:method      "wakuext_requestToJoinCommunity"
+             :params      [{:communityId       community-id
+                            :signatures        signatures
+                            :addressesToReveal addresses-to-reveal
+                            :airdropAddress    airdrop-address}]
+             :js-response true
+             :on-success  [:communities/requested-to-join]
+             :on-error    [:communities/requested-to-join-error community-id]}]]]}))
+
+(rf/reg-event-fx :communities/request-to-join-with-signatures-and-addresses
+ request-to-join-with-signatures-and-addresses)
+
+(defn sign-data-with-addresses
+  [_ [community-id password sign-params]]
+  {:fx [[:json-rpc/call
+         [{:method     "wakuext_signData"
+           :params     [(map #(assoc % :password password) sign-params)]
+           :on-success [:communities/request-to-join-with-signatures-and-addresses community-id]
+           :on-error   [:communities/requested-to-join-error community-id]}]]]})
+
+(rf/reg-event-fx :communities/sign-data-with-addresses sign-data-with-addresses)
+
+(defn request-to-join-with-addresses
+  [{:keys [db]}
+   [{:keys [community-id password]}]]
+  (let [pub-key             (get-in db [:profile/profile :public-key])
+        addresses-to-reveal (get-in db [:communities/selected-permission-addresses])]
+    {:fx [[:json-rpc/call
+           [{:method     "wakuext_generateJoiningCommunityRequestsForSigning"
+             :params     [pub-key community-id addresses-to-reveal]
+             :on-success [:communities/sign-data-with-addresses community-id password]
+             :on-error   [:communities/requested-to-join-error community-id]}]]]}))
+
+(rf/reg-event-fx :communities/request-to-join-with-addresses request-to-join-with-addresses)

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -335,3 +335,17 @@
  :<- [:communities]
  (fn [communities [_ community-id]]
    (get-in communities [community-id :intro-message])))
+
+(re-frame/reg-sub
+ :communities/airdrop-account
+ :<- [:communities/airdrop-address]
+ :<- [:wallet/accounts-with-customization-color]
+ (fn [[airdrop-address accounts]]
+   (first (filter #(= (:address %) airdrop-address) accounts))))
+
+(re-frame/reg-sub
+ :communities/selected-permission-accounts
+ :<- [:communities/selected-permission-addresses]
+ :<- [:wallet/accounts-with-customization-color]
+ (fn [[selected-permission-addresses accounts]]
+   (filter #(contains? selected-permission-addresses (:address %)) accounts)))

--- a/src/status_im/subs/communities_test.cljs
+++ b/src/status_im/subs/communities_test.cljs
@@ -459,3 +459,49 @@
                                       :loading?    checking-permissions?
                                       :img-src     token-image-eth}]]}
            (rf/sub [sub-name community-id])))))
+
+(h/deftest-sub :communities/airdrop-account
+  [sub-name]
+  (testing "returns airdrop account"
+    (swap! rf-db/app-db assoc
+      :communities/airdrop-address
+      "0x1"
+      :wallet {:accounts {"0x1" {:address "0x1"
+                                 :color   :blue
+                                 :name    "account1"}
+                          "0x2" {:address "0x2"
+                                 :color   :orange
+                                 :name    "account2"}}})
+    (is (match? {:address                   "0x1"
+                 :network-preferences-names #{}
+                 :name                      "account1"
+                 :color                     :blue
+                 :customization-color       :blue}
+                (rf/sub [sub-name])))))
+
+(h/deftest-sub :communities/selected-permission-accounts
+  [sub-name]
+  (testing "returns selected permission accounts"
+    (swap! rf-db/app-db assoc
+      :communities/selected-permission-addresses
+      #{"0x1" "0x3"}
+      :wallet {:accounts {"0x1" {:address "0x1"
+                                 :color   :blue
+                                 :name    "account1"}
+                          "0x2" {:address "0x2"
+                                 :color   :orange
+                                 :name    "account2"}
+                          "0x3" {:address "0x3"
+                                 :color   :purple
+                                 :name    "account3"}}})
+    (is (match? [{:address                   "0x1"
+                  :color                     :blue
+                  :customization-color       :blue
+                  :network-preferences-names #{}
+                  :name                      "account1"}
+                 {:address                   "0x3"
+                  :color                     :purple
+                  :customization-color       :purple
+                  :network-preferences-names #{}
+                  :name                      "account3"}]
+                (rf/sub [sub-name])))))

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -146,6 +146,7 @@
 (reg-root-key-sub :communities/selected-tab :communities/selected-tab)
 (reg-root-key-sub :contract-communities :contract-communities)
 (reg-root-key-sub :communities/selected-permission-addresses :communities/selected-permission-addresses)
+(reg-root-key-sub :communities/airdrop-address :communities/airdrop-address)
 
 ;;activity center
 (reg-root-key-sub :activity-center :activity-center)

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -459,3 +459,25 @@
     (let [{:keys [formatted-balance tokens]} (rf/sub [sub-name])]
       (is (match? 2 (count tokens)))
       (is (match? "$4506.00" formatted-balance)))))
+
+(h/deftest-sub :wallet/accounts-with-customization-color
+  [sub-name]
+  (testing "returns all accounts with customization color"
+    (swap! rf-db/app-db
+      #(-> %
+           (assoc-in [:wallet :accounts] accounts)
+           (assoc-in [:wallet :networks] network-data)))
+    (is
+     (= [(-> accounts
+             (get "0x1")
+             (assoc :customization-color :blue)
+             (assoc :network-preferences-names #{:ethereum :arbitrum :optimism}))
+         (-> accounts
+             (get "0x2")
+             (assoc :customization-color :purple)
+             (assoc :network-preferences-names #{:ethereum :arbitrum :optimism}))
+         (-> accounts
+             (get "0x3")
+             (assoc :customization-color :magenta)
+             (assoc :network-preferences-names #{}))]
+        (rf/sub [sub-name])))))


### PR DESCRIPTION
fixes #18081 

### Test Note
- To test this, change the `community-accounts-selection-enabled?` flag in `src/status_im2/config.cljs` to `true`.

> This feature is currently under a flag not enabled in the development branch, so these changes do not require manual QA.