### PR TITLE
disable `hermes` for debug android builds & enable `hermes` for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,9 @@ run-re-frisk: ##@run Start re-frisk server
 
 # TODO: Migrate this to a Nix recipe, much the same way as nix/mobile/android/targets/release-android.nix
 run-android: export TARGET := android
+# Disabled for debug builds to avoid 'maximum call stack exceeded' errors.
+# https://github.com/status-im/status-mobile/issues/18493
+run-android: export ORG_GRADLE_PROJECT_hermesEnabled := false
 # INFO: If it's empty (no devices attached, parsing issues, script error) - for Nix it's the same as not set.
 run-android: export ANDROID_ABI_INCLUDE ?= $(shell ./scripts/adb_devices_abis.sh)
 run-android: ##@run Build Android APK and start it on the device

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -57,4 +57,6 @@ newArchEnabled=false
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
-hermesEnabled=true
+# Disabled for debug builds to avoid 'maximum call stack exceeded' errors.
+# https://github.com/status-im/status-mobile/issues/18493
+hermesEnabled=false

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -79,6 +79,9 @@ in stdenv.mkDerivation rec {
   STATUS_GO_SRC_OVERRIDE = statusGoSrcOverride;
   ANDROID_ABI_SPLIT = androidAbiSplit;
   ANDROID_ABI_INCLUDE = androidAbiInclude;
+  # Disabled for debug builds to avoid 'maximum call stack exceeded' errors.
+  # https://github.com/status-im/status-mobile/issues/18493
+  ORG_GRADLE_PROJECT_hermesEnabled = true;
 
   # Fix for ERR_OSSL_EVP_UNSUPPORTED error.
   NODE_OPTIONS = "--openssl-legacy-provider";

--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -13,7 +13,8 @@
     [react-native.platform :as platform]
     [react-native.shake :as react-native-shake]
     [reagent.impl.batching :as batching]
-    [status-im.common.log :as log]
+    [status-im.common.log :as logging]
+    [taoensso.timbre :as log]
     [status-im.common.universal-links :as universal-links]
     [status-im.config :as config]
     [status-im.contexts.profile.push-notifications.events :as notifications]
@@ -34,12 +35,17 @@
 
 (def adjust-resize 16)
 
+(defn is-hermes
+  []
+  (boolean (.-HermesInternal js/global)))
+
 (defn init
   []
+
   (native-module/init #(re-frame/dispatch [:signals/signal-received %]))
   (when platform/android?
     (native-module/set-soft-input-mode adjust-resize))
-  (log/setup config/log-level)
+  (logging/setup config/log-level)
   (global-error/register-handler)
   (notifications/listen-notifications)
   (.addEventListener rn/app-state "change" #(re-frame/dispatch [:app-state-change %]))
@@ -54,5 +60,6 @@
   (async-storage/get-item :screen-height #(reset! shell.state/screen-height %))
 
   (dev/setup)
+  (log/info "hermesEnabled ->" (is-hermes))
 
   (re-frame/dispatch-sync [:app-started]))


### PR DESCRIPTION
fixes #18493

## Summary

We enabled `hermes` for android in the `react-native` upgrade to `0.72.5` 
Although things seemed fine but developers were seeing frequent crashes in their local environment.

After some investigation the crashes were traced to max native call stack depth in `hermes` engine.
Disabling `hermes` for local debug builds helps fix that issue.

This PR disables `hermes` by default with the help of a exporting an environment variable in the `make run-android` command.
It is annoying that this also modifies `android/gradle.properties` so we keep `hermesEnabled` as `false` there as well.
We also enable `hermes` when generating release builds so that we can take advantage of `hermes` engine in release builds.

We also add a log to print whether `hermes` is enabled or not. I think its helpful to have this so that we know whether `hermes` is enabled or not.

## Testing notes
Test locally to see if max native call stack error goes away.

## Testing notes
no change in release builds, `hermes` was enabled in release builds since the upgrade was merged.
Testing is not required.

#### Platforms
- Android

status: ready
