### PR TITLE
Fix quo/collectible-tag schema and props

### DIFF
--- a/src/quo/components/tags/collectible_tag/view.cljs
+++ b/src/quo/components/tags/collectible_tag/view.cljs
@@ -29,43 +29,43 @@
   (let [container-width (r/atom 0)
         on-layout       #(->> (oops/oget % :nativeEvent :layout :width)
                               (reset! container-width))]
-    (fn [{:keys [options size blur? theme collectible-img-src collectible-name collectible-id]
-          :or   {size :size-24}}]
-      [rn/view
-       {:on-layout on-layout}
-       [hole-view/hole-view
-        {:holes (if options
-                  [{:x            (- @container-width
-                                     (case size
-                                       :size-24 10
-                                       :size-32 12
-                                       nil))
-                    :y            (case size
-                                    :size-24 -6
-                                    :size-32 -4
-                                    nil)
-                    :width        16
-                    :height       16
-                    :borderRadius 8}]
-                  [])}
-        [rn/view {:style (style/container size options blur? theme)}
-         [rn/image {:style (style/collectible-img size) :source collectible-img-src}]
-         [text/text
-          {:size   :paragraph-2
-           :weight :medium
-           :style  (style/label theme)}
-          collectible-name]
-         [text/text
-          {:size        :paragraph-2
-           :weight      :medium
-           :margin-left 5
-           :style       (style/label theme)}
-          collectible-id]]]
-       (when options
-         [rn/view {:style (style/options-icon size)}
-          [icons/icon (if (= options :hold) :i/hold :i/add-token)
-           {:size     20
-            :no-color true}]])])))
+    (fn [{:keys [options blur? theme collectible-img-src collectible-name collectible-id] :as props}]
+      (let [size (or (:size props) :size-24)]
+        [rn/view
+         {:on-layout on-layout}
+         [hole-view/hole-view
+          {:holes (if options
+                    [{:x            (- @container-width
+                                       (case size
+                                         :size-24 10
+                                         :size-32 12
+                                         nil))
+                      :y            (case size
+                                      :size-24 -6
+                                      :size-32 -4
+                                      nil)
+                      :width        16
+                      :height       16
+                      :borderRadius 8}]
+                    [])}
+          [rn/view {:style (style/container size options blur? theme)}
+           [rn/image {:style (style/collectible-img size) :source collectible-img-src}]
+           [text/text
+            {:size   :paragraph-2
+             :weight :medium
+             :style  (style/label theme)}
+            collectible-name]
+           [text/text
+            {:size        :paragraph-2
+             :weight      :medium
+             :margin-left 5
+             :style       (style/label theme)}
+            collectible-id]]]
+         (when options
+           [rn/view {:style (style/options-icon size)}
+            [icons/icon (if (= options :hold) :i/hold :i/add-token)
+             {:size     20
+              :no-color true}]])]))))
 
 (def view
   (quo.theme/with-theme

--- a/src/quo/components/tags/collectible_tag/view.cljs
+++ b/src/quo/components/tags/collectible_tag/view.cljs
@@ -7,7 +7,7 @@
     [quo.theme]
     [react-native.core :as rn]
     [react-native.hole-view :as hole-view]
-    [reagent.core :as r]
+    [reagent.core :as reagent]
     [schema.core :as schema]))
 
 (def ?schema
@@ -26,7 +26,7 @@
 
 (defn- view-internal
   []
-  (let [container-width (r/atom 0)
+  (let [container-width (reagent/atom 0)
         on-layout       #(->> (oops/oget % :nativeEvent :layout :width)
                               (reset! container-width))]
     (fn [{:keys [options blur? theme collectible-img-src collectible-name collectible-id] :as props}]

--- a/src/quo/components/tags/collectible_tag/view.cljs
+++ b/src/quo/components/tags/collectible_tag/view.cljs
@@ -1,11 +1,13 @@
 (ns quo.components.tags.collectible-tag.view
   (:require
+    [oops.core :as oops]
     [quo.components.icon :as icons]
     [quo.components.markdown.text :as text]
     [quo.components.tags.collectible-tag.style :as style]
     [quo.theme]
     [react-native.core :as rn]
     [react-native.hole-view :as hole-view]
+    [reagent.core :as r]
     [schema.core :as schema]))
 
 (def ?schema
@@ -14,56 +16,56 @@
     [:props
      [:map {:closed true}
       [:options {:optional true} [:maybe [:enum false :add :hold]]]
-      [:size {:optional true} [:enum :size-24 :size-32]]
-      [:blur? {:optional true} :boolean]
+      [:size {:optional true} [:maybe [:enum :size-24 :size-32]]]
+      [:blur? {:optional true} [:maybe boolean?]]
       [:theme :schema.common/theme]
-      [:collectible-img-src [:or :int :string]]
-      [:collectible-name :string]
-      [:collectible-id :string]
-      [:container-width :number]
-      [:on-layout {:optional true} [:maybe fn?]]]]]
+      [:collectible-img-src :schema.common/image-source]
+      [:collectible-name string?]
+      [:collectible-id string?]]]]
    :any])
 
 (defn- view-internal
   []
-  (fn [{:keys [options size blur? theme collectible-img-src collectible-name collectible-id
-               container-width on-layout]
-        :or   {size :size-24}}]
-    [rn/view
-     {:on-layout on-layout}
-     [hole-view/hole-view
-      {:holes (if options
-                [{:x            (- container-width
-                                   (case size
-                                     :size-24 10
-                                     :size-32 12
-                                     nil))
-                  :y            (case size
-                                  :size-24 -6
-                                  :size-32 -4
-                                  nil)
-                  :width        16
-                  :height       16
-                  :borderRadius 8}]
-                [])}
-      [rn/view {:style (style/container size options blur? theme)}
-       [rn/image {:style (style/collectible-img size) :source collectible-img-src}]
-       [text/text
-        {:size   :paragraph-2
-         :weight :medium
-         :style  (style/label theme)}
-        collectible-name]
-       [text/text
-        {:size        :paragraph-2
-         :weight      :medium
-         :margin-left 5
-         :style       (style/label theme)}
-        collectible-id]]]
-     (when options
-       [rn/view {:style (style/options-icon size)}
-        [icons/icon (if (= options :hold) :i/hold :i/add-token)
-         {:size     20
-          :no-color true}]])]))
+  (let [container-width (r/atom 0)
+        on-layout       #(->> (oops/oget % :nativeEvent :layout :width)
+                              (reset! container-width))]
+    (fn [{:keys [options size blur? theme collectible-img-src collectible-name collectible-id]
+          :or   {size :size-24}}]
+      [rn/view
+       {:on-layout on-layout}
+       [hole-view/hole-view
+        {:holes (if options
+                  [{:x            (- @container-width
+                                     (case size
+                                       :size-24 10
+                                       :size-32 12
+                                       nil))
+                    :y            (case size
+                                    :size-24 -6
+                                    :size-32 -4
+                                    nil)
+                    :width        16
+                    :height       16
+                    :borderRadius 8}]
+                  [])}
+        [rn/view {:style (style/container size options blur? theme)}
+         [rn/image {:style (style/collectible-img size) :source collectible-img-src}]
+         [text/text
+          {:size   :paragraph-2
+           :weight :medium
+           :style  (style/label theme)}
+          collectible-name]
+         [text/text
+          {:size        :paragraph-2
+           :weight      :medium
+           :margin-left 5
+           :style       (style/label theme)}
+          collectible-id]]]
+       (when options
+         [rn/view {:style (style/options-icon size)}
+          [icons/icon (if (= options :hold) :i/hold :i/add-token)
+           {:size     20
+            :no-color true}]])])))
 
 (def view
   (quo.theme/with-theme

--- a/src/quo/components/tags/collectible_tag/view.cljs
+++ b/src/quo/components/tags/collectible_tag/view.cljs
@@ -15,7 +15,7 @@
    [:catn
     [:props
      [:map {:closed true}
-      [:options {:optional true} [:maybe [:enum false :add :hold]]]
+      [:options {:optional true} [:maybe [:enum :add :hold]]]
       [:size {:optional true} [:maybe [:enum :size-24 :size-32]]]
       [:blur? {:optional true} [:maybe boolean?]]
       [:theme :schema.common/theme]

--- a/src/status_im/contexts/preview/quo/tags/collectible_tag.cljs
+++ b/src/status_im/contexts/preview/quo/tags/collectible_tag.cljs
@@ -15,9 +15,7 @@
                :value "Size 32"}]}
    {:key     :options
     :type    :select
-    :options [{:key   false
-               :value false}
-              {:key   :add
+    :options [{:key   :add
                :value :add}
               {:key   :hold
                :value :hold}]}
@@ -34,7 +32,6 @@
                              :collectible-name    "Collectible"
                              :collectible-id      "#123"
                              :collectible-img-src (resources/mock-images :collectible)
-                             :options             false
                              :blur?               false})]
     (fn []
       [preview/preview-container

--- a/src/status_im/contexts/preview/quo/tags/collectible_tag.cljs
+++ b/src/status_im/contexts/preview/quo/tags/collectible_tag.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.preview.quo.tags.collectible-tag
   (:require
-    [oops.core :refer [oget]]
     [quo.core :as quo]
     [react-native.core :as rn]
     [reagent.core :as reagent]
@@ -31,16 +30,12 @@
 
 (defn view
   []
-  (let [state     (reagent/atom {:size                :size-24
-                                 :collectible-name    "Collectible"
-                                 :collectible-id      "#123"
-                                 :collectible-img-src (resources/mock-images :collectible)
-                                 :options             false
-                                 :blur?               false
-                                 :container-width     0})
-        on-layout #(swap! state assoc
-                     :container-width
-                     (oget % :nativeEvent :layout :width))]
+  (let [state (reagent/atom {:size                :size-24
+                             :collectible-name    "Collectible"
+                             :collectible-id      "#123"
+                             :collectible-img-src (resources/mock-images :collectible)
+                             :options             false
+                             :blur?               false})]
     (fn []
       [preview/preview-container
        {:state                 state
@@ -48,4 +43,4 @@
         :show-blur-background? true
         :descriptor            descriptor}
        [rn/view {:style {:align-items :center}}
-        [quo/collectible-tag (assoc @state :on-layout on-layout)]]])))
+        [quo/collectible-tag @state]]])))


### PR DESCRIPTION
fixes #18797 

### Summary

As a follow-up to #18748:
- fixed the schema error (`:number` was used) 
- removed the `container-width` and `on-layout` props, as they are only used for internal calculations and shouldn't be exposed to the consumer of the component (unless there is another reason for this @FFFra)
- removed `:or` when adding a default value to `size` when destructuring, as that doesn't handle the case when nil is passed (e.g. with `when`).

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->


### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Quo components -> tags -> collectible-tag

status: ready <!-- Can be ready or wip -->
