### PR TITLE
refactor: move perm/airdrop addrs into community

### DIFF
--- a/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
@@ -23,11 +23,8 @@
   []
   (let [{id :community-id}          (rf/sub [:get-screen-params])
         {:keys [name color images]} (rf/sub [:communities/community id])
-        airdrop-account             (rf/sub [:communities/airdrop-account])
-        selected-accounts           (rf/sub [:communities/selected-permission-accounts])]
-    (rn/use-effect (fn []
-                     (rf/dispatch [:communities/initialize-permission-addresses]))
-                   [])
+        airdrop-account             (rf/sub [:communities/airdrop-account id])
+        selected-accounts           (rf/sub [:communities/selected-permission-accounts id])]
     [rn/view {:style style/container}
      [quo/page-nav
       {:text-align          :left

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -8,7 +8,7 @@
             [utils.re-frame :as rf]))
 
 (defn- account-item
-  [item _ _ selected-addresses]
+  [item _ _ [selected-addresses community-id]]
   [quo/account-permissions
    {:account         {:name                (:name item)
                       :address             (:address item)
@@ -17,7 +17,7 @@
     :token-details   []
     :checked?        (contains? selected-addresses (:address item))
     :on-change       #(rf/dispatch [:communities/toggle-selected-permission-address
-                                    (:address item)])
+                                    (:address item) community-id])
     :container-style {:margin-bottom 8}}])
 
 (defn view
@@ -25,7 +25,7 @@
   (let [{id :community-id}          (rf/sub [:get-screen-params])
         {:keys [name color images]} (rf/sub [:communities/community id])
         accounts                    (rf/sub [:wallet/accounts-with-customization-color])
-        selected-addresses          (rf/sub [:communities/selected-permission-addresses])]
+        selected-addresses          (rf/sub [:communities/selected-permission-addresses id])]
     [rn/safe-area-view {:style style/container}
      [quo/drawer-top
       {:type                :context-tag
@@ -38,7 +38,7 @@
 
      [rn/flat-list
       {:render-fn               account-item
-       :render-data             selected-addresses
+       :render-data             [selected-addresses id]
        :content-container-style {:padding 20}
        :key-fn                  :address
        :data                    accounts}]
@@ -60,7 +60,7 @@
        {:type            :grey
         :container-style {:flex 1}
         :on-press        (fn []
-                           (rf/dispatch [:communities/reset-selected-permission-addresses])
+                           (rf/dispatch [:communities/reset-selected-permission-addresses id])
                            (rf/dispatch [:navigate-back]))}
        (i18n/label :t/cancel)]
       [quo/button
@@ -68,6 +68,6 @@
         :customization-color color
         :disabled?           (empty? selected-addresses)
         :on-press            (fn []
-                               (rf/dispatch [:communities/update-previous-permission-addresses])
+                               (rf/dispatch [:communities/update-previous-permission-addresses id])
                                (rf/dispatch [:navigate-back]))}
        (i18n/label :t/confirm-changes)]]]))

--- a/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
+++ b/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
@@ -8,12 +8,12 @@
     [utils.re-frame :as rf]))
 
 (defn- render-item
-  [item _ _ airdrop-address]
+  [item _ _ [airdrop-address community-id]]
   [quo/account-item
    {:account-props item
     :state         (when (= airdrop-address (:address item)) :selected)
     :on-press      (fn []
-                     (rf/dispatch [:communities/set-airdrop-address (:address item)])
+                     (rf/dispatch [:communities/set-airdrop-address (:address item) community-id])
                      (rf/dispatch [:navigate-back]))
     :emoji         (:emoji item)}])
 
@@ -21,8 +21,8 @@
   []
   (let [{id :community-id}          (rf/sub [:get-screen-params])
         {:keys [name images color]} (rf/sub [:communities/community id])
-        selected-accounts           (rf/sub [:communities/selected-permission-accounts])
-        airdrop-address             (rf/sub [:communities/airdrop-address])]
+        selected-accounts           (rf/sub [:communities/selected-permission-accounts id])
+        airdrop-address             (rf/sub [:communities/airdrop-address id])]
     [:<>
      [quo/drawer-top
       {:type                :context-tag
@@ -35,6 +35,6 @@
      [rn/flat-list
       {:data                    selected-accounts
        :render-fn               render-item
-       :render-data             airdrop-address
+       :render-data             [airdrop-address id]
        :content-container-style style/account-list-container
        :key-fn                  :address}]]))

--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -5,23 +5,27 @@
             [status-im.contexts.chat.messenger.messages.link-preview.events :as link-preview.events]
             [status-im.contexts.communities.events :as events]))
 
+(def community-id "community-id")
+
 (deftest initialize-permission-addresses-test
   (let [initial-db  {:db {:wallet {:accounts {"0x1" {:address  "0x1"
                                                      :position 0}
                                               "0x2" {:address  "0x2"
                                                      :position 1}}}}}
-        expected-db {:db (assoc (:db initial-db)
-                                :communities/previous-permission-addresses #{"0x1" "0x2"}
-                                :communities/selected-permission-addresses #{"0x1" "0x2"}
-                                :communities/airdrop-address               "0x1")}]
-    (is (match? expected-db (events/initialize-permission-addresses initial-db)))))
+        expected-db {:db (update-in (:db initial-db)
+                                    [:communities community-id]
+                                    assoc
+                                    :previous-permission-addresses #{"0x1" "0x2"}
+                                    :selected-permission-addresses #{"0x1" "0x2"}
+                                    :airdrop-address               "0x1")}]
+    (is (match? expected-db (events/initialize-permission-addresses initial-db [community-id])))))
 
 (deftest toggle-selected-permission-address-test
-  (let [initial-db {:db {:communities/selected-permission-addresses #{"0x1" "0x2"}}}]
-    (is (match? {:db {:communities/selected-permission-addresses #{"0x1"}}}
-                (events/toggle-selected-permission-address initial-db ["0x2"])))
-    (is (match? {:db {:communities/selected-permission-addresses #{"0x1" "0x2" "0x3"}}}
-                (events/toggle-selected-permission-address initial-db ["0x3"])))))
+  (let [initial-db {:db {:communities {community-id {:selected-permission-addresses #{"0x1" "0x2"}}}}}]
+    (is (match? {:db {:communities {community-id {:selected-permission-addresses #{"0x1"}}}}}
+                (events/toggle-selected-permission-address initial-db ["0x2" community-id])))
+    (is (match? {:db {:communities {community-id {:selected-permission-addresses #{"0x1" "0x2" "0x3"}}}}}
+                (events/toggle-selected-permission-address initial-db ["0x3" community-id])))))
 
 (deftest update-previous-permission-addresses-test
   (let [wallet {:accounts {"0x1" {:address  "0x1"
@@ -30,42 +34,45 @@
                                   :position 1}
                            "0x3" {:address  "0x3"
                                   :position 2}}}]
-    (let [initial-db  {:db {:wallet                                    wallet
-                            :communities/previous-permission-addresses #{"0x1" "0x2"}
-                            :communities/selected-permission-addresses #{"0x1" "0x2" "0x3"}
-                            :communities/airdrop-address               "0x1"}}
-          expected-db {:db {:wallet                                    wallet
-                            :communities/previous-permission-addresses #{"0x1" "0x2" "0x3"}
-                            :communities/selected-permission-addresses #{"0x1" "0x2" "0x3"}
-                            :communities/airdrop-address               "0x1"}}]
+    (let [initial-db  {:db {:wallet      wallet
+                            :communities {community-id {:previous-permission-addresses #{"0x1" "0x2"}
+                                                        :selected-permission-addresses #{"0x1" "0x2"
+                                                                                         "0x3"}
+                                                        :airdrop-address               "0x1"}}}}
+          expected-db {:db {:wallet      wallet
+                            :communities {community-id {:previous-permission-addresses #{"0x1" "0x2"
+                                                                                         "0x3"}
+                                                        :selected-permission-addresses #{"0x1" "0x2"
+                                                                                         "0x3"}
+                                                        :airdrop-address               "0x1"}}}}]
       (is
        (match? expected-db
-               (events/update-previous-permission-addresses initial-db))))
-    (let [initial-db  {:db {:wallet                                    wallet
-                            :communities/previous-permission-addresses #{"0x1" "0x2"}
-                            :communities/selected-permission-addresses #{"0x2" "0x3"}
-                            :communities/airdrop-address               "0x1"}}
-          expected-db {:db {:wallet                                    wallet
-                            :communities/previous-permission-addresses #{"0x2" "0x3"}
-                            :communities/selected-permission-addresses #{"0x2" "0x3"}
-                            :communities/airdrop-address               "0x2"}}]
+               (events/update-previous-permission-addresses initial-db [community-id]))))
+    (let [initial-db  {:db {:wallet      wallet
+                            :communities {community-id {:previous-permission-addresses #{"0x1" "0x2"}
+                                                        :selected-permission-addresses #{"0x2" "0x3"}
+                                                        :airdrop-address               "0x1"}}}}
+          expected-db {:db {:wallet      wallet
+                            :communities {community-id {:previous-permission-addresses #{"0x2" "0x3"}
+                                                        :selected-permission-addresses #{"0x2" "0x3"}
+                                                        :airdrop-address               "0x2"}}}}]
       (is
        (match? expected-db
-               (events/update-previous-permission-addresses initial-db))))))
+               (events/update-previous-permission-addresses initial-db [community-id]))))))
 
 (deftest fetch-community
   (testing "with community id"
     (testing "update fetching indicator in db"
       (is (match?
-           {:db {:communities/fetching-community {"community-id" true}}}
-           (events/fetch-community {} ["community-id"]))))
+           {:db {:communities/fetching-community {community-id true}}}
+           (events/fetch-community {} [community-id]))))
     (testing "call the fetch community rpc method with correct community id"
       (is (match?
            {:json-rpc/call [{:method "wakuext_fetchCommunity"
-                             :params [{:CommunityKey    "community-id"
+                             :params [{:CommunityKey    community-id
                                        :TryDatabase     true
                                        :WaitForResponse true}]}]}
-           (events/fetch-community {} ["community-id"])))))
+           (events/fetch-community {} [community-id])))))
   (testing "with no community id"
     (testing "do nothing"
       (is (match?
@@ -78,104 +85,104 @@
       (is (match?
            nil
            (get-in (events/community-failed-to-fetch {:db {:communities/fetching-community
-                                                           {"community-id" true}}}
-                                                     ["community-id"])
-                   [:db :communities/fetching-community "community-id"]))))))
+                                                           {community-id true}}}
+                                                     [community-id])
+                   [:db :communities/fetching-community community-id]))))))
 
 (deftest community-fetched
   (with-redefs [link-preview.events/community-link (fn [id] (str "community-link+" id))]
     (testing "given a community"
-      (let [cofx {:db {:communities/fetching-community {"community-id" true}}}
-            arg  ["community-id" {:id "community-id"}]]
+      (let [cofx {:db {:communities/fetching-community {community-id true}}}
+            arg  [community-id {:id community-id}]]
         (testing "remove community id from fetching indicator in db"
           (is (match?
                nil
                (get-in (events/community-fetched cofx arg)
-                       [:db :communities/fetching-community "community-id"]))))
+                       [:db :communities/fetching-community community-id]))))
         (testing "dispatch fxs"
           (is (match?
-               {:fx [[:dispatch [:communities/handle-community {:id "community-id"}]]
+               {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
-                       {:id "community-id"}]]]}
+                       {:id community-id}]]]}
                (events/community-fetched cofx arg))))))
     (testing "given a joined community"
-      (let [cofx {:db {:communities/fetching-community {"community-id" true}}}
-            arg  ["community-id" {:id "community-id" :joined true}]]
+      (let [cofx {:db {:communities/fetching-community {community-id true}}}
+            arg  [community-id {:id community-id :joined true}]]
         (testing "dispatch fxs, do not spectate community"
           (is (match?
-               {:fx [[:dispatch [:communities/handle-community {:id "community-id"}]]
+               {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
-                       {:id "community-id"}]]]}
+                       {:id community-id}]]]}
                (events/community-fetched cofx arg))))))
     (testing "given a token-gated community"
-      (let [cofx {:db {:communities/fetching-community {"community-id" true}}}
-            arg  ["community-id" {:id "community-id" :tokenPermissions [1]}]]
+      (let [cofx {:db {:communities/fetching-community {community-id true}}}
+            arg  [community-id {:id community-id :tokenPermissions [1]}]]
         (testing "dispatch fxs, do not spectate community"
           (is (match?
-               {:fx [[:dispatch [:communities/handle-community {:id "community-id"}]]
+               {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
-                       {:id "community-id"}]]]}
+                       {:id community-id}]]]}
                (events/community-fetched cofx arg))))))
     (testing "given nil community"
       (testing "do nothing"
         (is (match?
              nil
-             (events/community-fetched {} ["community-id" nil])))))))
+             (events/community-fetched {} [community-id nil])))))))
 
 (deftest spectate-community
   (testing "given a joined community"
     (testing "do nothing"
       (is (match?
            nil
-           (events/spectate-community {:db {:communities {"community-id" {:joined true}}}}
-                                      ["community-id"])))))
+           (events/spectate-community {:db {:communities {community-id {:joined true}}}}
+                                      [community-id])))))
   (testing "given a spectated community"
     (testing "do nothing"
       (is (match?
            nil
-           (events/spectate-community {:db {:communities {"community-id" {:spectated true}}}}
-                                      ["community-id"])))))
+           (events/spectate-community {:db {:communities {community-id {:spectated true}}}}
+                                      [community-id])))))
   (testing "given a spectating community"
     (testing "do nothing"
       (is (match?
            nil
-           (events/spectate-community {:db {:communities {"community-id" {:spectating true}}}}
-                                      ["community-id"])))))
+           (events/spectate-community {:db {:communities {community-id {:spectating true}}}}
+                                      [community-id])))))
   (testing "given a community"
     (testing "mark community spectating"
       (is (match?
-           {:db {:communities {"community-id" {:spectating true}}}}
-           (events/spectate-community {:db {:communities {"community-id" {}}}} ["community-id"]))))
+           {:db {:communities {community-id {:spectating true}}}}
+           (events/spectate-community {:db {:communities {community-id {}}}} [community-id]))))
     (testing "call spectate community rpc with correct community id"
       (is (match?
            {:json-rpc/call [{:method "wakuext_spectateCommunity"
-                             :params ["community-id"]}]}
-           (events/spectate-community {:db {:communities {"community-id" {}}}} ["community-id"]))))))
+                             :params [community-id]}]}
+           (events/spectate-community {:db {:communities {community-id {}}}} [community-id]))))))
 
 (deftest spectate-community-failed
   (testing "mark community spectating false"
     (is (match?
-         {:db {:communities {"community-id" {:spectating false}}}}
-         (events/spectate-community-failed {} ["community-id"])))))
+         {:db {:communities {community-id {:spectating false}}}}
+         (events/spectate-community-failed {} [community-id])))))
 
 (deftest spectate-community-success
   (testing "given communities"
     (testing "mark first community spectating false"
       (is (match?
-           {:db {:communities {"community-id" {:spectating false}}}}
-           (events/spectate-community-success {} [{:communities [{:id "community-id"}]}]))))
+           {:db {:communities {community-id {:spectating false}}}}
+           (events/spectate-community-success {} [{:communities [{:id community-id}]}]))))
     (testing "mark first community spectated true"
       (is (match?
-           {:db {:communities {"community-id" {:spectated true}}}}
-           (events/spectate-community-success {} [{:communities [{:id "community-id"}]}]))))
+           {:db {:communities {community-id {:spectated true}}}}
+           (events/spectate-community-success {} [{:communities [{:id community-id}]}]))))
     (testing "dispatch fxs for first community"
       (is (match?
-           {:fx [[:dispatch [:communities/handle-community {:id "community-id"}]]
+           {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
                  [:dispatch [::mailserver/request-messages]]]}
-           (events/spectate-community-success {} [{:communities [{:id "community-id"}]}])))))
+           (events/spectate-community-success {} [{:communities [{:id community-id}]}])))))
   (testing "given empty community"
     (testing "do nothing"
       (is (match?

--- a/src/status_im/contexts/communities/overview/events.cljs
+++ b/src/status_im/contexts/communities/overview/events.cljs
@@ -144,13 +144,12 @@
 
 (defn request-to-join-with-signatures-and-addresses
   [{:keys [db]} [community-id signatures]]
-  (let [airdrop-address     (get-in db [:communities/airdrop-address])
-        addresses-to-reveal (get-in db [:communities/selected-permission-addresses])]
+  (let [{:keys [airdrop-address selected-permission-addresses]} (get-in db [:communities community-id])]
     {:fx [[:json-rpc/call
            [{:method      "wakuext_requestToJoinCommunity"
              :params      [{:communityId       community-id
                             :signatures        signatures
-                            :addressesToReveal addresses-to-reveal
+                            :addressesToReveal selected-permission-addresses
                             :airdropAddress    airdrop-address}]
              :js-response true
              :on-success  [:communities/requested-to-join]
@@ -173,7 +172,7 @@
   [{:keys [db]}
    [{:keys [community-id password]}]]
   (let [pub-key             (get-in db [:profile/profile :public-key])
-        addresses-to-reveal (get-in db [:communities/selected-permission-addresses])]
+        addresses-to-reveal (get-in db [:communities community-id :selected-permission-addresses])]
     {:fx [[:json-rpc/call
            [{:method     "wakuext_generateJoiningCommunityRequestsForSigning"
              :params     [pub-key community-id addresses-to-reveal]

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -337,15 +337,31 @@
    (get-in communities [community-id :intro-message])))
 
 (re-frame/reg-sub
- :communities/airdrop-account
- :<- [:communities/airdrop-address]
- :<- [:wallet/accounts-with-customization-color]
- (fn [[airdrop-address accounts]]
-   (first (filter #(= (:address %) airdrop-address) accounts))))
+ :communities/selected-permission-addresses
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:communities/community community-id])])
+ (fn [[{:keys [selected-permission-addresses]}] _]
+   selected-permission-addresses))
 
 (re-frame/reg-sub
  :communities/selected-permission-accounts
- :<- [:communities/selected-permission-addresses]
- :<- [:wallet/accounts-with-customization-color]
- (fn [[selected-permission-addresses accounts]]
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:wallet/accounts-with-customization-color])
+    (re-frame/subscribe [:communities/selected-permission-addresses community-id])])
+ (fn [[accounts selected-permission-addresses]]
    (filter #(contains? selected-permission-addresses (:address %)) accounts)))
+
+(re-frame/reg-sub
+ :communities/airdrop-address
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:communities/community community-id])])
+ (fn [[{:keys [airdrop-address]}] _]
+   airdrop-address))
+
+(re-frame/reg-sub
+ :communities/airdrop-account
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:wallet/accounts-with-customization-color])
+    (re-frame/subscribe [:communities/airdrop-address community-id])])
+ (fn [[accounts airdrop-address]]
+   (first (filter #(= (:address %) airdrop-address) accounts))))

--- a/src/status_im/subs/communities_test.cljs
+++ b/src/status_im/subs/communities_test.cljs
@@ -463,37 +463,33 @@
 (h/deftest-sub :communities/airdrop-account
   [sub-name]
   (testing "returns airdrop account"
+    (swap! rf-db/app-db assoc-in [:communities community-id :airdrop-address] "0x1")
     (swap! rf-db/app-db assoc
-      :communities/airdrop-address
-      "0x1"
-      :wallet {:accounts {"0x1" {:address "0x1"
-                                 :color   :blue
-                                 :name    "account1"}
-                          "0x2" {:address "0x2"
-                                 :color   :orange
-                                 :name    "account2"}}})
+      :wallet
+      {:accounts {"0x1" {:address "0x1"
+                         :color   :blue
+                         :name    "account1"}
+                  "0x2" {:address "0x2"
+                         :color   :orange
+                         :name    "account2"}}})
     (is (match? {:address                   "0x1"
                  :network-preferences-names #{}
                  :name                      "account1"
                  :color                     :blue
                  :customization-color       :blue}
-                (rf/sub [sub-name])))))
+                (rf/sub [sub-name community-id])))))
 
 (h/deftest-sub :communities/selected-permission-accounts
   [sub-name]
   (testing "returns selected permission accounts"
+    (swap! rf-db/app-db assoc-in
+      [:communities community-id :selected-permission-addresses]
+      #{"0x1" "0x3"})
     (swap! rf-db/app-db assoc
-      :communities/selected-permission-addresses
-      #{"0x1" "0x3"}
-      :wallet {:accounts {"0x1" {:address "0x1"
-                                 :color   :blue
-                                 :name    "account1"}
-                          "0x2" {:address "0x2"
-                                 :color   :orange
-                                 :name    "account2"}
-                          "0x3" {:address "0x3"
-                                 :color   :purple
-                                 :name    "account3"}}})
+      :wallet
+      {:accounts {"0x1" {:address "0x1" :color :blue :name "account1"}
+                  "0x2" {:address "0x2" :color :orange :name "account2"}
+                  "0x3" {:address "0x3" :color :purple :name "account3"}}})
     (is (match? [{:address                   "0x1"
                   :color                     :blue
                   :customization-color       :blue
@@ -504,4 +500,4 @@
                   :customization-color       :purple
                   :network-preferences-names #{}
                   :name                      "account3"}]
-                (rf/sub [sub-name])))))
+                (rf/sub [sub-name community-id])))))

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -145,8 +145,6 @@
 (reg-root-key-sub :communities/collapsed-categories :communities/collapsed-categories)
 (reg-root-key-sub :communities/selected-tab :communities/selected-tab)
 (reg-root-key-sub :contract-communities :contract-communities)
-(reg-root-key-sub :communities/selected-permission-addresses :communities/selected-permission-addresses)
-(reg-root-key-sub :communities/airdrop-address :communities/airdrop-address)
 
 ;;activity center
 (reg-root-key-sub :activity-center :activity-center)


### PR DESCRIPTION
![CleanShot 2024-01-19 at 11 26 15@2x](https://github.com/status-im/status-mobile/assets/15090582/049969d0-8ee2-43d2-af5a-1dd1e5f16d47)

### why
checkout this commit https://github.com/status-im/status-mobile/commit/90a4b7460f
it's adding revealed address of already joined community

things will be computed from these addrs in subs and events and most of these computations requires community-id

status: ready <!-- Can be ready or wip -->