### PR TITLE
Remove hacks from darwin nix purge script

### DIFF
--- a/nix/scripts/kill_proc_prompt.sh
+++ b/nix/scripts/kill_proc_prompt.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
+set -Eeuo pipefail
+# script to prompt user for terminating a process
 
-# Function to prompt user for terminating a process
-kill_proc_prompt() {
-    local pid=$1
+pid="${1}"
 
-    # Ask the user whether to terminate the process
-    read -p "Do you want to terminate this process? (y/n): " choice
-    if [[ $choice == "y" ]]; then
-        sudo kill $pid
-        echo "Process $pid terminated."
-    else
-        echo "Process not terminated. Please close it manually and retry."
-        return 1
-    fi
-}
+read -p "Do you want to terminate this process? (y/n): " choice
+if [[ "${choice}" == "y" ]]; then
+    sudo kill "${pid}"
+    echo "Process ${pid} terminated."
+else
+    echo "Process not terminated. Please close it manually and retry."
+    exit 1
+fi

--- a/nix/scripts/kill_proc_prompt.sh
+++ b/nix/scripts/kill_proc_prompt.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Function to prompt user for terminating a process
+kill_proc_prompt() {
+    local pid=$1
+
+    # Ask the user whether to terminate the process
+    read -p "Do you want to terminate this process? (y/n): " choice
+    if [[ $choice == "y" ]]; then
+        sudo kill $pid
+        echo "Process $pid terminated."
+    else
+        echo "Process not terminated. Please close it manually and retry."
+        return 1
+    fi
+}

--- a/nix/scripts/purge.sh
+++ b/nix/scripts/purge.sh
@@ -4,7 +4,6 @@
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/nix/scripts/lib.sh"
 source "${GIT_ROOT}/scripts/colors.sh"
-source "${GIT_ROOT}/nix/scripts/kill_proc_prompt.sh"
 
 nix_purge_linux_multi_user_service() {
     NIX_SERVICES=(nix-daemon.service nix-daemon.socket)
@@ -47,9 +46,9 @@ nix_purge_darwin_multi_user_volumes() {
 
         # Identify the process using the volume
         local pid=$(lsof +D /nix | awk 'NR==2{print $2}')
-        if [ -n "$pid" ]; then
+        if [[ -n "$pid" ]]; then
             echo "The volume /nix is in use by process ID $pid."
-            kill_proc_prompt "$pid" || return 1
+            "${GIT_ROOT}/nix/scripts/kill_proc_prompt.sh" "${pid}" || return 1
 
         else
             echo "No process found using /nix. Manual intervention required."

--- a/nix/scripts/purge.sh
+++ b/nix/scripts/purge.sh
@@ -25,8 +25,8 @@ nix_purge_darwin_multi_user_service() {
     cd /Library/LaunchDaemons
     NIX_SERVICES=(org.nixos.darwin-store.plist org.nixos.nix-daemon.plist)
     for NIX_SERVICE in "${NIX_SERVICES[@]}"; do
-        sudo launchctl unload "${NIX_SERVICE}" || true
-        sudo launchctl remove "${NIX_SERVICE}" || true
+        sudo launchctl unload "${NIX_SERVICE}"
+        sudo launchctl remove "${NIX_SERVICE}"
     done
 }
 
@@ -71,9 +71,9 @@ nix_purge_darwin_multi_user_volumes() {
 
 nix_purge_multi_user() {
     if [[ $(uname -s) == "Darwin" ]]; then
-        nix_purge_darwin_multi_user_service || true
-        nix_purge_darwin_multi_user_users || true
-        nix_purge_darwin_multi_user_volumes || true
+        nix_purge_darwin_multi_user_service
+        nix_purge_darwin_multi_user_users
+        nix_purge_darwin_multi_user_volumes
     else
         nix_purge_linux_multi_user_service
         nix_purge_linux_multi_user_users


### PR DESCRIPTION
fixes #18360

## Summary
In this PR we : 
- instead of `cd` to `/Library/LaunchDaemons` and then attempting to `launchctl unload` the nixos plist files we just pass the full path to unload as seen in `nix` documentation here : https://nixos.org/manual/nix/stable/installation/uninstall.html#:~:text=Stop%20and%20remove%20the%20Nix%20daemon%20services%3A

- move killing a process by prompting for confirmation to a new shell script as per feedback from previous PR : https://github.com/status-im/status-mobile/pull/18192#discussion_r1439495310

- fix few small typos

## Testing notes
we don't need QA for this PR since it only affects how we purge `nix` locally for `macOS`.

## Review notes
execute `make nix-purge` and the expectation would be that the script purges `nix` completely and does not break in the middle.
> [!WARNING]
> doing so would remove `nix` and `nix store` and next time you build the app it would take an **_hour or more_** to get the `nix store` back :) 

## Platforms
- macOS

status: ready
