### PR TITLE
fix - Button colors have become darker

### DIFF
--- a/src/quo/components/buttons/button/properties.cljs
+++ b/src/quo/components/buttons/button/properties.cljs
@@ -4,11 +4,15 @@
 
 (def backgrounds #{:photo :blur})
 
+;; Note: We hardcode the :light theme for the background-color and apply an overlay when necessary, such
+;; as for dark themes and pressed states. This approach is taken because, for communities, we only have
+;; one color available, which is the light theme version.
+;; For more information, see the related issue: https://github.com/status-im/status-mobile/issues/16396
 (defn- custom-color-type
-  [customization-color icon-only? theme]
+  [customization-color icon-only?]
   {:icon-color                  colors/white-opa-70
    :label-color                 colors/white
-   :background-color            (colors/resolve-color customization-color theme)
+   :background-color            (colors/resolve-color customization-color :light)
    :border-radius               (when icon-only? 24)
    :overlay-customization-color customization-color})
 
@@ -87,8 +91,7 @@
                                  type)]
     (cond
       (contains? #{:primary :positive :danger} type) (custom-color-type customization-color
-                                                                        icon-only?
-                                                                        theme)
+                                                                        icon-only?)
       (and (= :photo background) (= type :grey))     (grey-photo theme pressed?)
       (and (= :blur background) (= type :grey))      (grey-blur theme pressed?)
       (and (= :blur background) (= type :outline))   (outline-blur theme pressed?)


### PR DESCRIPTION
fixes #18762 

This issue was introduced by my [PR](https://github.com/status-im/status-mobile/pull/18513) when I tried to replace the deprecated `colors/custom-color` function with `colors/resolve-color`. I have reverted the change.

status: ready <!-- Can be ready or wip -->
