### PR TITLE
Remove rounding

### DIFF
--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -27,7 +27,7 @@
              :collectible-img-src (resources/get-mock-image :collectible))
 
       (= type constants/community-token-type-erc20)
-      (assoc :amount (str (money/with-precision (money/token->unit amount decimals) 3))
+      (assoc :amount (str (money/token->unit amount decimals))
              :token  (:symbol balance)))))
 
 (defn- account-item

--- a/src/status_im/contexts/communities/actions/token_gating/view.cljs
+++ b/src/status_im/contexts/communities/actions/token_gating/view.cljs
@@ -8,8 +8,7 @@
 (defn token-requirements
   []
   (fn [id]
-    (let [{:keys [can-request-access?
-                  number-of-hold-tokens tokens]} (rf/sub [:community/token-gated-overview id])]
+    (let [{:keys [can-request-access? tokens]} (rf/sub [:community/token-gated-overview id])]
       [rn/view {:style {:padding-horizontal 12}}
        [quo/text {:weight :medium}
         (if can-request-access?
@@ -17,7 +16,6 @@
           (i18n/label :t/you-not-eligible-to-join))]
        [quo/text {:style {:padding-bottom 18} :size :paragraph-2}
         (if can-request-access?
-          (i18n/label :t/you-hold-number-of-hold-tokens-of-these
-                      {:number-of-hold-tokens number-of-hold-tokens})
+          (i18n/label :t/you-hodl)
           (i18n/label :t/you-must-hold))]
        [quo/token-requirement-list {:tokens tokens}]])))

--- a/translations/en.json
+++ b/translations/en.json
@@ -2038,7 +2038,7 @@
     "blank-messages-text": "Your messages will be here",
     "blank-contacts-text": "Your contacts will be here",
     "groups": "Groups",
-    "you-must-hold": "You must hold:",
+    "you-must-hold": "You must hodl:",
     "you-must-now-hold": "You must now hold:",
     "you-must-always-hold": "You must always hold:",
     "shell-placeholder-title": "Your open tabs will be here",


### PR DESCRIPTION
Rounding is not needed, and lead to some odd scenario where it would show `0` for example tokens, if you had a low enough token amount.