### PR TITLE
fix: do not show community view until it's loaded

### DIFF
--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -370,9 +370,10 @@
   (let [{:keys [id joined]
          :as   community} (rf/sub [:communities/community id])
         pending?          (rf/sub [:communities/my-pending-request-to-join id])]
-    (when joined
-      (rf/dispatch [:activity-center.notifications/dismiss-community-overview id]))
-    [community-scroll-page community pending?]))
+    (when community
+      (when joined
+        (rf/dispatch [:activity-center.notifications/dismiss-community-overview id]))
+      [community-scroll-page community pending?])))
 
 (defn overview
   [id]


### PR DESCRIPTION
-------
related to #17770
community overview loading is not implemented yet
design is not ready yet
this PR just hide the weird screen until community is loaded

before

https://github.com/status-im/status-mobile/assets/15090582/25ed28b9-8f11-407a-8e20-69f9261f4093

after


https://github.com/status-im/status-mobile/assets/15090582/13d22901-033d-4bf3-a90b-6c7d4d4bc038


before

![CleanShot 2024-01-19 at 10 42 24@2x](https://github.com/status-im/status-mobile/assets/15090582/f67185bc-a7a5-425c-a445-adf6d0144fc6)

after

![CleanShot 2024-01-19 at 10 40 32@2x](https://github.com/status-im/status-mobile/assets/15090582/1612527b-a3ac-4d47-a1d9-364bc8e7589e)


status: ready <!-- Can be ready or wip -->