### PR TITLE
[#18495] Fix token not ready for next screen

### DIFF
--- a/src/quo/components/utilities/token/view.cljs
+++ b/src/quo/components/utilities/token/view.cljs
@@ -12,7 +12,7 @@
    [:cat
     [:map {:closed true}
      [:size {:optional true :default 32} [:or keyword? pos-int?]]
-     [:token {:optional true} [:or keyword? string?]]
+     [:token {:optional true} [:maybe keyword? string?]]
      [:style {:optional true} map?]
      ;; Ignores `token` and uses this as parameter to `rn/image`'s source.
      [:image-source {:optional true} [:maybe [:or :schema.common/image-source :string]]]]]

--- a/src/quo/components/utilities/token/view.cljs
+++ b/src/quo/components/utilities/token/view.cljs
@@ -12,7 +12,7 @@
    [:cat
     [:map {:closed true}
      [:size {:optional true :default 32} [:or keyword? pos-int?]]
-     [:token {:optional true} [:maybe keyword? string?]]
+     [:token {:optional true} [:maybe [:or keyword? string?]]]
      [:style {:optional true} map?]
      ;; Ignores `token` and uses this as parameter to `rn/image`'s source.
      [:image-source {:optional true} [:maybe [:or :schema.common/image-source :string]]]]]

--- a/src/quo/components/wallet/token_input/view.cljs
+++ b/src/quo/components/wallet/token_input/view.cljs
@@ -111,33 +111,32 @@
          :value (if controlled-input? value @value-atom)}]])))
 
 (defn- view-internal
-  [{:keys [on-swap]}]
-  (let [width          (:width (rn/get-window))
-        value-atom     (reagent/atom nil)
-        crypto?        (reagent/atom true)
-        handle-on-swap (fn []
-                         (swap! crypto? not)
-                         (when on-swap
-                           (on-swap @crypto?)))]
-    (fn [{:keys [theme container-style value] :as props}]
-      [rn/view {:style (merge (style/main-container width) container-style)}
-       [rn/view {:style style/amount-container}
-        [input-section
-         (assoc props
-                :value-atom value-atom
-                :crypto?    @crypto?)]
-        [button/button
-         {:icon                true
-          :icon-only?          true
-          :size                32
-          :on-press            handle-on-swap
-          :type                :outline
-          :accessibility-label :reorder}
-         :i/reorder]]
-       [divider-line/view {:container-style (style/divider theme)}]
-       [data-info
-        (assoc props
-               :crypto? @crypto?
-               :amount  (or value @value-atom))]])))
+  []
+  (let [width      (:width (rn/get-window))
+        value-atom (reagent/atom nil)
+        crypto?    (reagent/atom true)]
+    (fn [{:keys [theme container-style value on-swap] :as props}]
+      (let [handle-on-swap (fn []
+                             (swap! crypto? not)
+                             (when on-swap (on-swap @crypto?)))]
+        [rn/view {:style (merge (style/main-container width) container-style)}
+         [rn/view {:style style/amount-container}
+          [input-section
+           (assoc props
+                  :value-atom value-atom
+                  :crypto?    @crypto?)]
+          [button/button
+           {:icon                true
+            :icon-only?          true
+            :size                32
+            :on-press            handle-on-swap
+            :type                :outline
+            :accessibility-label :reorder}
+           :i/reorder]]
+         [divider-line/view {:container-style (style/divider theme)}]
+         [data-info
+          (assoc props
+                 :crypto? @crypto?
+                 :amount  (or value @value-atom))]]))))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -74,11 +74,13 @@
 (defn get-standard-crypto-format
   "For full details: https://github.com/status-im/status-mobile/issues/18225"
   [{:keys [market-values-per-currency]} token-units]
-  (let [price          (get-in market-values-per-currency [:usd :price])
-        one-cent-value (if (pos? price) (/ 0.01 price) 0)
-        decimals-count (calc-max-crypto-decimals one-cent-value)]
-    (if (money/equal-to token-units 0)
-      "0"
+  (if (or (nil? token-units)
+          (nil? market-values-per-currency)
+          (money/equal-to token-units 0))
+    "0"
+    (let [price          (-> market-values-per-currency :usd :price)
+          one-cent-value (if (pos? price) (/ 0.01 price) 0)
+          decimals-count (calc-max-crypto-decimals one-cent-value)]
       (if (< token-units one-cent-value)
         (str "<" (remove-trailing-zeroes (.toFixed one-cent-value decimals-count)))
         (remove-trailing-zeroes (.toFixed token-units decimals-count))))))

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -58,7 +58,8 @@
  (fn [{:keys [db]}]
    {:db (update-in db [:wallet :ui :send] dissoc :recipient :to-address)}))
 
-(rf/reg-event-fx :wallet/select-send-address
+(rf/reg-event-fx
+ :wallet/select-send-address
  (fn [{:keys [db]} [{:keys [address token recipient stack-id]}]]
    (let [[prefix to-address] (utils/split-prefix-and-address address)
          prefix-seq          (string/split prefix #":")
@@ -75,7 +76,8 @@
               [:wallet-send-input-amount stack-id]
               [:wallet-select-asset stack-id])]]})))
 
-(rf/reg-event-fx :wallet/update-receiver-networks
+(rf/reg-event-fx
+ :wallet/update-receiver-networks
  (fn [{:keys [db]} [selected-networks]]
    {:db (assoc-in db [:wallet :ui :send :selected-networks] selected-networks)}))
 
@@ -84,11 +86,10 @@
    {:db (-> db
             (update-in [:wallet :ui :send] dissoc :collectible)
             (assoc-in [:wallet :ui :send :token] token))
-    :fx [[:dispatch-later
-          {:ms       1
-           :dispatch [:navigate-to-within-stack [:wallet-send-input-amount stack-id]]}]]}))
+    :fx [[:navigate-to-within-stack [:wallet-send-input-amount stack-id]]]}))
 
-(rf/reg-event-fx :wallet/send-select-token-drawer
+(rf/reg-event-fx
+ :wallet/send-select-token-drawer
  (fn [{:keys [db]} [{:keys [token]}]]
    {:db (assoc-in db [:wallet :ui :send :token] token)}))
 

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -53,8 +53,9 @@
   (h/test "Default render"
     (h/setup-subs sub-mocks)
     (h/render [input-amount/view
-               {:crypto-decimals 2
-                :limit-crypto    250}])
+               {:crypto-decimals          2
+                :limit-crypto             250
+                :initial-crypto-currency? false}])
     (h/is-truthy (h/get-by-text "0"))
     (h/is-truthy (h/get-by-text "ETH"))
     (h/is-truthy (h/get-by-text "$0.00"))
@@ -65,9 +66,10 @@
     (h/setup-subs sub-mocks)
     (let [on-confirm (h/mock-fn)]
       (h/render [input-amount/view
-                 {:on-confirm      on-confirm
-                  :crypto-decimals 10
-                  :limit-crypto    1000}])
+                 {:on-confirm               on-confirm
+                  :crypto-decimals          10
+                  :limit-crypto             1000
+                  :initial-crypto-currency? false}])
 
       (h/fire-event :press (h/query-by-label-text :keyboard-key-1))
       (h/fire-event :press (h/query-by-label-text :keyboard-key-2))
@@ -88,9 +90,10 @@
 
     (let [on-confirm (h/mock-fn)]
       (h/render [input-amount/view
-                 {:crypto-decimals 10
-                  :limit-crypto    1000
-                  :on-confirm      on-confirm}])
+                 {:crypto-decimals          10
+                  :limit-crypto             1000
+                  :on-confirm               on-confirm
+                  :initial-crypto-currency? false}])
 
       (h/fire-event :press (h/query-by-label-text :keyboard-key-1))
       (h/fire-event :press (h/query-by-label-text :keyboard-key-2))

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -60,15 +60,18 @@
     (> new-value prev-value)))
 
 (defn- f-view-internal
-  ;; crypto-decimals and limit-crypto args are needed for component tests only
-  [{default-on-confirm      :on-confirm
-    default-limit-crypto    :limit-crypto
-    default-crypto-decimals :crypto-decimals}]
+  ;; crypto-decimals, limit-crypto and initial-crypto-currency? args are needed
+  ;; for component tests only
+  [{default-on-confirm       :on-confirm
+    default-limit-crypto     :limit-crypto
+    default-crypto-decimals  :crypto-decimals
+    initial-crypto-currency? :initial-crypto-currency?
+    :or                      {initial-crypto-currency? true}}]
   (let [_ (rn/dismiss-keyboard!)
         bottom                (safe-area/get-bottom)
         input-value           (reagent/atom "")
         input-error           (reagent/atom false)
-        crypto-currency?      (reagent/atom true)
+        crypto-currency?      (reagent/atom initial-crypto-currency?)
         handle-swap           (fn [{:keys [crypto? limit-fiat limit-crypto]}]
                                 (let [num-value     (parse-double @input-value)
                                       current-limit (if crypto? limit-crypto limit-fiat)]

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -17,22 +17,21 @@
    {:id :tab/collectibles :label (i18n/label :t/collectibles) :accessibility-label :collectibles-tab}])
 
 (defn- asset-component
-  []
-  (fn [token _ _ {:keys [currency currency-symbol]}]
-    (let [on-press         #(rf/dispatch [:wallet/send-select-token
-                                          {:token    token
-                                           :stack-id :wallet-select-asset}])
-          token-units      (utils/total-token-units-in-all-chains token)
-          crypto-formatted (utils/get-standard-crypto-format token token-units)
-          fiat-value       (utils/total-token-fiat-value currency token)
-          fiat-formatted   (utils/get-standard-fiat-format crypto-formatted currency-symbol fiat-value)]
-      [quo/token-network
-       {:token       (:symbol token)
-        :label       (:name token)
-        :token-value (str crypto-formatted " " (:symbol token))
-        :fiat-value  fiat-formatted
-        :networks    (:networks token)
-        :on-press    on-press}])))
+  [token _ _ {:keys [currency currency-symbol]}]
+  (let [on-press         #(rf/dispatch [:wallet/send-select-token
+                                        {:token    token
+                                         :stack-id :wallet-select-asset}])
+        token-units      (utils/total-token-units-in-all-chains token)
+        crypto-formatted (utils/get-standard-crypto-format token token-units)
+        fiat-value       (utils/total-token-fiat-value currency token)
+        fiat-formatted   (utils/get-standard-fiat-format crypto-formatted currency-symbol fiat-value)]
+    [quo/token-network
+     {:token       (:symbol token)
+      :label       (:name token)
+      :token-value (str crypto-formatted " " (:symbol token))
+      :fiat-value  fiat-formatted
+      :networks    (:networks token)
+      :on-press    on-press}]))
 
 (defn- asset-list
   [search-text]


### PR DESCRIPTION
fixes #18495
fixes #18524
fixes #18493

Update:
 fixes #18469

### Summary

This PR fixes the exception thrown whilke picking an asset to send in this screen:
![image](https://github.com/status-im/status-mobile/assets/90291778/3dc724ae-6ee9-4e48-9bff-8287ab086b34)

And after that, we needed to pick twice the same token in order to actually send it, now it works fine.


### Review notes
The behavior happened because re-frame didn't had the db changes ready before navigating, IDK why this is happening.

### Steps to test

- Open Status
- Add an address owning assets
- Select the added account, click on the send button, pick another adddress to send, pick an asset

The behavior is now fixed. 


status: ready
