### PR TITLE
fix error and app freezing when deselecting account one by one

### DIFF
--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/style.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/style.cljs
@@ -8,12 +8,6 @@
    :padding-horizontal 20
    :padding-vertical   12})
 
-(def error-message
-  {:flex-direction  :row
-   :gap             4
-   :justify-content :center
-   :margin-bottom   8})
-
 (def highest-role
   {:flex-direction  :row
    :gap             4

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -53,8 +53,9 @@
             {:keys [highest-permission-role]} (rf/sub [:community/token-gated-overview id])
             accounts                          (rf/sub [:wallet/accounts-with-customization-color])
             selected-addresses                (rf/sub [:communities/selected-permission-addresses id])
-            highest-role-text                 (i18n/label (communities.utils/role->translation-key
-                                                           highest-permission-role))]
+            highest-role-text                 (when highest-permission-role
+                                                (i18n/label (communities.utils/role->translation-key
+                                                             highest-permission-role)))]
         [rn/safe-area-view {:style style/container}
          [quo/drawer-top
           {:type                :context-tag
@@ -73,7 +74,7 @@
            :key-fn                  :address
            :data                    accounts}]
 
-         (when (and highest-permission-role (seq selected-addresses))
+         (if (and highest-permission-role (seq selected-addresses))
            [rn/view
             {:style style/highest-role}
             [quo/text
@@ -84,19 +85,15 @@
              {:type    :icon
               :icon    :i/members
               :size    24
-              :context highest-role-text}]])
-
-         (when (empty? selected-addresses)
-           [rn/view
-            {:style style/error-message}
-            [quo/icon
-             :i/info
-             {:color colors/danger-50
-              :size  16}]
-            [quo/text
-             {:size  :paragraph-2
-              :style {:color colors/danger-50}}
-             (i18n/label :t/no-addresses-selected)]])
+              :context highest-role-text}]]
+           [quo/info-message
+            {:type  :error
+             :size  :default
+             :icon  :i/info
+             :style {:justify-content :center}}
+            (if (empty? selected-addresses)
+              (i18n/label :t/no-addresses-selected)
+              (i18n/label :t/addresses-dont-contain-tokens-needed))])
 
          [rn/view {:style style/buttons}
           [quo/button

--- a/translations/en.json
+++ b/translations/en.json
@@ -2265,6 +2265,7 @@
     "eligible-to-join-as": "Eligible to join as",
     "you-not-eligible-to-join": "You’re not eligible to join",
     "you-hold-number-of-hold-tokens-of-these": "You hold {{number-of-hold-tokens}} of these:",
+    "addresses-dont-contain-tokens-needed": "These addresses don’t contain tokens needed to join",
     "token-gated-communities": "Token gated communities",
     "read-more": "Read more",
     "token-gated-communities-info": "Here will be something relevant about this topic. This will help the user get more context and therefore have a better understanding of it.",


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/18753

### Summary

**Note**: PR is based on https://github.com/status-im/status-mobile/pull/18530, and changes will be reverted before merging

What's fixed?
- Added null check for permission role so the app doesn't crash/freeze when selected addresses don't contain tokens needed
- Added info message `These addresses don’t contain tokens needed to join`

Out of Scope
- If the Permissions sheet is closed by swiping down instead of the cancel button then we will arrive at a [weird state](https://github.com/status-im/status-mobile/issues/18753#issuecomment-1933977943)
- Check for permissions to join the community is slow and a little inconsistent.

These issues are caused because we are changing the global state while toggling accounts instead of only updating the local state and then submitting when confirm is pressed. Probably there is a reason, why it is implemented this way. (Will log these issues)

status: ready