### PR TITLE
Fix permission screen & trailing zeros

### DIFF
--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -167,5 +167,5 @@
 
 (def default-kdf-iterations 3200)
 
-(def community-accounts-selection-enabled? (enabled? (get-config :ACCOUNT_SELECTION_ENABLED "0")))
+(def community-accounts-selection-enabled? true)
 (def fetch-messages-enabled? (enabled? (get-config :FETCH_MESSAGES_ENABLED "1")))

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -1,10 +1,10 @@
 (ns status-im.subs.communities
   (:require
     [clojure.string :as string]
-    [legacy.status-im.data-store.communities :as data-store]
     [legacy.status-im.ui.screens.profile.visibility-status.utils :as visibility-status-utils]
     [re-frame.core :as re-frame]
     [status-im.constants :as constants]
+    [status-im.contexts.wallet.common.utils :as wallet.utils]
     [utils.i18n :as i18n]))
 
 (re-frame/reg-sub
@@ -298,58 +298,42 @@
  (fn [collapsed-categories [_ community-id]]
    (get collapsed-categories community-id)))
 
-(defn- permission-id->permission-value
-  [token-permissions permission-id]
-  (get (into {} token-permissions) permission-id))
+
+(defn token-requirement->token
+  [checking-permissions?
+   token-images
+   {:keys [satisfied criteria]}]
+  (let [sym    (:symbol criteria)
+        amount (:amount criteria)]
+    {:symbol      sym
+     :sufficient? satisfied
+     :loading?    checking-permissions?
+     :amount      (wallet.utils/remove-trailing-zeroes amount)
+     :img-src     (get token-images sym)}))
 
 (re-frame/reg-sub
  :community/token-gated-overview
  (fn [[_ community-id]]
    [(re-frame/subscribe [:communities/community community-id])])
- (fn [[{:keys [token-permissions-check token-permissions checking-permissions? token-images]}] _]
-   (let [can-request-access? (:satisfied token-permissions-check)
-         highest-permission-role
-         (when can-request-access?
-           (->> token-permissions-check
-                :permissions
-                (reduce-kv
-                 (fn [highest-permission-role permission-id {:keys [criteria]}]
-                   (if-let [permission-type
-                            (and (first criteria)
-                                 (some #{(:type (permission-id->permission-value token-permissions
-                                                                                 permission-id))}
-                                       constants/community-role-permissions))]
-                     (if highest-permission-role
-                       (min highest-permission-role permission-type)
-                       permission-type)
-                     highest-permission-role))
-                 nil)))
-         highest-permission-role (if (and can-request-access? (nil? highest-permission-role))
-                                   constants/community-token-permission-become-member
-                                   highest-permission-role)]
+ (fn [[{:keys [token-permissions-check checking-permissions? token-images]}] _]
+   (let [highest-role            (:highestRole token-permissions-check)
+         networks-not-supported? (:networksNotSupported token-permissions-check)
+         lowest-role             (last (:roles token-permissions-check))
+         highest-permission-role (:type highest-role)
+         can-request-access?     (and (boolean highest-permission-role) (not networks-not-supported?))]
      {:can-request-access?     can-request-access?
       :highest-permission-role highest-permission-role
-      :number-of-hold-tokens   (reduce
-                                (fn [acc [_ {:keys [criteria]}]]
-                                  (reduce #(+ %1 (if %2 1 0)) acc criteria))
-                                0
-                                (:permissions token-permissions-check))
-      :tokens                  (->>
-                                 token-permissions
-                                 (filter (fn [[_ permission]]
-                                           (data-store/role-permission? permission)))
-                                 (map (fn [[perm-key {:keys [token_criteria]}]]
-                                        (let [check-criteria (get-in token-permissions-check
-                                                                     [:permissions perm-key :criteria])]
-                                          (map
-                                           (fn [{sym :symbol amount :amount} sufficient?]
-                                             {:symbol      sym
-                                              :sufficient? (when (seq check-criteria) sufficient?)
-                                              :loading?    checking-permissions?
-                                              :amount      amount
-                                              :img-src     (get token-images sym)})
-                                           token_criteria
-                                           (or check-criteria token_criteria))))))})))
+      :networks-not-supported? networks-not-supported?
+      :no-member-permission?   (and highest-permission-role
+                                    (not (-> token-permissions-check :highestRole :criteria)))
+      :tokens                  (map (fn [{:keys [tokenRequirement]}]
+                                      (map
+                                       (partial token-requirement->token
+                                                checking-permissions?
+                                                token-images)
+                                       tokenRequirement))
+                                    (or (:criteria highest-role)
+                                        (:criteria lowest-role)))})))
 
 (re-frame/reg-sub
  :community/images

--- a/src/status_im/subs/communities_test.cljs
+++ b/src/status_im/subs/communities_test.cljs
@@ -382,88 +382,74 @@
   [sub-name]
   (let
     [checking-permissions? true
-     token-image-eth "data:image/jpeg;base64,/9j/2w"
-     community {:id                      community-id
-                :checking-permissions?   checking-permissions?
-                :permissions             {:access 3}
-                :highest-permission-role constants/community-token-permission-become-admin
-                :token-images            {"ETH" token-image-eth}
-                :token-permissions       [[:permission-id-01
-                                           {:id "permission-id-01"
-                                            :type constants/community-token-permission-can-view-channel
-                                            :token_criteria [{:contract_addresses {:5 "0x0"}
-                                                              :type               1
-                                                              :symbol             "SNT"
-                                                              :amount             "0.002"
-                                                              :decimals           18}]
-                                            :chat_ids [(str community-id
-                                                            "89f98a1e-6776-4e5f-8626-8ab9f855253f")]}]
-                                          [:permission-id-02
-                                           {:id "permission-id-02"
-                                            :type constants/community-token-permission-become-admin
-                                            :token_criteria [{:contract_addresses {:5 "0x0"}
-                                                              :type               1
-                                                              :symbol             "DAI"
-                                                              :amount             "5.0"
-                                                              :decimals           18}]
-                                            :chat_ids [(str community-id
-                                                            "89f98a1e-6776-4e5f-8626-8ab9f855253f")]}]
-                                          [:permission-id-03
-                                           {:id "permission-id-03"
-                                            :type constants/community-token-permission-become-member
-                                            :token_criteria [{:contract_addresses {:5 "0x0"}
-                                                              :type               1
-                                                              :symbol             "ETH"
-                                                              :amount             "0.001"
-                                                              :decimals           18}]}]]
-                :name                    "Community super name"
-                :chats                   {"89f98a1e-6776-4e5f-8626-8ab9f855253f"
-                                          {:description "x"
-                                           :emoji       "🎲"
-                                           :permissions {:access 1}
-                                           :color       "#88B0FF"
-                                           :name        "random"
-                                           :categoryID  "0c3c64e7-d56e-439b-a3fb-a946d83cb056"
-                                           :id          "89f98a1e-6776-4e5f-8626-8ab9f855253f"
-                                           :position    4
-                                           :can-post?   false
-                                           :members     {"0x04" {"roles" [1]}}}
-                                          "a076358e-4638-470e-a3fb-584d0a542ce6"
-                                          {:description "General channel for the community"
-                                           :emoji       "🐷 "
-                                           :permissions {:access 1}
-                                           :color       "#4360DF"
-                                           :name        "general"
-                                           :categoryID  "0c3c64e7-d56e-439b-a3fb-a946d83cb056"
-                                           :id          "a076358e-4638-470e-a3fb-584d0a542ce6"
-                                           :position    0
-                                           :can-post?   false
-                                           :members     {"0x04" {"roles" [1]}}}}
-                :token-permissions-check {:satisfied true
-                                          :permissions
-                                          {:a3dd5b6b-d93b-452c-b22a-09a8f42ec566 {:criteria [true false
-                                                                                             true]}}
-                                          :validCombinations
-                                          [{:address  "0xd722eaa60dc73e334b588d34ba66a3b27e537783"
-                                            :chainIds nil}
-                                           {:address  "0x738d3146831c5871fa15872b409e8f360e341784"
-                                            :chainIds [5 420]}]}
-                :members                 {"0x04" {"roles" [1]}}
-                :can-request-access?     false
-                :outroMessage            "bla"
-                :verified                false}]
+     token-image-eth       "data:image/jpeg;base64,/9j/2w"
+     community             {:id community-id
+                            :checking-permissions? checking-permissions?
+                            :permissions {:access 3}
+                            :highest-permission-role constants/community-token-permission-become-admin
+                            :token-images {"ETH" token-image-eth}
+                            :name "Community super name"
+                            :chats {"89f98a1e-6776-4e5f-8626-8ab9f855253f"
+                                    {:description "x"
+                                     :emoji       "🎲"
+                                     :permissions {:access 1}
+                                     :color       "#88B0FF"
+                                     :name        "random"
+                                     :categoryID  "0c3c64e7-d56e-439b-a3fb-a946d83cb056"
+                                     :id          "89f98a1e-6776-4e5f-8626-8ab9f855253f"
+                                     :position    4
+                                     :can-post?   false
+                                     :members     {"0x04" {"roles" [1]}}}
+                                    "a076358e-4638-470e-a3fb-584d0a542ce6"
+                                    {:description "General channel for the community"
+                                     :emoji       "🐷 "
+                                     :permissions {:access 1}
+                                     :color       "#4360DF"
+                                     :name        "general"
+                                     :categoryID  "0c3c64e7-d56e-439b-a3fb-a946d83cb056"
+                                     :id          "a076358e-4638-470e-a3fb-584d0a542ce6"
+                                     :position    0
+                                     :can-post?   false
+                                     :members     {"0x04" {"roles" [1]}}}}
+                            :token-permissions-check
+                            {:satisfied true
+                             :highestRole {:type     constants/community-token-permission-become-admin
+                                           :criteria [{:tokenRequirement [{:satisfied true
+                                                                           :criteria {:contract_addresses
+                                                                                      {:5 "0x0"}
+                                                                                      :type 1
+                                                                                      :symbol "DAI"
+                                                                                      :amount "5.0"
+                                                                                      :decimals 18}}]}
+                                                      {:tokenRequirement [{:satisfied false
+                                                                           :criteria  {:type     1
+                                                                                       :symbol   "ETH"
+                                                                                       :amount   "0.002"
+                                                                                       :decimals 18}}]}]}
+
+                             :permissions
+                             {:a3dd5b6b-d93b-452c-b22a-09a8f42ec566 {:criteria [true false
+                                                                                true]}}
+                             :validCombinations
+                             [{:address  "0xd722eaa60dc73e334b588d34ba66a3b27e537783"
+                               :chainIds nil}
+                              {:address  "0x738d3146831c5871fa15872b409e8f360e341784"
+                               :chainIds [5 420]}]}
+                            :members {"0x04" {"roles" [1]}}
+                            :can-request-access? false
+                            :outroMessage "bla"
+                            :verified false}]
     (swap! rf-db/app-db assoc-in [:communities community-id] community)
-    (is (match? {:can-request-access?   true
-                 :number-of-hold-tokens 2
-                 :tokens                [[{:symbol      "DAI"
-                                           :amount      "5.0"
-                                           :sufficient? nil
-                                           :loading?    checking-permissions?}]
-                                         [{:symbol      "ETH"
-                                           :amount      "0.001"
-                                           :sufficient? nil
-                                           :loading?    checking-permissions?
-                                           :img-src     token-image-eth}]]}
+    (is (match? {:can-request-access? true
+                 :tokens              [[{:symbol      "DAI"
+                                         :amount      "5"
+                                         :sufficient? true
+                                         :loading?    checking-permissions?}]
+                                       [{:symbol      "ETH"
+                                         :amount      "0.002"
+                                         :sufficient? false
+                                         :loading?    checking-permissions?
+                                         :img-src     token-image-eth}]]}
                 (rf/sub [sub-name community-id])))))
 
 (h/deftest-sub :communities/airdrop-account

--- a/src/status_im/subs/communities_test.cljs
+++ b/src/status_im/subs/communities_test.cljs
@@ -383,35 +383,8 @@
   (let
     [checking-permissions? true
      token-image-eth       "data:image/jpeg;base64,/9j/2w"
-     community             {:id community-id
-                            :checking-permissions? checking-permissions?
-                            :permissions {:access 3}
-                            :highest-permission-role constants/community-token-permission-become-admin
-                            :token-images {"ETH" token-image-eth}
-                            :name "Community super name"
-                            :chats {"89f98a1e-6776-4e5f-8626-8ab9f855253f"
-                                    {:description "x"
-                                     :emoji       "🎲"
-                                     :permissions {:access 1}
-                                     :color       "#88B0FF"
-                                     :name        "random"
-                                     :categoryID  "0c3c64e7-d56e-439b-a3fb-a946d83cb056"
-                                     :id          "89f98a1e-6776-4e5f-8626-8ab9f855253f"
-                                     :position    4
-                                     :can-post?   false
-                                     :members     {"0x04" {"roles" [1]}}}
-                                    "a076358e-4638-470e-a3fb-584d0a542ce6"
-                                    {:description "General channel for the community"
-                                     :emoji       "🐷 "
-                                     :permissions {:access 1}
-                                     :color       "#4360DF"
-                                     :name        "general"
-                                     :categoryID  "0c3c64e7-d56e-439b-a3fb-a946d83cb056"
-                                     :id          "a076358e-4638-470e-a3fb-584d0a542ce6"
-                                     :position    0
-                                     :can-post?   false
-                                     :members     {"0x04" {"roles" [1]}}}}
-                            :token-permissions-check
+     checks                {:checking? checking-permissions?
+                            :check
                             {:satisfied true
                              :highestRole {:type     constants/community-token-permission-become-admin
                                            :criteria [{:tokenRequirement [{:satisfied true
@@ -434,22 +407,52 @@
                              [{:address  "0xd722eaa60dc73e334b588d34ba66a3b27e537783"
                                :chainIds nil}
                               {:address  "0x738d3146831c5871fa15872b409e8f360e341784"
-                               :chainIds [5 420]}]}
-                            :members {"0x04" {"roles" [1]}}
-                            :can-request-access? false
-                            :outroMessage "bla"
-                            :verified false}]
+                               :chainIds [5 420]}]}}
+     community             {:id                      community-id
+                            :checking-permissions?   checking-permissions?
+                            :permissions             {:access 3}
+                            :highest-permission-role constants/community-token-permission-become-admin
+                            :token-images            {"ETH" token-image-eth}
+                            :name                    "Community super name"
+                            :chats                   {"89f98a1e-6776-4e5f-8626-8ab9f855253f"
+                                                      {:description "x"
+                                                       :emoji "🎲"
+                                                       :permissions {:access 1}
+                                                       :color "#88B0FF"
+                                                       :name "random"
+                                                       :categoryID "0c3c64e7-d56e-439b-a3fb-a946d83cb056"
+                                                       :id "89f98a1e-6776-4e5f-8626-8ab9f855253f"
+                                                       :position 4
+                                                       :can-post? false
+                                                       :members {"0x04" {"roles" [1]}}}
+                                                      "a076358e-4638-470e-a3fb-584d0a542ce6"
+                                                      {:description "General channel for the community"
+                                                       :emoji "🐷 "
+                                                       :permissions {:access 1}
+                                                       :color "#4360DF"
+                                                       :name "general"
+                                                       :categoryID "0c3c64e7-d56e-439b-a3fb-a946d83cb056"
+                                                       :id "a076358e-4638-470e-a3fb-584d0a542ce6"
+                                                       :position 0
+                                                       :can-post? false
+                                                       :members {"0x04" {"roles" [1]}}}}
+                            :members                 {"0x04" {"roles" [1]}}
+                            :can-request-access?     false
+                            :outroMessage            "bla"
+                            :verified                false}]
     (swap! rf-db/app-db assoc-in [:communities community-id] community)
-    (is (match? {:can-request-access? true
-                 :tokens              [[{:symbol      "DAI"
-                                         :amount      "5"
-                                         :sufficient? true
-                                         :loading?    checking-permissions?}]
-                                       [{:symbol      "ETH"
-                                         :amount      "0.002"
-                                         :sufficient? false
-                                         :loading?    checking-permissions?
-                                         :img-src     token-image-eth}]]}
+    (swap! rf-db/app-db assoc-in [:communities/permissions-check community-id] checks)
+    (is (match? {:can-request-access?     true
+                 :networks-not-supported? nil
+                 :tokens                  [[{:symbol      "DAI"
+                                             :amount      "5"
+                                             :sufficient? true
+                                             :loading?    checking-permissions?}]
+                                           [{:symbol      "ETH"
+                                             :amount      "0.002"
+                                             :sufficient? false
+                                             :loading?    checking-permissions?
+                                             :img-src     token-image-eth}]]}
                 (rf/sub [sub-name community-id])))))
 
 (h/deftest-sub :communities/airdrop-account

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -148,6 +148,8 @@
 (reg-root-key-sub :communities/selected-tab :communities/selected-tab)
 (reg-root-key-sub :contract-communities :contract-communities)
 (reg-root-key-sub :communities/permissioned-balances :communities/permissioned-balances)
+(reg-root-key-sub :communities/permissions-check :communities/permissions-check)
+(reg-root-key-sub :communities/channel-permissions-check :communities/channel-permissions-check)
 
 ;;activity center
 (reg-root-key-sub :activity-center :activity-center)

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.174.3",
-    "commit-sha1": "c15f9e73654ed2f21887af680d7730dec5bec3e3",
-    "src-sha256": "09jvamavnkii2fikpz2a5d345aspfp5lzlg5lpymz7lyjif4qn1s"
+    "version": "chore/debug-token-permissions",
+    "commit-sha1": "b7b7660a534a01099e55ee0e4253f6a9531c7f02",
+    "src-sha256": "0nrmm3j9z6iwlr32mggd3xl63226drvvhrlrhrkgxcpgrgpixcfj"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "chore/debug-token-permissions",
-    "commit-sha1": "b7b7660a534a01099e55ee0e4253f6a9531c7f02",
-    "src-sha256": "0nrmm3j9z6iwlr32mggd3xl63226drvvhrlrhrkgxcpgrgpixcfj"
+    "version": "v0.174.5",
+    "commit-sha1": "1ea2bd99d4c11f591df554c089aa9283b9742c59",
+    "src-sha256": "0b9411581gmxrrrbgbjk34db8xgz5qlhvrhp9hngggar1b7vmp1w"
 }

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -416,6 +416,8 @@ class CommunityView(HomeView):
         self.membership_request_pending_text = Text(self.driver, translation_id="membership-request-pending")
         self.join_button = Button(self.driver, accessibility_id="show-request-to-join-screen-button")
         self.join_community_button = Button(self.driver, accessibility_id="join-community-button")
+        self.slide_to_request_to_join_button = Button(
+            self.driver, xpath="(//*[@resource-id='slide-button-track']//*[@content-desc='icon'])[1]")
         self.follow_button = Button(self.driver, translation_id="follow")
         self.community_tags = BaseElement(
             self.driver, xpath="//*[@content-desc='chat-name-text']/../android.widget.HorizontalScrollView")
@@ -434,7 +436,7 @@ class CommunityView(HomeView):
         self.driver.info("Joining community")
         ChatView(self.driver).chat_element_by_text("https://status.app/c/").click_on_link_inside_message_body()
         self.join_button.wait_and_click(120)
-        self.join_community_button.scroll_and_click()
+        self.slide_to_request_to_join_button.swipe_right_on_element(width_percentage=16)
         self.password_input.send_keys(password)
         Button(self.driver,
                xpath="//*[@content-desc='password-input']/../following-sibling::*//*[@text='Join Community']").click()

--- a/translations/en.json
+++ b/translations/en.json
@@ -2266,6 +2266,8 @@
     "you-not-eligible-to-join": "You’re not eligible to join",
     "you-hold-number-of-hold-tokens-of-these": "You hold {{number-of-hold-tokens}} of these:",
     "addresses-dont-contain-tokens-needed": "These addresses don’t contain tokens needed to join",
+    "you-hodl": "You hodl:",
+    "network-not-supported": "Networks not supported",
     "token-gated-communities": "Token gated communities",
     "read-more": "Read more",
     "token-gated-communities-info": "Here will be something relevant about this topic. This will help the user get more context and therefore have a better understanding of it.",


### PR DESCRIPTION
There were a few issues with the permission screen:
1) Wrong permission was displayed when able to join
2) If not able to join, we were showing both admin/member permissions
3) Trailing zeros in token amount