### PR TITLE
Add a UI for toggling developer feature flags 

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -16,18 +16,19 @@
                 :clj-kondo-config              {:level :error}
                 :cond-else                     {:level :error}
                 :consistent-alias              {:level   :error
-                                                :aliases {clojure.set      set
-                                                          clojure.string   string
-                                                          clojure.walk     walk
-                                                          malli.core       malli
-                                                          malli.dev.pretty malli.pretty
-                                                          malli.dev.virhe  malli.virhe
-                                                          malli.error      malli.error
-                                                          malli.generator  malli.generator
-                                                          malli.transform  malli.transform
-                                                          malli.util       malli.util
-                                                          schema.core      schema
-                                                          taoensso.timbre  log}}
+                                                :aliases {clojure.set             set
+                                                          clojure.string          string
+                                                          clojure.walk            walk
+                                                          malli.core              malli
+                                                          malli.dev.pretty        malli.pretty
+                                                          malli.dev.virhe         malli.virhe
+                                                          malli.error             malli.error
+                                                          malli.generator         malli.generator
+                                                          malli.transform         malli.transform
+                                                          malli.util              malli.util
+                                                          schema.core             schema
+                                                          status-im.feature-flags ff
+                                                          taoensso.timbre         log}}
                 :deprecated-namespace          {:level :warning}
                 :docstring-blank               {:level :error}
                 :equals-true                   {:level :error}

--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -169,8 +169,3 @@
 
 (def community-accounts-selection-enabled? (enabled? (get-config :ACCOUNT_SELECTION_ENABLED "0")))
 (def fetch-messages-enabled? (enabled? (get-config :FETCH_MESSAGES_ENABLED "1")))
-
-(def wallet-feature-flags
-  {:edit-default-keypair false
-   :bridge-token         false
-   :remove-account       false})

--- a/src/status_im/contexts/preview/feature_flags/style.cljs
+++ b/src/status_im/contexts/preview/feature_flags/style.cljs
@@ -1,0 +1,5 @@
+(ns status-im.contexts.preview.feature-flags.style)
+
+(def container
+  {:flex        1
+   :margin-left 20})

--- a/src/status_im/contexts/preview/feature_flags/view.cljs
+++ b/src/status_im/contexts/preview/feature_flags/view.cljs
@@ -1,0 +1,34 @@
+(ns status-im.contexts.preview.feature-flags.view
+  (:require
+    [quo.core :as quo]
+    [re-frame.core :as rf]
+    [react-native.core :as rn]
+    [status-im.feature-flags :as ff]))
+
+(defn view
+  []
+  [rn/view {:flex 1}
+   [quo/page-nav
+    {:type       :title
+     :text-align :left
+     :title      "Features Flags"
+     :icon-name  :i/arrow-left
+     :on-press   #(rf/dispatch [:navigate-back])}]
+   (for [[context-name context-flags] (ff/feature-flags)]
+     ^{:key (str context-name)}
+     [rn/view
+      {:flex        1
+       :margin-left 20}
+      [quo/text {:color :black} (name context-name)]
+
+      (for [[flag _v] context-flags]
+        ^{:key (str context-name flag)}
+
+        [rn/view {:flex-direction :row}
+         (prn (ff/get-flag context-name flag))
+         [quo/selectors
+          {:type            :toggle
+           :checked?        (ff/get-flag context-name flag)
+           :container-style {:margin-right 8}
+           :on-change       #(ff/update-flag context-name flag)}]
+         [quo/text {:color :black} (name flag)]])])])

--- a/src/status_im/contexts/profile/settings/list_items.cljs
+++ b/src/status_im/contexts/profile/settings/list_items.cljs
@@ -96,6 +96,13 @@
        :action      :arrow
        :image       :icon
        :blur?       true
+       :image-props :i/light})
+    (when config/quo-preview-enabled?
+      {:title       "Feature Flags"
+       :on-press    #(rf/dispatch [:navigate-to :feature-flags])
+       :action      :arrow
+       :image       :icon
+       :blur?       true
        :image-props :i/light})]
    [{:title    (i18n/label :t/about)
      :on-press not-implemented/alert

--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -3,11 +3,11 @@
     [quo.core :as quo]
     [react-native.core :as rn]
     [reagent.core :as reagent]
-    [status-im.config :as config]
     [status-im.contexts.wallet.account.style :as style]
     [status-im.contexts.wallet.account.tabs.view :as tabs]
     [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im.contexts.wallet.common.temp :as temp]
+    [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -53,9 +53,9 @@
              :receive-action #(rf/dispatch [:open-modal :wallet-share-address {:status :receive}])
              :buy-action     #(rf/dispatch [:show-bottom-sheet
                                             {:content buy-drawer}])
-             :bridge-action  (if (:bridge-token config/wallet-feature-flags)
-                               #(rf/dispatch [:open-modal :wallet-bridge])
-                               #(js/alert "feature disabled in config file"))}])
+             :bridge-action  #(ff/alert :wallet
+                                        :bridge-token
+                                        (fn [] (rf/dispatch [:open-modal :wallet-bridge])))}])
          [quo/tabs
           {:style            style/tabs
            :size             32

--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -53,8 +53,7 @@
              :receive-action #(rf/dispatch [:open-modal :wallet-share-address {:status :receive}])
              :buy-action     #(rf/dispatch [:show-bottom-sheet
                                             {:content buy-drawer}])
-             :bridge-action  #(ff/alert :wallet
-                                        :bridge-token
+             :bridge-action  #(ff/alert ::ff/wallet.bridge-token
                                         (fn [] (rf/dispatch [:open-modal :wallet-bridge])))}])
          [quo/tabs
           {:style            style/tabs

--- a/src/status_im/contexts/wallet/common/sheets/account_options/view.cljs
+++ b/src/status_im/contexts/wallet/common/sheets/account_options/view.cljs
@@ -9,10 +9,10 @@
             [react-native.gesture :as gesture]
             [react-native.platform :as platform]
             [reagent.core :as reagent]
-            [status-im.config :as config]
             [status-im.contexts.wallet.common.sheets.account-options.style :as style]
             [status-im.contexts.wallet.common.sheets.remove-account.view :as remove-account]
             [status-im.contexts.wallet.common.utils :as utils]
+            [status-im.feature-flags :as ff]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
@@ -100,13 +100,12 @@
            :accessibility-label :remove-account
            :label               (i18n/label :t/remove-account)
            :danger?             true
-           :on-press            (fn []
-                                  (if (:remove-account config/wallet-feature-flags)
-                                    (rf/dispatch [:show-bottom-sheet
-                                                  {:content
-                                                   (fn []
-                                                     [remove-account/view])}])
-                                    (js/alert "Feature disabled in config file")))})]]]
+           :on-press            #(ff/alert ::ff/wallet.remove-account
+                                           (fn []
+                                             (rf/dispatch [:show-bottom-sheet
+                                                           {:content
+                                                            (fn []
+                                                              [remove-account/view])}])))})]]]
      (when show-account-selector?
        [:<>
         [quo/divider-line {:container-style style/divider-label}]

--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -32,8 +32,7 @@
                         :size                :xxs
                         :customization-color account-color}
     :action            :button
-    :action-props      {:on-press    #(ff/alert :wallet
-                                                :edit-default-keypair
+    :action-props      {:on-press    #(ff/alert ::ff/wallet.edit-default-keypair
                                                 (fn []
                                                   (rf/dispatch [:navigate-to :wallet-select-keypair])))
                         :button-text (i18n/label :t/edit)

--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -9,10 +9,10 @@
     [reagent.core :as reagent]
     [status-im.common.emoji-picker.utils :as emoji-picker.utils]
     [status-im.common.standard-authentication.core :as standard-auth]
-    [status-im.config :as config]
     [status-im.constants :as constants]
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.create-account.style :as style]
+    [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.responsiveness :refer [iphone-11-Pro-20-pixel-from-width]]
@@ -32,9 +32,10 @@
                         :size                :xxs
                         :customization-color account-color}
     :action            :button
-    :action-props      {:on-press    (if (:edit-default-keypair config/wallet-feature-flags)
-                                       #(rf/dispatch [:navigate-to :wallet-select-keypair])
-                                       #(js/alert "feature disabled in config file"))
+    :action-props      {:on-press    #(ff/alert :wallet
+                                                :edit-default-keypair
+                                                (fn []
+                                                  (rf/dispatch [:navigate-to :wallet-select-keypair])))
                         :button-text (i18n/label :t/edit)
                         :alignment   :flex-start}
     :description       :text

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -2,13 +2,13 @@
   (:require [quo.core :as quo]
             [react-native.core :as rn]
             [reagent.core :as reagent]
-            [status-im.config :as config]
             [status-im.contexts.wallet.common.screen-base.create-or-edit-account.view
              :as create-or-edit-account]
             [status-im.contexts.wallet.common.sheets.network-preferences.view
              :as network-preferences]
             [status-im.contexts.wallet.common.sheets.remove-account.view :as remove-account]
             [status-im.contexts.wallet.edit-account.style :as style]
+            [status-im.feature-flags :as ff]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
@@ -66,13 +66,12 @@
          {:page-nav-right-side [(when-not default-account?
                                   {:icon-name :i/delete
                                    :on-press
-                                   (fn []
-                                     (if (:remove-account config/wallet-feature-flags)
-                                       (rf/dispatch [:show-bottom-sheet
-                                                     {:content
-                                                      (fn []
-                                                        [remove-account/view])}])
-                                       (js/alert "Feature disabled in config file")))})]
+                                   #(ff/alert ::ff/wallet.remove-account
+                                              (fn []
+                                                (rf/dispatch [:show-bottom-sheet
+                                                              {:content
+                                                               (fn []
+                                                                 [remove-account/view])}])))})]
           :account-name        account-name
           :account-emoji       emoji
           :account-color       color

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -1,0 +1,32 @@
+(ns status-im.feature-flags
+  (:require
+    [react-native.config :as config]
+    [reagent.core :as reagent]))
+
+(defn- enabled? [v] (= "1" v))
+
+(defn check-env [k] (enabled? (config/get-config k)))
+
+(def ^:private feature-flags-config
+  (reagent/atom
+   {:wallet
+    {:edit-default-keypair (check-env :DEV_FF_EDIT_DEFAULT_KEYPAIR)
+     :bridge-token         (check-env :DEV_FF_BRIDGE_TOKEN)}}))
+
+(defn feature-flags [] @feature-flags-config)
+
+(defn get-flag
+  [section flag]
+  (get-in (feature-flags) [section flag]))
+
+(defn update-flag
+  [section flag]
+  (swap! feature-flags-config
+    (fn [a]
+      (update-in a [section flag] not))))
+
+(defn alert
+  [context flag action]
+  (if (get-flag context flag)
+    (action)
+    (js/alert (str flag " is currently feature flagged off"))))

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -11,7 +11,8 @@
 (defonce ^:private feature-flags-config
   (reagent/atom
    {::wallet.edit-default-keypair (enabled-in-env? :FLAG_EDIT_DEFAULT_KEYPAIR_ENABLED)
-    ::wallet.bridge-token         (enabled-in-env? :FLAG_BRIDGE_TOKEN_ENABLED)}))
+    ::wallet.bridge-token         (enabled-in-env? :FLAG_BRIDGE_TOKEN_ENABLED)
+    ::wallet.remove-account       (enabled-in-env? :FLAG_REMOVE_ACCOUNT_ENABLED)}))
 
 (defn feature-flags [] @feature-flags-config)
 

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -31,6 +31,7 @@
     [status-im.contexts.onboarding.syncing.progress.view :as syncing-devices]
     [status-im.contexts.onboarding.syncing.results.view :as syncing-results]
     [status-im.contexts.onboarding.welcome.view :as welcome]
+    [status-im.contexts.preview.feature-flags.view :as feature-flags]
     [status-im.contexts.preview.quo.component-preview.view :as component-preview]
     [status-im.contexts.preview.quo.main :as quo.preview]
     [status-im.contexts.preview.status-im.main :as status-im-preview]
@@ -406,4 +407,9 @@
      status-im-preview/screens)
 
    (when config/quo-preview-enabled?
-     status-im-preview/main-screens)))
+     status-im-preview/main-screens)
+
+   (when config/quo-preview-enabled?
+     [{:name      :feature-flags
+       :options   {:insets {:top? true}}
+       :component feature-flags/view}])))


### PR DESCRIPTION
This pr: https://github.com/status-im/status-mobile/pull/18530 and some recent discussions in the Wallet Team to start using Feature Epics (e.g https://github.com/status-im/status-mobile/issues/18568) encouraged the need for small improvements in how we use feature-flags.

**Note** - Please review by commit `chore: add feature flags poc` only

Created a simple UI page for a devs, QA, designer to toggle on/off these feature flags - intended for development purposes only 

I wanted to bring this discussion so this pr is completely open to suggestion and hapopy to scrap the whle thing and take a new approach if needs be.

quick demo:

https://github.com/status-im/status-mobile/assets/22799766/a0e0ab4e-0b89-42f7-8d03-8ef1bbea01e7


<img src="https://github.com/status-im/status-mobile/assets/22799766/1e59dbd7-a432-4c1e-b2a6-712e8be07eac" width="250px" />

I didn't pull other features into this screen just yet as this can be done in a follow up.

Testing notes:
two features are feature flag.

The bridging - go to a wallet account, press the "Bridge" button.

The second is edit keypair, go to "Add account", press "edit" button beside "<name> default keypair"