### PR TITLE
chore: bump go to 1.20 and update patches

### DIFF
--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -795,7 +795,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "StatusImTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 5.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StatusIm.app/StatusIm";
 			};
 			name = Debug;
@@ -828,7 +828,7 @@
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "StatusImTests-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 5.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StatusIm.app/StatusIm";
 			};
 			name = Release;
@@ -899,14 +899,15 @@
 					"$(inherited)",
 					"-lc++",
 					"-ObjC",
+					"-lresolv",
 				);
-				PRESERVE_DEAD_CODE_INITS_AND_TERMS = YES;
+				DEAD_CODE_STRIPPING = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = im.status.ethereum;
 				PRODUCT_NAME = StatusIm;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "StatusIm-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 5.2;
 				TARGETED_DEVICE_FAMILY = 1;
 				VALID_ARCHS = "x86_64 arm64";
 				"VALID_ARCHS[sdk=iphonesimulator*]" = "x86_64 ";
@@ -973,14 +974,15 @@
 					"$(inherited)",
 					"-lc++",
 					"-ObjC",
+					"-lresolv",
 				);
-				PRESERVE_DEAD_CODE_INITS_AND_TERMS = YES;
+				DEAD_CODE_STRIPPING = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = im.status.ethereum;
 				PRODUCT_NAME = StatusIm;
 				PROVISIONING_PROFILE = "e2202b12-7a66-4ff7-af3c-a52e35f32dc1";
 				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc im.status.ethereum";
 				SWIFT_OBJC_BRIDGING_HEADER = "StatusIm-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 5.2;
 				TARGETED_DEVICE_FAMILY = 1;
 				VALID_ARCHS = arm64;
 			};
@@ -1051,13 +1053,14 @@
 					"$(inherited)",
 					"-lc++",
 					"-ObjC",
+					"-lresolv",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = im.status.ethereum.pr;
 				PRODUCT_NAME = "Status PR";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development im.status.ethereum.pr";
 				SWIFT_OBJC_BRIDGING_HEADER = "StatusIm-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 5.2;
 				TARGETED_DEVICE_FAMILY = 1;
 				VALID_ARCHS = arm64;
 			};
@@ -1122,12 +1125,13 @@
 					"$(inherited)",
 					"-lc++",
 					"-ObjC",
+					"-lresolv",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = im.status.ethereum.pr;
 				PRODUCT_NAME = "Status PR";
 				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc im.status.ethereum.pr";
 				SWIFT_OBJC_BRIDGING_HEADER = "StatusIm-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 5.2;
 				TARGETED_DEVICE_FAMILY = 1;
 				VALID_ARCHS = arm64;
 			};
@@ -1216,7 +1220,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				PRESERVE_DEAD_CODE_INITS_AND_TERMS = YES;
+				DEAD_CODE_STRIPPING = YES;
 				SDKROOT = iphoneos;
 				VALID_ARCHS = arm64;
 				"VALID_ARCHS[sdk=iphonesimulator*]" = x86_64;
@@ -1297,7 +1301,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				PRESERVE_DEAD_CODE_INITS_AND_TERMS = YES;
+				DEAD_CODE_STRIPPING = YES;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = arm64;

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -72,15 +72,21 @@ in {
     version = "15.0";
     allowHigher = true;
   };
-  go = super.go_1_19;
+  go = super.go_1_20;
   clang = super.clang_15;
-  buildGoPackage = super.buildGo119Package;
-  buildGoModule = super.buildGo119Module;
+  buildGoPackage = super.buildGo120Package;
+  buildGoModule = super.buildGo120Module;
   gomobile = (super.gomobile.overrideAttrs (old: {
-    patches = self.fetchurl { # https://github.com/golang/mobile/pull/84
-      url = "https://github.com/golang/mobile/commit/f20e966e05b8f7e06bed500fa0da81cf6ebca307.patch";
-      sha256 = "sha256-TZ/Yhe8gMRQUZFAs9G5/cf2b9QGtTHRSObBFD5Pbh7Y=";
-    };
+    patches = [
+      (self.fetchurl { # https://github.com/golang/mobile/pull/84
+        url = "https://github.com/golang/mobile/commit/f20e966e05b8f7e06bed500fa0da81cf6ebca307.patch";
+        sha256 = "sha256-TZ/Yhe8gMRQUZFAs9G5/cf2b9QGtTHRSObBFD5Pbh7Y=";
+      })
+      (self.fetchurl { # https://github.com/golang/go/issues/58426
+        url = "https://github.com/golang/mobile/commit/406ed3a7b8e44dc32844953647b49696d8847d51.patch";
+        sha256 = "sha256-dqbYukHkQEw8npOkKykOAzMC3ot/Y4DEuh7fE+ptlr8=";
+      })
+    ];
   })).override {
     # FIXME: No Android SDK packages for aarch64-darwin.
     withAndroidPkgs = stdenv.system != "aarch64-darwin";

--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -47,7 +47,7 @@ in buildGoPackage {
       -ldflags="$ldflags" \
       -target=${concatStringsSep "," targets} \
       ${optionalString isAndroid "-androidapi=${platformVersion}" } \
-      ${optionalString isIOS "-iosversion=${platformVersion}" } \
+      ${optionalString isIOS "-iosversion=${platformVersion} -tags=netgo" } \
      -tags='${optionalString isIOS "nowatchdog"} gowaku_skip_migrations gowaku_no_rln' \
       -o ${outputFileName} \
       ${source.goPackagePath}/mobile

--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -47,8 +47,8 @@ in buildGoPackage {
       -ldflags="$ldflags" \
       -target=${concatStringsSep "," targets} \
       ${optionalString isAndroid "-androidapi=${platformVersion}" } \
-      ${optionalString isIOS "-iosversion=${platformVersion} -tags=netgo" } \
-     -tags='${optionalString isIOS "nowatchdog"} gowaku_skip_migrations gowaku_no_rln' \
+      ${optionalString isIOS "-iosversion=${platformVersion}" } \
+     -tags='${optionalString isIOS "nowatchdog"} gowaku_skip_migrations gowaku_no_rln netgo' \
       -o ${outputFileName} \
       ${source.goPackagePath}/mobile
 

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.172.8",
-    "commit-sha1": "436d22985661322ffda4eb44c1a160e6804f3823",
-    "src-sha256": "1y3l469k2085qaml7dmaky1rlanl4phq2p6yyk97074yw839jzj1"
+    "version": "bump-go-waku-and-golang",
+    "commit-sha1": "0c79a2209268edbedee8cda78902727b38b52c8e",
+    "src-sha256": "1nc0x4fl7ka63ig1c95pfs017flmw7iffb13q7vz1p03cibq7cff"
 }


### PR DESCRIPTION
## Summary

This PR 

- upgrades `golang` version to `1.20`  
- updates `gomobile` to a newer commit 
- adds one more patch for `gomobile` to build because of this issue : https://github.com/golang/go/issues/58426
- updates `SWIFT_VERSION` flag for `project.pbxproj` to `5.2`
- removed deprecated `PRESERVE_DEAD_CODE_INITS_AND_TERMS` flag from `project.pbxproj`
- points to `golang` bump, `gowaku` upgrade and `libp2p` upgrade done in status-go here -> https://github.com/status-im/status-go/pull/4601


## Testing Notes
Please test everything since `golang` has been upgraded on `status-go` side.
`go-waku` and `libp2p` has also been upgraded on `status-go` side.

status: ready
