### PR TITLE
Implement menu on collectible preview page

### DIFF
--- a/src/status_im/common/lightbox/top_view.cljs
+++ b/src/status_im/common/lightbox/top_view.cljs
@@ -46,7 +46,7 @@
     (rf/dispatch [:lightbox/share-image uri])))
 
 (defn top-view
-  [images insets index animations derived landscape? screen-width options-drawer-component]
+  [images insets index animations derived landscape? screen-width on-options-press]
   (let [{:keys [description header]} (nth images @index)
         bg-color                     (if landscape?
                                        colors/neutral-100-opa-70
@@ -93,7 +93,6 @@
       [rn/touchable-opacity
        {:active-opacity      1
         :accessibility-label :image-options
-        :on-press            #(rf/dispatch [:show-bottom-sheet
-                                            {:content (fn [] [options-drawer-component images @index])}])
+        :on-press            #(on-options-press images @index)
         :style               style/close-container}
        [quo/icon :options {:size 20 :color colors/white}]]]]))

--- a/src/status_im/common/lightbox/top_view.cljs
+++ b/src/status_im/common/lightbox/top_view.cljs
@@ -9,7 +9,6 @@
     [status-im.common.lightbox.animations :as anim]
     [status-im.common.lightbox.constants :as constants]
     [status-im.common.lightbox.style :as style]
-    [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.url :as url]))
 
@@ -40,25 +39,6 @@
         (anim/animate top-view-width screen-width)
         (anim/animate top-view-bg colors/neutral-100-opa-0)))))
 
-(defn drawer
-  [images index]
-  (let [{:keys [image]} (nth images index)
-        uri             (url/replace-port image (rf/sub [:mediaserver/port]))]
-    [quo/action-drawer
-     [[{:icon                :i/save
-        :accessibility-label :save-image
-        :label               (i18n/label :t/save-image-library)
-        :on-press            (fn []
-                               (rf/dispatch [:hide-bottom-sheet])
-                               (rf/dispatch
-                                [:lightbox/save-image-to-gallery
-                                 uri
-                                 #(rf/dispatch [:toasts/upsert
-                                                {:id              :random-id
-                                                 :type            :positive
-                                                 :container-style {:bottom (when platform/android? 20)}
-                                                 :text            (i18n/label :t/photo-saved)}])]))}]]]))
-
 (defn share-image
   [images index]
   (let [{:keys [image]} (nth images index)
@@ -66,7 +46,7 @@
     (rf/dispatch [:lightbox/share-image uri])))
 
 (defn top-view
-  [images insets index animations derived landscape? screen-width]
+  [images insets index animations derived landscape? screen-width options-drawer-component]
   (let [{:keys [description header]} (nth images @index)
         bg-color                     (if landscape?
                                        colors/neutral-100-opa-70
@@ -114,6 +94,6 @@
        {:active-opacity      1
         :accessibility-label :image-options
         :on-press            #(rf/dispatch [:show-bottom-sheet
-                                            {:content (fn [] [drawer images @index])}])
+                                            {:content (fn [] [options-drawer-component images @index])}])
         :style               style/close-container}
        [quo/icon :options {:size 20 :color colors/white}]]]]))

--- a/src/status_im/common/lightbox/view.cljs
+++ b/src/status_im/common/lightbox/view.cljs
@@ -44,7 +44,8 @@
    [rn/view {:style {:width constants/separator-width}}]])
 
 (defn lightbox-content
-  [{:keys [props state animations derived images index handle-items-changed bottom-text-component]}]
+  [{:keys [props state animations derived images index handle-items-changed bottom-text-component
+           options-drawer-component]}]
   (let [{:keys [data transparent? scroll-index
                 set-full-height?]} state
         insets                     (safe-area/get-insets)
@@ -69,7 +70,7 @@
                                                    {:height screen-height})}
      (when-not @transparent?
        [:f> top-view/top-view images insets scroll-index animations derived landscape?
-        screen-width])
+        screen-width options-drawer-component])
      [gesture/gesture-detector
       {:gesture (utils/drag-gesture animations (and landscape? platform/ios?) set-full-height?)}
       [reanimated/view
@@ -136,7 +137,8 @@
 
 (defn- f-lightbox
   []
-  (let [{:keys [images index bottom-text-component]} (rf/sub [:get-screen-params])
+  (let [{:keys [images index bottom-text-component options-drawer-component]}
+        (rf/sub [:get-screen-params])
         props
         (utils/init-props)
         state
@@ -153,14 +155,15 @@
           (utils/orientation-change props state animations))
         (utils/effect props animations index)
         [:f> lightbox-content
-         {:props                 props
-          :state                 state
-          :animations            animations
-          :derived               derived
-          :images                images
-          :index                 index
-          :handle-items-changed  handle-items-changed
-          :bottom-text-component bottom-text-component}]))))
+         {:props                    props
+          :state                    state
+          :animations               animations
+          :derived                  derived
+          :images                   images
+          :index                    index
+          :handle-items-changed     handle-items-changed
+          :bottom-text-component    bottom-text-component
+          :options-drawer-component options-drawer-component}]))))
 
 (defn lightbox
   []

--- a/src/status_im/common/lightbox/view.cljs
+++ b/src/status_im/common/lightbox/view.cljs
@@ -45,7 +45,7 @@
 
 (defn lightbox-content
   [{:keys [props state animations derived images index handle-items-changed bottom-text-component
-           options-drawer-component]}]
+           on-options-press]}]
   (let [{:keys [data transparent? scroll-index
                 set-full-height?]} state
         insets                     (safe-area/get-insets)
@@ -70,7 +70,7 @@
                                                    {:height screen-height})}
      (when-not @transparent?
        [:f> top-view/top-view images insets scroll-index animations derived landscape?
-        screen-width options-drawer-component])
+        screen-width on-options-press])
      [gesture/gesture-detector
       {:gesture (utils/drag-gesture animations (and landscape? platform/ios?) set-full-height?)}
       [reanimated/view
@@ -137,7 +137,7 @@
 
 (defn- f-lightbox
   []
-  (let [{:keys [images index bottom-text-component options-drawer-component]}
+  (let [{:keys [images index bottom-text-component on-options-press]}
         (rf/sub [:get-screen-params])
         props
         (utils/init-props)
@@ -155,15 +155,15 @@
           (utils/orientation-change props state animations))
         (utils/effect props animations index)
         [:f> lightbox-content
-         {:props                    props
-          :state                    state
-          :animations               animations
-          :derived                  derived
-          :images                   images
-          :index                    index
-          :handle-items-changed     handle-items-changed
-          :bottom-text-component    bottom-text-component
-          :options-drawer-component options-drawer-component}]))))
+         {:props                 props
+          :state                 state
+          :animations            animations
+          :derived               derived
+          :images                images
+          :index                 index
+          :handle-items-changed  handle-items-changed
+          :bottom-text-component bottom-text-component
+          :on-options-press      on-options-press}]))))
 
 (defn lightbox
   []

--- a/src/status_im/contexts/chat/messenger/messages/content/album/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/album/view.cljs
@@ -66,7 +66,8 @@
                                                   album-messages))
                                    :bottom-text-component
                                    [lightbox/bottom-text-for-lightbox
-                                    first-image]}])}
+                                    first-image]
+                                   :options-drawer-component lightbox/drawer}])}
               [fast-image/fast-image
                {:style     (style/image dimensions index portrait? images-count)
                 :source    {:uri (url/replace-port (:image (:content item)) media-server-port)}

--- a/src/status_im/contexts/chat/messenger/messages/content/album/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/album/view.cljs
@@ -67,7 +67,11 @@
                                    :bottom-text-component
                                    [lightbox/bottom-text-for-lightbox
                                     first-image]
-                                   :options-drawer-component lightbox/drawer}])}
+                                   :on-options-press (fn [images index]
+                                                       (rf/dispatch [:show-bottom-sheet
+                                                                     {:content (fn [] [lightbox/drawer
+                                                                                       images
+                                                                                       index])}]))}])}
               [fast-image/fast-image
                {:style     (style/image dimensions index portrait? images-count)
                 :source    {:uri (url/replace-port (:image (:content item)) media-server-port)}

--- a/src/status_im/contexts/chat/messenger/messages/content/image/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/image/view.cljs
@@ -58,7 +58,12 @@
                                        :insets insets
                                        :bottom-text-component
                                        [lightbox/bottom-text-for-lightbox message]
-                                       :options-drawer-component lightbox/drawer}])}
+                                       :on-options-press (fn [images index]
+                                                           (rf/dispatch [:show-bottom-sheet
+                                                                         {:content (fn []
+                                                                                     [lightbox/drawer
+                                                                                      images
+                                                                                      index])}]))}])}
       [fast-image/fast-image
        {:source              {:uri image-local-url}
         :style               (merge dimensions {:border-radius 12})

--- a/src/status_im/contexts/chat/messenger/messages/content/image/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/image/view.cljs
@@ -57,7 +57,8 @@
                                        :index 0
                                        :insets insets
                                        :bottom-text-component
-                                       [lightbox/bottom-text-for-lightbox message]}])}
+                                       [lightbox/bottom-text-for-lightbox message]
+                                       :options-drawer-component lightbox/drawer}])}
       [fast-image/fast-image
        {:source              {:uri image-local-url}
         :style               (merge dimensions {:border-radius 12})

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -3,11 +3,8 @@
     [quo.core :as quo]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
-<<<<<<< HEAD
-    [react-native.svg :as svg]
-=======
     [react-native.platform :as platform]
->>>>>>> 49161eff7 (Options component moved out of lightbox)
+    [react-native.svg :as svg]
     [reagent.core :as reagent]
     [status-im.common.scroll-page.view :as scroll-page]
     [status-im.contexts.wallet.collectible.style :as style]
@@ -138,21 +135,27 @@
              :on-press       (fn []
                                (if svg?
                                  (js/alert "Can't visualize SVG images in lightbox")
-                                 (rf/dispatch [:lightbox/navigate-to-lightbox
-                                               token-id
-                                               {:images [{:image        preview-uri
-                                                          :image-width  300 ; collectibles don't have
-                                                          ; width/height but we need
-                                                          ; to pass something
-                                                          :image-height 300 ; without it animation
-                                                          ; doesn't work smoothly and
-                                                          ; :border-radius not
-                                                          ; applied
-                                                          :id           token-id
-                                                          :header       collectible-name
-                                                          :description  collection-name}]
-                                                :index  0
-                                                :options-drawer-component options-drawer}])))}
+                                 (rf/dispatch
+                                  [:lightbox/navigate-to-lightbox
+                                   token-id
+                                   {:images           [{:image        preview-uri
+                                                        :image-width  300 ; collectibles don't have
+                                                                          ; width/height but we need
+                                                                          ; to pass something
+                                                        :image-height 300 ; without it animation
+                                                                          ; doesn't work smoothly
+                                                                          ; and :border-radius not
+                                                                          ; applied
+                                                        :id           token-id
+                                                        :header       collectible-name
+                                                        :description  collection-name}]
+                                    :index            0
+                                    :on-options-press (fn [images index]
+                                                        (rf/dispatch [:show-bottom-sheet
+                                                                      {:content (fn []
+                                                                                  [options-drawer
+                                                                                   images
+                                                                                   index])}]))}])))}
             (if svg?
               [rn/view
                {:style     (assoc style/preview :overflow :hidden)

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -3,13 +3,18 @@
     [quo.core :as quo]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
+<<<<<<< HEAD
     [react-native.svg :as svg]
+=======
+    [react-native.platform :as platform]
+>>>>>>> 49161eff7 (Options component moved out of lightbox)
     [reagent.core :as reagent]
     [status-im.common.scroll-page.view :as scroll-page]
     [status-im.contexts.wallet.collectible.style :as style]
     [status-im.contexts.wallet.collectible.tabs.view :as tabs]
     [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+    [utils.re-frame :as rf]
+    [utils.url :as url]))
 
 (defn header
   [collectible-name collection-name collection-image-url]
@@ -71,6 +76,32 @@
       :accessibility-label :share-details
       :label               (i18n/label :t/share-details)}]]])
 
+(defn options-drawer
+  [images index]
+  (let [{:keys [image]} (nth images index)
+        uri             (url/replace-port image (rf/sub [:mediaserver/port]))]
+    [quo/action-drawer
+     [[{:icon                :i/link
+        :accessibility-label :view-on-etherscan
+        :label               (i18n/label :t/view-on-eth)}]
+      [{:icon                :i/save
+        :accessibility-label :save-image
+        :label               (i18n/label :t/save-image-to-photos)
+        :on-press            (fn []
+                               (rf/dispatch [:hide-bottom-sheet])
+                               (rf/dispatch
+                                [:lightbox/save-image-to-gallery
+                                 uri
+                                 #(rf/dispatch [:toasts/upsert
+                                                {:id              :random-id
+                                                 :type            :positive
+                                                 :container-style {:bottom (when platform/android? 20)}
+                                                 :text            (i18n/label :t/photo-saved)}])]))}]
+      [{:icon                :i/share
+        :accessibility-label :share-collectible
+        :label               (i18n/label :t/share-collectible)
+        :right-icon          :i/external}]]]))
+
 (defn view-internal
   [{:keys [theme] :as _props}]
   (let [selected-tab  (reagent/atom :overview)
@@ -120,7 +151,8 @@
                                                           :id           token-id
                                                           :header       collectible-name
                                                           :description  collection-name}]
-                                                :index  0}])))}
+                                                :index  0
+                                                :options-drawer-component options-drawer}])))}
             (if svg?
               [rn/view
                {:style     (assoc style/preview :overflow :hidden)

--- a/translations/en.json
+++ b/translations/en.json
@@ -1283,6 +1283,7 @@
     "share-channel": "Share channel",
     "share-address": "Share address",
     "share-chat": "Share chat",
+    "share-collectible": "Share collectible",
     "share-contact-code": "Share my chat key",
     "share-community": "Share community",
     "share-dapp-text": "Check out this DApp I'm using on Status: {{link}}",


### PR DESCRIPTION
fixes #18623

### Summary

Menu added to collectible preview according to designs

![Simulator Screenshot - iPhone 13 - 2024-01-26 at 17 37 02](https://github.com/status-im/status-mobile/assets/5786310/dfed1bdb-47f9-467f-b158-04de85e4b5a3)

[Figma designs](https://www.figma.com/file/HKncH4wnDwZDAhc4AryK8Y/Wallet-for-Mobile?type=design&node-id=2081-444926&mode=design&t=kXfIb1FXEsf9uGjJ-4)

### Review notes
To implement different menus for collectible preview and image preview in chat, lightbox was adjusted to accept options drawer as an external component

status: ready
