### PR TITLE
⚒️ Fix typo

### DIFF
--- a/src/quo/components/wallet/confirmation_progress/component_spec.cljs
+++ b/src/quo/components/wallet/confirmation_progress/component_spec.cljs
@@ -15,101 +15,101 @@
 
 (h/describe "Confirmation Progress"
   (h/test "component renders when state is sending and network is optimism"
-    (h/render-with-theme-provider [quo/confirmation-propgress
+    (h/render-with-theme-provider [quo/confirmation-progress
                                    (get-test-data {:state   :sending
                                                    :network :optimism})])
     (h/is-truthy (h/get-by-label-text :progress-box))))
 
 (h/test "component renders when state is confirmed and network is optimism"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress
+   [quo/confirmation-progress
     (get-test-data {:state   :confirmed
                     :network :optimism})])
   (h/is-truthy (h/get-by-label-text :progress-box)))
 
 (h/test "component renders when state is finalising and network is optimism"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress
+   [quo/confirmation-progress
     (get-test-data {:state   :finalising
                     :network :optimism})])
   (h/is-truthy (h/get-by-label-text :progress-box)))
 
 (h/test "component renders when state is finalized and network is optimism"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress
+   [quo/confirmation-progress
     (get-test-data {:state   :finalized
                     :network :optimism})])
   (h/is-truthy (h/get-by-label-text :progress-box)))
 
 (h/test "component renders when state is error and network is optimism"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress
+   [quo/confirmation-progress
     (get-test-data {:state   :error
                     :network :optimism})])
   (h/is-truthy (h/get-by-label-text :progress-box)))
 
 (h/test "component renders when state is sending and network is arbitrum"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress
+   [quo/confirmation-progress
     (get-test-data {:state   :sending
                     :network :arbitrum})])
   (h/is-truthy (h/get-by-label-text :progress-box)))
 
 (h/test "component renders when state is confirmed and network is arbitrum"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress
+   [quo/confirmation-progress
     (get-test-data {:state   :confirmed
                     :network :arbitrum})])
   (h/is-truthy (h/get-by-label-text :progress-box)))
 
 (h/test "component renders when state is finalising and network is arbitrum"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress
+   [quo/confirmation-progress
     (get-test-data {:state   :finalising
                     :network :arbitrum})])
   (h/is-truthy (h/get-by-label-text :progress-box)))
 
 (h/test "component renders when state is finalized and network is arbitrum"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress
+   [quo/confirmation-progress
     (get-test-data {:state   :finalized
                     :network :arbitrum})])
   (h/is-truthy (h/get-by-label-text :progress-box)))
 
 (h/test "component renders when state is error and network is arbitrum"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress
+   [quo/confirmation-progress
     (get-test-data {:state   :error
                     :network :arbitrum})])
   (h/is-truthy (h/get-by-label-text :progress-box)))
 
 (h/test "component renders when state is pending and network is mainnet"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress (get-test-data {})])
+   [quo/confirmation-progress (get-test-data {})])
   (h/is-truthy (h/get-by-label-text :mainnet-progress-box)))
 
 (h/test "component renders when state is sending and network is mainnet"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress (get-test-data {:state :sending})])
+   [quo/confirmation-progress (get-test-data {:state :sending})])
   (h/is-truthy (h/get-by-label-text :mainnet-progress-box)))
 
 (h/test "component renders when state is confirmed and network is mainnet"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress (get-test-data {:state :confirmed})])
+   [quo/confirmation-progress (get-test-data {:state :confirmed})])
   (h/is-truthy (h/get-by-label-text :mainnet-progress-box)))
 
 (h/test "component renders when state is finalising and network is mainnet"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress (get-test-data {:state :finalising})])
+   [quo/confirmation-progress (get-test-data {:state :finalising})])
   (h/is-truthy (h/get-by-label-text :mainnet-progress-box)))
 
 (h/test "component renders when state is finalized and network is mainnet"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress (get-test-data {:state :finalized})])
+   [quo/confirmation-progress (get-test-data {:state :finalized})])
   (h/is-truthy (h/get-by-label-text :mainnet-progress-box)))
 
 (h/test "component renders when state is error and network is mainnet"
   (h/render-with-theme-provider
-   [quo/confirmation-propgress
+   [quo/confirmation-progress
     (get-test-data {:state :error})])
   (h/is-truthy (h/get-by-label-text :mainnet-progress-box)))

--- a/src/quo/core.cljs
+++ b/src/quo/core.cljs
@@ -418,7 +418,7 @@
 (def account-permissions quo.components.wallet.account-permissions.view/view)
 (def address-text quo.components.wallet.address-text.view/view)
 (def amount-input quo.components.wallet.amount-input.view/view)
-(def confirmation-propgress quo.components.wallet.confirmation-progress.view/view)
+(def confirmation-progress quo.components.wallet.confirmation-progress.view/view)
 (def keypair quo.components.wallet.keypair.view/view)
 (def network-amount quo.components.wallet.network-amount.view/view)
 (def network-bridge quo.components.wallet.network-bridge.view/view)

--- a/src/status_im/contexts/preview/quo/wallet/confirmation_progress.cljs
+++ b/src/status_im/contexts/preview/quo/wallet/confirmation_progress.cljs
@@ -69,7 +69,7 @@
          (stop-interval)))
      [(:state @state)])
     [preview/preview-container {:state state :descriptor descriptor}
-     [quo/confirmation-propgress
+     [quo/confirmation-progress
       (assoc @state
              :counter
              @counter)]]))


### PR DESCRIPTION
This PR fixes a typo in the `confirmation-progress` quo component. 
Doesn't affect any other part. No testing needed. 

There are apples on a tree, there are low hanging apples. 
Then there is this PR. It's an apple that was fallen on the ground.

status: ready
