### PR TITLE
[WIP] Enable account selection feature flag

### DIFF
--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -167,5 +167,5 @@
 
 (def default-kdf-iterations 3200)
 
-(def community-accounts-selection-enabled? (enabled? (get-config :ACCOUNT_SELECTION_ENABLED "0")))
+(def community-accounts-selection-enabled? true)
 (def fetch-messages-enabled? (enabled? (get-config :FETCH_MESSAGES_ENABLED "1")))


### PR DESCRIPTION
This PR's branch will try to keep track of `develop`. It exists for the sole purpose of generating up-to-date builds with the flag `community-accounts-selection-enabled?` enabled  (particularly useful for QAs).

**This WIP PR should be kept open until the project https://github.com/orgs/status-im/projects/100 is stable enough that we can enable the flag by default in `develop`.**