### PR TITLE
[Fix] Wallet - Route not fetching

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -60,7 +60,9 @@
  (fn [{:keys [db]} [{:keys [address token recipient stack-id]}]]
    (let [[prefix to-address] (utils/split-prefix-and-address address)
          prefix-seq          (string/split prefix #":")
-         selected-networks   (mapv #(utils/short-name->id (keyword %)) prefix-seq)]
+         selected-networks   (->> prefix-seq
+                                  (remove string/blank?)
+                                  (mapv #(utils/short-name->id (keyword %))))]
      {:db (-> db
               (assoc-in [:wallet :ui :send :recipient] (or recipient address))
               (assoc-in [:wallet :ui :send :to-address] to-address)


### PR DESCRIPTION
fixes #18652

### Summary

This PR fixes the route not fetched bug on the send flow.

### Review notes

The bug is actually caused by the receiver network being nil and it sends the same to `status-go`.

### Platforms

- Android
- iOS

#### Areas that may be impacted

##### Functional

- wallet/transactions

### Steps to test

- Open Status
- Navigate to the Wallet tab
- Try to send some tokens to any other accounts
- Verify routes are fetched
- Verify the transaction is successful

status: ready
