### PR TITLE
clean gradle deps before running `make nix-update-gradle` & retry 3 times for pom failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,16 @@ nix-purge: SHELL := /bin/sh
 nix-purge: ##@nix Completely remove Nix setup, including /nix directory
 	nix/scripts/purge.sh
 
+nix-clean-gradle-deps: SHELL := /bin/sh
+nix-clean-gradle-deps: ##@nix Clean gradle deps before next run
+	@echo "Restoring gradle files..."
+	@git restore nix/deps/gradle/deps.json nix/deps/gradle/deps.list nix/deps/gradle/deps.urls nix/deps/gradle/proj.list
+
+nix-update-gradle: nix-clean-gradle-deps
 nix-update-gradle: export TARGET := gradle
 nix-update-gradle: ##@nix Update maven nix expressions based on current gradle setup
-	nix/deps/gradle/generate.sh
+	@echo "Running generate.sh script..."
+	@nix/deps/gradle/generate.sh
 
 nix-update-clojure: export TARGET := clojure
 nix-update-clojure: ##@nix Update maven Nix expressions based on current clojure setup

--- a/nix/pkgs/go-maven-resolver/default.nix
+++ b/nix/pkgs/go-maven-resolver/default.nix
@@ -6,11 +6,11 @@ buildGoModule rec {
 
   vendorSha256 = "1p9pl33zpbw8zc85301mnp692lkr46ppm1q99wnqwynzi7x8hnkn";
 
-  src = fetchFromGitHub rec {
-    name = "${repo}-${version}-source";
+  # https://github.com/status-im/go-maven-resolver/pull/7
+  src = fetchFromGitHub {
     owner = "status-im";
     repo = pname;
-    rev = version;
-    sha256 = "0p3qz5w8spzdxs70m1sdfwi0ajv4ciw3f7fxligf45vj2fwp5dab";
+    rev = "2196acb4fbbc3bacf8d2a5d6afb7c73f7f6bc812";
+    sha256 = "sha256-GtB+DGQ3yyA8hNUBG4ZgDdT28cabk7D7nqpwtgiSCsc=";
   };
 }


### PR DESCRIPTION
## Summary

When `make nix-update-gradle` fails due to whatever reason.
The local folder has incomplete progress in the following files : 

- `nix/deps/gradle/deps.json`
- `nix/deps/gradle/deps.list`
- `nix/deps/gradle/deps.urls`
- `nix/deps/gradle/proj.list`

This PR adds a makefile command to restore the changes made to these file before running `make nix-update-gradle` so that we get consistent results every-time without manually revert changes in those files.

This PR also links to a branch in go-maven-resolver which retries getting pom url incase of failures.
PR in go-maven-resolver -> https://github.com/status-im/go-maven-resolver/pull/7

fixes #18294

## Testing notes 
QA is not required for this PR

status: ready
