### PR TITLE
[#18566] Worklets in clojure

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -45,6 +45,7 @@
    ;; To match the folder created by Nix build of JSBundle.
    :output-dir "result"
    :init-fn status-im.core/init
+   :build-hooks [(status-im.setup.build-hooks.worklets/transform-output)]
    ;; When false, the Shadow-CLJS watcher won't automatically refresh
    ;; the target files (a.k.a hot reload). When false, you can manually
    ;; reload by calling `shadow.cljs.devtools.api/watch-compile-all!`.

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -45,7 +45,9 @@
    ;; To match the folder created by Nix build of JSBundle.
    :output-dir "result"
    :init-fn status-im.core/init
-   :build-hooks [(status-im.setup.build-hooks.worklets/transform-output)]
+   :build-hooks [(status-im.setup.build-hooks.worklets/transform-output)
+                 (status-im.setup.build-hooks.worklets/optimize-start)
+                 (status-im.setup.build-hooks.worklets/optimize-output)]
    ;; When false, the Shadow-CLJS watcher won't automatically refresh
    ;; the target files (a.k.a hot reload). When false, you can manually
    ;; reload by calling `shadow.cljs.devtools.api/watch-compile-all!`.

--- a/src/react_native/reanimated.cljs
+++ b/src/react_native/reanimated.cljs
@@ -20,7 +20,8 @@
                      LinearTransition
                      enableLayoutAnimations
                      useAnimatedScrollHandler
-                     runOnJS)]
+                     runOnJS)
+     :as reanimated*]
     ["react-native-redash" :refer (withPause)]
     [oops.core :as oops]
     [react-native.flat-list :as rn-flat-list]
@@ -112,6 +113,8 @@
   [anim v]
   (when (and anim (some? v))
     (set! (.-value anim) v)))
+
+(def interpolate* reanimated*/interpolate)
 
 (defn interpolate
   ([shared-value input-range output-range]

--- a/src/status_im/contexts/profile/settings/header/avatar.cljs
+++ b/src/status_im/contexts/profile/settings/header/avatar.cljs
@@ -1,34 +1,36 @@
-(ns status-im.contexts.profile.settings.header.avatar
+(ns ^:workletize status-im.contexts.profile.settings.header.avatar
   (:require [quo.core :as quo]
             [quo.theme :as quo.theme]
             [react-native.reanimated :as reanimated]
             [status-im.contexts.profile.settings.header.style :as style]))
 
-(def scroll-animation-input-range [0 50])
-(def header-extrapolation-option
-  {:extrapolateLeft  "clamp"
-   :extrapolateRight "clamp"})
-
 (defn f-avatar
   [{:keys [scroll-y full-name online? profile-picture customization-color]}]
-  (let [image-scale-animation       (reanimated/interpolate scroll-y
-                                                            scroll-animation-input-range
-                                                            [1 0.4]
-                                                            header-extrapolation-option)
-        image-top-margin-animation  (reanimated/interpolate scroll-y
-                                                            scroll-animation-input-range
-                                                            [0 20]
-                                                            header-extrapolation-option)
-        image-side-margin-animation (reanimated/interpolate scroll-y
-                                                            scroll-animation-input-range
-                                                            [0 -20]
-                                                            header-extrapolation-option)
-        theme                       (quo.theme/get-theme)]
-    [reanimated/view
-     {:style (style/avatar-container theme
-                                     image-scale-animation
-                                     image-top-margin-animation
-                                     image-side-margin-animation)}
+  (let [avatar-total-size     88
+        border-height         4
+        translation-to-bottom (fn [scale inverse-scale]
+                                (js* "'worklet'")
+                                (let [current-avatar-size (* avatar-total-size (- 1 scale))
+                                      current-center      (/ current-avatar-size 2)]
+                                  (* current-center inverse-scale)))
+        transform             (reanimated/use-animated-style
+                               (fn []
+                                 (js* "'worklet'")
+                                 (let [scale         (reanimated/interpolate*
+                                                      (.-value scroll-y)
+                                                      #js [0 48]
+                                                      #js [1 0.4]
+                                                      "clamp")
+                                       inverse-scale (/ 1 scale)
+                                       translation   (translation-to-bottom scale inverse-scale)
+                                       bottom        (* border-height inverse-scale (- 1 scale))]
+                                   #js
+                                    {:transform #js
+                                                 [#js {:scale scale}
+                                                  #js {:translateX (- translation)}
+                                                  #js {:translateY (- translation bottom)}]})))
+        theme                 (quo.theme/get-theme)]
+    [reanimated/view {:style [transform (style/avatar-container theme)]}
      [quo/user-avatar
       {:full-name           full-name
        :online?             online?

--- a/src/status_im/contexts/profile/settings/header/header_shape.cljs
+++ b/src/status_im/contexts/profile/settings/header/header_shape.cljs
@@ -1,4 +1,4 @@
-(ns status-im.contexts.profile.settings.header.header-shape
+(ns ^:workletize status-im.contexts.profile.settings.header.header-shape
   (:require [quo.foundations.colors :as colors]
             [react-native.core :as rn]
             [react-native.reanimated :as reanimated]
@@ -21,13 +21,17 @@
 
 (defn f-view
   [{:keys [scroll-y customization-color theme]}]
-  (let [background-color  (colors/resolve-color customization-color theme 40)
-        opacity-animation (reanimated/interpolate scroll-y
-                                                  [0 45 50]
-                                                  [1 1 0])]
+  (let [background-color (colors/resolve-color customization-color theme 40)
+        opacity          (reanimated/use-animated-style
+                          (fn []
+                            (js* "'worklet'")
+                            #js
+                             {:opacity (reanimated/interpolate* (.-value scroll-y)
+                                                                #js [0 45 50]
+                                                                #js [1 1 0])}))]
     [:<>
      [rn/view {:style (style/header-middle-shape background-color)}]
-     [reanimated/view {:style (style/radius-container opacity-animation)}
+     [reanimated/view {:style [opacity style/radius-container]}
       [left-radius background-color]
       [right-radius background-color]]]))
 

--- a/src/status_im/contexts/profile/settings/header/header_shape.cljs
+++ b/src/status_im/contexts/profile/settings/header/header_shape.cljs
@@ -5,6 +5,7 @@
             [react-native.svg :as svg]
             [status-im.contexts.profile.settings.header.style :as style]))
 
+
 (defn left-radius
   [background-color]
   [svg/svg {:width "20" :height "20" :viewBox "0 0 20 20" :fill "none"}

--- a/src/status_im/contexts/profile/settings/header/style.cljs
+++ b/src/status_im/contexts/profile/settings/header/style.cljs
@@ -27,19 +27,13 @@
    :height           48
    :flex-grow        1})
 
-(defn radius-container
-  [opacity-animation]
-  {:opacity         opacity-animation
-   :flex-direction  :row
+(def radius-container
+  {:flex-direction  :row
    :justify-content :space-between})
 
 (defn avatar-container
-  [theme scale-animation top-margin-animation side-margin-animation]
-  [{:transform     [{:scale scale-animation}]
-    :margin-top    top-margin-animation
-    :margin-left   side-margin-animation
-    :margin-bottom side-margin-animation}
-   {:align-items   :flex-start
-    :border-width  4
-    :border-color  (colors/theme-colors colors/border-avatar-light colors/neutral-80-opa-80 theme)
-    :border-radius 100}])
+  [theme]
+  {:align-items   :flex-start
+   :border-width  4
+   :border-color  (colors/theme-colors colors/border-avatar-light colors/neutral-80-opa-80 theme)
+   :border-radius 44})

--- a/src/status_im/setup/build_hooks/worklets.clj
+++ b/src/status_im/setup/build_hooks/worklets.clj
@@ -1,0 +1,65 @@
+(ns status-im.setup.build-hooks.worklets
+  (:require [clojure.set])
+  (:import (java.io BufferedReader InputStreamReader PrintWriter)))
+
+(defn- update-js-output
+  [build-state code-processed]
+  (reduce-kv (fn [prev-build-state ns-key new-code]
+               (assoc-in prev-build-state [:output ns-key :js] new-code))
+             build-state
+             code-processed))
+
+(defn- get-workletized-code!
+  [code-seq store-atom]
+  (doall
+   (pmap (fn [[[_ filepath :as ns-key] js-code]]
+           (println "Workletizing:" filepath) ;; TODO: debug remove
+           (try
+             (let [command       "node workletize-code.js"
+                   process       (.exec (Runtime/getRuntime) command)
+                   output-stream (.getOutputStream process)
+                   writer        (PrintWriter. output-stream)
+                   reader        (BufferedReader. (InputStreamReader. (.getInputStream process)))]
+               (.println writer js-code)
+               (.flush writer)
+               (.close writer)
+
+               (let [output     (apply str (interleave (line-seq reader) (repeat "\n")))
+                     _exit-code (.waitFor process)]
+                 (swap! store-atom assoc ns-key output)))
+
+             (catch Exception e
+               (println (str "Exception while workletizing: " filepath "\n")
+                        (.getMessage e)))))
+         code-seq)))
+
+(defn- get-js-code-with-ns
+  [build-state-output file-path]
+  (let [ns-key  [:shadow.build.classpath/resource file-path]
+        js-code (get-in build-state-output [ns-key :js])]
+    [ns-key js-code]))
+
+(defn- get-files-to-workletize
+  [{:keys [shadow.build/build-info compiler-env] :as _build-state}]
+  (let [files-compiled      (->> build-info
+                                 :compiled
+                                 (map second)
+                                 (set))
+        namespaces-metadata (->> compiler-env
+                                 :cljs.analyzer/namespaces
+                                 vals
+                                 (map :meta))
+        files-marked        (->> namespaces-metadata
+                                 (filter :workletize)
+                                 (map :file)
+                                 (set))]
+    (clojure.set/intersection files-compiled files-marked)))
+
+(defn transform-output
+  {:shadow.build/stage :compile-finish}
+  [{:keys [output] :as build-state}]
+  (let [files-to-workletize  (get-files-to-workletize build-state)
+        js-code-with-ns      (map #(get-js-code-with-ns output %) files-to-workletize)
+        code-processed-store (atom {})]
+    (get-workletized-code! js-code-with-ns code-processed-store)
+    (update-js-output build-state @code-processed-store)))

--- a/workletize-code.js
+++ b/workletize-code.js
@@ -1,0 +1,22 @@
+const process = require('process');
+const babel = require('@babel/core');
+const plugin = require('./node_modules/react-native-reanimated/plugin');
+
+function transformString(inputString) {
+  return babel.transformSync(inputString, {
+    filename: '/dev/null',
+    compact: false,
+    plugins: [plugin],
+  }).code;
+}
+
+process.stdin.setEncoding('utf8');
+let input = '';
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+
+process.stdin.on('end', () => {
+  const result = transformString(input);
+  process.stdout.write(result);
+});


### PR DESCRIPTION
fixes #18566

## Summary

:warning: This PR presents a feature that still needs to be improved, but this is a first working version :warning: 


This PR adds the ability to write worklets directly in ClojureScript :tada: it [workletizes](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary/#to-workletize) the code, so now we can use the reanimated hooks inside the components. It also works with Shadow-cljs hot reload :smile: 

## What can we do now?

Use hooks like `useAnimatedStyle` or `useDerivedValue`, or just create a worklet function directly in components written in ClojureScript, simple example:

```clojure 
(defn my-f-component []
  (let [greeting          (fn [value]
                            (js* "'worklet'")
                            (js/console.log "I'm running on the UI thread" value))
        my-animated-style (reanimated/use-animated-style
                           (fn []
                             (js* "'worklet'")
                             (greeting 10)
                             #js{:margin 10}))]
    [reanimated/view {:style my-animated-style}]))
```

## Before vs Now

Previously, we had to write JS code for worklets, restart the app to see the changes. We created some general worklets, but each time we wanted to write something new, we had to write a new worklet in JS again.

In this PR I'm updating the profile settings screen animations as an example:

<img src="https://github.com/status-im/status-mobile/assets/90291778/f212aaf1-8774-46d6-b039-ac16d2752fcd" height="400"/>

### Before
Let's take a look at what the avatar animation does:

[Screencast from 2024-02-12 15-13-33.webm](https://github.com/status-im/status-mobile/assets/90291778/a2c06da8-6490-4c06-8137-f40ff7f4f360)

in `status-im.contexts.profile.settings.header.avatar`

we have multiple calls to `reanimated/interpolate`:

```clojure
(defn f-avatar
  [...]
  (let [image-scale-animation       (reanimated/interpolate scroll-y  ;; <- these
                                                            scroll-animation-input-range
                                                            [1 0.4]
                                                            header-extrapolation-option)
        image-top-margin-animation  (reanimated/interpolate scroll-y
                                                            scroll-animation-input-range
                                                            [0 20]
                                                            header-extrapolation-option)
        image-side-margin-animation (reanimated/interpolate scroll-y
                                                            scroll-animation-input-range
                                                            [0 -20]
                                                            header-extrapolation-option)
        theme                       (quo.theme/get-theme)]
    [reanimated/view
     {:style (style/avatar-container theme
                                     image-scale-animation
                                     image-top-margin-animation
                                     image-side-margin-animation)}
     ...]))
```

And then each call is a wrapper that transforms the values and passes them to `worklets.core/interpolate-value`:

```clojure
(defn interpolate
  ([shared-value input-range output-range]
   (interpolate shared-value input-range output-range nil))
  ([shared-value input-range output-range extrapolation]
   (worklets.core/interpolate-value ;;<- here
    shared-value
    (clj->js input-range)
    (clj->js output-range)
    (clj->js extrapolation))))
```

The `interpolate-value` calls an imported JS function:

```clojure
(def core-js (js/require "../src/js/worklets/core.js"))

(defn interpolate-value
  [shared-value
   input-range
   output-range
   extrapolation]
  (.interpolateValue ^js core-js ;; <- imported JS fn
                     shared-value
                     (clj->js input-range)
                     (clj->js output-range)
                     (clj->js extrapolation)))

```

And that JS function does the following:

```js
export function interpolateValue(sharedValue, inputRange, outputRange, extrapolation) {
  return useDerivedValue(function () {
    'worklet';
    return interpolate(sharedValue.value, inputRange, outputRange, extrapolation);
  });
}
```

We can see it has a call to `useDerivedValue`, not good because we are hiding important details that may lead to bugs.

Hooks have some rules (like not call them conditionally) or conventions (like execute them at the beginning), and our wrapper isn't called `use-*`. A developer has to follow the whole call chain to understand a hook is being used.

At the end we pass each interpolated-value to specific styles `:margin-top`, `:transform`, etc.

### Now

For the namespaces to process, we need to add the metadata: `:workletize`

And we no longer need all those wrappers, so the code looks as follows:

```clojure
(defn f-avatar
  [...]
  (let [image-scale-animation (reanimated/use-derived-value
                               (fn []
                                 (js* "'worklet'")
                                 (reanimated/interpolate* ;; <- the real reanimated interpolate
                                  (.-value scroll-y)
                                  scroll-animation-input-range
                                  [1 0.4]
                                  header-extrapolation-option)))
        ... other interpolate calls ...
        ]
    [reanimated/view
     {:style (style/avatar-container theme
                                     image-scale-animation
                                     image-top-margin-animation
                                     image-side-margin-animation)}
     ...]))
```

And what you see is the whole code being executed!

But the main problem here is we need to write code that doesn't use Clojure-specific functionality, like the custom data structures (vectors, maps, sets, etc) and instead we must write js Arrays and objects. The advantage is still great, since most of our worklets don't need a lot of logic inside them.

While rewriting this, I noticed we were interpolating a lot because of the lack of flexibility we had, so instead of independently interpolate and get multiple reanimated derived-values, we can just create the style object we need!

Also the animation was a bit unstable (it shakes while resizing), and it's not properly aligned, since it's easier to debug now, I managed to get the animation working better with the following code:


```clojure
(defn f-avatar
  [...]
  (let [avatar-total-size     88
        border-height         4
        translation-to-bottom (fn [scale inverse-scale]
                                (js* "'worklet'")
                                (let [current-avatar-size (* avatar-total-size (- 1 scale))
                                      current-center      (/ current-avatar-size 2)]
                                  (* current-center inverse-scale)))
        transform             (reanimated/use-animated-style ; <- we just return the styles
                               (fn []
                                 (js* "'worklet'")
                                 (let [scale         (reanimated/interpolate* ; <- interpolate once
                                                      (.-value scroll-y)
                                                      #js [0 48]
                                                      #js [1 0.4]
                                                      "clamp")
                                       inverse-scale (/ 1 scale)
                                       translation   (translation-to-bottom scale inverse-scale)
                                       bottom        (* border-height inverse-scale (- 1 scale))]
                                   ;; The style object we need:
                                   #js{:transform #js[#js {:scale scale}
                                                      #js {:translateX (- translation)}
                                                      #js {:translateY (- translation bottom)}]})))
        theme                 (quo.theme/get-theme)]
    [reanimated/view {:style [transform (style/avatar-container theme)]}
     ...]))
```

Previous animation:

[Screencast from 2024-02-12 15-13-33.webm](https://github.com/status-im/status-mobile/assets/90291778/5c9faedd-c859-40f2-895e-252f850eddcf)

Now: 

[Screencast from 2024-02-12 15-15-36.webm](https://github.com/status-im/status-mobile/assets/90291778/7fa4e120-ecd1-47df-a95d-f1abab2fe8d4)

Figma:
![image](https://github.com/status-im/status-mobile/assets/90291778/eadef908-9f3a-4089-bd47-427a6776cc3f)

Before:
![Screenshot from 2024-02-12 15-12-50](https://github.com/status-im/status-mobile/assets/90291778/0071d7c3-5aab-486e-bd0d-2918339497fe)

Now:
![Screenshot from 2024-02-12 15-17-06](https://github.com/status-im/status-mobile/assets/90291778/e90a52eb-d388-4436-9a5c-29d2f02d250b)

![Screenshot from 2024-02-12 15-17-01](https://github.com/status-im/status-mobile/assets/90291778/8056a986-4d55-4495-bfd4-fb926456acf4)


## Limitations and pending improvements

- :disappointed: The implementation I added to transform the code is not too performant, processing the whole codebase is slow, so we must mark the namespaces with `^:workletize`, one good thing is we are just processing the files changed each time hot reload is tiggered.

- :disappointed:  Lint fix leaves ugly code for `#js`.

- :disappointed: We must avoid writing Clojure specific code inside worklets, (but we can try adding squint! [check this code, no need of #JS!](https://squint-cljs.github.io/squint/?repl=true&src=KGxldCBbc2NhbGUgKHJlYW5pbWF0ZWQvaW50ZXJwb2xhdGUqCiAgICAgICAgICAgICAgKC4tdmFsdWUgc2Nyb2xsLXkpCiAgICAgICAgICAgICAgWzAgNDhdCiAgICAgICAgICAgICAgWzEgMC40XQogICAgICAgICAgICAgICJjbGFtcCIKICAgICAgICAgICAgICBpbnZlcnNlLXNjYWxlKQogICAgICBpbnZlcnNlLXNjYWxlICgvIDEgc2NhbGUpCiAgICAgIHRyYW5zbGF0aW9uICh0cmFuc2xhdGlvbi10by1ib3R0b20gc2NhbGUgaW52ZXJzZS1zY2FsZSkKICAgICAgYm90dG9tICgqIGJvcmRlci1oZWlnaHQgaW52ZXJzZS1zY2FsZSAoLSAxIHNjYWxlKSldCiAgezp0cmFuc2Zvcm0KICAgW3s6c2NhbGUgc2NhbGV9CiAgICB7OnRyYW5zbGF0ZVggKC0gdHJhbnNsYXRpb24pfQogICAgezp0cmFuc2xhdGVZICgtIHRyYW5zbGF0aW9uIGJvdHRvbSl9XX0p)

- :disappointed: We can't define worklets in the global scope, and cannot use any global scoped var inside worklets. so don't define them using `def`, `defn`, or use vars defined with those... Well, it actually works, but it breaks the hot reload and we must restart the app to see the changes made.

- :disappointed: the `(js* "'worklet'")` directive is needed, we could omit it if we used `useAnimatedStyle` instead of our wrapped one `use-animated-style`. This limitation comes from reanimated, but it's important to mention,

- :bulb: It'd be really good to explore the idea of creating a custom macro that adds squint and the JS directive, we could write code easier inside, and get rid of those `#js`, but it was too much for this PR.

### Testing notes
Just check the profile settings page, and you can play with the code there.

## Performance

We are getting rid of many wrappers, so the performance is being slightly increased. The transformations of the code are being done at compile time, so it's not affecting the app.


#### Platforms

- Android
- iOS

status: ready
