### PR TITLE
Account permissions component malli schema fix

### DIFF
--- a/src/quo/components/wallet/account_permissions/schema.cljs
+++ b/src/quo/components/wallet/account_permissions/schema.cljs
@@ -12,7 +12,7 @@
         [:address [:maybe :string]]
         [:emoji [:maybe :string]]
         [:customization-color {:optional true} [:maybe :schema.common/customization-color]]]]
-      [:token-details {:optional true} [:maybe [:vector required-tokens/?schema]]]
+      [:token-details {:optional true} [:maybe [:sequential required-tokens/?schema]]]
       [:keycard? {:optional true} [:maybe :boolean]]
       [:checked? {:optional true} [:maybe :boolean]]
       [:disabled? {:optional true} [:maybe :boolean]]


### PR DESCRIPTION
Just a small fix to the account permissions component schema.

No QA is needed.

status: ready