### PR TITLE
Remove the invocation of wakuext_chatMentionReplaceWithPublicKey

### DIFF
--- a/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
@@ -30,7 +30,7 @@
   (js/setTimeout #(reanimated/set-shared-value background-y
                                                (- window-height))
                  300)
-  (rf/dispatch [:chat.ui/replace-mentions-and-send-current-message])
+  (rf/dispatch [:chat.ui/send-current-message])
   (rf/dispatch [:chat.ui/set-input-maximized false])
   (rf/dispatch [:chat.ui/set-input-content-height comp-constants/input-height])
   (rf/dispatch [:chat.ui/set-chat-input-text nil])

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.172.2",
-    "commit-sha1": "5cb1972261de90fee1469ae60ffb7f25900a9850",
-    "src-sha256": "1z37yinlxwpzprd10h2f4vzs5k2a1k85ks9lvl067lb4rqflcwny"
+    "version": "v0.172.5",
+    "commit-sha1": "ea3e59ffeefa623373b4a39ecf7fa5558e384ad0",
+    "src-sha256": "11rds4i2ylngaddiz5f4g0r0rzwplcbkg5c4wvwzzxl49gza50j3"
 }


### PR DESCRIPTION
#### Description
RT.
Relate status-go [PR](https://github.com/status-im/status-go/pull/4579)

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
chat message with mention should be reolved correctly as before.

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- UserA Login Status
- Invite UserB to join community
- After UserB join community, send a message with mention in community channel, e.g. "hello @UserB"
- Check the message rendering on both side, we should expect: the mention in the message should be recognized correctly with highlight as before


status: ready <!-- Can be ready or wip -->
