### PR TITLE
fix: fix button color on input amount screen

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -128,7 +128,8 @@
                                (empty? @input-value)
                                (<= input-num-value 0)
                                (> input-num-value (:amount @current-limit)))
-            amount            (str @input-value " " token-symbol)]
+            amount            (str @input-value " " token-symbol)
+            {:keys [color]}   (rf/sub [:wallet/current-viewing-account])]
         (rn/use-effect
          (fn []
            (let [dismiss-keyboard-fn   #(when (= % "active") (rn/dismiss-keyboard!))
@@ -170,10 +171,11 @@
            :loading-networks (find-affordable-networks token @input-value)
            :networks         (:networks token)}]
          [quo/bottom-actions
-          {:actions          :1-action
-           :button-one-label (i18n/label :t/confirm)
-           :button-one-props {:disabled? confirm-disabled?
-                              :on-press  on-confirm}}]
+          {:actions             :1-action
+           :button-one-label    (i18n/label :t/confirm)
+           :button-one-props    {:disabled? confirm-disabled?
+                                 :on-press  on-confirm}
+           :customization-color color}]
          [quo/numbered-keyboard
           {:container-style (style/keyboard-container bottom)
            :left-action     :dot

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -128,7 +128,8 @@
     (fn []
       (let [selected-tab          (or (rf/sub [:wallet/send-tab]) (:id (first tabs-data)))
             token                 (rf/sub [:wallet/wallet-send-token])
-            valid-ens-or-address? (boolean (rf/sub [:wallet/valid-ens-or-address?]))]
+            valid-ens-or-address? (boolean (rf/sub [:wallet/valid-ens-or-address?]))
+            {:keys [color]}       (rf/sub [:wallet/current-viewing-account])]
         (rn/use-effect (fn []
                          (fn []
                            (rf/dispatch [:wallet/clean-scanned-address])
@@ -146,7 +147,8 @@
                       :on-press            #(rf/dispatch [:wallet/select-send-address
                                                           {:address  @input-value
                                                            :token    token
-                                                           :stack-id :wallet-select-address}])}
+                                                           :stack-id :wallet-select-address}])
+                      :customization-color color}
                      (i18n/label :t/continue)])}
          [quo/text-combinations
           {:title                     (i18n/label :t/send-to)


### PR DESCRIPTION
fixes #18565 

### Summary

This PR fixes button color on input amount screen in the wallet send flow

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Login with an account
- Go to wallet
- Select an account
- Go to the send flow
- Select an address and token
- Verify the button color in the input amount screen is correct

status: ready