### PR TITLE
adjust input field size to the scanned data

### DIFF
--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -59,7 +59,7 @@
        :button              (when empty-input?
                               {:on-press paste-on-input
                                :text     (i18n/label :t/paste)})
-       :value               @input-value}]
+       :value               (or scanned-address @input-value)}]
      [quo/button
       {:type            :outline
        :on-press        (fn []


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/17943

When investigating this issue, I was only able to reproduce it while scanning an address to watch from the wallet screen. Scanning to add a new contact or to view profile seemed to work just fine. 

This issue looks resolved in both cases

**Before**

https://github.com/status-im/status-mobile/assets/28704507/ef3d946a-b72a-48ab-bb20-64e7946468af

**After**

https://github.com/status-im/status-mobile/assets/28704507/12ffcfcf-5335-4047-ac96-8df0002575fb



