### PR TITLE
fix: xcbeautify but without omitting crucial logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,11 +282,12 @@ SIMULATOR=iPhone 13
 # TODO: fix IOS_STATUS_GO_TARGETS to be either amd64 or arm64 when RN is upgraded
 run-ios: export TARGET := ios
 run-ios: export IOS_STATUS_GO_TARGETS := ios/arm64;iossimulator/amd64
+run-ios: export XCBeautify=$(shell which xcbeautify) # for react-native-cli to pick this up and to auto format output
 run-ios: ##@run Build iOS app and start it in a simulator/device
 ifneq ("$(SIMULATOR)", "")
-	npx react-native run-ios --simulator="$(SIMULATOR)" | xcbeautify
+	npx react-native run-ios --simulator="$(SIMULATOR)"
 else
-	npx react-native run-ios | xcbeautify
+	npx react-native run-ios
 endif
 
 show-ios-devices: ##@other shows connected ios device and its name


### PR DESCRIPTION
## Summary

I introduced `xcbeautify` inside `make run-ios` command which would sometimes skip spitting crucial logs to the terminal.
In cases where the `react-native-cli` would prompt me of a port being used by another metro server, those prompts would also never reach me since they were piped into `xcbeautify` essentially giving me the impression that `make run-ios` is still doing something when it was actually hung.

This is how `react-native-community/cli` looks for `xcbeautify` ->
https://github.com/react-native-community/cli/blob/main/packages/cli-platform-apple/src/commands/buildCommand/buildProject.ts#L139

This PR fixes the problem by exporting an env variable making `react-native-cli` aware that we have `xcbeautify` installed and this way we now get the full log output we were used to. 

## Review notes

 run `make run-ios` in this branch vs any other branch and observe the differences.

## Testing notes

Does not require testing since this only affects local iOS build step.

status: ready
