### PR TITLE
fix double @@ in `component-test-watch` and don't do `yarn install` for component tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,9 +386,8 @@ component-test-watch: export COMPONENT_TEST := true
 component-test-watch: export BABEL_ENV := test
 component-test-watch: export JEST_USE_SILENT_REPORTER := false
 component-test-watch: ##@ Watch tests and re-run no changes to cljs files
-	@@scripts/check-metro-shadow-process.sh
+	@scripts/check-metro-shadow-process.sh
 	rm -rf ./component-spec
-	yarn install
 	nodemon --exec 'yarn shadow-cljs compile component-test && jest --config=test/jest/jest.config.js --testEnvironment node ' -e cljs
 
 component-test: export TARGET := clojure
@@ -398,7 +397,6 @@ component-test: export JEST_USE_SILENT_REPORTER := false
 component-test: ##@test Run component tests once in NodeJS
 	@scripts/check-metro-shadow-process.sh
 	rm -rf ./component-spec
-	yarn install
 	yarn shadow-cljs compile component-test && \
 	jest --clearCache && jest --config=test/jest/jest.config.js --testEnvironment node
 


### PR DESCRIPTION
### Summary

This PR contains tiny fixes for the `Makefile`

status: ready
