### PR TITLE
chore: remove `hermes` enable condition from android build step

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -267,25 +267,24 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
-    implementation "androidx.core:core-splashscreen:1.0.0"
-
-    if (hermesEnabled.toBoolean()) {
-        implementation("com.facebook.react:hermes-android")
-      } else {
-      implementation jscFlavor
-    }
+    implementation("androidx.core:core-splashscreen:1.0.0")
+    // we don't use hermes for debug but we need its pom file for release builds
+    // https://github.com/status-im/status-mobile/pull/18675
+    implementation("com.facebook.react:hermes-android")
+    // FIXME: implementing both hermes & JSC increases bundle size by ~ 2MB
+    implementation(jscFlavor)
 
     // react-native-screens
-    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'
-    implementation 'androidx.multidex:multidex:2.0.1' // required by status-mobile/android/app/src/main/java/im/status/ethereum/MainApplication.java
+    implementation("androidx.appcompat:appcompat:1.1.0-rc01")
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02")
+    implementation("androidx.multidex:multidex:2.0.1") // required by status-mobile/android/app/src/main/java/im/status/ethereum/MainApplication.java
     implementation project(':react-native-blur')
     implementation project(':react-native-status')
     implementation project(':react-native-status-keycard')
-    implementation 'com.github.status-im:function:0.0.1'
-    implementation 'com.facebook.fresco:fresco:2.5.0'
-    implementation 'com.facebook.fresco:animated-gif:2.5.0'
-    implementation "com.squareup.okhttp3:okhttp-tls:4.9.2"
+    implementation("com.github.status-im:function:0.0.1")
+    implementation("com.facebook.fresco:fresco:2.5.0")
+    implementation("com.facebook.fresco:animated-gif:2.5.0")
+    implementation("com.squareup.okhttp3:okhttp-tls:4.9.2")
     implementation("com.google.prefab:cli:2.0.0")
 }
 

--- a/nix/deps/gradle/deps.json
+++ b/nix/deps/gradle/deps.json
@@ -11344,12 +11344,12 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-bom/4.0.0-rc-2",
+    "path": "com/google/protobuf/protobuf-bom/4.26.0-RC1",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-bom-4.0.0-rc-2.pom": {
-        "sha1": "1cf14b7774313bc34805dd58fffa3cbc35601184",
-        "sha256": "sha256-45/pSYKw70HwkoTPbtPkj0Bsu/ZtioKD0MYmk04KYTI="
+      "protobuf-bom-4.26.0-RC1.pom": {
+        "sha1": "95b890ee6f318b67514a9d3573c78aebfd8cf4c1",
+        "sha256": "sha256-rGscgQUEAvrvFw6SnyMSbIw7N0J6SEgo4bo8nmAbO04="
       }
     }
   },
@@ -11520,16 +11520,16 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-java/4.0.0-rc-2",
+    "path": "com/google/protobuf/protobuf-java/4.26.0-RC1",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-java-4.0.0-rc-2.pom": {
-        "sha1": "8fab0fe0746b1d370663a3db7dd483c2c4d34a6f",
-        "sha256": "sha256-q//aKX5NdsCktWMRsnjG/L3jNI9g/ucIGLN119ZzT50="
+      "protobuf-java-4.26.0-RC1.pom": {
+        "sha1": "9b053265705abd2eb8dd06831b4728ed19e8f79a",
+        "sha256": "sha256-cexXywR1/FPS885SUYezfvvww1TAjy6gAtAmxJVxn0Y="
       },
-      "protobuf-java-4.0.0-rc-2.jar": {
-        "sha1": "ae590f34383d2d6fde2b3b8e2ffb668e64579099",
-        "sha256": "sha256-PMJSvvZfetM8UwzuxxZkzR2gsmUhrWZzpl2fpJMegio="
+      "protobuf-java-4.26.0-RC1.jar": {
+        "sha1": "a4718e6e4943736bb27aa3c7f8ef3c0a851c35b1",
+        "sha256": "sha256-cgTa51zMiegEQa2I9pyGy9psCQ5tPJU9MfMoC8DyDDg="
       }
     }
   },
@@ -11627,38 +11627,38 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-parent/4.0.0-rc-2",
+    "path": "com/google/protobuf/protobuf-parent/4.26.0-RC1",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-parent-4.0.0-rc-2.pom": {
-        "sha1": "c5391c7917ca1197cbbda4efc6454a87e7e7107e",
-        "sha256": "sha256-4NJwgSugXAqrlx4wtRyl0VcmYBkGxiGsIM3LLkq2fi8="
+      "protobuf-parent-4.26.0-RC1.pom": {
+        "sha1": "80963cafb79bc1b0f5dd2c1c82c67016c2362ad4",
+        "sha256": "sha256-n+4hEMufYvUwFQts4WiDUYKyGGnivQQhyc2bS7fODMs="
       }
     }
   },
 
   {
-    "path": "com/google/truth/truth-parent/1.2.0",
+    "path": "com/google/truth/truth-parent/1.4.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "truth-parent-1.2.0.pom": {
-        "sha1": "d24447b2a11846a354e503575ed95e393ba5158d",
-        "sha256": "sha256-Q8/2l2yxZ5ETlTWluYDpwTW8Fgxk7hGc/6qNHv9aquI="
+      "truth-parent-1.4.0.pom": {
+        "sha1": "08b3f870d82e4e34caa1aa94ca03c29d9b40d3d2",
+        "sha256": "sha256-K+3ssiZ3EYKh/sxgh3NFLyTPuMEjreDzymb4pmmU3Gs="
       }
     }
   },
 
   {
-    "path": "com/google/truth/truth/1.2.0",
+    "path": "com/google/truth/truth/1.4.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "truth-1.2.0.pom": {
-        "sha1": "44853be2a0532449235377b3eea680b679cefa7e",
-        "sha256": "sha256-4snQPEXLKYR49KPOM37mXXsk+nVA/PSEy/OkvuQCuVo="
+      "truth-1.4.0.pom": {
+        "sha1": "6ff4bdfe8a3758a755b52ad894b7d983c88e4850",
+        "sha256": "sha256-v4+lYqfRXWNEU9f/LidC/eACm2VNhwtK0uejf89mTnY="
       },
-      "truth-1.2.0.jar": {
-        "sha1": "0135db6c1dfab1b3ca326c8ce51c09381d332d43",
-        "sha256": "sha256-tGEIQNXjffFOZqqwuEDA7j+l6Vl9o6KQIGQYcXHCM5o="
+      "truth-1.4.0.jar": {
+        "sha1": "2a9475ed8cf2081b859fda8f9c860d5c449cd9ed",
+        "sha256": "sha256-I1wo6W7mcBqwHMhS+ylMsPNHVvY2qBVLmu8I+xIVu8Q="
       }
     }
   },
@@ -17512,16 +17512,16 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-reflect/2.0.0-Beta2",
+    "path": "org/jetbrains/kotlin/kotlin-reflect/2.0.0-Beta3",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-reflect-2.0.0-Beta2.pom": {
-        "sha1": "71908b10dd3fefa0509880918948931ad0b8d7c8",
-        "sha256": "sha256-TmkaczZz+Eqbux6yz2SyE9WhflLrknrULgk8j/2sfUs="
+      "kotlin-reflect-2.0.0-Beta3.pom": {
+        "sha1": "dc97aad46542eaa0cb64120911ac1013483969ac",
+        "sha256": "sha256-NnPskjZQvqH3zdWL94mDT/EMvy51senYGEbKjz+ya64="
       },
-      "kotlin-reflect-2.0.0-Beta2.jar": {
-        "sha1": "0cf9ed5d13e31c4e4ab74be627b7cedc0ecc7715",
-        "sha256": "sha256-PAz62O51jigTUVGhAJHGrWdbLoVdCFwwhhI883u50bw="
+      "kotlin-reflect-2.0.0-Beta3.jar": {
+        "sha1": "6915153788502bdccc98753f41dcbd5bf7c7e128",
+        "sha256": "sha256-k4zOXYaKP8MBwjWAOLuEt0ahsLlSHtdnldJma/o0e2Y="
       }
     }
   },
@@ -18769,28 +18769,28 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/2.0.0-Beta2",
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/2.0.0-Beta3",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-stdlib-2.0.0-Beta2.pom": {
-        "sha1": "a1310fbc42c0cbc786766d2e35dcbfdaf3f8a8b1",
-        "sha256": "sha256-8upeJFveFokz2f2rBOXj2KZ9+OzyWxWtqZ9/2qcJGnI="
+      "kotlin-stdlib-2.0.0-Beta3.pom": {
+        "sha1": "1005b3f259dffb93f972e5227eb18fc579b71811",
+        "sha256": "sha256-2qxjaqrwUBME9CbB4lpEKGV4qi2VGn8USteyCSZ8lq4="
       },
-      "kotlin-stdlib-2.0.0-Beta2-all.jar": {
-        "sha1": "c844df2813fa56f8baa346530a5172ccf03277d0",
-        "sha256": "sha256-o8TV9hZ9IGumB5g+8nq6R6YU+VxlRV0PJ3IsSsMRsSM="
+      "kotlin-stdlib-2.0.0-Beta3-all.jar": {
+        "sha1": "845c7a75152307a41522e800bb9706a58e02b228",
+        "sha256": "sha256-YwNHMM8zT64dAULHPNt+zLXQ5xTeAvtP/HKybthMDWI="
       },
-      "kotlin-stdlib-2.0.0-Beta2-common.jar": {
+      "kotlin-stdlib-2.0.0-Beta3-common.jar": {
         "sha1": "e0224f6b9468655e1feffe789ab7ebd4965a9431",
         "sha256": "sha256-ikItp8AZFxM/bokvCF68e2Q+oNGbbJxTILtPDnj7uMI="
       },
-      "kotlin-stdlib-2.0.0-Beta2.jar": {
-        "sha1": "61be8a13ad24f43c915ba6962440cd30af4700ec",
-        "sha256": "sha256-yDOkRXCSzieZ5nejro0ku4suO6qDwWlDBdnb5ZHgquA="
+      "kotlin-stdlib-2.0.0-Beta3.jar": {
+        "sha1": "9982637ebb69602015ed823cceca7054d2ab8bbe",
+        "sha256": "sha256-1+6KuGuMgmiuPLpxx+cJSZ3/pnVOMmLdtzmk3mwB0ro="
       },
-      "kotlin-stdlib-2.0.0-Beta2.module": {
-        "sha1": "22702775430e8d3a9f8d824167e00484e07d5932",
-        "sha256": "sha256-J6vVZxhfZbGpw8tTtV4RQTPJrkFqMwetPevDDG/iO/U="
+      "kotlin-stdlib-2.0.0-Beta3.module": {
+        "sha1": "5026675037ebf81e108eb3cc581a24570ec7ceb2",
+        "sha256": "sha256-rlVFQM89Ga0h57LsViIgT8iSdE18G0rd/TN7/u9UKrU="
       }
     }
   },
@@ -19055,16 +19055,16 @@
   },
 
   {
-    "path": "org/junit/junit-bom/5.10.1",
+    "path": "org/junit/junit-bom/5.10.2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "junit-bom-5.10.1.pom": {
-        "sha1": "41a86ea51227739a5b7ca3430ae88ce44a64a42a",
-        "sha256": "sha256-IcSwKG9LIAaVd/9LIJeKhcEArIpGtvHIZy+6qzN7w/I="
+      "junit-bom-5.10.2.pom": {
+        "sha1": "b25ed98a5bd08cdda60e569cf22822a760e76019",
+        "sha256": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
       },
-      "junit-bom-5.10.1.module": {
-        "sha1": "1b577334c47deb59a29dc31e5211499d0eb3c17b",
-        "sha256": "sha256-IbCvz//i7LN3D16wCuehn+rulOdx+jkYFzhQ2ueAZ7c="
+      "junit-bom-5.10.2.module": {
+        "sha1": "ce536748a853ae6ac09e7815fce0678a96cff778",
+        "sha256": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo="
       }
     }
   },
@@ -19160,16 +19160,16 @@
   },
 
   {
-    "path": "org/mockito/mockito-core/5.9.0",
+    "path": "org/mockito/mockito-core/5.10.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "mockito-core-5.9.0.pom": {
-        "sha1": "2054dcc15b9ede899cb9ec6e8e960e36c68b4574",
-        "sha256": "sha256-BJDEL+Yu7WRzQdpAojcHGW2BO0TbKj3KMB2IFz56yPc="
+      "mockito-core-5.10.0.pom": {
+        "sha1": "25e309d012d326eef980de463edeb2a592cf9cdb",
+        "sha256": "sha256-D4gyKTuHHyO2/0QkET7mXBdfq9G2uswY7Dg8s5akOq8="
       },
-      "mockito-core-5.9.0.jar": {
-        "sha1": "faa88b96db3aeb96a93e83dec7491345bfbfc414",
-        "sha256": "sha256-u62Rhe1zSWX6x+Nn8OUVlvaVMeUdiyy87BBI3W+0Hyw="
+      "mockito-core-5.10.0.jar": {
+        "sha1": "b3812fa2ee069f1d0b41c1c0155da79d0e1dcde0",
+        "sha256": "sha256-AyP1kbBNOg18qevuu56fNKB8DskWm3RE7jlRtx1MrVY="
       }
     }
   },

--- a/nix/deps/gradle/deps.urls
+++ b/nix/deps/gradle/deps.urls
@@ -718,7 +718,7 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.7.1/prot
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.10.0/protobuf-bom-3.10.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.13.0/protobuf-bom-3.13.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.17.2/protobuf-bom-3.17.2.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/4.0.0-rc-2/protobuf-bom-4.0.0-rc-2.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/4.26.0-RC1/protobuf-bom-4.26.0-RC1.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-javalite/3.17.2/protobuf-javalite-3.17.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java-util/3.4.0/protobuf-java-util-3.4.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java-util/3.10.0/protobuf-java-util-3.10.0.pom
@@ -730,7 +730,7 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.7.1/pro
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.10.0/protobuf-java-3.10.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.13.0/protobuf-java-3.13.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.17.2/protobuf-java-3.17.2.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/4.0.0-rc-2/protobuf-java-4.0.0-rc-2.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/4.26.0-RC1/protobuf-java-4.26.0-RC1.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-lite/3.0.1/protobuf-lite-3.0.1.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.0.0/protobuf-parent-3.0.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.4.0/protobuf-parent-3.4.0.pom
@@ -739,9 +739,9 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.7.1/p
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.10.0/protobuf-parent-3.10.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.13.0/protobuf-parent-3.13.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.17.2/protobuf-parent-3.17.2.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/4.0.0-rc-2/protobuf-parent-4.0.0-rc-2.pom
-https://repo.maven.apache.org/maven2/com/google/truth/truth-parent/1.2.0/truth-parent-1.2.0.pom
-https://repo.maven.apache.org/maven2/com/google/truth/truth/1.2.0/truth-1.2.0.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/4.26.0-RC1/protobuf-parent-4.26.0-RC1.pom
+https://repo.maven.apache.org/maven2/com/google/truth/truth-parent/1.4.0/truth-parent-1.4.0.pom
+https://repo.maven.apache.org/maven2/com/google/truth/truth/1.4.0/truth-1.4.0.pom
 https://repo.maven.apache.org/maven2/com/ibm/icu/icu4j/53.1/icu4j-53.1.pom
 https://repo.maven.apache.org/maven2/com/intellij/annotations/12.0/annotations-12.0.pom
 https://repo.maven.apache.org/maven2/com/parse/bolts/bolts-tasks/1.4.0/bolts-tasks-1.4.0.pom
@@ -1146,7 +1146,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.20/kotlin-reflect-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.7.10/kotlin-reflect-1.7.10.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.7.22/kotlin-reflect-1.7.22.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.0.0-Beta2/kotlin-reflect-2.0.0-Beta2.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.0.0-Beta3/kotlin-reflect-2.0.0-Beta3.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.6.20/kotlin-scripting-common-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.7.22/kotlin-scripting-common-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.9.0/kotlin-scripting-common-1.9.0.pom
@@ -1229,7 +1229,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.7.10/k
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.7.22/kotlin-stdlib-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.0/kotlin-stdlib-1.9.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.21/kotlin-stdlib-1.9.21.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.0.0-Beta2/kotlin-stdlib-2.0.0-Beta2.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.0.0-Beta3/kotlin-stdlib-2.0.0-Beta3.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/1.7.22/kotlin-tooling-core-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/1.9.0/kotlin-tooling-core-1.9.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-metadata/1.6.20/kotlin-tooling-metadata-1.6.20.pom
@@ -1247,14 +1247,14 @@ https://repo.maven.apache.org/maven2/org/json/json/20231013/json-20231013.pom
 https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.13.1/jsoup-1.13.1.pom
 https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.2/junit-bom-5.9.2.pom
 https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom
-https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom
+https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.2/junit-bom-5.10.2.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.7.7/stax-ex-1.7.7.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.8/stax-ex-1.8.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/2.1.0/stax-ex-2.1.0.pom
 https://repo.maven.apache.org/maven2/org/mockito/mockito-core/3.12.4/mockito-core-3.12.4.pom
 https://repo.maven.apache.org/maven2/org/mockito/mockito-core/4.0.0/mockito-core-4.0.0.pom
-https://repo.maven.apache.org/maven2/org/mockito/mockito-core/5.9.0/mockito-core-5.9.0.pom
+https://repo.maven.apache.org/maven2/org/mockito/mockito-core/5.10.0/mockito-core-5.10.0.pom
 https://repo.maven.apache.org/maven2/org/mockito/mockito-inline/4.0.0/mockito-inline-4.0.0.pom
 https://repo.maven.apache.org/maven2/org/objenesis/objenesis-parent/3.2/objenesis-parent-3.2.pom
 https://repo.maven.apache.org/maven2/org/objenesis/objenesis-parent/3.3/objenesis-parent-3.3.pom


### PR DESCRIPTION
## Summary

We recently disabled `hermes` for debug builds here -> https://github.com/status-im/status-mobile/pull/18675
A side effect of that is when we run `make nix-update-gradle` the `hermes` pom gets removed from `deps.list`
This pom is necessary for release builds.
Currently that pom exists in `deps.list` but someone may accidentally remove it when running `make nix-update-gradle`

In this PR we remove the conditional implementation of `hermes` or `jsc` in `build.gradle`
This ensures that the `hermes` pom we need during release builds is not removed from `deps.list`.

I also ran `make nix-update-gradle` just to be sure.

## Testing notes
Testing is not needed

## Platforms
- Android

status: ready 
