### PR TITLE
[#18463] Page top refactor - Wallet

### DIFF
--- a/src/quo/components/text_combinations/page_top/style.cljs
+++ b/src/quo/components/text_combinations/page_top/style.cljs
@@ -12,7 +12,8 @@
    :height          32})
 
 (def header-title
-  {:flex-direction :row
+  {:flex           1
+   :flex-direction :row
    :column-gap     8})
 
 (def header-counter

--- a/src/quo/components/text_combinations/page_top/view.cljs
+++ b/src/quo/components/text_combinations/page_top/view.cljs
@@ -33,12 +33,13 @@
          (format-counter counter-bottom))]])
 
 (defn- header
-  [{:keys        [title input counter-top counter-bottom
+  [{:keys        [title title-accessibility-label input counter-top counter-bottom
                   title-right title-right-props]
     avatar-props :avatar}]
   (let [title-props (assoc title-right-props
-                           :title title
-                           :right title-right)]
+                           :title               title
+                           :right               title-right
+                           :accessibility-label title-accessibility-label)]
     [rn/view {:style style/header}
      [rn/view {:style style/header-title}
       (when avatar-props

--- a/src/quo/components/text_combinations/page_top/view.cljs
+++ b/src/quo/components/text_combinations/page_top/view.cljs
@@ -112,10 +112,10 @@
         emojis))
 
 (defn- view-internal
-  [{:keys  [theme description input blur? input-props]
+  [{:keys  [theme description input blur? input-props container-style]
     emojis :emoji-dash
     :as    props}]
-  [rn/view
+  [rn/view {:style container-style}
    [rn/view {:style style/top-container}
     [header props]
     (when description

--- a/src/quo/components/text_combinations/page_top/view.cljs
+++ b/src/quo/components/text_combinations/page_top/view.cljs
@@ -8,6 +8,7 @@
             [quo.components.markdown.text :as text]
             [quo.components.tags.context-tag.view :as context-tag]
             [quo.components.text-combinations.page-top.style :as style]
+            [quo.components.text-combinations.standard-title.view :as standard-title]
             [quo.theme]
             [react-native.core :as rn]
             [react-native.fast-image :as fast-image]
@@ -32,18 +33,19 @@
          (format-counter counter-bottom))]])
 
 (defn- header
-  [{:keys        [title input counter-top counter-bottom]
+  [{:keys        [title input counter-top counter-bottom
+                  title-right title-right-props]
     avatar-props :avatar}]
-  [rn/view {:style style/header}
-   [rn/view {:style style/header-title}
-    (when avatar-props
-      [channel-avatar/view (assoc avatar-props :size :size-32)])
-    [text/text
-     {:weight :semi-bold
-      :size   :heading-1}
-     title]]
-   (when (= input :recovery-phrase)
-     [header-counter counter-top counter-bottom])])
+  (let [title-props (assoc title-right-props
+                           :title title
+                           :right title-right)]
+    [rn/view {:style style/header}
+     [rn/view {:style style/header-title}
+      (when avatar-props
+        [channel-avatar/view (assoc avatar-props :size :size-32)])
+      [standard-title/view title-props]]
+     (when (= input :recovery-phrase)
+       [header-counter counter-top counter-bottom])]))
 
 (defn- summary-description
   [{:keys [row-1 row-2] :as _summary-props} blur?]

--- a/src/quo/components/text_combinations/standard_title/style.cljs
+++ b/src/quo/components/text_combinations/standard_title/style.cljs
@@ -2,7 +2,8 @@
   (:require [quo.foundations.colors :as colors]))
 
 (def container
-  {:flex-direction  :row
+  {:flex            1
+   :flex-direction  :row
    :justify-content :space-between})
 
 (def right-container {:margin-left 20})

--- a/src/quo/components/text_combinations/standard_title/view.cljs
+++ b/src/quo/components/text_combinations/standard_title/view.cljs
@@ -53,9 +53,12 @@
       :icon-color          (style/right-tag-icon-color blur? theme)}]))
 
 (defn- view-internal
-  [{:keys [title right] :as props}]
+  [{:keys [title right accessibility-label] :as props}]
   [rn/view {:style style/container}
-   [text/text {:size :heading-1 :weight :semi-bold}
+   [text/text
+    {:size                :heading-1
+     :weight              :semi-bold
+     :accessibility-label accessibility-label}
     title]
    (when right
      [rn/view {:style style/right-container}

--- a/src/quo/core.cljs
+++ b/src/quo/core.cljs
@@ -405,7 +405,9 @@
 (def channel-name quo.components.text-combinations.channel-name.view/view)
 (def page-top quo.components.text-combinations.page-top.view/view)
 (def standard-title quo.components.text-combinations.standard-title.view/view)
-(def text-combinations quo.components.text-combinations.view/view)
+(def ^{:deprecated "quo.components.text-combinations.page-top.view should be used instead"}
+  text-combinations
+  quo.components.text-combinations.view/view)
 (def username quo.components.text-combinations.username.view/view)
 
 ;;;; Utilities - Outside of design system

--- a/src/quo/core.cljs
+++ b/src/quo/core.cljs
@@ -406,7 +406,7 @@
 (def page-top quo.components.text-combinations.page-top.view/view)
 (def standard-title quo.components.text-combinations.standard-title.view/view)
 (def ^{:deprecated "quo.components.text-combinations.page-top.view should be used instead"}
-  text-combinations
+     text-combinations
   quo.components.text-combinations.view/view)
 (def username quo.components.text-combinations.username.view/view)
 

--- a/src/status_im/contexts/wallet/account/bridge/style.cljs
+++ b/src/status_im/contexts/wallet/account/bridge/style.cljs
@@ -1,9 +1,5 @@
 (ns status-im.contexts.wallet.account.bridge.style)
 
-(def header-container
-  {:padding-horizontal 20
-   :padding-vertical   12})
-
 (def input-container
   {:padding-horizontal 20
    :padding-vertical   8})

--- a/src/status_im/contexts/wallet/account/bridge/view.cljs
+++ b/src/status_im/contexts/wallet/account/bridge/view.cljs
@@ -17,9 +17,7 @@
        [account-switcher/view
         {:on-press            #(rf/dispatch [:navigate-back])
          :accessibility-label :top-bar}]
-       [quo/text-combinations
-        {:container-style style/header-container
-         :title           (i18n/label :t/bridge)}]
+       [quo/page-top {:title (i18n/label :t/bridge)}]
        [quo/input
         {:container-style style/input-container
          :icon-name       :i/search

--- a/src/status_im/contexts/wallet/account/bridge_to/style.cljs
+++ b/src/status_im/contexts/wallet/account/bridge_to/style.cljs
@@ -1,9 +1,5 @@
 (ns status-im.contexts.wallet.account.bridge-to.style)
 
-(def header-container
-  {:padding-horizontal 20
-   :padding-vertical   12})
-
 (def content-container
   {:padding-horizontal 8})
 

--- a/src/status_im/contexts/wallet/account/bridge_to/view.cljs
+++ b/src/status_im/contexts/wallet/account/bridge_to/view.cljs
@@ -43,17 +43,15 @@
         tokens           (:tokens account)
         mainnet          (first network-details)
         layer-2-networks (rest network-details)
-        account-token    (some #(when (= token-symbol (:symbol %)) %) tokens)]
-
-
+        account-token    (some #(when (= token-symbol (:symbol %)) %) tokens)
+        bridge-to-title  (i18n/label :t/bridge-to
+                                     {:name (string/upper-case (str (:name token)))})]
     [rn/view
      [account-switcher/view
       {:on-press            #(rf/dispatch [:navigate-back-within-stack :wallet-bridge-to])
        :icon-name           :i/arrow-left
        :accessibility-label :top-bar}]
-     [quo/text-combinations
-      {:container-style style/header-container
-       :title           (i18n/label :t/bridge-to {:name (string/upper-case (str (:name token)))})}]
+     [quo/page-top {:title bridge-to-title}]
      [rn/view style/content-container
       [bridge-token-component (assoc mainnet :network-name :t/mainnet) account-token]]
 

--- a/src/status_im/contexts/wallet/add_address_to_watch/style.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/style.cljs
@@ -1,9 +1,6 @@
 (ns status-im.contexts.wallet.add-address-to-watch.style)
 
-(def header-container
-  {:margin-horizontal 20
-   :margin-top        12
-   :margin-bottom     20})
+(def header-container {:padding-bottom 8})
 
 (def scan
   {:margin-top 26})

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -134,7 +134,7 @@
                    :container-style     {:z-index 2}}
                   (i18n/label :t/continue)]}
         [quo/page-top
-         {:container-style  {:padding-bottom 8}
+         {:container-style  style/header-container
           :title            (i18n/label :t/add-address)
           :description      :text
           :description-text (i18n/label :t/enter-eth)}]

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -133,10 +133,11 @@
                                           (clear-input))
                    :container-style     {:z-index 2}}
                   (i18n/label :t/continue)]}
-        [quo/text-combinations
-         {:container-style style/header-container
-          :title           (i18n/label :t/add-address)
-          :description     (i18n/label :t/enter-eth)}]
+        [quo/page-top
+         {:container-style  {:padding-bottom 8}
+          :title            (i18n/label :t/add-address)
+          :description      :text
+          :description-text (i18n/label :t/enter-eth)}]
         [:f> address-input
          {:input-value    input-value
           :validate       validate

--- a/src/status_im/contexts/wallet/create_account/new_keypair/backup_recovery_phrase/style.cljs
+++ b/src/status_im/contexts/wallet/create_account/new_keypair/backup_recovery_phrase/style.cljs
@@ -4,10 +4,6 @@
     [quo.theme :as quo.theme]
     [react-native.platform :as platform]))
 
-(def header-container
-  {:margin-horizontal 20
-   :margin-vertical   12})
-
 (defn seed-phrase-container
   [theme]
   {:margin-horizontal  20

--- a/src/status_im/contexts/wallet/create_account/new_keypair/backup_recovery_phrase/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/new_keypair/backup_recovery_phrase/view.cljs
@@ -68,7 +68,8 @@
                    :padding-top        20}}
           [quo/text
            {:weight :semi-bold
-            :style  {:margin-bottom 8}} (i18n/label :t/how-to-backup)]
+            :style  {:margin-bottom 8}}
+           (i18n/label :t/how-to-backup)]
           [rn/flat-list
            {:data           step-labels
             :render-fn      step-item

--- a/src/status_im/contexts/wallet/create_account/new_keypair/backup_recovery_phrase/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/new_keypair/backup_recovery_phrase/view.cljs
@@ -51,10 +51,10 @@
         {:icon-name           :i/close
          :on-press            #(rf/dispatch [:navigate-back])
          :accessibility-label :top-bar}]
-       [quo/text-combinations
-        {:container-style style/header-container
-         :title           (i18n/label :t/backup-recovery-phrase)
-         :description     (i18n/label :t/backup-recovery-phrase-description)}]
+       [quo/page-top
+        {:title            (i18n/label :t/backup-recovery-phrase)
+         :description      :text
+         :description-text (i18n/label :t/backup-recovery-phrase-description)}]
        [rn/view {:style (style/seed-phrase-container theme)}
         [words-column temp/secret-phrase true]
         [rn/view {:style (style/separator theme)}]

--- a/src/status_im/contexts/wallet/create_account/new_keypair/check_your_backup/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/new_keypair/check_your_backup/view.cljs
@@ -87,9 +87,10 @@
           {:icon-name           :i/arrow-left
            :on-press            #(rf/dispatch [:navigate-back])
            :accessibility-label :top-bar}]
-         [quo/page-top {:title            (i18n/label :t/check-your-backup)
-                        :description      :text
-                        :description-text (i18n/label :t/confirm-the-position)}]
+         [quo/page-top
+          {:title            (i18n/label :t/check-your-backup)
+           :description      :text
+           :description-text (i18n/label :t/confirm-the-position)}]
          [rn/flat-list
           {:data                    random-indices
            :render-fn               (fn [num index]

--- a/src/status_im/contexts/wallet/create_account/new_keypair/check_your_backup/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/new_keypair/check_your_backup/view.cljs
@@ -87,10 +87,9 @@
           {:icon-name           :i/arrow-left
            :on-press            #(rf/dispatch [:navigate-back])
            :accessibility-label :top-bar}]
-         [quo/text-combinations
-          {:container-style style/header-container
-           :title           (i18n/label :t/check-your-backup)
-           :description     (i18n/label :t/confirm-the-position)}]
+         [quo/page-top {:title            (i18n/label :t/check-your-backup)
+                        :description      :text
+                        :description-text (i18n/label :t/confirm-the-position)}]
          [rn/flat-list
           {:data                    random-indices
            :render-fn               (fn [num index]

--- a/src/status_im/contexts/wallet/create_account/select_keypair/style.cljs
+++ b/src/status_im/contexts/wallet/create_account/select_keypair/style.cljs
@@ -1,9 +1,7 @@
 (ns status-im.contexts.wallet.create-account.select-keypair.style)
 
 (def header-container
-  {:margin-horizontal 20
-   :margin-top        12
-   :margin-bottom     20})
+  {:margin-bottom 8})
 
 (def bottom-action-container
   {:position :absolute

--- a/src/status_im/contexts/wallet/create_account/select_keypair/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/select_keypair/view.cljs
@@ -42,8 +42,7 @@
   []
   (let [{:keys [public-key compressed-key
                 customization-color]} (rf/sub [:profile/profile])
-        display-name                  (first (rf/sub [:contacts/contact-two-names-by-identity
-                                                      public-key]))
+        [display-name _]              (rf/sub [:contacts/contact-two-names-by-identity public-key])
         profile-with-image            (rf/sub [:profile/profile-with-image])
         profile-picture               (profile.utils/photo profile-with-image)]
     [rn/view {:style {:flex 1}}
@@ -51,29 +50,30 @@
       {:icon-name           :i/close
        :on-press            #(rf/dispatch [:navigate-back])
        :accessibility-label :top-bar}]
-     [quo/text-combinations
-      {:container-style     style/header-container
-       :title               (i18n/label :t/keypairs)
-       :description         (i18n/label :t/keypairs-description)
-       :button-icon         :i/add
-       :button-on-press     #(rf/dispatch [:show-bottom-sheet
-                                           {:content keypair-options}])
-       :customization-color customization-color}]
+     [quo/page-top
+      {:container-style   style/header-container
+       :title             (i18n/label :t/keypairs)
+       :title-right       :action
+       :title-right-props {:icon                :i/add
+                           :customization-color customization-color
+                           :on-press            #(rf/dispatch
+                                                  [:show-bottom-sheet {:content keypair-options}])}
+       :description       :text
+       :description-text  (i18n/label :t/keypairs-description)}]
      [quo/keypair
-      (merge
-       {:customization-color customization-color
-        :profile-picture     profile-picture
-        :status-indicator    false
-        :type                :default-keypair
-        :stored              :on-device
-        :on-options-press    #(js/alert "Options pressed")
-        :action              :selector
-        :blur?               false
-        :details             {:full-name display-name
-                              :address   (utils/get-shortened-compressed-key compressed-key)}
-        :accounts            accounts
-        :container-style     {:margin-horizontal 20
-                              :margin-vertical   8}})]
+      {:customization-color customization-color
+       :profile-picture     profile-picture
+       :status-indicator    false
+       :type                :default-keypair
+       :stored              :on-device
+       :on-options-press    #(js/alert "Options pressed")
+       :action              :selector
+       :blur?               false
+       :details             {:full-name display-name
+                             :address   (utils/get-shortened-compressed-key compressed-key)}
+       :accounts            accounts
+       :container-style     {:margin-horizontal 20
+                             :margin-vertical   8}}]
      [quo/bottom-actions
       {:actions          :one-action
        :button-one-label (i18n/label :t/confirm-account-origin)

--- a/src/status_im/contexts/wallet/send/select_address/style.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/style.cljs
@@ -3,10 +3,6 @@
 (def container
   {:flex 1})
 
-(def title-container
-  {:margin-horizontal 20
-   :margin-vertical   12})
-
 (def tabs
   {:padding-top    20
    :padding-bottom 12})

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -160,9 +160,8 @@
                                                                              :wallet-select-address}])
                                         :customization-color color}
                                        (i18n/label :t/continue)])}
-         [quo/text-combinations
+         [quo/page-top
           {:title                     (i18n/label :t/send-to)
-           :container-style           style/title-container
            :title-accessibility-label :title-label}]
          [address-input input-value input-focused?]
          [quo/divider-line]

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -69,9 +69,8 @@
         {:icon-name     :i/arrow-left
          :on-press      on-close
          :switcher-type :select-account}]
-       [quo/text-combinations
+       [quo/page-top
         {:title                     (i18n/label :t/select-asset)
-         :container-style           style/title-container
          :title-accessibility-label :title-label}]
        [quo/segmented-control
         {:size            32

--- a/src/status_im/contexts/wallet/share_address/style.cljs
+++ b/src/status_im/contexts/wallet/share_address/style.cljs
@@ -1,5 +1,3 @@
 (ns status-im.contexts.wallet.share-address.style)
 
-(def header-container
-  {:padding-horizontal 20
-   :padding-vertical   12})
+(def header-container {:margin-bottom 8})

--- a/src/status_im/contexts/wallet/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/share_address/view.cljs
@@ -32,18 +32,17 @@
 
 (defn- open-preferences
   [selected-networks]
-  (rf/dispatch [:show-bottom-sheet
-                {:theme :dark
-                 :shell? true
-                 :content
-                 (fn []
-                   [network-preferences/view
-                    {:blur?             true
-                     :selected-networks (set @selected-networks)
-                     :on-save           (fn [chain-ids]
-                                          (rf/dispatch [:hide-bottom-sheet])
-                                          (reset! selected-networks (map #(get utils/id->network %)
-                                                                         chain-ids)))}])}]))
+  (let [on-save       (fn [chain-ids]
+                        (rf/dispatch [:hide-bottom-sheet])
+                        (reset! selected-networks (map utils/id->network chain-ids)))
+        sheet-content (fn []
+                        [network-preferences/view
+                         {:blur?             true
+                          :selected-networks (set @selected-networks)
+                          :on-save           on-save}])]
+    (rf/dispatch [:show-bottom-sheet {:theme   :dark
+                                      :shell?  true
+                                      :content sheet-content}])))
 
 
 (defn view

--- a/src/status_im/contexts/wallet/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/share_address/view.cljs
@@ -82,8 +82,9 @@
             :right-side          [{:icon-name :i/scan
                                    :on-press  #(js/alert "To be implemented")}]
             :accessibility-label :top-bar}]
-          [quo/page-top {:title           title
-                         :container-style style/header-container}]
+          [quo/page-top
+           {:title           title
+            :container-style style/header-container}]
           [rn/view {:style {:padding-horizontal 20}}
            [quo/share-qr-code
             {:type                (if watch-only? :watched-address :wallet)

--- a/src/status_im/contexts/wallet/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/share_address/view.cljs
@@ -74,8 +74,7 @@
         [quo/overlay {:type :shell}
          [rn/view
           {:flex        1
-           :padding-top padding-top
-           :key         :share-adress}
+           :padding-top padding-top}
           [quo/page-nav
            {:icon-name           :i/close
             :on-press            #(rf/dispatch [:navigate-back])
@@ -83,9 +82,8 @@
             :right-side          [{:icon-name :i/scan
                                    :on-press  #(js/alert "To be implemented")}]
             :accessibility-label :top-bar}]
-          [quo/text-combinations
-           {:container-style style/header-container
-            :title           title}]
+          [quo/page-top {:title           title
+                         :container-style style/header-container}]
           [rn/view {:style {:padding-horizontal 20}}
            [quo/share-qr-code
             {:type                (if watch-only? :watched-address :wallet)

--- a/src/status_im/contexts/wallet/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/share_address/view.cljs
@@ -40,9 +40,10 @@
                          {:blur?             true
                           :selected-networks (set @selected-networks)
                           :on-save           on-save}])]
-    (rf/dispatch [:show-bottom-sheet {:theme   :dark
-                                      :shell?  true
-                                      :content sheet-content}])))
+    (rf/dispatch [:show-bottom-sheet
+                  {:theme   :dark
+                   :shell?  true
+                   :content sheet-content}])))
 
 
 (defn view


### PR DESCRIPTION
fixes #18463

### Summary

This PR is just a refactor, we've been using a `text-combinations` component that doesn't exist in designs, the `page-top` compontent has been recently implemented but hasn't been used. This PR uses the new component in the wallet screens and deprecates the old one.

While replacing it, I checked all the designs still matched, and they did. So we don't need a design review for this one.

### Review notes

One small UI bug has been cached, the designs:

![Screenshot from 2024-02-07 12-25-56](https://github.com/status-im/status-mobile/assets/90291778/78aa2717-cab4-4dfa-b691-593d480cd0a4)

Before | now
<img src=https://github.com/status-im/status-mobile/assets/90291778/4eed3440-add0-4433-8ff1-412ca67e8c7d
width=400> <img src=https://github.com/status-im/status-mobile/assets/90291778/4a6630f3-fb0c-4645-8a3f-2f62bbaa247a
width=400>

To make easier see the difference, this is the new one:

![Screenshot from 2024-02-07 12-26-00](https://github.com/status-im/status-mobile/assets/90291778/226bdaf5-8846-4dc7-be9c-e26e1e91f287)

The fix is the previous one lacked of a bottom-margin


##### Non-functional

- A refactor

status: ready
