### PR TITLE
Account Selection: Use bottom sheet as defined in Figma

### DIFF
--- a/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
@@ -5,6 +5,8 @@
     [react-native.gesture :as gesture]
     [status-im.common.password-authentication.view :as password-authentication]
     [status-im.contexts.communities.actions.accounts-selection.style :as style]
+    [status-im.contexts.communities.actions.addresses-for-permissions.view :as addresses-for-permissions]
+    [status-im.contexts.communities.actions.airdrop-addresses.view :as airdrop-addresses]
     [status-im.contexts.communities.actions.community-rules.view :as community-rules]
     [status-im.contexts.communities.utils :as communities.utils]
     [utils.i18n :as i18n]
@@ -52,8 +54,9 @@
        [quo/category
         {:list-type :settings
          :data      [{:title             (i18n/label :t/join-as-a {:role highest-role-text})
-                      :on-press          #(rf/dispatch [:open-modal :addresses-for-permissions
-                                                        {:community-id id}])
+                      :on-press          #(rf/dispatch [:show-bottom-sheet
+                                                        {:community-id id
+                                                         :content      addresses-for-permissions/view}])
                       :description       :text
                       :action            :arrow
                       :label             :preview
@@ -61,8 +64,9 @@
                                           :data selected-accounts}
                       :description-props {:text (i18n/label :t/all-addresses)}}
                      {:title             (i18n/label :t/for-airdrops)
-                      :on-press          #(rf/dispatch [:open-modal :airdrop-addresses
-                                                        {:community-id id}])
+                      :on-press          #(rf/dispatch [:show-bottom-sheet
+                                                        {:community-id id
+                                                         :content      airdrop-addresses/view}])
                       :description       :text
                       :action            :arrow
                       :label             :preview

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/style.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/style.cljs
@@ -1,7 +1,5 @@
 (ns status-im.contexts.communities.actions.addresses-for-permissions.style)
 
-(def container {:flex 1})
-
 (def buttons
   {:flex-direction     :row
    :gap                12

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -2,6 +2,7 @@
   (:require [quo.core :as quo]
             [quo.foundations.colors :as colors]
             [react-native.core :as rn]
+            [react-native.gesture :as gesture]
             [status-im.common.not-implemented :as not-implemented]
             [status-im.contexts.communities.actions.addresses-for-permissions.style :as style]
             [status-im.contexts.communities.utils :as communities.utils]
@@ -31,7 +32,7 @@
         highest-role-text
         (i18n/label
          (communities.utils/role->translation-key highest-permission-role))]
-    [rn/safe-area-view {:style style/container}
+    [:<>
      [quo/drawer-top
       {:type                :context-tag
        :title               (i18n/label :t/addresses-for-permissions)
@@ -42,7 +43,7 @@
        :community-logo      (get-in images [:thumbnail :uri])
        :customization-color color}]
 
-     [rn/flat-list
+     [gesture/flat-list
       {:render-fn               account-item
        :render-data             [selected-addresses id]
        :content-container-style {:padding 20}
@@ -80,7 +81,7 @@
         :container-style {:flex 1}
         :on-press        (fn []
                            (rf/dispatch [:communities/reset-selected-permission-addresses id])
-                           (rf/dispatch [:navigate-back]))}
+                           (rf/dispatch [:hide-bottom-sheet]))}
        (i18n/label :t/cancel)]
       [quo/button
        {:container-style     {:flex 1}
@@ -88,5 +89,5 @@
         :disabled?           (empty? selected-addresses)
         :on-press            (fn []
                                (rf/dispatch [:communities/update-previous-permission-addresses id])
-                               (rf/dispatch [:navigate-back]))}
+                               (rf/dispatch [:hide-bottom-sheet]))}
        (i18n/label :t/confirm-changes)]]]))

--- a/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
+++ b/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
@@ -1,20 +1,20 @@
 (ns status-im.contexts.communities.actions.airdrop-addresses.view
   (:require
     [quo.core :as quo]
-    [react-native.core :as rn]
+    [react-native.gesture :as gesture]
     [status-im.common.not-implemented :as not-implemented]
     [status-im.contexts.communities.actions.airdrop-addresses.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn- render-item
+(defn- address-item
   [item _ _ [airdrop-address community-id]]
   [quo/account-item
    {:account-props item
     :state         (when (= airdrop-address (:address item)) :selected)
     :on-press      (fn []
                      (rf/dispatch [:communities/set-airdrop-address (:address item) community-id])
-                     (rf/dispatch [:navigate-back]))
+                     (rf/dispatch [:hide-bottom-sheet]))
     :emoji         (:emoji item)}])
 
 (defn view
@@ -33,9 +33,9 @@
        :on-button-press     not-implemented/alert
        :community-logo      (get-in images [:thumbnail :uri])
        :customization-color color}]
-     [rn/flat-list
+     [gesture/flat-list
       {:data                    selected-accounts
-       :render-fn               render-item
+       :render-fn               address-item
        :render-data             [airdrop-address id]
        :content-container-style style/account-list-container
        :key-fn                  :address}]]))


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/18619
Fixes https://github.com/status-im/status-mobile/issues/18617
Fixes https://github.com/status-im/status-mobile/issues/18754
Fixes https://github.com/status-im/status-mobile/issues/18615

### Summary

See issues for all the details.

### Example (incorrect)

[incorrect.webm](https://github.com/status-im/status-mobile/assets/46027/b6668a98-93db-4f19-bb0d-a6a5661a9ad7)

### Example (fixed)

[with fewer items.webm](https://github.com/status-im/status-mobile/assets/46027/80ff0fcc-d071-4389-8a36-db6893b1293b)

[with more items.webm](https://github.com/status-im/status-mobile/assets/46027/b6de904b-2872-4d02-8a8c-fa9db63d1311)

### Areas that may be impacted

None because all the code is behind a disabled feature flag.

### Steps to test

1. Enable flag `status-im.config/community-accounts-selection-enabled?`.
2. Go to _Request to join_ screen.
3. Press on _Join as a Member_ or _For airdrops_ and see the bottom sheets are displayed and that the user can scroll when there are more addresses than fit the screen.

status: ready
