### PR TITLE
🐰 Fix #18375 - Disappearing tabs when sending assets

### DIFF
--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -168,14 +168,13 @@
              [local-suggestions-list]]]
            [:<>
             [quo/tabs
-             {:style            style/tabs
-              :container-style  style/tabs-content
-              :size             32
-              :default-active   selected-tab
-              :data             tabs-data
-              :scrollable?      true
-              :scroll-on-press? true
-              :on-change        on-change-tab}]
+             {:style           style/tabs
+              :container-style style/tabs-content
+              :size            32
+              :default-active  selected-tab
+              :data            tabs-data
+              :scrollable?     true
+              :on-change       on-change-tab}]
             [tabs/view {:selected-tab selected-tab}]])]))))
 
 (defn view


### PR DESCRIPTION
Fixes #18375

### Summary
Remove the option to scroll on click, when selecting an address from various sources.
Having the scroll-on-click turned on breaks the UI (as outlined in #18375). 

I have not been able to find the exact cause of this, but it feels related to having nested scroll views. The issue occurs in flat-list component which is outside the scope of our app (have highlighted the error on the issue page)

With this fix in place, the UX takes a tiny hit, but the functionality remains intact. So far, the functionality was breaking down.

#### Platforms
- Android
- iOS

##### Functional
- wallet / transactions

### Steps to test
1. Goto wallet tab
2. Select an account
3. Click "Send"
4. Chose any tab for address source except for first one (any except ''Recent")
5. Press the address input
6. Make sure software keyboard pulls up
7. Now press on the empty screen to trigger on-blur event on input
8. You should be brought back to send page you started with
9. All tabs should be visible

With the bug, some tabs disappeared.

status: ready
