### PR TITLE
fix: password input triggers re-render of whole login view

### DIFF
--- a/src/status_im/common/standard_authentication/password_input/view.cljs
+++ b/src/status_im/common/standard_authentication/password_input/view.cljs
@@ -7,6 +7,7 @@
     [react-native.core :as rn]
     [status-im.common.standard-authentication.forgot-password-doc.view :as forgot-password-doc]
     [status-im.common.standard-authentication.password-input.style :as style]
+    [utils.debounce :as debounce]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
@@ -22,9 +23,10 @@
 
 (defn- on-change-password
   [entered-password]
-  (rf/dispatch [:set-in [:profile/login :password]
-                (security/mask-data entered-password)])
-  (rf/dispatch [:set-in [:profile/login :error] ""]))
+  (debounce/debounce-and-dispatch [:profile/on-password-input-changed
+                                   {:password (security/mask-data entered-password)
+                                    :error    ""}]
+                                  100))
 
 (defn- view-internal
   [{:keys [default-password theme shell? on-press-biometrics blur?]}]

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -247,3 +247,8 @@
                  #(-> %
                       (dissoc :processing)
                       (assoc :error "Invalid password")))}))
+
+(re-frame/reg-event-fx
+ :profile/on-password-input-changed
+ (fn [{:keys [db]} [{:keys [password error]}]]
+   {:db (update db :profile/login assoc :password password :error error)}))

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -338,6 +338,18 @@
  (fn [[{:keys [key-uid]} profiles]]
    (get profiles key-uid)))
 
+(re-frame/reg-sub
+ :profile/login-processing
+ :<- [:profile/login]
+ (fn [{:keys [processing]}]
+   processing))
+
+(re-frame/reg-sub
+ :profile/login-password
+ :<- [:profile/login]
+ (fn [{:keys [password]}]
+   password))
+
 ;; LINK PREVIEW
 ;; ========================================================================================================
 


### PR DESCRIPTION
fixes #18011

### Summary

debounce pwd input for better performance

Add a 100ms denounce for password input. Only affects dev experience. 

before

https://github.com/status-im/status-mobile/assets/15090582/c0c12f6c-124c-4afc-bdb9-3ce0080a06b3

after

https://github.com/status-im/status-mobile/assets/15090582/75eaa389-508b-4bb6-9426-c4bb7b88983e

### Testing notes

Affected area: login screen

Should have better performance


status: ready <!-- Can be ready or wip -->