### PR TITLE
Disable flag ACCOUNT_SELECTION_ENABLED by default

### DIFF
--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -160,7 +160,7 @@
 
 (def default-kdf-iterations 3200)
 
-(def community-accounts-selection-enabled? (enabled? (get-config :ACCOUNT_SELECTION_ENABLED "1")))
+(def community-accounts-selection-enabled? (enabled? (get-config :ACCOUNT_SELECTION_ENABLED "0")))
 (def fetch-messages-enabled? (enabled? (get-config :FETCH_MESSAGES_ENABLED "1")))
 
 (def wallet-feature-flags


### PR DESCRIPTION
### Summary

Unfortunately `develop` has the flag enabled by default at the time of merging https://github.com/status-im/status-mobile/pull/18549.

This PR fixes that by disabling the flag by default so e2e tests are cool.

status: ready
