### PR TITLE
nix: upgrade from 2.13.4 to 2.19.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ export KEYSTORE_PATH ?= $(HOME)/.gradle/status-im.keystore
 # Our custom config is located in nix/nix.conf
 export NIX_USER_CONF_FILES = $(PWD)/nix/nix.conf
 # Location of symlinks to derivations that should not be garbage collected
-export _NIX_GCROOTS = /nix/var/nix/gcroots/per-user/$(USER)/status-mobile
+export _NIX_GCROOTS = ./.nix-gcroots
 # Defines which variables will be kept for Nix pure shell, use semicolon as divider
 export _NIX_KEEP ?= TMPDIR,BUILD_ENV,\
 	BUILD_TYPE,BUILD_NUMBER,COMMIT_HASH,\

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -5,7 +5,7 @@ library 'status-jenkins-lib@v1.8.5'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'linux && x86_64 && nix-2.14' }
+  agent { label 'linux && x86_64 && nix-2.19' }
 
   options {
     timestamps()

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -5,7 +5,7 @@ library 'status-jenkins-lib@v1.8.5'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'macos && arm64 && nix-2.14 && xcode-15.1' }
+  agent { label 'macos && arm64 && nix-2.19 && xcode-15.1' }
 
   parameters {
     string(

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -5,7 +5,7 @@ library 'status-jenkins-lib@v1.8.5'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'linux && x86_64 && nix-2.14' }
+  agent { label 'linux && x86_64 && nix-2.19' }
 
   options {
     timestamps()

--- a/nix/DETAILS.md
+++ b/nix/DETAILS.md
@@ -84,8 +84,10 @@ Would fail.
 
 # Garbage Collection
 
-The `make nix-gc` target calls `nix-store --gc` and normally would remove almost everything, but to prevent that we place symlinks to protected derivations in `/nix/var/nix/gcroots` subfolder. Specifically:
+The `make nix-gc` target calls `nix-store --gc` and normally would remove almost everything, but to prevent that we place symlinks to protected derivations in `.nix-gcroots` folder. Specifically:
 ```sh
-_NIX_GCROOTS="${_NIX_GCROOTS:-/nix/var/nix/gcroots/per-user/${USER}/status-mobile}"
+_NIX_GCROOTS="${_NIX_GCROOTS:-${GIT_ROOT}/.nix-gcroots}
 ```
+These symlinks in turn will be symlinked from  `/nix/var/nix/gcroots/auto` through use of `nix-store --add-gcroots`.
+
 Whenever `nix/scripts/build.sh` or `nix/scripts/shell.sh` are called they update symlinks named after given targets in that folder. This in combination with `keep-outputs = true` set in `nix/nix.conf` prevents garbage collection from removing too much.

--- a/nix/scripts/gcroots.sh
+++ b/nix/scripts/gcroots.sh
@@ -2,11 +2,11 @@
 
 set -Ee
 
-_NIX_GCROOTS="${_NIX_GCROOTS:-/nix/var/nix/gcroots/per-user/${USER}/status-mobile}"
-
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/nix/scripts/source.sh"
 source "${GIT_ROOT}/scripts/colors.sh"
+
+_NIX_GCROOTS="${_NIX_GCROOTS:-${GIT_ROOT}/.nix-gcroots}"
 
 TARGET="${1}"
 shift

--- a/nix/scripts/version.sh
+++ b/nix/scripts/version.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-# WARNING: Versions 2.14, 2.15, 2.16 have an issue creating gcroots:
-# https://github.com/NixOS/nix/issues/8564
-export NIX_VERSION="2.13.4"
-export NIX_PACKAGE="nixVersions.nix_2_13"
+export NIX_VERSION="2.19.3"
+export NIX_PACKAGE="nixVersions.nix_2_19"
 export NIX_INSTALL_URL="https://nixos.org/releases/nix/nix-${NIX_VERSION}/install"
-export NIX_INSTALL_SHA256="a9908cc48f5886b4f22172bdd2f9657873276fd295e78c6ed97fb308c6d284d0"
+export NIX_INSTALL_SHA256="73d47b0ab783fddca1b2d44a03d52a74c97c28a1fc8ff5a29419079302ef9c3d"
 export NIX_INSTALL_PATH="/tmp/nix-install-${NIX_VERSION}"


### PR DESCRIPTION
We are moving location of symlinks for build derivations for `gcroots` from `/nix/var/nix/gcroots/per-user` to `.nix-gcroots` in the repo to avoid errors like this caused by profile migration in `2.14` release:
```
error: creating directory '/nix/var/nix/gcroots/per-user/joe': Permission denied
```
For more details see: https://github.com/NixOS/nix/issues/8564

To upgrade without using `make nix-purge` use `make nix-upgrade`.

Related infra change:
- [`infra-ci#37c6ce47`](https://github.com/status-im/infra-ci/commit/37c6ce47) - nix-setup: upgrade from 2.14.1 to 2.19.2