### PR TITLE
[Fix] Edited wallet account name persists in other edit account screens

### DIFF
--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -33,7 +33,8 @@
                   {:account    edited-account-data
                    :on-success #(show-save-account-toast updated-key)}])))
 
-(def view
+(defn view
+  []
   (let [edited-account-name  (reagent/atom nil)
         show-confirm-button? (reagent/atom false)
         on-change-color      (fn [edited-color {:keys [color] :as account}]


### PR DESCRIPTION
fixes #18701

### Summary

This PR fixes the edited wallet account name that persists in other account edit screens.

The fix is simple to return a function (to re-create the screen & atoms) instead of var (which holds the atom state)

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Create a profile
- Navigate to the Wallet tab
- Create a new Wallet account (Eg: `Account 2`)
- Edit the name of the account 2 and save it
- Navigate to the Edit page of the first account
- Verify the edited name of the second account is NOT displayed in it

status: ready
