### PR TITLE
Account selection: Fix community logo/name not rendered correctly

### DIFF
--- a/src/quo/components/drawers/drawer_top/view.cljs
+++ b/src/quo/components/drawers/drawer_top/view.cljs
@@ -182,7 +182,7 @@
 
 (defn- view-internal
   [{:keys [title title-icon type theme description blur? community-name community-logo button-icon
-           account-name emoji
+           account-name emoji context-tag-type
            on-button-press
            on-button-long-press
            button-disabled? account-avatar-emoji account-avatar-type customization-color icon-avatar
@@ -214,6 +214,7 @@
       :description         description
       :community-name      community-name
       :community-logo      community-logo
+      :context-tag-type    context-tag-type
       :customization-color customization-color
       :account-name        account-name
       :emoji               emoji}]]

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -35,6 +35,7 @@
      [quo/drawer-top
       {:type                :context-tag
        :title               (i18n/label :t/addresses-for-permissions)
+       :context-tag-type    :community
        :community-name      name
        :button-icon         :i/info
        :on-button-press     not-implemented/alert

--- a/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
+++ b/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
@@ -26,6 +26,7 @@
     [:<>
      [quo/drawer-top
       {:type                :context-tag
+       :context-tag-type    :community
        :title               (i18n/label :t/airdrop-addresses)
        :community-name      name
        :button-icon         :i/info


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/18618

### Summary

Details on issue.

#### Areas that may be impacted

None because the code is behind a disabled feature flag.

### Steps to test

1. Enable flag `community-accounts-selection-enabled?`
2. Try to join a community without membership permissions.
3. Open the screens to select account addresses or the airdrop address and observe the the context tag is correctly displayed.

### Before and after

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After 1</th>
      <th>After 2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/8ed5ec39-656e-4f37-9fb8-df8372e6c6fd" width="390" /></td>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/65e4c202-f260-43e5-8535-7ed4710109e1" width="390" /></td>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/5044ac20-b23f-43d5-a9ac-f5a01e4ecdc6" width="390" /></td>
    </tr>
  </tbody>
</table>


status: ready
