### PR TITLE
Allow Chinese characters in usernames

### DIFF
--- a/src/status_im/common/validation/profile.cljs
+++ b/src/status_im/common/validation/profile.cljs
@@ -10,7 +10,7 @@
 (def emoji-regex
   #"(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])")
 
-(def status-regex #"^[a-zA-Z0-9\-_\u3400-\u9FFF]+$")
+(def status-regex #"^[a-zA-Z0-9\-_\u3400-\u9FFF ]+$")
 
 (def common-names ["Ethereum" "Bitcoin"])
 

--- a/src/status_im/common/validation/profile.cljs
+++ b/src/status_im/common/validation/profile.cljs
@@ -10,7 +10,7 @@
 (def emoji-regex
   #"(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])")
 
-(def status-regex #"^[a-zA-Z0-9\-_ ]+$")
+(def status-regex #"^[a-zA-Z0-9\-_\u3400-\u9FFF]+$")
 
 (def common-names ["Ethereum" "Bitcoin"])
 


### PR DESCRIPTION
This PR allows Chinese characters in usernames.

### Rationale
Blocking over 1.5 billion people from using their names in the app just because Westerners cannot type them isn't a good solution to the "unable to mention this user" problem. Blocking Chinese from using the language is a good way to lose potential market share.

### Research
During my time as an ambassador, I've introduced thousands of people in China to Status. The biggest complaint and source of friction was the fact that users couldn't type usernames in Simplified Chinese.

When I asked if the ability to have a Chinese username and/or ENS name would make the app more attractive, everyone said yes.

### Considerations
Maybe we should allow all CJK characters? They have no conflicts or ASCII lookalikes so I don't see any risks or downsides.