### PR TITLE
[Fix] Scanned address not populated in send flow

### DIFF
--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -36,6 +36,7 @@
         :on-blur               #(reset! input-focused? false)
         :on-scan               (fn []
                                  (rn/dismiss-keyboard!)
+                                 (rf/dispatch [:wallet/clean-scanned-address])
                                  (rf/dispatch [:open-modal :scan-address]))
         :ens-regex             constants/regx-ens
         :scanned-value         (or (when recipient-plain-address? send-address) scanned-address)


### PR DESCRIPTION
fixes #18681

### Summary

This PR fixes the scanned address that is not pasted/populated in the "Send to" input field.

### Review notes

The bug is caused when we scan the same address again. To fix it, we clear the scanned address in `app-db` before we scan any QR.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the Wallet tab
- Open a wallet account
- Tap on the `Send` button
- Tap on the `[-]` icon in the input field
- Scan an address
- Clear the address in the input field
- Try to scan the SAME address again
- Verify the input field is populated with the scanned address

status: ready 