### PR TITLE
[#18754] fix: scrollable addresses permission list in android

### DIFF
--- a/src/status_im/common/bottom_sheet_screen/view.cljs
+++ b/src/status_im/common/bottom_sheet_screen/view.cljs
@@ -15,12 +15,12 @@
 (def ^:const drag-threshold 200)
 
 (defn drag-gesture
-  [{:keys [translate-y opacity scroll-enabled curr-scroll close reset-open-sheet set-animating-true]}]
+  [{:keys [translate-y opacity scroll-enabled? curr-scroll close reset-open-sheet set-animating-true]}]
   (-> (gesture/gesture-pan)
       (gesture/on-start (fn [e]
                           (set-animating-true)
                           (when (< (oops/oget e "velocityY") 0)
-                            (reset! scroll-enabled true))))
+                            (reset! scroll-enabled? true))))
       (gesture/on-update (fn [e]
                            (let [translation (oops/oget e "translationY")
                                  progress    (Math/abs (/ translation drag-threshold))]
@@ -34,7 +34,7 @@
       (gesture/on-finalize (fn [e]
                              (when (and (>= (oops/oget e "velocityY") 0)
                                         (<= @curr-scroll (if platform/ios? -1 0)))
-                               (reset! scroll-enabled false))))))
+                               (reset! scroll-enabled? false))))))
 
 (defn on-scroll
   [e curr-scroll]
@@ -43,7 +43,7 @@
 
 (defn- f-view
   [_]
-  (let [scroll-enabled      (reagent/atom true)
+  (let [scroll-enabled?     (reagent/atom true)
         curr-scroll         (reagent/atom 0)
         animating?          (reagent/atom true)
         set-animating-true  #(reset! animating? true)
@@ -63,7 +63,7 @@
                                (reanimated/animate translate-y 0 300)
                                (reanimated/animate opacity 1 300)
                                (set-animating-false 300)
-                               (reset! scroll-enabled true))]
+                               (reset! scroll-enabled? true))]
         (rn/use-effect
          (fn []
            (reanimated/animate translate-y 0 300)
@@ -76,7 +76,7 @@
          [gesture/gesture-detector
           {:gesture (drag-gesture {:translate-y        translate-y
                                    :opacity            opacity
-                                   :scroll-enabled     scroll-enabled
+                                   :scroll-enabled?    scroll-enabled?
                                    :curr-scroll        curr-scroll
                                    :close              close
                                    :reset-open-sheet   reset-open-sheet
@@ -87,7 +87,7 @@
            [content
             {:insets           insets
              :close            close
-             :scroll-enabled   scroll-enabled
+             :scroll-enabled?  @scroll-enabled?
              :current-scroll   curr-scroll
              :on-scroll        #(on-scroll % curr-scroll)
              :sheet-animating? animating?}]]]]))))

--- a/src/status_im/common/emoji_picker/view.cljs
+++ b/src/status_im/common/emoji_picker/view.cljs
@@ -94,11 +94,11 @@
     :container-style style/empty-results}])
 
 (defn- render-list
-  [{:keys [theme filtered-data on-viewable-items-changed scroll-enabled on-scroll
+  [{:keys [theme filtered-data on-viewable-items-changed scroll-enabled? on-scroll
            on-select set-scroll-ref close sheet-animating?]}]
   [gesture/flat-list
    {:ref                             set-scroll-ref
-    :scroll-enabled                  @scroll-enabled
+    :scroll-enabled                  scroll-enabled?
     :data                            (or filtered-data emoji-picker.data/flatten-data)
     :initial-num-to-render           14
     :max-to-render-per-batch         10

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -65,7 +65,7 @@
        item])))
 
 (defn- view-internal
-  [{:keys [scroll-enabled on-scroll close theme]}]
+  [{:keys [scroll-enabled? on-scroll close theme]}]
   (let [contacts                          (rf/sub [:contacts/sorted-and-grouped-by-first-letter])
         selected-contacts-count           (rf/sub [:selected-contacts-count])
         selected-contacts                 (rf/sub [:group/selected-contacts])
@@ -105,7 +105,7 @@
          :render-section-header-fn       contact-list/contacts-section-header
          :content-container-style        {:padding-bottom 70}
          :render-fn                      contact-item-render
-         :scroll-enabled                 @scroll-enabled
+         :scroll-enabled                 scroll-enabled?
          :on-scroll                      on-scroll}])
      (when contacts-selected?
        [quo/button

--- a/src/status_im/contexts/chat/messenger/photo_selector/album_selector/view.cljs
+++ b/src/status_im/contexts/chat/messenger/photo_selector/album_selector/view.cljs
@@ -61,7 +61,7 @@
   (str (:title item) index))
 
 (defn- f-album-selector
-  [{:keys [scroll-enabled on-scroll]} album? selected-album top]
+  [{:keys [scroll-enabled? on-scroll]} album? selected-album top]
   (let [albums                     (rf/sub [:camera-roll/albums])
         total-photos-count-android (rf/sub [:camera-roll/total-photos-count-android])
         total-photos-count-ios     (rf/sub [:camera-roll/total-photos-count-ios])
@@ -87,7 +87,7 @@
        :content-container-style        {:padding-top    64
                                         :padding-bottom 40}
        :key-fn                         key-fn
-       :scroll-enabled                 @scroll-enabled
+       :scroll-enabled                 scroll-enabled?
        :on-scroll                      on-scroll
        :style                          {:height window-height}}]]))
 

--- a/src/status_im/contexts/chat/messenger/photo_selector/view.cljs
+++ b/src/status_im/contexts/chat/messenger/photo_selector/view.cljs
@@ -90,7 +90,7 @@
          (inc (utils.collection/first-index #(= (:uri item) (:uri %)) @selected))]])]))
 
 (defn photo-selector
-  [{:keys [scroll-enabled on-scroll current-scroll close] :as sheet}]
+  [{:keys [scroll-enabled? on-scroll current-scroll close] :as sheet}]
   (rf/dispatch [:photo-selector/get-photos-for-selected-album])
   (rf/dispatch [:photo-selector/camera-roll-get-albums])
   (let [album?              (reagent/atom false)
@@ -134,7 +134,7 @@
                                        :padding-bottom (+ (safe-area/get-bottom) 100)
                                        :padding-top    64}
              :on-scroll               on-scroll
-             :scroll-enabled          @scroll-enabled
+             :scroll-enabled          scroll-enabled?
              :on-end-reached          (fn []
                                         (when (and (not loading?) has-next-page?)
                                           (rf/dispatch [:photo-selector/camera-roll-loading-more true])

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -2,6 +2,7 @@
   (:require [quo.core :as quo]
             [quo.foundations.colors :as colors]
             [react-native.core :as rn]
+            [react-native.gesture :as gesture]
             [status-im.common.not-implemented :as not-implemented]
             [status-im.common.resources :as resources]
             [status-im.constants :as constants]
@@ -45,7 +46,7 @@
       :container-style {:margin-bottom 8}}]))
 
 (defn view
-  []
+  [{:keys [scroll-enabled on-scroll]}]
   (let [{id :community-id} (rf/sub [:get-screen-params])]
     (rf/dispatch [:communities/get-permissioned-balances id])
     (fn []
@@ -67,10 +68,12 @@
            :community-logo      (get-in images [:thumbnail :uri])
            :customization-color color}]
 
-         [rn/flat-list
+         [gesture/flat-list
           {:render-fn               account-item
            :render-data             [selected-addresses id]
            :content-container-style {:padding 20}
+           :scroll-enabled          @scroll-enabled
+           :on-scroll               on-scroll
            :key-fn                  :address
            :data                    accounts}]
 

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -46,7 +46,7 @@
       :container-style {:margin-bottom 8}}]))
 
 (defn view
-  [{:keys [scroll-enabled on-scroll]}]
+  [{:keys [scroll-enabled? on-scroll]}]
   (let [{id :community-id} (rf/sub [:get-screen-params])]
     (rf/dispatch [:communities/get-permissioned-balances id])
     (fn []
@@ -72,7 +72,7 @@
           {:render-fn               account-item
            :render-data             [selected-addresses id]
            :content-container-style {:padding 20}
-           :scroll-enabled          @scroll-enabled
+           :scroll-enabled          scroll-enabled?
            :on-scroll               on-scroll
            :key-fn                  :address
            :data                    accounts}]


### PR DESCRIPTION
fixes #18754

### Summary

Can't scroll through "addresses for permissions" list (Andoird)

#### Platforms

- Android

### Result
[Screen_recording_20240213_223629.webm](https://github.com/status-im/status-mobile/assets/71308738/11ae97ec-a96b-4370-885f-72a56e3ffd4f)


status: ready 
