### PR TITLE
[#18459] - Add cursor-based input handling to `token-input`

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -110,10 +110,10 @@
                                   (reset! crypto-currency? crypto?)
                                   (reset-input-error num-value current-limit input-error)))
         handle-keyboard-press (fn [v loading-routes? current-limit-amount]
-                                (let [current-value @input-value
-                                      new-value     (make-new-input current-value v input-selection)
-                                      num-value     (or (parse-double new-value) 0)]
-                                  (when (not loading-routes?)
+                                (when-not loading-routes?
+                                  (let [current-value @input-value
+                                        new-value     (make-new-input current-value v input-selection)
+                                        num-value     (or (parse-double new-value) 0)]
                                     (reset! input-value new-value)
                                     (reset-input-error num-value current-limit-amount input-error)
                                     (reagent/flush))))

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -103,7 +103,7 @@
         input-value           (reagent/atom "")
         input-error           (reagent/atom false)
         crypto-currency?      (reagent/atom initial-crypto-currency?)
-        input-selection           (reagent/atom {:start 0 :end 0})
+        input-selection       (reagent/atom {:start 0 :end 0})
         handle-swap           (fn [{:keys [crypto? limit-fiat limit-crypto]}]
                                 (let [num-value     (parse-double @input-value)
                                       current-limit (if crypto? limit-crypto limit-fiat)]
@@ -146,13 +146,13 @@
                                 (rf/dispatch [:wallet/send-select-amount
                                               {:amount   @input-value
                                                :stack-id :wallet-send-input-amount}]))
-        selection-change          (fn [selection]
-                                    ;; `reagent/flush` is needed to properly propagate the
-                                    ;; input cursor state. Since this is a controlled
-                                    ;; component the cursor will become static if
-                                    ;; `reagent/flush` is removed.
-                                    (reset! input-selection selection)
-                                    (reagent/flush))]
+        selection-change      (fn [selection]
+                                ;; `reagent/flush` is needed to properly propagate the
+                                ;; input cursor state. Since this is a controlled
+                                ;; component the cursor will become static if
+                                ;; `reagent/flush` is removed.
+                                (reset! input-selection selection)
+                                (reagent/flush))]
     (fn []
       (let [{fiat-currency :currency} (rf/sub [:profile/profile])
             {:keys [color]}           (rf/sub [:wallet/current-viewing-account])
@@ -196,25 +196,25 @@
            :on-press      on-navigate-back
            :switcher-type :select-account}]
          [quo/token-input
-          {:container-style style/input-container
-           :token           token-symbol
-           :currency        current-currency
-           :crypto-decimals crypto-decimals
-           :error?          @input-error
-           :networks        token-networks
-           :title           (i18n/label :t/send-limit {:limit limit-label})
-           :conversion      conversion-rate
-           :show-keyboard?  false
-           :value           @input-value
+          {:container-style     style/input-container
+           :token               token-symbol
+           :currency            current-currency
+           :crypto-decimals     crypto-decimals
+           :error?              @input-error
+           :networks            token-networks
+           :title               (i18n/label :t/send-limit {:limit limit-label})
+           :conversion          conversion-rate
+           :show-keyboard?      false
+           :value               @input-value
            :selection           @input-selection
-           :on-change-text  #(handle-on-change % current-limit)
+           :on-change-text      #(handle-on-change % current-limit)
            :on-selection-change selection-change
-           :on-swap         #(handle-swap
-                              {:crypto?      %
-                               :currency     current-currency
-                               :token-symbol token-symbol
-                               :limit-fiat   fiat-limit
-                               :limit-crypto crypto-limit})}]
+           :on-swap             #(handle-swap
+                                  {:crypto?      %
+                                   :currency     current-currency
+                                   :token-symbol token-symbol
+                                   :limit-fiat   fiat-limit
+                                   :limit-crypto crypto-limit})}]
          [routes/view
           {:amount       amount-text
            :routes       suggested-routes


### PR DESCRIPTION
fixes #18459
fixes #18466

### Summary

This PR adds capabilities to delete and type using the cursor position to the token input.

[Screencast from 2024-01-22 23-04-19.webm](https://github.com/status-im/status-mobile/assets/90291778/14d87fb6-5ced-42c9-9433-12728866fa07)

**NOTE: This PR doesn't handle the active cursor selection typing/erasing** 

NOT HANDLED:
![image](https://github.com/status-im/status-mobile/assets/90291778/7e1a7a53-87a5-49a6-8c85-ec05b4e5dc88)
It just does nothing if we press the keyboard

### Review notes
Properly handling all possibilites and validations for the active cursor selection is an exhaustive task, and it's a little hard to know what do we exactly expect for every case, it's also an error-prone task.

If the handling in this PR is not the expected, I'd suggest opening a separate issue with the interactions we have and the  result we expect (probably we should align with designers). I believe it's better to merge this PR since it adds parts of the total work that needs to get done.

Do we really want to reimplement this logic? inputs already handle this behavior if we use a regular keyboard (not our custom one).

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

### Steps to test

- Open Status
- Go to wallet, pick an address with funds, press send, select and address to send and pick any token.
- The Token input now is able to add numbers in cursor's position.


status: ready
