### PR TITLE
fix: make identifier carousel swipe-able

### DIFF
--- a/src/status_im/contexts/onboarding/identifiers/profile_card/view.cljs
+++ b/src/status_im/contexts/onboarding/identifiers/profile_card/view.cljs
@@ -30,7 +30,7 @@
                                :status-indicator?   false
                                :customization-color customization-color}]]
     [rn/view
-     {:style style/card-view}
+     {:pointer-events :none :style style/card-view}
      [reanimated/view
       {:style (style/card-container container-background)}
       [rn/view {:style style/card-header}

--- a/src/status_im/contexts/onboarding/identifiers/style.cljs
+++ b/src/status_im/contexts/onboarding/identifiers/style.cljs
@@ -15,3 +15,8 @@
   {:justify-self      :flex-end
    :margin-bottom     46
    :margin-horizontal 20})
+
+(defn carousel-background
+  [height width]
+  {:height height
+   :width  width})

--- a/src/status_im/contexts/onboarding/identifiers/view.cljs
+++ b/src/status_im/contexts/onboarding/identifiers/view.cljs
@@ -42,7 +42,7 @@
        {:animate?     true
         :progress     progress
         :paused?      paused?
-        :gesture      :tappable
+        :gesture      :swipeable
         :is-dragging? is-dragging?
         :drag-amount  drag-amount
         :header-text  header-text}]

--- a/src/status_im/contexts/onboarding/identifiers/view.cljs
+++ b/src/status_im/contexts/onboarding/identifiers/view.cljs
@@ -53,7 +53,7 @@
                                                           (* (count header-text) window-width))}]}]
       [rn/view
        {:style          style/content-container
-        :pointer-events :none}
+        :pointer-events :box-none}
        [profile-card/profile-card
         {:profile-picture     photo-path
          :name                display-name

--- a/src/status_im/contexts/onboarding/identifiers/view.cljs
+++ b/src/status_im/contexts/onboarding/identifiers/view.cljs
@@ -26,6 +26,8 @@
         paused?              (atom nil)
         is-dragging?         (atom nil)
         drag-amount          (atom nil)
+        window-width         (rf/sub [:dimensions/window-width])
+        window-height        (rf/sub [:dimensions/window-height])
         {:keys [emoji-hash display-name compressed-key
                 public-key]} (rf/sub [:profile/profile])
         {:keys [color]}      (rf/sub [:onboarding/profile])
@@ -45,8 +47,13 @@
         :gesture      :swipeable
         :is-dragging? is-dragging?
         :drag-amount  drag-amount
-        :header-text  header-text}]
-      [rn/view {:style style/content-container}
+        :header-text  header-text
+        :background   [rn/view
+                       {:style (style/carousel-background window-height
+                                                          (* (count header-text) window-width))}]}]
+      [rn/view
+       {:style          style/content-container
+        :pointer-events :none}
        [profile-card/profile-card
         {:profile-picture     photo-path
          :name                display-name


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/17505

Makes the identifier (during onboarding) carousel swipe-able rather than tappable

status: ready 
