### PR TITLE
fixed: mute-icon when channel is muted

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -159,7 +159,7 @@
                                                     unmute-chat-label
                                                     mute-chat-label))
                  :color               cover-bg-color
-                 :icon                (if muted? :i/muted :i/activity-center)
+                 :icon                (if muted? :i/activity-center :i/muted)
                  :on-press            (fn []
                                         (if muted?
                                           (home.actions/unmute-chat-action chat-id)


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/18222

This pr just creates the order in which these icons are displayed depending on the if-case

**Before  &  After**

<img src="https://github.com/status-im/status-mobile/assets/28704507/00a1ef26-7251-42bf-8804-508fb89033da" width="325">
<img src="https://github.com/status-im/status-mobile/assets/28704507/bbc2c9b6-e774-4a3d-9f8f-fb22cf70508e" width="325">