### PR TITLE
fix: sync history regardless of using a data plan or wifi

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.173.0",
-    "commit-sha1": "b83cd418af77ec8dabe3849bf51984a4232740d9",
-    "src-sha256": "00w8kqdkrv9x95dmlxy7zdm70vilh0gpnj6n81hg1124dy4gwikd"
+    "version": "e9b10c4beb2ddd16e9ddff089831392a951b5851",
+    "commit-sha1": "e9b10c4beb2ddd16e9ddff089831392a951b5851",
+    "src-sha256": "04f40067rh0s667yx4p94irl2h84ipi8ig0m023ifqik068fjdjv"
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/18637
Requires https://github.com/status-im/status-go/pull/4656

According to https://github.com/status-im/status-mobile/issues/18637#issuecomment-1919958341 , this feature is no longer provided, so it can be removed. 