### PR TITLE
fix: remove quo preview from nightly builds

### DIFF
--- a/src/quo/components/settings/category/settings/view.cljs
+++ b/src/quo/components/settings/category/settings/view.cljs
@@ -8,19 +8,20 @@
 
 (defn- category-internal
   [{:keys [label data container-style] :as props}]
-  [rn/view {:style (merge (style/container label) container-style)}
-   (when label
-     [text/text
-      {:weight :medium
-       :size   :paragraph-2
-       :style  (style/label props)}
-      label])
-   [rn/view {:style (style/settings-items props)}
-    (for [item data]
-      ^{:key item}
-      [:<>
-       [settings-item/view item]
-       (when-not (= item (last data))
-         [rn/view {:style (style/settings-separator props)}])])]])
+  (let [settings-item (filter identity data)]
+    [rn/view {:style (merge (style/container label) container-style)}
+     (when label
+       [text/text
+        {:weight :medium
+         :size   :paragraph-2
+         :style  (style/label props)}
+        label])
+     [rn/view {:style (style/settings-items props)}
+      (for [item settings-item]
+        ^{:key item}
+        [:<>
+         [settings-item/view item]
+         (when-not (= item (last settings-item))
+           [rn/view {:style (style/settings-separator props)}])])]]))
 
 (def settings-category (quo.theme/with-theme category-internal))

--- a/src/status_im/contexts/profile/settings/list_items.cljs
+++ b/src/status_im/contexts/profile/settings/list_items.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.profile.settings.list-items
   (:require [status-im.common.not-implemented :as not-implemented]
+            [status-im.config :as config]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
@@ -89,12 +90,13 @@
      :image       :icon
      :blur?       true
      :image-props :i/toggle}
-    {:title       "Quo preview"
-     :on-press    #(rf/dispatch [:navigate-to :quo-preview])
-     :action      :arrow
-     :image       :icon
-     :blur?       true
-     :image-props :i/light}]
+    (when config/quo-preview-enabled?
+      {:title       "Quo preview"
+       :on-press    #(rf/dispatch [:navigate-to :quo-preview])
+       :action      :arrow
+       :image       :icon
+       :blur?       true
+       :image-props :i/light})]
    [{:title    (i18n/label :t/about)
      :on-press not-implemented/alert
      :action   :arrow}


### PR DESCRIPTION
remove quo preview from nightly builds

status: ready
