### PR TITLE
fix: crash when selecting a collectible

### DIFF
--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -18,7 +18,7 @@
        :assets       [assets/view]
        :collectibles [collectibles/view
                       {:collectibles         collectible-list
-                       :on-collectible-press (fn [id]
+                       :on-collectible-press (fn [{:keys [id]}]
                                                (rf/dispatch [:wallet/get-collectible-details id])
                                                (rf/dispatch [:navigate-to :wallet-collectible]))}]
        :activity     [activity/view]

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -33,6 +33,7 @@
         :render-fn               (fn [{:keys [preview-url] :as collectible}]
                                    [quo/collectible
                                     {:images   [preview-url]
-                                     :on-press #(on-collectible-press collectible)}])}])))
+                                     :on-press #(when on-collectible-press
+                                                  (on-collectible-press collectible))}])}])))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/home/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/view.cljs
@@ -15,7 +15,7 @@
        :assets       [assets/view]
        :collectibles [collectibles/view
                       {:collectibles         collectible-list
-                       :on-collectible-press (fn [id]
+                       :on-collectible-press (fn [{:keys [id]}]
                                                (rf/dispatch [:wallet/get-collectible-details id])
                                                (rf/dispatch [:navigate-to :wallet-collectible]))}]
        [activity/view])]))


### PR DESCRIPTION
Fixes crash when selecting a collectible from the accounts tab or home tab

Steps to test:
- Log in to an account with collectibles
- Go to wallet
- Tap on a collectible
- Verify it doesnt crash 

status: ready