### PR TITLE
fix: reintroduce changes for sending erc20 and erc721 tokens

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -3,10 +3,12 @@
     [camel-snake-kebab.core :as csk]
     [camel-snake-kebab.extras :as cske]
     [clojure.string :as string]
+    [native-module.core :as native-module]
     [status-im.constants :as constants]
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.send.utils :as send-utils]
     [taoensso.timbre :as log]
+    [utils.address :as address]
     [utils.money :as money]
     [utils.number]
     [utils.re-frame :as rf]))
@@ -79,7 +81,9 @@
 
 (rf/reg-event-fx :wallet/send-select-token
  (fn [{:keys [db]} [{:keys [token stack-id]}]]
-   {:db (assoc-in db [:wallet :ui :send :token] token)
+   {:db (-> db
+            (update-in [:wallet :ui :send] dissoc :collectible)
+            (assoc-in [:wallet :ui :send :token] token))
     :fx [[:dispatch-later
           {:ms       1
            :dispatch [:navigate-to-within-stack [:wallet-send-input-amount stack-id]]}]]}))
@@ -92,6 +96,15 @@
  (fn [{:keys [db]}]
    {:db (assoc-in db [:wallet :ui :send :token] nil)}))
 
+(rf/reg-event-fx :wallet/send-select-collectible
+ (fn [{:keys [db]} [{:keys [collectible stack-id]}]]
+   {:db (-> db
+            (update-in [:wallet :ui :send] dissoc :token)
+            (assoc-in [:wallet :ui :send :collectible] collectible)
+            (assoc-in [:wallet :ui :send :amount] 1))
+    :fx [[:dispatch [:wallet/get-suggested-routes 1]]
+         [:navigate-to-within-stack [:wallet-transaction-confirmation stack-id]]]}))
+
 (rf/reg-event-fx :wallet/send-select-amount
  (fn [{:keys [db]} [{:keys [amount stack-id]}]]
    {:db (assoc-in db [:wallet :ui :send :amount] amount)
@@ -101,19 +114,25 @@
  (fn [{:keys [db now]} [amount]]
    (let [wallet-address          (get-in db [:wallet :current-viewing-account-address])
          token                   (get-in db [:wallet :ui :send :token])
-         account-address         (get-in db [:wallet :ui :send :send-account-address])
-         selected-networks       (get-in db [:wallet :ui :send :selected-networks])
-         to-address              (or account-address (get-in db [:wallet :ui :send :to-address]))
-         token-decimal           (:decimals token)
-         token-id                (:symbol token)
-         network-preferences     selected-networks
+         collectible             (get-in db [:wallet :ui :send :collectible])
+         to-address              (get-in db [:wallet :ui :send :to-address])
+         token-decimal           (when token (:decimals token))
+         token-id                (if token
+                                   (:symbol token)
+                                   (str (get-in collectible [:id :contract-id :address])
+                                        ":"
+                                        (get-in collectible [:id :token-id])))
+         network-preferences     (if token [] [(get-in collectible [:id :contract-id :chain-id])])
          gas-rates               constants/gas-rate-medium
-         amount-in               (send-utils/amount-in-hex amount token-decimal)
+         amount-in               (send-utils/amount-in-hex amount (if token token-decimal 0))
          from-address            wallet-address
          disabled-from-chain-ids []
          disabled-to-chain-ids   []
          from-locked-amount      {}
-         request-params          [constants/send-type-transfer
+         transaction-type        (if token
+                                   constants/send-type-transfer
+                                   constants/send-type-erc-721-transfer)
+         request-params          [transaction-type
                                   from-address
                                   to-address
                                   amount-in
@@ -157,21 +176,46 @@
    {:fx [[:dispatch [:dismiss-modal :wallet-transaction-progress]]]}))
 
 (defn- transaction-bridge
-  [{:keys [from-address to-address route]}]
-  (let [{:keys [from bridge-name amount-out gas-amount gas-fees]}           route
-        {:keys [gas-price max-fee-per-gas-medium max-priority-fee-per-gas]} gas-fees]
-    [{:BridgeName bridge-name
-      :ChainID    (:chain-id from)
-      :TransferTx {:From                 from-address
-                   :To                   to-address
-                   :Gas                  (money/to-hex gas-amount)
-                   :GasPrice             (money/to-hex (money/->wei :gwei gas-price))
-                   :Value                amount-out
-                   :Nonce                nil
-                   :MaxFeePerGas         (money/to-hex (money/->wei :gwei max-fee-per-gas-medium))
-                   :MaxPriorityFeePerGas (money/to-hex (money/->wei :gwei max-priority-fee-per-gas))
-                   :Input                ""
-                   :Data                 "0x"}}]))
+  [{:keys [from-address from-chain-id to-address token-id token-address route data eth-transfer?]}]
+  (let [{:keys [bridge-name amount-out gas-amount
+                gas-fees]}                 route
+        eip-1559-enabled?                  (:eip-1559-enabled gas-fees)
+        {:keys [gas-price max-fee-per-gas-medium
+                max-priority-fee-per-gas]} gas-fees
+        transfer-tx                        (cond-> {:From  from-address
+                                                    :To    (or token-address to-address)
+                                                    :Gas   (money/to-hex gas-amount)
+                                                    :Value (when eth-transfer? amount-out)
+                                                    :Nonce nil
+                                                    :Input ""
+                                                    :Data  (or data "0x")}
+                                             eip-1559-enabled?       (assoc :TxType "0x02"
+                                                                            :MaxFeePerGas
+                                                                            (money/to-hex
+                                                                             (money/->wei
+                                                                              :gwei
+                                                                              max-fee-per-gas-medium))
+                                                                            :MaxPriorityFeePerGas
+                                                                            (money/to-hex
+                                                                             (money/->wei
+                                                                              :gwei
+                                                                              max-priority-fee-per-gas)))
+                                             (not eip-1559-enabled?) (assoc :TxType   "0x00"
+                                                                            :GasPrice (money/to-hex
+                                                                                       (money/->wei
+                                                                                        :gwei
+                                                                                        gas-price))))]
+    [(cond-> {:BridgeName bridge-name
+              :ChainID    from-chain-id}
+
+       (= bridge-name constants/bridge-name-erc-721-transfer)
+       (assoc :ERC721TransferTx
+              (assoc transfer-tx
+                     :Recipient to-address
+                     :TokenID   token-id))
+
+       (= bridge-name constants/bridge-name-transfer)
+       (assoc :TransferTx transfer-tx))]))
 
 (defn- multi-transaction-command
   [{:keys [from-address to-address from-asset to-asset amount-out transfer-type]
@@ -185,25 +229,50 @@
 
 (rf/reg-event-fx :wallet/send-transaction
  (fn [{:keys [db]} [sha3-pwd]]
-   (let [route          (get-in db [:wallet :ui :send :route])
-         from-address   (get-in db [:wallet :current-viewing-account-address])
-         to-address     (get-in db [:wallet :ui :send :to-address])
-         token          (get-in db [:wallet :ui :send :token])
-         token-id       (:symbol token)
-         request-params [(multi-transaction-command {:from-address from-address
-                                                     :to-address   to-address
-                                                     :from-asset   token-id
-                                                     :to-asset     token-id
-                                                     :amount-out   (:amount-out route)})
-                         (transaction-bridge {:to-address   to-address
-                                              :from-address from-address
-                                              :route        route})
-                         sha3-pwd]]
+   (let [route           (get-in db [:wallet :ui :send :route])
+         from-address    (get-in db [:wallet :current-viewing-account-address])
+         token           (get-in db [:wallet :ui :send :token])
+         collectible     (get-in db [:wallet :ui :send :collectible])
+         from-chain-id   (get-in route [:from :chain-id])
+         token-id        (if token
+                           (:symbol token)
+                           (get-in collectible [:id :token-id]))
+         erc20-transfer? (and token (not= token-id "ETH"))
+         eth-transfer?   (and token (not erc20-transfer?))
+         token-address   (cond collectible
+                               (get-in collectible
+                                       [:id :contract-id :address])
+                               erc20-transfer?
+                               (get-in token [:balances-per-chain from-chain-id :address]))
+         to-address      (get-in db [:wallet :ui :send :to-address])
+         data            (when erc20-transfer?
+                           (native-module/encode-transfer (address/normalized-hex to-address)
+                                                          (:amount-out route)))
+         request-params  [(multi-transaction-command
+                           {:from-address from-address
+                            :to-address   to-address
+                            :from-asset   token-id
+                            :to-asset     token-id
+                            :amount-out   (if eth-transfer? (:amount-out route) "0x0")})
+                          (transaction-bridge {:to-address    to-address
+                                               :from-address  from-address
+                                               :route         route
+                                               :from-chain-id from-chain-id
+                                               :token-address token-address
+                                               :token-id      (when collectible
+                                                                (money/to-hex (js/parseInt token-id)))
+                                               :data          data
+                                               :eth-transfer? eth-transfer?})
+                          sha3-pwd]]
      {:json-rpc/call [{:method     "wallet_createMultiTransaction"
                        :params     request-params
                        :on-success (fn [result]
                                      (rf/dispatch [:hide-bottom-sheet])
-                                     (rf/dispatch [:wallet/add-authorized-transaction result]))
+                                     (rf/dispatch [:wallet/add-authorized-transaction result])
+                                     (rf/dispatch [:wallet/clean-scanned-address])
+                                     (rf/dispatch [:wallet/clean-local-suggestions])
+                                     (rf/dispatch [:wallet/clean-send-address])
+                                     (rf/dispatch [:wallet/select-address-tab nil]))
                        :on-error   (fn [error]
                                      (log/error "failed to send transaction"
                                                 {:event  :wallet/send-transaction

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/style.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/style.cljs
@@ -14,16 +14,18 @@
   {:margin-right 4})
 
 (defn details-container
-  [route? theme]
+  [{:keys [loading-suggested-routes? route-loaded? theme]}]
   {:flex-direction     :row
-   :justify-content    (if route? :space-between :center)
-   :height             52
+   :justify-content    (if route-loaded? :space-between :center)
+   :height             (when (or loading-suggested-routes? route-loaded?) 52)
    :padding-horizontal 12
    :padding-top        7
    :padding-bottom     8
    :border-radius      16
    :border-width       1
-   :border-color       (colors/theme-colors colors/neutral-10 colors/neutral-90 theme)})
+   :border-color       (if (or loading-suggested-routes? route-loaded?)
+                         (colors/theme-colors colors/neutral-10 colors/neutral-90 theme)
+                         :transparent)})
 
 (def details-title-container
   {:padding-horizontal 20

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -74,9 +74,10 @@
      :account-props account-props}]])
 
 (defn- transaction-details
-  [{:keys [estimated-time-min max-fees token amount to-address route theme]}]
-  (let [currency-symbol (rf/sub [:profile/currency-symbol])
-        route-loaded?   (some? route)]
+  [{:keys [estimated-time-min max-fees token-symbol amount to-address route theme]}]
+  (let [currency-symbol           (rf/sub [:profile/currency-symbol])
+        route-loaded?             (some? route)
+        loading-suggested-routes? (rf/sub [:wallet/wallet-send-loading-suggested-routes?])]
     [rn/view
      {:style style/details-title-container}
      [quo/text
@@ -86,8 +87,14 @@
        :accessibility-label :summary-from-label}
       (i18n/label :t/details)]
      [rn/view
-      {:style (style/details-container route-loaded? theme)}
-      (if route-loaded?
+      {:style (style/details-container
+               {:loading-suggested-routes? loading-suggested-routes?
+                :route-loaded?             route-loaded?
+                :theme                     theme})}
+      (cond
+        loading-suggested-routes?
+        [rn/activity-indicator {:style {:align-self :center}}]
+        route-loaded?
         [:<>
          [quo/data-item
           {:container-style style/detail-item
@@ -123,8 +130,10 @@
            :status          :default
            :size            :small
            :title           (i18n/label :t/user-gets {:name (utils/get-shortened-address to-address)})
-           :subtitle        (str amount " " (:symbol token))}]]
-        [rn/activity-indicator {:style {:align-self :center}}])]]))
+           :subtitle        (str amount " " token-symbol)}]]
+        :else
+        [quo/text {:style {:align-self :center}}
+         (i18n/label :t/no-routes-found-confirmation)])]]))
 
 (defn- view-internal
   [_]
@@ -140,9 +149,10 @@
             collectible-data      (:collectible-data collectible)
             collectible-id        (get-in collectible [:id :token-id])
             token-symbol          (if collectible
-                                    (first (remove string/blank?
-                                                   [(:name collectible-data)
-                                                    (str (:name collection-data) " #" collectible-id)]))
+                                    (first (remove
+                                            string/blank?
+                                            [(:name collectible-data)
+                                             (str (:name collection-data) " #" collectible-id)]))
                                     (:symbol token))
             image-url             (when collectible (:image-url collectible-data))
             amount                (:amount send-transaction-data)
@@ -157,7 +167,8 @@
                                    :emoji               (:emoji account)
                                    :type                :default
                                    :name                (:name account)
-                                   :address             (utils/get-shortened-address (:address account))}
+                                   :address             (utils/get-shortened-address (:address
+                                                                                      account))}
             user-props            {:full-name to-address
                                    :address   (utils/get-shortened-address to-address)}]
         [rn/view {:style {:flex 1}}
@@ -173,17 +184,17 @@
                                                               :on-press            #(js/alert
                                                                                      "to be implemented")
                                                               :accessibility-label :advanced-options}]}]
-           :footer                   (if route
+           :footer                   (when route
                                        [standard-auth/slide-button
                                         {:size                :size-48
                                          :track-text          (i18n/label :t/slide-to-send)
                                          :container-style     {:z-index 2}
                                          :customization-color account-color
-                                         :on-auth-success     #(rf/dispatch [:wallet/send-transaction
-                                                                             (security/safe-unmask-data
-                                                                              %)])
-                                         :auth-button-label   (i18n/label :t/confirm)}]
-                                       [rn/activity-indicator])
+                                         :on-auth-success     #(rf/dispatch
+                                                                [:wallet/send-transaction
+                                                                 (security/safe-unmask-data
+                                                                  %)])
+                                         :auth-button-label   (i18n/label :t/confirm)}])
            :gradient-cover?          true
            :customization-color      (:color account)}
           [rn/view
@@ -213,7 +224,7 @@
            [transaction-details
             {:estimated-time-min estimated-time-min
              :max-fees           max-fees
-             :token              token
+             :token-symbol       token-symbol
              :amount             amount
              :to-address         to-address
              :theme              theme

--- a/translations/en.json
+++ b/translations/en.json
@@ -2480,5 +2480,6 @@
     "preferred-by-receiver": "Preferred by receiver",
     "not-preferred-by-receiver": "Not preferred by receiver",
     "apply-changes": "Apply changes",
-    "receiver-networks-warning": "Changing these settings may result in sending tokens to networks the recipient doesn't use"
+    "receiver-networks-warning": "Changing these settings may result in sending tokens to networks the recipient doesn't use",
+    "no-routes-found-confirmation": "No routes found. Token type may not be supported or you may don't have enough ETH to cover gas."
 }


### PR DESCRIPTION
fixes ?

### Summary

This PR reintroduces changes to send ERC721 and ERC20 tokens that were accidentally removed in a rebase. Linked issue should be fixed as well, but also we should test the send flow is working.

### Review notes

No new features here, just rollback some changes

status: ready