### PR TITLE
[Refactor#18748] - Collectible Tag

### DIFF
--- a/src/quo/components/tags/collectible_tag/component_spec.cljs
+++ b/src/quo/components/tags/collectible_tag/component_spec.cljs
@@ -5,7 +5,6 @@
 
 (def collectible-name "Collectible")
 (def collectible-id "#123")
-(def ^:private theme :light)
 
 (defn get-test-data
   [{:keys [options blur? size]}]
@@ -14,41 +13,40 @@
    :collectible-img-src {:uri "https://example.com/image.jpg"}
    :options             options
    :blur?               (or blur? false)
-   :size                (or size :size-24)
-   :theme               theme})
+   :size                (or size :size-24)})
 
 (h/describe "Collectible_tag tests"
   (h/test "Renders Default option"
     (let [data (get-test-data {})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/render-with-theme-provider [collectible-tag/view data])
       (h/is-truthy (h/get-by-text collectible-name))))
 
   (h/test "Renders Add option"
     (let [data (get-test-data {:options :add})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/render-with-theme-provider [collectible-tag/view data])
       (h/is-truthy (h/get-by-text collectible-name))))
 
   (h/test "Renders Hold option"
     (let [data (get-test-data {:options :hold})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/render-with-theme-provider [collectible-tag/view data])
       (h/is-truthy (h/get-by-text collectible-name))))
 
   (h/test "Renders with Blur"
     (let [data (get-test-data {:blur? true})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/render-with-theme-provider [collectible-tag/view data])
       (h/is-truthy (h/get-by-text collectible-name))))
 
   (h/test "Renders without Blur"
     (let [data (get-test-data {:blur? false})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/render-with-theme-provider [collectible-tag/view data])
       (h/is-truthy (h/get-by-text collectible-name))))
 
   (h/test "Renders with Size 24"
     (let [data (get-test-data {:size :size-24})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/render-with-theme-provider [collectible-tag/view data])
       (h/is-truthy (h/get-by-text collectible-name))))
 
   (h/test "Renders with Size 32"
     (let [data (get-test-data {:size :size-32})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/render-with-theme-provider [collectible-tag/view data])
       (h/is-truthy (h/get-by-text collectible-name)))))

--- a/src/quo/components/tags/collectible_tag/component_spec.cljs
+++ b/src/quo/components/tags/collectible_tag/component_spec.cljs
@@ -1,0 +1,87 @@
+(ns quo.components.tags.collectible-tag.component-spec
+  (:require
+    [quo.components.tags.collectible-tag.view :as collectible-tag]
+    [test-helpers.component :as h]))
+
+(def collectible-name "Collectible")
+(def collectible-id "#123")
+(def ^:private theme :light)
+
+(defn get-test-data
+  [{:keys [options blur?]}]
+  {:collectible-name    collectible-name
+   :collectible-id      collectible-id
+   :collectible-img-src 1055
+   :container-width     139.33
+   :options             options
+   :blur?               (or blur? false)
+   :theme               theme})
+
+(h/describe "Collectible_tag tests"
+  (h/test "Renders Default option"
+    (let [data (get-test-data {:options false})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "Renders Add option"
+    (let [data (get-test-data {:options :add})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "Renders Hold option"
+    (let [data (get-test-data {:options :hold})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "Renders with Blur"
+    (let [data (get-test-data {:blur? true})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "Renders without Blur"
+    (let [data (get-test-data {:blur? false})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "Renders with Size 24"
+    (let [data (get-test-data {:size :size-24})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "Renders with Size 32"
+    (let [data (get-test-data {:size :size-32})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "On-layout fires correctly"
+    (let [on-layout (h/mock-fn)
+          data      (get-test-data {:on-layout on-layout})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      ;; Simulate a layout change
+      (on-layout {:nativeEvent {:layout {:x 0 :y 0 :width 100 :height 100}}})
+      (h/was-called on-layout)))
+
+  (h/test "Renders with :collectible-img-src as int"
+    (let [data (get-test-data {:collectible-img-src 1055})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "Renders with :collectible-img-src as string"
+    (let [data (get-test-data {:collectible-img-src "1055"})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "Renders with :container-width as int"
+    (let [data (get-test-data {:container-width 100})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "Renders with :container-width as double"
+    (let [data (get-test-data {:container-width 100.5})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name))))
+
+  (h/test "Renders with :container-width as string"
+    (let [data (get-test-data {:container-width "100"})]
+      (h/render-with-theme-provider [collectible-tag/view data] theme)
+      (h/is-truthy (h/get-by-text collectible-name)))))

--- a/src/quo/components/tags/collectible_tag/component_spec.cljs
+++ b/src/quo/components/tags/collectible_tag/component_spec.cljs
@@ -8,18 +8,18 @@
 (def ^:private theme :light)
 
 (defn get-test-data
-  [{:keys [options blur?]}]
+  [{:keys [options blur? size]}]
   {:collectible-name    collectible-name
    :collectible-id      collectible-id
-   :collectible-img-src 1055
-   :container-width     139.33
+   :collectible-img-src {:uri "https://example.com/image.jpg"}
    :options             options
    :blur?               (or blur? false)
+   :size                (or size :size-24)
    :theme               theme})
 
 (h/describe "Collectible_tag tests"
   (h/test "Renders Default option"
-    (let [data (get-test-data {:options false})]
+    (let [data (get-test-data {})]
       (h/render-with-theme-provider [collectible-tag/view data] theme)
       (h/is-truthy (h/get-by-text collectible-name))))
 
@@ -50,38 +50,5 @@
 
   (h/test "Renders with Size 32"
     (let [data (get-test-data {:size :size-32})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
-      (h/is-truthy (h/get-by-text collectible-name))))
-
-  (h/test "On-layout fires correctly"
-    (let [on-layout (h/mock-fn)
-          data      (get-test-data {:on-layout on-layout})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
-      ;; Simulate a layout change
-      (on-layout {:nativeEvent {:layout {:x 0 :y 0 :width 100 :height 100}}})
-      (h/was-called on-layout)))
-
-  (h/test "Renders with :collectible-img-src as int"
-    (let [data (get-test-data {:collectible-img-src 1055})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
-      (h/is-truthy (h/get-by-text collectible-name))))
-
-  (h/test "Renders with :collectible-img-src as string"
-    (let [data (get-test-data {:collectible-img-src "1055"})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
-      (h/is-truthy (h/get-by-text collectible-name))))
-
-  (h/test "Renders with :container-width as int"
-    (let [data (get-test-data {:container-width 100})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
-      (h/is-truthy (h/get-by-text collectible-name))))
-
-  (h/test "Renders with :container-width as double"
-    (let [data (get-test-data {:container-width 100.5})]
-      (h/render-with-theme-provider [collectible-tag/view data] theme)
-      (h/is-truthy (h/get-by-text collectible-name))))
-
-  (h/test "Renders with :container-width as string"
-    (let [data (get-test-data {:container-width "100"})]
       (h/render-with-theme-provider [collectible-tag/view data] theme)
       (h/is-truthy (h/get-by-text collectible-name)))))

--- a/src/quo/components/tags/collectible_tag/schema.cljs
+++ b/src/quo/components/tags/collectible_tag/schema.cljs
@@ -5,13 +5,11 @@
    [:catn
     [:props
      [:map {:closed true}
-      [:options {:optional true} [:maybe [:enum false :add :hold]]]
-      [:size {:optional true} [:enum :size-24 :size-32]]
-      [:blur? {:optional true} [:maybe :boolean]]
+      [:options {:optional true} [:maybe [:enum :add :hold]]]
+      [:size {:optional true} [:maybe [:enum :size-24 :size-32]]]
+      [:blur? {:optional true} [:maybe boolean?]]
       [:theme :schema.common/theme]
-      [:collectible-img-src [:or :int :string]]
-      [:collectible-name :string]
-      [:collectible-id :string]
-      [:container-width [:or :int :double :string]]
-      [:on-layout {:optional true} [:maybe fn?]]]]]
+      [:collectible-img-src :schema.common/image-source]
+      [:collectible-name string?]
+      [:collectible-id string?]]]]
    :any])

--- a/src/quo/components/tags/collectible_tag/schema.cljs
+++ b/src/quo/components/tags/collectible_tag/schema.cljs
@@ -4,12 +4,12 @@
   [:=>
    [:catn
     [:props
-     [:map {:closed true}
+     [:map
       [:options {:optional true} [:maybe [:enum :add :hold]]]
       [:size {:optional true} [:maybe [:enum :size-24 :size-32]]]
-      [:blur? {:optional true} [:maybe boolean?]]
+      [:blur? {:optional true} [:maybe :boolean]]
       [:theme :schema.common/theme]
       [:collectible-img-src :schema.common/image-source]
-      [:collectible-name string?]
-      [:collectible-id string?]]]]
+      [:collectible-name :string]
+      [:collectible-id :string]]]]
    :any])

--- a/src/quo/components/tags/collectible_tag/schema.cljs
+++ b/src/quo/components/tags/collectible_tag/schema.cljs
@@ -1,0 +1,17 @@
+(ns quo.components.tags.collectible-tag.schema)
+
+(def ?schema
+  [:=>
+   [:catn
+    [:props
+     [:map {:closed true}
+      [:options {:optional true} [:maybe [:enum false :add :hold]]]
+      [:size {:optional true} [:enum :size-24 :size-32]]
+      [:blur? {:optional true} [:maybe :boolean]]
+      [:theme :schema.common/theme]
+      [:collectible-img-src [:or :int :string]]
+      [:collectible-name :string]
+      [:collectible-id :string]
+      [:container-width [:or :int :double :string]]
+      [:on-layout {:optional true} [:maybe fn?]]]]]
+   :any])

--- a/src/quo/components/tags/collectible_tag/view.cljs
+++ b/src/quo/components/tags/collectible_tag/view.cljs
@@ -1,5 +1,6 @@
 (ns quo.components.tags.collectible-tag.view
   (:require
+    [oops.core :as oops]
     [quo.components.icon :as icons]
     [quo.components.markdown.text :as text]
     [quo.components.tags.collectible-tag.schema :as component-schema]
@@ -7,48 +8,51 @@
     [quo.theme]
     [react-native.core :as rn]
     [react-native.hole-view :as hole-view]
+    [reagent.core :as reagent]
     [schema.core :as schema]))
 
 (defn- view-internal
   []
-  (fn [{:keys [options size blur? theme collectible-img-src collectible-name collectible-id
-               container-width on-layout]
-        :or   {size :size-24}}]
-    [rn/view
-     {:on-layout on-layout}
-     [hole-view/hole-view
-      {:holes (if options
-                [{:x            (- container-width
-                                   (case size
-                                     :size-24 10
-                                     :size-32 12
-                                     nil))
-                  :y            (case size
-                                  :size-24 -6
-                                  :size-32 -4
-                                  nil)
-                  :width        16
-                  :height       16
-                  :borderRadius 8}]
-                [])}
-      [rn/view {:style (style/container size options blur? theme)}
-       [rn/image {:style (style/collectible-img size) :source collectible-img-src}]
-       [text/text
-        {:size   :paragraph-2
-         :weight :medium
-         :style  (style/label theme)}
-        collectible-name]
-       [text/text
-        {:size        :paragraph-2
-         :weight      :medium
-         :margin-left 5
-         :style       (style/label theme)}
-        collectible-id]]]
-     (when options
-       [rn/view {:style (style/options-icon size)}
-        [icons/icon (if (= options :hold) :i/hold :i/add-token)
-         {:size     20
-          :no-color true}]])]))
+  (let [container-width (reagent/atom 0)
+        on-layout       #(->> (oops/oget % :nativeEvent :layout :width)
+                              (reset! container-width))]
+    (fn [{:keys [options blur? theme collectible-img-src collectible-name collectible-id] :as props}]
+      (let [size (or (:size props) :size-24)]
+        [rn/view
+         {:on-layout on-layout}
+         [hole-view/hole-view
+          {:holes (if options
+                    [{:x            (- @container-width
+                                       (case size
+                                         :size-24 10
+                                         :size-32 12
+                                         nil))
+                      :y            (case size
+                                      :size-24 -6
+                                      :size-32 -4
+                                      nil)
+                      :width        16
+                      :height       16
+                      :borderRadius 8}]
+                    [])}
+          [rn/view {:style (style/container size options blur? theme)}
+           [rn/image {:style (style/collectible-img size) :source collectible-img-src}]
+           [text/text
+            {:size   :paragraph-2
+             :weight :medium
+             :style  (style/label theme)}
+            collectible-name]
+           [text/text
+            {:size        :paragraph-2
+             :weight      :medium
+             :margin-left 5
+             :style       (style/label theme)}
+            collectible-id]]]
+         (when options
+           [rn/view {:style (style/options-icon size)}
+            [icons/icon (if (= options :hold) :i/hold :i/add-token)
+             {:size     20
+              :no-color true}]])]))))
 
 (def view
   (quo.theme/with-theme

--- a/src/quo/components/tags/collectible_tag/view.cljs
+++ b/src/quo/components/tags/collectible_tag/view.cljs
@@ -25,10 +25,12 @@
                     [{:x            (- @container-width
                                        (case size
                                          :size-24 10
-                                         :size-32 12))
+                                         :size-32 12
+                                         nil))
                       :y            (case size
                                       :size-24 -6
-                                      :size-32 -4)
+                                      :size-32 -4
+                                      nil)
                       :width        16
                       :height       16
                       :borderRadius 8}]

--- a/src/quo/components/tags/collectible_tag/view.cljs
+++ b/src/quo/components/tags/collectible_tag/view.cljs
@@ -25,12 +25,10 @@
                     [{:x            (- @container-width
                                        (case size
                                          :size-24 10
-                                         :size-32 12
-                                         nil))
+                                         :size-32 12))
                       :y            (case size
                                       :size-24 -6
-                                      :size-32 -4
-                                      nil)
+                                      :size-32 -4)
                       :width        16
                       :height       16
                       :borderRadius 8}]

--- a/src/quo/components/tags/collectible_tag/view.cljs
+++ b/src/quo/components/tags/collectible_tag/view.cljs
@@ -2,27 +2,12 @@
   (:require
     [quo.components.icon :as icons]
     [quo.components.markdown.text :as text]
+    [quo.components.tags.collectible-tag.schema :as component-schema]
     [quo.components.tags.collectible-tag.style :as style]
     [quo.theme]
     [react-native.core :as rn]
     [react-native.hole-view :as hole-view]
     [schema.core :as schema]))
-
-(def ?schema
-  [:=>
-   [:catn
-    [:props
-     [:map {:closed true}
-      [:options {:optional true} [:maybe [:enum false :add :hold]]]
-      [:size {:optional true} [:enum :size-24 :size-32]]
-      [:blur? {:optional true} :boolean]
-      [:theme :schema.common/theme]
-      [:collectible-img-src [:or :int :string]]
-      [:collectible-name :string]
-      [:collectible-id :string]
-      [:container-width :number]
-      [:on-layout {:optional true} [:maybe fn?]]]]]
-   :any])
 
 (defn- view-internal
   []
@@ -67,4 +52,4 @@
 
 (def view
   (quo.theme/with-theme
-   (schema/instrument #'view-internal ?schema)))
+   (schema/instrument #'view-internal component-schema/?schema)))

--- a/src/quo/core_spec.cljs
+++ b/src/quo/core_spec.cljs
@@ -79,6 +79,7 @@
     quo.components.share.share-qr-code.component-spec
     quo.components.switchers.base-card.component-spec
     quo.components.switchers.group-messaging-card.component-spec
+    quo.components.tags.collectible-tag.component-spec
     quo.components.tags.network-tags.component-spec
     quo.components.tags.status-tags-component-spec
     quo.components.tags.summary-tag.component-spec

--- a/src/status_im/contexts/preview/quo/tags/collectible_tag.cljs
+++ b/src/status_im/contexts/preview/quo/tags/collectible_tag.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.preview.quo.tags.collectible-tag
   (:require
-    [oops.core :refer [oget]]
     [quo.core :as quo]
     [react-native.core :as rn]
     [reagent.core :as reagent]
@@ -16,9 +15,7 @@
                :value "Size 32"}]}
    {:key     :options
     :type    :select
-    :options [{:key   false
-               :value false}
-              {:key   :add
+    :options [{:key   :add
                :value :add}
               {:key   :hold
                :value :hold}]}
@@ -31,16 +28,11 @@
 
 (defn view
   []
-  (let [state     (reagent/atom {:size                :size-24
-                                 :collectible-name    "Collectible"
-                                 :collectible-id      "#123"
-                                 :collectible-img-src (resources/mock-images :collectible)
-                                 :options             false
-                                 :blur?               false
-                                 :container-width     0})
-        on-layout #(swap! state assoc
-                     :container-width
-                     (oget % :nativeEvent :layout :width))]
+  (let [state (reagent/atom {:size                :size-24
+                             :collectible-name    "Collectible"
+                             :collectible-id      "#123"
+                             :collectible-img-src (resources/mock-images :collectible)
+                             :blur?               false})]
     (fn []
       [preview/preview-container
        {:state                 state
@@ -48,4 +40,4 @@
         :show-blur-background? true
         :descriptor            descriptor}
        [rn/view {:style {:align-items :center}}
-        [quo/collectible-tag (assoc @state :on-layout on-layout)]]])))
+        [quo/collectible-tag @state]]])))


### PR DESCRIPTION
fixes #18797
closes https://github.com/status-im/status-mobile/pull/18799

### Summary

Following the merge of the [Quo Collectible Tag](https://github.com/status-im/status-mobile/pull/18748), it was observed that certain alerts were being triggered due to schema inconsistencies. This PR addresses those issues and incorporates `component_specs` to enhance functionality.

https://private-user-images.githubusercontent.com/5999878/303010047-2fabdc8b-9103-42f6-b67b-094d145a82e2.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDc4MzYxNTUsIm5iZiI6MTcwNzgzNTg1NSwicGF0aCI6Ii81OTk5ODc4LzMwMzAxMDA0Ny0yZmFiZGM4Yi05MTAzLTQyZjYtYjY3Yi0wOTRkMTQ1YTgyZTIubXA0P1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDIxMyUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDAyMTNUMTQ1MDU1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ZGMxODY0YzU1MTEwOGY5ODc2OTIwNTUwOGRmYjBlZWVhNDkxMGJlNzE0MTM1NDgzNWE1NTRjMjc0NmYxYjFjZSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.6mbBW_vdRuLSX_KbvmnZZbjJe3zPRv8Mc_LvJe9TXfE

### Review Notes

This PR maintains the existing design and functionality.

#### Platforms

- Android
- iOS

##### Functionalities

- 1-1 chats
- Public chats
- Group chats

### Steps to Test

1. Navigate to the quo components, either from the login screen or under the user menu.
2. Scroll to tags and select "Collectible Tag."

Status: Ready
