### PR TITLE
fix: ENS regex not being used to detect an ENS on address input

### DIFF
--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -313,6 +313,10 @@
      (background-timer/clear-timeout current-timeout)
      {:db (assoc db :wallet/local-suggestions [] :wallet/valid-ens-or-address? false)})))
 
+(rf/reg-event-fx :wallet/clean-ens-or-address-validation
+ (fn [{:keys [db]}]
+   {:db (assoc db :wallet/valid-ens-or-address? false)}))
+
 (rf/reg-event-fx :wallet/get-address-details-success
  (fn [{:keys [db]} [{:keys [hasActivity]}]]
    {:db (assoc-in db

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -32,27 +32,29 @@
           chain-id                 (rf/sub [:chain-id])
           contacts                 (rf/sub [:contacts/active])]
       [quo/address-input
-       {:on-focus              #(reset! input-focused? true)
-        :on-blur               #(reset! input-focused? false)
-        :on-scan               (fn []
-                                 (rn/dismiss-keyboard!)
-                                 (rf/dispatch [:wallet/clean-scanned-address])
-                                 (rf/dispatch [:open-modal :scan-address]))
-        :ens-regex             constants/regx-ens
-        :scanned-value         (or (when recipient-plain-address? send-address) scanned-address)
-        :address-regex         constants/regx-multichain-address
-        :on-detect-address     #(debounce/debounce-and-dispatch
-                                 [:wallet/validate-address %]
-                                 300)
-        :on-detect-ens         (fn [text cb]
-                                 (debounce/debounce-and-dispatch
-                                  [:wallet/find-ens text contacts chain-id cb]
-                                  300))
-        :on-change-text        (fn [text]
-                                 (when (empty? text)
-                                   (rf/dispatch [:wallet/clean-local-suggestions]))
-                                 (reset! input-value text))
-        :valid-ens-or-address? valid-ens-or-address?}])))
+       {:on-focus               #(reset! input-focused? true)
+        :on-blur                #(reset! input-focused? false)
+        :on-scan                (fn []
+                                  (rn/dismiss-keyboard!)
+                                  (rf/dispatch [:wallet/clean-scanned-address])
+                                  (rf/dispatch [:open-modal :scan-address]))
+        :ens-regex              constants/regx-ens
+        :scanned-value          (or (when recipient-plain-address? send-address) scanned-address)
+        :address-regex          constants/regx-multichain-address
+        :on-detect-address      #(debounce/debounce-and-dispatch
+                                  [:wallet/validate-address %]
+                                  300)
+        :on-detect-ens          (fn [text cb]
+                                  (debounce/debounce-and-dispatch
+                                   [:wallet/find-ens text contacts chain-id cb]
+                                   300))
+        :on-detect-unclassified #(when valid-ens-or-address?
+                                   (rf/dispatch [:wallet/clean-ens-or-address-validation]))
+        :on-change-text         (fn [text]
+                                  (when (empty? text)
+                                    (rf/dispatch [:wallet/clean-local-suggestions]))
+                                  (reset! input-value text))
+        :valid-ens-or-address?  valid-ens-or-address?}])))
 
 (defn- ens-linked-address
   [{:keys [address networks theme]}]


### PR DESCRIPTION
fixes ?

### Summary

Currently, in the Select Address screen, we are passing a regex to Address Input component so we can detect an ENS to dispatch `:wallet/find-ens` to resolve it. But we are not using that regex and we are dispatching on-detect-ens event on every character input, causing some issues like this one: https://github.com/status-im/status-mobile/pull/18569#issuecomment-1908378129
This PR introduces the usage of the regex so we don't dispatch unnecessary events.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Login
- Go to wallet
- Select an account
- Select Send option
- Introduce an ENS, verify that ENS resolving is working correctly

status: ready