### PR TITLE
fix: fix slide button padding on transaction confirmation page

### DIFF
--- a/src/status_im/common/floating_button_page/view.cljs
+++ b/src/status_im/common/floating_button_page/view.cljs
@@ -52,7 +52,8 @@
      :remove-listeners    remove-listeners}))
 
 (defn view
-  [{:keys [header footer customization-color gradient-cover?]} &
+  [{:keys [header footer customization-color footer-container-padding gradient-cover?]
+    :or   {footer-container-padding (safe-area/get-top)}} &
    children]
   (reagent/with-let [window-height                (:height (rn/get-window))
                      footer-container-height      (reagent/atom 0)
@@ -94,7 +95,7 @@
                children)]
         [rn/keyboard-avoiding-view
          {:style                    style/keyboard-avoiding-view
-          :keyboard-vertical-offset (if platform/ios? (safe-area/get-top) 0)
+          :keyboard-vertical-offset (if platform/ios? footer-container-padding 0)
           :pointer-events           :box-none}
          [floating-container/view
           {:on-layout       set-footer-container-height

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -122,17 +122,17 @@
                                 (rf/dispatch [:wallet/clean-scanned-address])
                                 (rf/dispatch [:wallet/clear-address-activity-check])
                                 (rf/dispatch [:navigate-back]))}]
-         :footer
-         [quo/button
-          {:customization-color customization-color
-           :disabled?           (or (string/blank? @input-value) (some? (validate @input-value)))
-           :on-press            (fn []
-                                  (rf/dispatch [:navigate-to
-                                                :confirm-address-to-watch
-                                                {:address @input-value}])
-                                  (clear-input))
-           :container-style     {:z-index 2}}
-          (i18n/label :t/continue)]}
+         :footer [quo/button
+                  {:customization-color customization-color
+                   :disabled?           (or (string/blank? @input-value)
+                                            (some? (validate @input-value)))
+                   :on-press            (fn []
+                                          (rf/dispatch [:navigate-to
+                                                        :confirm-address-to-watch
+                                                        {:address @input-value}])
+                                          (clear-input))
+                   :container-style     {:z-index 2}}
+                  (i18n/label :t/continue)]}
         [quo/text-combinations
          {:container-style style/header-container
           :title           (i18n/label :t/add-address)

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -135,21 +135,23 @@
                            (rf/dispatch [:wallet/clean-scanned-address])
                            (rf/dispatch [:wallet/clean-local-suggestions]))))
         [floating-button-page/view
-         {:header [account-switcher/view
-                   {:on-press      on-close
-                    :margin-top    (safe-area/get-top)
-                    :switcher-type :select-account}]
-          :footer (when (> (count @input-value) 0)
-                    [quo/button
-                     {:accessibility-label :continue-button
-                      :type                :primary
-                      :disabled?           (not valid-ens-or-address?)
-                      :on-press            #(rf/dispatch [:wallet/select-send-address
-                                                          {:address  @input-value
-                                                           :token    token
-                                                           :stack-id :wallet-select-address}])
-                      :customization-color color}
-                     (i18n/label :t/continue)])}
+         {:footer-container-padding 0
+          :header                   [account-switcher/view
+                                     {:on-press      on-close
+                                      :margin-top    (safe-area/get-top)
+                                      :switcher-type :select-account}]
+          :footer                   (when (> (count @input-value) 0)
+                                      [quo/button
+                                       {:accessibility-label :continue-button
+                                        :type                :primary
+                                        :disabled?           (not valid-ens-or-address?)
+                                        :on-press            #(rf/dispatch [:wallet/select-send-address
+                                                                            {:address @input-value
+                                                                             :token token
+                                                                             :stack-id
+                                                                             :wallet-select-address}])
+                                        :customization-color color}
+                                       (i18n/label :t/continue)])}
          [quo/text-combinations
           {:title                     (i18n/label :t/send-to)
            :container-style           style/title-container

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -162,28 +162,30 @@
                                    :address   (utils/get-shortened-address to-address)}]
         [rn/view {:style {:flex 1}}
          [floating-button-page/view
-          {:header              [quo/page-nav
-                                 {:icon-name           :i/arrow-left
-                                  :on-press            on-close
-                                  :margin-top          (safe-area/get-top)
-                                  :background          :blur
-                                  :accessibility-label :top-bar
-                                  :right-side          [{:icon-name           :i/advanced
-                                                         :on-press            #(js/alert
-                                                                                "to be implemented")
-                                                         :accessibility-label :advanced-options}]}]
-           :footer              (if route
-                                  [standard-auth/slide-button
-                                   {:size                :size-48
-                                    :track-text          (i18n/label :t/slide-to-send)
-                                    :container-style     {:z-index 2}
-                                    :customization-color account-color
-                                    :on-auth-success     #(rf/dispatch [:wallet/send-transaction
-                                                                        (security/safe-unmask-data %)])
-                                    :auth-button-label   (i18n/label :t/confirm)}]
-                                  [rn/activity-indicator])
-           :gradient-cover?     true
-           :customization-color (:color account)}
+          {:footer-container-padding 0
+           :header                   [quo/page-nav
+                                      {:icon-name           :i/arrow-left
+                                       :on-press            on-close
+                                       :margin-top          (safe-area/get-top)
+                                       :background          :blur
+                                       :accessibility-label :top-bar
+                                       :right-side          [{:icon-name           :i/advanced
+                                                              :on-press            #(js/alert
+                                                                                     "to be implemented")
+                                                              :accessibility-label :advanced-options}]}]
+           :footer                   (if route
+                                       [standard-auth/slide-button
+                                        {:size                :size-48
+                                         :track-text          (i18n/label :t/slide-to-send)
+                                         :container-style     {:z-index 2}
+                                         :customization-color account-color
+                                         :on-auth-success     #(rf/dispatch [:wallet/send-transaction
+                                                                             (security/safe-unmask-data
+                                                                              %)])
+                                         :auth-button-label   (i18n/label :t/confirm)}]
+                                       [rn/activity-indicator])
+           :gradient-cover?          true
+           :customization-color      (:color account)}
           [rn/view
            [transaction-title
             {:token-symbol token-symbol

--- a/src/status_im/contexts/wallet/send/transaction_progress/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_progress/view.cljs
@@ -32,19 +32,20 @@
     (fn []
       (let [transaction-details (rf/sub [:wallet/send-transaction-progress])]
         [floating-button-page/view
-         {:header              [quo/page-nav
-                                {:type                :no-title
-                                 :background          :blur
-                                 :icon-name           :i/close
-                                 :margin-top          (safe-area/get-top)
-                                 :on-press            leave-page
-                                 :accessibility-label :top-bar}]
-          :footer              [quo/button
-                                {:customization-color color
-                                 :on-press            leave-page}
-                                (i18n/label :t/done)]
-          :customization-color color
-          :gradient-cover?     true}
+         {:footer-container-padding 0
+          :header                   [quo/page-nav
+                                     {:type                :no-title
+                                      :background          :blur
+                                      :icon-name           :i/close
+                                      :margin-top          (safe-area/get-top)
+                                      :on-press            leave-page
+                                      :accessibility-label :top-bar}]
+          :footer                   [quo/button
+                                     {:customization-color color
+                                      :on-press            leave-page}
+                                     (i18n/label :t/done)]
+          :customization-color      color
+          :gradient-cover?          true}
          [rn/view {:style style/content-container}
           [rn/image
            {:source (resources/get-image :transaction-progress)


### PR DESCRIPTION
fixes #18407 

### Summary

This PR fixes unnecessary padding on transaction confirmation page caused by wrong value being set on `KeyboardVerticalOffset` prop of `KeyboardAvoidingView` in `status-im.common.floating-button-page.view` namespace

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in
- Go to wallet
- Select an account
- Select Send
- Select an address
- Select an asset
- Input an amount and wait for a route to be detected
- Select confirm to go to transaction confirmation page
- Verify padding on slide button is correct

status: ready