### PR TITLE
fix bottom tabs blur overlay color

### DIFF
--- a/src/status_im/contexts/shell/jump_to/components/bottom_tabs/style.cljs
+++ b/src/status_im/contexts/shell/jump_to/components/bottom_tabs/style.cljs
@@ -2,6 +2,7 @@
   (:require
     [quo.foundations.colors :as colors]
     [react-native.platform :as platform]
+    [react-native.reanimated :as reanimated]
     [status-im.contexts.shell.jump-to.utils :as utils]))
 
 (defn bottom-tabs-container
@@ -28,10 +29,11 @@
 
 (defn bottom-tabs-blur-overlay
   [height]
-  [{:height height}
+  (reanimated/apply-animations-to-style
+   {:height height}
    {:position         :absolute
     :left             0
     :right            0
     :bottom           0
     :height           (utils/bottom-tabs-container-height)
-    :background-color colors/neutral-100-opa-70-blur}])
+    :background-color colors/neutral-100-opa-70-blur}))


### PR DESCRIPTION
related to https://discord.com/channels/1103692771585433630/1103692773363810317/1199894835797172274

It looks like inline reanimated styles are breaking blur view. I am reverting the use for this case.
(Please feel free to close PR if you find cause or another solution)

status: ready