### PR TITLE
[#18545] Add missing linear gradient to dark themed cards

### DIFF
--- a/src/quo/components/wallet/account_card/properties.cljs
+++ b/src/quo/components/wallet/account_card/properties.cljs
@@ -3,17 +3,13 @@
 
 (defn gradient-start-color
   [theme customization-color]
-  (colors/theme-colors
-   (colors/resolve-color customization-color theme 0)
-   colors/neutral-95
-   theme))
+  (colors/resolve-color customization-color theme 0))
 
 (defn gradient-end-color
   [theme customization-color]
-  (colors/theme-colors
-   (colors/resolve-color customization-color theme 6)
-   colors/neutral-95
-   theme))
+  (colors/theme-colors (colors/resolve-color customization-color theme 6)
+                       (colors/resolve-color customization-color theme 6)
+                       theme))
 
 (defn alert-icon-color
   [theme]

--- a/src/quo/components/wallet/account_card/properties.cljs
+++ b/src/quo/components/wallet/account_card/properties.cljs
@@ -7,9 +7,7 @@
 
 (defn gradient-end-color
   [theme customization-color]
-  (colors/theme-colors (colors/resolve-color customization-color theme 6)
-                       (colors/resolve-color customization-color theme 6)
-                       theme))
+  (colors/resolve-color customization-color theme 6))
 
 (defn alert-icon-color
   [theme]


### PR DESCRIPTION
fixes #18545 

This PR also fix the `:ellipsis-mode` property, it had a typo

now:
![image](https://github.com/status-im/status-mobile/assets/90291778/fa531ab7-09b5-45e8-8af5-7b668e1ee2a6)

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Go to wallet tab
- Add a watch only account
- The cards are usign the selected color.

status: ready
