### PR TITLE
init: `maestro` dev automations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -457,3 +457,18 @@ repl-clojure: ##@repl Start Clojure repl for mobile App
 	yarn shadow-cljs cljs-repl mobile
 
 repl-nix: nix-repl ##@repl Start an interactive Nix REPL
+
+#--------------
+# Dev Automation Flows
+#--------------
+
+auto-login: export TARGET := default
+auto-login: ##@auto runs flow for login or onboarding app on simulator/emulator
+	maestro test "maestro/create-account-or-login.yaml"
+
+auto-custom: export TARGET := default
+auto-custom: ##@auto runs any custom maestro automation flow on simulator/emulator
+ifndef FLOW
+	$(error Usage: make automate FLOW=your-maestro-flow-file.yaml)
+endif
+	maestro test "$(FLOW)"

--- a/maestro/create-account-or-login.yaml
+++ b/maestro/create-account-or-login.yaml
@@ -1,0 +1,11 @@
+appId: im.status.ethereum.debug
+---
+- runFlow: # to run onboarding flow only when device is in onboarding state
+      when:
+        visible: "I’m new to Status"
+      file: onboarding.yaml
+
+- runFlow: # to run login flow only when device is on login screen
+      when:
+        visible: "Profile password"
+      file: login.yaml

--- a/maestro/login.yaml
+++ b/maestro/login.yaml
@@ -1,0 +1,5 @@
+appId: im.status.ethereum.debug
+---
+- tapOn: "password-input"
+- inputText: "password123" # update your account password here
+- tapOn: login-button

--- a/maestro/onboarding.yaml
+++ b/maestro/onboarding.yaml
@@ -1,0 +1,15 @@
+appId: im.status.ethereum.debug
+---
+- tapOn: "I’m new to Status"
+- tapOn: "small-option-card"
+- tapOn: "Your name"
+- inputText: "DeviceA"
+- tapOn: "submit-create-profile-button"
+- inputText: "password123"
+- tapOn: "Repeat password"
+- inputText: "password123"
+- tapOn: "disclaimer-touchable-opacity"
+- tapOn: "Confirm password"
+- tapOn: "skip-identifiers"
+- tapOn: "enable-notifications-later-button"
+- tapOn: "welcome-button"

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -97,4 +97,5 @@ in {
   patchMavenSources = callPackage ./pkgs/patch-maven-srcs { };
   goMavenResolver = callPackage ./pkgs/go-maven-resolver { };
   xcbeautify = callPackage ./pkgs/xcbeautify { };
+  idb-companion = callPackage ./pkgs/idb-companion { };
 }

--- a/nix/pkgs/idb-companion/default.nix
+++ b/nix/pkgs/idb-companion/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "idb-companion";
+  version = "1.1.8";
+
+  src = fetchurl {
+    url = "https://github.com/facebook/idb/releases/download/v${version}/idb-companion.universal.tar.gz";
+    sha256 = "sha256-O3LMappbGiKhiCBahAkNOilDR6hGGA79dVzxo8hI4+c=";
+  };
+
+  buildInputs = [ ];
+
+  unpackPhase = ''
+    tar -xzf $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r ./* $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "A powerful command line tool for automating iOS simulators and devices";
+    homepage = "https://github.com/facebook/idb";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -23,9 +23,9 @@ in mkShell {
       # build specific utilities
       clojure maven watchman
       # other nice to have stuff
-      yarn nodejs python310
+      yarn nodejs python310 maestro
     ] # and some special cases
-      ++ lib.optionals   stdenv.isDarwin ([ cocoapods clang tcl ] ++ appleSDKFrameworks)
+      ++ lib.optionals   stdenv.isDarwin ([ cocoapods clang tcl idb-companion ] ++ appleSDKFrameworks)
       ++ lib.optionals (!stdenv.isDarwin) [ gcc8 ]
     );
 


### PR DESCRIPTION
## Summary

This PR introduces `maestro` dev automations.
The purpose of this PR is to allow running `maestro` automations to enhance productivity by **automating** mundane tasks.

Other flows like 
- send contact request
- sync devices
- join a community 
etc will be a part of follow up PRs.

This PR also exists to facilitate a discussion whether the team finds this useful or not.
Any/all feedback is welcome.

In this PR we provide a `make` command to run a very common task like creating account & login : 
`make auto-login`

We also allow another `make` command to run any other custom flow : 
`make auto-custom FLOW="maestro/create-account-or-login.yaml"`

A `maestro` folder has been added with 3 `yaml` files which are very easy to understand 
ref : https://maestro.mobile.dev/api-reference/commands

## Review notes
follow these steps and share your experience
- `make run-clojure`
- `make run-metro`
- `make run-ios` OR `make run-android`
- `make automate-login`

## Testing notes
doesn't need testing, this PR is only for devs to automate few tasks locally.

## Platforms
- Android
- iOS

## Screen recording

https://github.com/status-im/status-mobile/assets/64726664/62002796-df55-4051-8228-4a293a4fb629


status: ready 
