### PR TITLE
Implement Name Selection Flow

### DIFF
--- a/src/quo/components/overlay/view.cljs
+++ b/src/quo/components/overlay/view.cljs
@@ -14,7 +14,7 @@
        :blur-type     :transparent
        :overlay-color :transparent
        :style         style/container}
-      [rn/view {:style (merge style/blur-container container-style)}
-       children]]
-     [rn/view {:style (merge style/container container-style)}
-      children])])
+      (into [rn/view {:style (merge style/blur-container container-style)}]
+            children)]
+     (into [rn/view {:style (merge style/container container-style)}]
+           children))])

--- a/src/quo/components/settings/settings_item/style.cljs
+++ b/src/quo/components/settings/settings_item/style.cljs
@@ -57,10 +57,8 @@
 
 (defn image-color
   [blur? image-right? theme]
-  {:color (if blur?
-            (if image-right?
-              colors/white-opa-40
-              colors/white-opa-70)
+  {:color (if (and blur? image-right?)
+            colors/white-opa-40
             (color blur? theme))})
 
 (defn label-dot

--- a/src/quo/components/settings/settings_item/style.cljs
+++ b/src/quo/components/settings/settings_item/style.cljs
@@ -32,8 +32,8 @@
 (defn image-container
   [image image-right? tag description]
   {:height      (if (= image :icon-avatar) 32 20)
-   :margin-top  (if (or tag description) 1 0)
-   :margin-left (if image-right? 8 0)})
+   :margin-top  (when (or tag description) 1)
+   :margin-left (when image-right? 8)})
 
 (def status-container
   {:flex-direction :row

--- a/src/quo/components/settings/settings_item/style.cljs
+++ b/src/quo/components/settings/settings_item/style.cljs
@@ -31,8 +31,8 @@
 
 (defn image-container
   [image image-right? tag description]
-  {:height     (if (= image :icon-avatar) 32 20)
-   :margin-top (if (or tag description) 1 0)
+  {:height      (if (= image :icon-avatar) 32 20)
+   :margin-top  (if (or tag description) 1 0)
    :margin-left (if image-right? 8 0)})
 
 (def status-container
@@ -55,7 +55,7 @@
             colors/white-opa-70
             (colors/theme-colors colors/neutral-50 colors/neutral-40 theme))})
 
-(defn image-color 
+(defn image-color
   [blur? image-right? theme]
   {:color (if blur?
             (if image-right?

--- a/src/quo/components/settings/settings_item/style.cljs
+++ b/src/quo/components/settings/settings_item/style.cljs
@@ -55,6 +55,14 @@
             colors/white-opa-70
             (colors/theme-colors colors/neutral-50 colors/neutral-40 theme))})
 
+(defn image-color 
+  [blur? image-right? theme]
+  {:color (if blur?
+            (if image-right?
+              colors/white-opa-40
+              colors/white-opa-70)
+            (color blur? theme))})
+
 (defn label-dot
   [background-color]
   {:width            15

--- a/src/quo/components/settings/settings_item/style.cljs
+++ b/src/quo/components/settings/settings_item/style.cljs
@@ -30,9 +30,10 @@
    :justify-content   :flex-start})
 
 (defn image-container
-  [image tag description]
+  [image image-right? tag description]
   {:height     (if (= image :icon-avatar) 32 20)
-   :margin-top (if (or tag description) 1 0)})
+   :margin-top (if (or tag description) 1 0)
+   :margin-left (if image-right? 8 0)})
 
 (def status-container
   {:flex-direction :row

--- a/src/quo/components/settings/settings_item/view.cljs
+++ b/src/quo/components/settings/settings_item/view.cljs
@@ -102,7 +102,8 @@
      nil)])
 
 (defn- internal-view
-  [{:keys [image-right? title on-press action-props accessibility-label blur? container-style] :as props}]
+  [{:keys [image-right? title on-press action-props accessibility-label blur? container-style]
+    :as   props}]
   [rn/pressable
    {:style               (merge style/container container-style)
     :on-press            on-press

--- a/src/quo/components/settings/settings_item/view.cljs
+++ b/src/quo/components/settings/settings_item/view.cljs
@@ -53,7 +53,7 @@
   [rn/view
    {:style (style/image-container image image-right? tag description)}
    (case image
-     :icon        [icon/icon image-props (style/color blur? theme)]
+     :icon        [icon/icon image-props (style/image-color blur? image-right? theme)]
      :avatar      [user-avatar/user-avatar image-props]
      :icon-avatar [icon-avatar/icon-avatar image-props]
      nil)])

--- a/src/quo/components/settings/settings_item/view.cljs
+++ b/src/quo/components/settings/settings_item/view.cljs
@@ -49,9 +49,9 @@
     nil))
 
 (defn image-component
-  [{:keys [image image-props description tag blur? theme]}]
+  [{:keys [image image-right? image-props description tag blur? theme]}]
   [rn/view
-   {:style (style/image-container description tag image)}
+   {:style (style/image-container image image-right? tag description)}
    (case image
      :icon        [icon/icon image-props (style/color blur? theme)]
      :avatar      [user-avatar/user-avatar image-props]
@@ -102,13 +102,13 @@
      nil)])
 
 (defn- internal-view
-  [{:keys [image-right title on-press action-props accessibility-label blur? container-style] :as props}]
+  [{:keys [image-right? title on-press action-props accessibility-label blur? container-style] :as props}]
   [rn/pressable
    {:style               (merge style/container container-style)
     :on-press            on-press
     :accessibility-label accessibility-label}
    [rn/view {:style (style/left-sub-container props)}
-    (when-not image-right
+    (when-not image-right?
       [image-component props])
     [rn/view {:style (style/left-container (:image props))}
      [text/text
@@ -119,7 +119,7 @@
    [rn/view {:style (style/sub-container (:alignment action-props))}
     [label-component props]
     [action-component props]
-    (when image-right
+    (when image-right?
       [image-component props])]])
 
 (def view (quo.theme/with-theme internal-view))

--- a/src/quo/components/settings/settings_item/view.cljs
+++ b/src/quo/components/settings/settings_item/view.cljs
@@ -102,13 +102,14 @@
      nil)])
 
 (defn- internal-view
-  [{:keys [title on-press action-props accessibility-label blur? container-style] :as props}]
+  [{:keys [image-right title on-press action-props accessibility-label blur? container-style] :as props}]
   [rn/pressable
    {:style               (merge style/container container-style)
     :on-press            on-press
     :accessibility-label accessibility-label}
    [rn/view {:style (style/left-sub-container props)}
-    [image-component props]
+    (when-not image-right
+      [image-component props])
     [rn/view {:style (style/left-container (:image props))}
      [text/text
       {:weight :medium
@@ -117,6 +118,8 @@
      [tag-component props]]]
    [rn/view {:style (style/sub-container (:alignment action-props))}
     [label-component props]
-    [action-component props]]])
+    [action-component props]
+    (when image-right
+      [image-component props])]])
 
 (def view (quo.theme/with-theme internal-view))

--- a/src/status_im/common/bottom_sheet_screen/style.cljs
+++ b/src/status_im/common/bottom_sheet_screen/style.cljs
@@ -23,10 +23,11 @@
     :right            0}))
 
 (defn main-view
-  [translate-y theme]
+  [translate-y theme skip-background?]
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y translate-y}]}
-   {:background-color        (colors/theme-colors colors/white colors/neutral-95 theme)
+   {:background-color        (when-not skip-background? 
+                               (colors/theme-colors colors/white colors/neutral-95 theme))
     :border-top-left-radius  20
     :border-top-right-radius 20
     :flex                    1

--- a/src/status_im/common/bottom_sheet_screen/view.cljs
+++ b/src/status_im/common/bottom_sheet_screen/view.cljs
@@ -82,7 +82,7 @@
                                    :close              close
                                    :reset-open-sheet   reset-open-sheet
                                    :set-animating-true set-animating-true})}
-          [reanimated/view {:style (style/main-view translate-y theme)}
+          [reanimated/view {:style (style/main-view translate-y theme skip-background?)}
            [rn/view {:style style/handle-container}
             [rn/view {:style (style/handle theme)}]]
            [content

--- a/src/status_im/contexts/profile/edit/ens/events.cljs
+++ b/src/status_im/contexts/profile/edit/ens/events.cljs
@@ -3,6 +3,6 @@
 
 (defn remove-ens-name
   [{:keys [db]} [name]]
-  {:db (update-in db [:ens/names] dissoc name)})
+  {:db (update db :ens/names dissoc name)})
 
 (rf/reg-event-fx :ens/remove-ens remove-ens-name)

--- a/src/status_im/contexts/profile/edit/ens/events.cljs
+++ b/src/status_im/contexts/profile/edit/ens/events.cljs
@@ -1,0 +1,8 @@
+(ns status-im.contexts.profile.edit.ens.events
+  (:require [utils.re-frame :as rf]))
+
+(defn remove-ens-name
+  [{:keys [db]} [name]]
+  {:db (update-in db [:ens/names] dissoc name)})
+
+(rf/reg-event-fx :ens/remove-ens remove-ens-name)

--- a/src/status_im/contexts/profile/edit/ens/events_test.cljs
+++ b/src/status_im/contexts/profile/edit/ens/events_test.cljs
@@ -5,7 +5,7 @@
 
 (deftest edit-name-test
   (let [new-name "test.eth"
-        cofx     {:db {:ens/names {"test.eth" {:name "test.eth"}
+        cofx     {:db {:ens/names {"test.eth"  {:name "test.eth"}
                                    "test2.eth" {:name "test2.eth"}}}}
         expected {:db {:ens/names {"test2.eth" {:name "test2.eth"}}}}]
     (is (match? expected

--- a/src/status_im/contexts/profile/edit/ens/events_test.cljs
+++ b/src/status_im/contexts/profile/edit/ens/events_test.cljs
@@ -3,7 +3,7 @@
             matcher-combinators.test
             [status-im.contexts.profile.edit.ens.events :as sut]))
 
-(deftest edit-name-test
+(deftest remove-ens-name-test
   (let [new-name "test.eth"
         cofx     {:db {:ens/names {"test.eth"  {:name "test.eth"}
                                    "test2.eth" {:name "test2.eth"}}}}

--- a/src/status_im/contexts/profile/edit/ens/events_test.cljs
+++ b/src/status_im/contexts/profile/edit/ens/events_test.cljs
@@ -1,0 +1,12 @@
+(ns status-im.contexts.profile.edit.ens.events-test
+  (:require [cljs.test :refer [deftest is]]
+            matcher-combinators.test
+            [status-im.contexts.profile.edit.ens.events :as sut]))
+
+(deftest edit-name-test
+  (let [new-name "test.eth"
+        cofx     {:db {:ens/names {"test.eth" {:name "test.eth"}
+                                   "test2.eth" {:name "test2.eth"}}}}
+        expected {:db {:ens/names {"test2.eth" {:name "test2.eth"}}}}]
+    (is (match? expected
+                (sut/remove-ens-name cofx [new-name])))))

--- a/src/status_im/contexts/profile/edit/ens/style.cljs
+++ b/src/status_im/contexts/profile/edit/ens/style.cljs
@@ -2,7 +2,7 @@
 
 (defn page-wrapper
   [insets]
-  {:padding-top        (:top insets)
+  {:padding-top        8
    :padding-bottom     (:bottom insets)
    :padding-horizontal 1
    :flex               1})

--- a/src/status_im/contexts/profile/edit/ens/style.cljs
+++ b/src/status_im/contexts/profile/edit/ens/style.cljs
@@ -1,0 +1,17 @@
+(ns status-im.contexts.profile.edit.ens.style)
+
+(defn page-wrapper
+  [insets]
+  {:padding-top        (:top insets)
+   :padding-bottom     (:bottom insets)
+   :padding-horizontal 1
+   :flex               1})
+
+(def screen-container
+  {:flex               1
+   :padding-top        14
+   :padding-horizontal 20
+   :justify-content    :space-between})
+
+(def button-wrapper
+  {:margin-vertical 12})

--- a/src/status_im/contexts/profile/edit/ens/view.cljs
+++ b/src/status_im/contexts/profile/edit/ens/view.cljs
@@ -1,11 +1,11 @@
 (ns status-im.contexts.profile.edit.ens.view
   (:require
-   [quo.core :as quo]
-   [react-native.core :as rn]
-   [react-native.safe-area :as safe-area]
-   [status-im.contexts.profile.edit.ens.style :as style]
-   [utils.i18n :as i18n]
-   [utils.re-frame :as rf]))
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [react-native.safe-area :as safe-area]
+    [status-im.contexts.profile.edit.ens.style :as style]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (defn view
   []

--- a/src/status_im/contexts/profile/edit/ens/view.cljs
+++ b/src/status_im/contexts/profile/edit/ens/view.cljs
@@ -22,7 +22,7 @@
      [rn/view
       {:key   :content
        :style style/screen-container}
-      [rn/view {:style {:gap 22}}
+      [rn/view
        [quo/text-combinations {:title user-name}]]
       [rn/view {:style style/button-wrapper}
        [quo/button

--- a/src/status_im/contexts/profile/edit/ens/view.cljs
+++ b/src/status_im/contexts/profile/edit/ens/view.cljs
@@ -11,26 +11,25 @@
   []
   (let [insets    (safe-area/get-insets)
         user-name (rf/sub [:get-screen-params :edit-ens])]
-    (fn []
-      [quo/overlay
-       {:type            :shell
-        :container-style (style/page-wrapper insets)}
-       [quo/page-nav
-        {:key        :header
-         :background :blur
-         :icon-name  :i/close
-         :on-press   #(rf/dispatch [:navigate-back])}]
-       [rn/view
-        {:key   :content
-         :style style/screen-container}
-        [rn/view {:style {:gap 22}}
-         [quo/text-combinations {:title user-name}]]
-        [rn/view {:style style/button-wrapper}
-         [quo/button
-          {:type      :danger
-           :blur?     true
-           :icon-left :i/delete
-           :on-press  (fn []
-                        (rf/dispatch [:ens/remove-ens user-name])
-                        (rf/dispatch [:navigate-back]))}
-          (i18n/label :t/remove)]]]])))
+    [quo/overlay
+     {:type            :shell
+      :container-style (style/page-wrapper insets)}
+     [quo/page-nav
+      {:key        :header
+       :background :blur
+       :icon-name  :i/close
+       :on-press   #(rf/dispatch [:navigate-back])}]
+     [rn/view
+      {:key   :content
+       :style style/screen-container}
+      [rn/view {:style {:gap 22}}
+       [quo/text-combinations {:title user-name}]]
+      [rn/view {:style style/button-wrapper}
+       [quo/button
+        {:type      :danger
+         :blur?     true
+         :icon-left :i/delete
+         :on-press  (fn []
+                      (rf/dispatch [:ens/remove-ens user-name])
+                      (rf/dispatch [:navigate-back]))}
+        (i18n/label :t/remove)]]]]))

--- a/src/status_im/contexts/profile/edit/ens/view.cljs
+++ b/src/status_im/contexts/profile/edit/ens/view.cljs
@@ -25,7 +25,6 @@
       [rn/view {:style style/button-wrapper}
        [quo/button
         {:type      :danger
-         :blur?     true
          :icon-left :i/delete
          :on-press  (fn []
                       (rf/dispatch [:ens/remove-ens user-name])

--- a/src/status_im/contexts/profile/edit/ens/view.cljs
+++ b/src/status_im/contexts/profile/edit/ens/view.cljs
@@ -15,13 +15,11 @@
      {:type            :shell
       :container-style (style/page-wrapper insets)}
      [quo/page-nav
-      {:key        :header
-       :background :blur
+      {:background :blur
        :icon-name  :i/close
        :on-press   #(rf/dispatch [:navigate-back])}]
      [rn/view
-      {:key   :content
-       :style style/screen-container}
+      {:style style/screen-container}
       [rn/view
        [quo/text-combinations {:title user-name}]]
       [rn/view {:style style/button-wrapper}

--- a/src/status_im/contexts/profile/edit/ens/view.cljs
+++ b/src/status_im/contexts/profile/edit/ens/view.cljs
@@ -31,5 +31,6 @@
            :blur?     true
            :icon-left :i/delete
            :on-press  (fn []
-                        (rf/dispatch [:ens/remove-ens user-name]))}
+                        (rf/dispatch [:ens/remove-ens user-name])
+                        (rf/dispatch [:navigate-back]))}
           (i18n/label :t/remove)]]]])))

--- a/src/status_im/contexts/profile/edit/ens/view.cljs
+++ b/src/status_im/contexts/profile/edit/ens/view.cljs
@@ -1,0 +1,35 @@
+(ns status-im.contexts.profile.edit.ens.view
+  (:require
+   [quo.core :as quo]
+   [react-native.core :as rn]
+   [react-native.safe-area :as safe-area]
+   [status-im.contexts.profile.edit.ens.style :as style]
+   [utils.i18n :as i18n]
+   [utils.re-frame :as rf]))
+
+(defn view
+  []
+  (let [insets    (safe-area/get-insets)
+        user-name (rf/sub [:get-screen-params :edit-ens])]
+    (fn []
+      [quo/overlay
+       {:type            :shell
+        :container-style (style/page-wrapper insets)}
+       [quo/page-nav
+        {:key        :header
+         :background :blur
+         :icon-name  :i/close
+         :on-press   #(rf/dispatch [:navigate-back])}]
+       [rn/view
+        {:key   :content
+         :style style/screen-container}
+        [rn/view {:style {:gap 22}}
+         [quo/text-combinations {:title user-name}]]
+        [rn/view {:style style/button-wrapper}
+         [quo/button
+          {:type      :danger
+           :blur?     true
+           :icon-left :i/delete
+           :on-press  (fn []
+                        (rf/dispatch [:ens/remove-ens user-name]))}
+          (i18n/label :t/remove)]]]])))

--- a/src/status_im/contexts/profile/edit/list_items.cljs
+++ b/src/status_im/contexts/profile/edit/list_items.cljs
@@ -15,7 +15,7 @@
         full-name           (profile.utils/displayed-name profile)]
     [{:label (i18n/label :t/profile)
       :items [{:title           (i18n/label :t/name)
-               :on-press        #(rf/dispatch [:open-modal :edit-name])
+               :on-press        #(rf/dispatch [:open-modal :edit-names])
                :blur?           true
                :label           :text
                :label-props     full-name

--- a/src/status_im/contexts/profile/edit/name/style.cljs
+++ b/src/status_im/contexts/profile/edit/name/style.cljs
@@ -2,7 +2,7 @@
 
 (defn page-wrapper
   [insets]
-  {:padding-top        (:top insets)
+  {:padding-top        8
    :padding-bottom     (:bottom insets)
    :padding-horizontal 1
    :flex               1})

--- a/src/status_im/contexts/profile/edit/name/view.cljs
+++ b/src/status_im/contexts/profile/edit/name/view.cljs
@@ -7,7 +7,6 @@
             [status-im.common.validation.profile :as profile-validator]
             [status-im.constants :as constants]
             [status-im.contexts.profile.edit.name.style :as style]
-            [status-im.contexts.profile.utils :as profile.utils]
             [utils.debounce :as debounce]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
@@ -17,7 +16,7 @@
   (let [insets              (safe-area/get-insets)
         profile             (rf/sub [:profile/profile-with-image])
         customization-color (rf/sub [:profile/customization-color])
-        display-name        (profile.utils/displayed-name profile)
+        display-name        (:display-name profile)
         full-name           (reagent/atom display-name)
         error-msg           (reagent/atom nil)
         typing?             (reagent/atom false)

--- a/src/status_im/contexts/profile/edit/name/view.cljs
+++ b/src/status_im/contexts/profile/edit/name/view.cljs
@@ -36,7 +36,7 @@
        [quo/page-nav
         {:key        :header
          :background :blur
-         :icon-name  :i/arrow-left
+         :icon-name  :i/close
          :on-press   #(rf/dispatch [:navigate-back])}]
        [rn/keyboard-avoiding-view
         {:key   :content

--- a/src/status_im/contexts/profile/edit/name/view.cljs
+++ b/src/status_im/contexts/profile/edit/name/view.cljs
@@ -43,7 +43,7 @@
         {:key   :content
          :style style/screen-container}
         [rn/view {:style {:gap 22}}
-         [quo/text-combinations {:title (i18n/label :t/name)}]
+         [quo/text-combinations {:title (i18n/label :t/edit-profile-name)}]
          [quo/input
           {:theme           :dark
            :blur?           true

--- a/src/status_im/contexts/profile/edit/names/style.cljs
+++ b/src/status_im/contexts/profile/edit/names/style.cljs
@@ -2,9 +2,9 @@
   (:require [quo.foundations.colors :as colors]))
 
 (defn page-wrapper
-  [insets]
-  {:padding-top        (:top insets)
-   :padding-bottom     (:bottom insets)
+  [{:keys [top bottom]}]
+  {:padding-top        top
+   :padding-bottom     bottom
    :padding-horizontal 1
    :flex               1})
 

--- a/src/status_im/contexts/profile/edit/names/style.cljs
+++ b/src/status_im/contexts/profile/edit/names/style.cljs
@@ -18,3 +18,6 @@
   {:background-color colors/white-opa-5
    :border-radius    16
    :margin-bottom    4})
+
+(def header-wrapper
+  {:margin-bottom 20})

--- a/src/status_im/contexts/profile/edit/names/style.cljs
+++ b/src/status_im/contexts/profile/edit/names/style.cljs
@@ -1,4 +1,5 @@
-(ns status-im.contexts.profile.edit.names.style)
+(ns status-im.contexts.profile.edit.names.style
+  (:require [quo.foundations.colors :as colors]))
 
 (defn page-wrapper
   [insets]
@@ -14,6 +15,6 @@
    :justify-content    :space-between})
 
 (def item-container
-  {:background-color "rgba(255, 255, 255, 0.05)"
+  {:background-color colors/white-opa-5
    :border-radius    16
    :margin-bottom    4})

--- a/src/status_im/contexts/profile/edit/names/style.cljs
+++ b/src/status_im/contexts/profile/edit/names/style.cljs
@@ -1,0 +1,19 @@
+(ns status-im.contexts.profile.edit.names.style)
+
+(defn page-wrapper
+  [insets]
+  {:padding-top        (:top insets)
+   :padding-bottom     (:bottom insets)
+   :padding-horizontal 1
+   :flex               1})
+
+(def screen-container
+  {:flex               1
+   :padding-top        14
+   :padding-horizontal 20
+   :justify-content    :space-between})
+
+(def item-container
+  {:background-color "rgba(255, 255, 255, 0.05)"
+   :border-radius    16
+   :margin-bottom    8})

--- a/src/status_im/contexts/profile/edit/names/style.cljs
+++ b/src/status_im/contexts/profile/edit/names/style.cljs
@@ -16,4 +16,4 @@
 (def item-container
   {:background-color "rgba(255, 255, 255, 0.05)"
    :border-radius    16
-   :margin-bottom    8})
+   :margin-bottom    4})

--- a/src/status_im/contexts/profile/edit/names/view.cljs
+++ b/src/status_im/contexts/profile/edit/names/view.cljs
@@ -1,11 +1,11 @@
 (ns status-im.contexts.profile.edit.names.view
   (:require
-   [quo.core :as quo]
-   [react-native.core :as rn]
-   [react-native.safe-area :as safe-area]
-   [status-im.contexts.profile.edit.names.style :as style]
-   [utils.i18n :as i18n]
-   [utils.re-frame :as rf]))
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [react-native.safe-area :as safe-area]
+    [status-im.contexts.profile.edit.names.style :as style]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (defn- name-item
   [{:keys [name ens-name? selected?]}]
@@ -18,19 +18,22 @@
     :image-right?    true
     :on-press        #(rf/dispatch [:open-modal (if ens-name? :edit-ens :edit-name) name])
     :action          :selector
-    :action-props    {:type :radio
-                      :blur? true
-                      :checked? selected?
+    :action-props    {:type      :radio
+                      :blur?     true
+                      :checked?  selected?
                       :on-change (fn [checked?]
                                    (when checked?
-                                     (rf/dispatch [:profile.settings/profile-update :preferred-name name])))}
+                                     (rf/dispatch [:profile.settings/profile-update :preferred-name
+                                                   name])))}
     :container-style style/item-container}])
 
-(defn- header-view []
+(defn- header-view
+  []
   [rn/view {:style {:margin-bottom 8}}
    [quo/text-combinations {:title (i18n/label :t/name)}]])
 
-(defn view []
+(defn view
+  []
   (let [insets             (safe-area/get-insets)
         profile-user-names (rf/sub [:profile/profile-user-names])]
     [quo/overlay
@@ -42,7 +45,7 @@
        :icon-name  :i/arrow-left
        :on-press   #(rf/dispatch [:navigate-back])}]
      [rn/view
-      {:key  :content
+      {:key   :content
        :style style/screen-container}
       [rn/flat-list
        {:key                             :list

--- a/src/status_im/contexts/profile/edit/names/view.cljs
+++ b/src/status_im/contexts/profile/edit/names/view.cljs
@@ -9,7 +9,6 @@
 
 (defn- name-item
   [{:keys [name ens-name? selected?]}]
-  ^{:key name}
   [quo/settings-item
    {:title           name
     :image-props     (if ens-name? :i/chevron-right :i/edit)
@@ -40,16 +39,13 @@
      {:type            :shell
       :container-style (style/page-wrapper insets)}
      [quo/page-nav
-      {:key        :header
-       :background :blur
+      {:background :blur
        :icon-name  :i/arrow-left
        :on-press   #(rf/dispatch [:navigate-back])}]
      [rn/view
-      {:key   :content
-       :style style/screen-container}
+      {:style style/screen-container}
       [rn/flat-list
-       {:key                             :list
-        :header                          [header-view]
+       {:header                          [header-view]
         :data                            profile-user-names
         :key-fn                          :name
         :shows-vertical-scroll-indicator false

--- a/src/status_im/contexts/profile/edit/names/view.cljs
+++ b/src/status_im/contexts/profile/edit/names/view.cljs
@@ -29,7 +29,7 @@
 
 (defn- header-view
   []
-  [rn/view {:style {:margin-bottom 8}}
+  [rn/view {:style style/header-wrapper}
    [quo/text-combinations {:title (i18n/label :t/name)}]])
 
 (defn view

--- a/src/status_im/contexts/profile/edit/names/view.cljs
+++ b/src/status_im/contexts/profile/edit/names/view.cljs
@@ -49,7 +49,7 @@
        :style style/screen-container}
       [rn/flat-list
        {:key                             :list
-        :header                          (header-view)
+        :header                          [header-view]
         :data                            profile-user-names
         :key-fn                          :name
         :shows-vertical-scroll-indicator false

--- a/src/status_im/contexts/profile/edit/names/view.cljs
+++ b/src/status_im/contexts/profile/edit/names/view.cljs
@@ -1,0 +1,53 @@
+(ns status-im.contexts.profile.edit.names.view
+  (:require
+   [quo.core :as quo]
+   [quo.theme :as quo.theme]
+   [react-native.core :as rn]
+   [react-native.safe-area :as safe-area]
+   [status-im.contexts.profile.edit.names.style :as style]
+   [utils.i18n :as i18n]
+   [utils.re-frame :as rf]))
+
+(defn- name-item
+  [{:keys [name ens-name? ]}]
+  ^{:key name}
+  [quo/settings-item
+   {:title           name
+    :image-props     (if ens-name? :i/chevron-right :i/edit)
+    :image           :icon
+    :blur?           true
+    :image-right     true
+    :on-press        #(rf/dispatch [:open-modal (if ens-name? :edit-ens :edit-name) name])
+    :action          :selector
+    :action-props    {:type :radio :blur? true}
+    :container-style style/item-container}])
+
+(defn- header-view []
+  [rn/view {:style {:margin-bottom 8}}
+   [quo/text-combinations {:title (i18n/label :t/name)}]])
+
+(defn- internal-view
+  [_theme]
+  (let [insets             (safe-area/get-insets)
+        profile-user-names (rf/sub [:profile/profile-user-names])]
+    (fn []
+      [quo/overlay
+       {:type            :shell
+        :container-style (style/page-wrapper insets)}
+       [quo/page-nav
+        {:key        :header
+         :background :blur
+         :icon-name  :i/arrow-left
+         :on-press   #(rf/dispatch [:navigate-back])}]
+       [rn/view
+        {:key  :content
+         :style style/screen-container}
+        [rn/flat-list
+         {:key                             :list
+          :header                          (header-view)
+          :data                            profile-user-names
+          :key-fn                          :name
+          :shows-vertical-scroll-indicator false
+          :render-fn                       name-item}]]])))
+
+(def view (quo.theme/with-theme internal-view))

--- a/src/status_im/contexts/profile/edit/names/view.cljs
+++ b/src/status_im/contexts/profile/edit/names/view.cljs
@@ -16,7 +16,7 @@
     :image-props     (if ens-name? :i/chevron-right :i/edit)
     :image           :icon
     :blur?           true
-    :image-right     true
+    :image-right?    true
     :on-press        #(rf/dispatch [:open-modal (if ens-name? :edit-ens :edit-name) name])
     :action          :selector
     :action-props    {:type :radio :blur? true}

--- a/src/status_im/contexts/profile/edit/names/view.cljs
+++ b/src/status_im/contexts/profile/edit/names/view.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.profile.edit.names.view
   (:require
    [quo.core :as quo]
-   [quo.theme :as quo.theme]
    [react-native.core :as rn]
    [react-native.safe-area :as safe-area]
    [status-im.contexts.profile.edit.names.style :as style]
@@ -26,8 +25,7 @@
   [rn/view {:style {:margin-bottom 8}}
    [quo/text-combinations {:title (i18n/label :t/name)}]])
 
-(defn- internal-view
-  [_theme]
+(defn view []
   (let [insets             (safe-area/get-insets)
         profile-user-names (rf/sub [:profile/profile-user-names])]
     (fn []
@@ -49,5 +47,3 @@
           :key-fn                          :name
           :shows-vertical-scroll-indicator false
           :render-fn                       name-item}]]])))
-
-(def view (quo.theme/with-theme internal-view))

--- a/src/status_im/contexts/profile/edit/names/view.cljs
+++ b/src/status_im/contexts/profile/edit/names/view.cljs
@@ -28,22 +28,21 @@
 (defn view []
   (let [insets             (safe-area/get-insets)
         profile-user-names (rf/sub [:profile/profile-user-names])]
-    (fn []
-      [quo/overlay
-       {:type            :shell
-        :container-style (style/page-wrapper insets)}
-       [quo/page-nav
-        {:key        :header
-         :background :blur
-         :icon-name  :i/arrow-left
-         :on-press   #(rf/dispatch [:navigate-back])}]
-       [rn/view
-        {:key  :content
-         :style style/screen-container}
-        [rn/flat-list
-         {:key                             :list
-          :header                          (header-view)
-          :data                            profile-user-names
-          :key-fn                          :name
-          :shows-vertical-scroll-indicator false
-          :render-fn                       name-item}]]])))
+    [quo/overlay
+     {:type            :shell
+      :container-style (style/page-wrapper insets)}
+     [quo/page-nav
+      {:key        :header
+       :background :blur
+       :icon-name  :i/arrow-left
+       :on-press   #(rf/dispatch [:navigate-back])}]
+     [rn/view
+      {:key  :content
+       :style style/screen-container}
+      [rn/flat-list
+       {:key                             :list
+        :header                          (header-view)
+        :data                            profile-user-names
+        :key-fn                          :name
+        :shows-vertical-scroll-indicator false
+        :render-fn                       name-item}]]]))

--- a/src/status_im/contexts/profile/edit/names/view.cljs
+++ b/src/status_im/contexts/profile/edit/names/view.cljs
@@ -8,7 +8,7 @@
    [utils.re-frame :as rf]))
 
 (defn- name-item
-  [{:keys [name ens-name?]}]
+  [{:keys [name ens-name? selected?]}]
   ^{:key name}
   [quo/settings-item
    {:title           name
@@ -18,7 +18,12 @@
     :image-right?    true
     :on-press        #(rf/dispatch [:open-modal (if ens-name? :edit-ens :edit-name) name])
     :action          :selector
-    :action-props    {:type :radio :blur? true}
+    :action-props    {:type :radio
+                      :blur? true
+                      :checked? selected?
+                      :on-change (fn [checked?]
+                                   (when checked?
+                                     (rf/dispatch [:profile.settings/profile-update :preferred-name name])))}
     :container-style style/item-container}])
 
 (defn- header-view []

--- a/src/status_im/contexts/profile/edit/names/view.cljs
+++ b/src/status_im/contexts/profile/edit/names/view.cljs
@@ -9,7 +9,7 @@
    [utils.re-frame :as rf]))
 
 (defn- name-item
-  [{:keys [name ens-name? ]}]
+  [{:keys [name ens-name?]}]
   ^{:key name}
   [quo/settings-item
    {:title           name

--- a/src/status_im/contexts/profile/events.cljs
+++ b/src/status_im/contexts/profile/events.cljs
@@ -5,6 +5,7 @@
     [re-frame.core :as re-frame]
     [status-im.contexts.profile.edit.accent-colour.events]
     [status-im.contexts.profile.edit.bio.events]
+    [status-im.contexts.profile.edit.ens.events]
     [status-im.contexts.profile.edit.header.events]
     [status-im.contexts.profile.edit.name.events]
     [status-im.contexts.profile.login.events :as profile.login]

--- a/src/status_im/db.cljs
+++ b/src/status_im/db.cljs
@@ -9,6 +9,8 @@
 (def app-db
   {:activity-center                    {:filter {:status (:filter-status activity-center/defaults)
                                                  :type   (:filter-type activity-center/defaults)}}
+   :ens/names                          {"seanstrom.eth"  {:name "seanstrom.eth"}
+                                        "hagstromsg.eth" {:name "hagstromsg.eth"}}
    :contacts/contacts                  {}
    :pairing/installations              {}
    :group/selected-contacts            #{}

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -191,7 +191,9 @@
      :component edit-accent-colour/view}
 
     {:name      :edit-name
-     :options   options/transparent-screen-options
+     :options   (merge options/transparent-screen-options
+                       {:sheet? true
+                        :skip-background? true})
      :component edit-name/view}
 
     {:name      :edit-bio
@@ -203,7 +205,9 @@
      :component edit-names/view}
 
     {:name      :edit-ens
-     :options   options/transparent-screen-options
+     :options   (merge options/transparent-screen-options
+                       {:sheet? true
+                        :skip-background? true})
      :component edit-ens/view}
 
     {:name      :new-to-status

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -191,7 +191,7 @@
      :component edit-accent-colour/view}
 
     {:name      :edit-name
-     :options   options/transparent-modal-screen-options
+     :options   options/transparent-screen-options
      :component edit-name/view}
 
     {:name      :edit-bio

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -199,7 +199,7 @@
      :component edit-bio/view}
 
     {:name      :edit-names
-     :options   options/transparent-screen-options
+     :options   options/transparent-modal-screen-options
      :component edit-names/view}
 
     {:name      :edit-ens

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -37,7 +37,9 @@
     [status-im.contexts.preview.status-im.main :as status-im-preview]
     [status-im.contexts.profile.edit.accent-colour.view :as edit-accent-colour]
     [status-im.contexts.profile.edit.bio.view :as edit-bio]
+    [status-im.contexts.profile.edit.ens.view :as edit-ens]
     [status-im.contexts.profile.edit.name.view :as edit-name]
+    [status-im.contexts.profile.edit.names.view :as edit-names]
     [status-im.contexts.profile.edit.view :as edit-profile]
     [status-im.contexts.profile.profiles.view :as profiles]
     [status-im.contexts.profile.settings.screens.password.view :as settings-password]
@@ -195,6 +197,14 @@
     {:name      :edit-bio
      :options   options/transparent-modal-screen-options
      :component edit-bio/view}
+
+    {:name      :edit-names
+     :options   options/transparent-screen-options
+     :component edit-names/view}
+
+    {:name      :edit-ens
+     :options   options/transparent-screen-options
+     :component edit-ens/view}
 
     {:name      :new-to-status
      :options   {:theme                  :dark

--- a/src/status_im/navigation/view.cljs
+++ b/src/status_im/navigation/view.cljs
@@ -58,7 +58,7 @@
                                                 (get-screens)
                                                 screens)
                                               (keyword screen-key))
-           {:keys [insets sheet? theme]} options
+           {:keys [insets sheet? theme skip-background?]} options
            user-theme                    (theme/get-theme)
            background-color              (or (get-in options [:layout :backgroundColor])
                                              (when sheet? :transparent))]
@@ -67,7 +67,8 @@
         [rn/view {:style (wrapped-screen-style insets background-color)}
          [inactive]
          (if sheet?
-           [bottom-sheet-screen/view {:content component}]
+           [bottom-sheet-screen/view {:content component 
+                                      :skip-background? skip-background?}]
            [component])]
         (when js/goog.DEBUG
           [:<>

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -335,18 +335,16 @@
  :profile/profile-user-names
  :<- [:profile/profile]
  :<- [:ens/names]
- (fn [[profile ens-names] _]
-   (let [display-name   (:display-name profile)
-         preferred-name (:preferred-name profile)]
-     (-> (map (fn [{:keys [name]}]
-                {:name      name
-                 :ens-name? true
-                 :selected? (= name preferred-name)})
-              (vals ens-names))
-         (conj {:name      (:display-name profile)
-                :ens-name? false
-                :selected? (or (nil? preferred-name)
-                               (= display-name preferred-name))})))))
+ (fn [[{:keys [display-name preferred-name]} ens-names] _]
+   (-> (map (fn [{:keys [name]}]
+              {:name      name
+               :ens-name? true
+               :selected? (= name preferred-name)})
+            (vals ens-names))
+       (conj {:name      display-name
+              :ens-name? false
+              :selected? (or (nil? preferred-name)
+                             (= display-name preferred-name))}))))
 
 (re-frame/reg-sub
  :profile/login-profile

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -336,18 +336,17 @@
  :<- [:profile/profile]
  :<- [:ens/names]
  (fn [[profile ens-names] _]
-   (->> (-> (map (fn [{:keys [name]}]
-                   {:name      name
-                    :ens-name? true})
-                 (vals ens-names))
-            (conj {:name      (:display-name profile)
-                   :ens-name? false}))
-        (map (fn [{:keys [name ens-name?] :as name-item}]
-               (let [preferred-name (:preferred-name profile)]
-                 (merge name-item
-                        (if (nil? preferred-name)
-                          {:selected? (not ens-name?)}
-                          {:selected? (= name preferred-name)}))))))))
+   (let [display-name   (:display-name profile)
+         preferred-name (:preferred-name profile)]
+     (-> (map (fn [{:keys [name]}]
+                {:name      name
+                 :ens-name? true
+                 :selected? (= name preferred-name)})
+              (vals ens-names))
+         (conj {:name      (:display-name profile)
+                :ens-name? false
+                :selected? (or (nil? preferred-name)
+                               (= display-name preferred-name))})))))
 
 (re-frame/reg-sub
  :profile/login-profile

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -342,10 +342,12 @@
                  (vals ens-names))
             (conj {:name      (:display-name profile)
                    :ens-name? false}))
-        (map (fn [name-item]
-               (merge name-item
-                      {:selected? (= (:name name-item)
-                                     (:preferred-name profile))}))))))
+        (map (fn [{:keys [name ens-name?] :as name-item}]
+               (let [preferred-name (:preferred-name profile)]
+                 (merge name-item
+                        (if (nil? preferred-name)
+                          {:selected? (not ens-name?)}
+                          {:selected? (= name preferred-name)}))))))))
 
 (re-frame/reg-sub
  :profile/login-profile

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -332,6 +332,18 @@
    (replace-multiaccount-image-uri profile ens-names port font-file avatar-opts)))
 
 (re-frame/reg-sub
+ :profile/profile-user-names
+ :<- [:profile/profile]
+ :<- [:ens/names]
+ (fn [[profile ens-names] _]
+   (-> (map (fn [{:keys [name]}]
+              {:name      name
+               :ens-name? true})
+            (vals ens-names))
+       (conj {:name      (:display-name profile)
+              :ens-name? false}))))
+
+(re-frame/reg-sub
  :profile/login-profile
  :<- [:profile/login]
  :<- [:profile/profiles-overview]

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -336,12 +336,16 @@
  :<- [:profile/profile]
  :<- [:ens/names]
  (fn [[profile ens-names] _]
-   (-> (map (fn [{:keys [name]}]
-              {:name      name
-               :ens-name? true})
-            (vals ens-names))
-       (conj {:name      (:display-name profile)
-              :ens-name? false}))))
+   (->> (-> (map (fn [{:keys [name]}]
+                   {:name      name
+                    :ens-name? true})
+                 (vals ens-names))
+            (conj {:name      (:display-name profile)
+                   :ens-name? false}))
+        (map (fn [name-item]
+               (merge name-item
+                      {:selected? (= (:name name-item)
+                                     (:preferred-name profile))}))))))
 
 (re-frame/reg-sub
  :profile/login-profile

--- a/translations/en.json
+++ b/translations/en.json
@@ -495,6 +495,7 @@
     "edit": "Edit",
     "edit-group": "Edit group",
     "edit-profile": "Edit Profile",
+    "edit-profile-name": "Edit profile name",
     "emojihash": "Emojihash",
     "emojihash-description": "A visual representation of your chat key. It will help other users recognize your profile.",
     "emojis": "Emojis",


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #18642 

### Summary

A user may have multiple user names related to their Display Name and ENS names. Ideally, the user would be able to choose which name they prefer to be seen as in the app. This PR implements some new screens for editing the user profile:
* A user can now choose between their Display Name and ENS names as their preferred name.
* A user can now also remove their ENS names from their profile.

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->
* There's some mocked out data inside the reframe db for the ENS names. This will likely be removed before merging.

### Testing notes
<!-- (Optional) -->

#### Platforms
- Android
- iOS

#### Areas that maybe impacted

##### Functional

- user profile name settings

### Steps to test

- Open Status
- Open the User Profile
- Press on the Edit Profile Setting
- Press on the Name setting

#### Choose Preferred Name
- Select between profile names by pressing on radio selector

#### Manage ENS name by pressing
- Press on a ENS profile name
- Remove ENS profile name

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

| Figma (if available) | iOS (if available)    | Android (if available)
| --- | --- | --- |
| Please embed Image/Video here of the before and after.  | ![Before](https://github.com/status-im/status-mobile/assets/2845768/81b2a4b8-3b05-4209-9123-1b7efc0f41c3)  | ![Before](https://github.com/status-im/status-mobile/assets/2845768/e12d9ac9-a2ef-4553-bba2-8f59507a9282) |
| --- | ![After](https://github.com/status-im/status-mobile/assets/2845768/e69277bb-fb50-44d5-b48e-fc2c9cbad794) | ![After](https://github.com/status-im/status-mobile/assets/2845768/0b016ee5-dede-4ca8-845c-4e747f737281) |

status: ready
