### PR TITLE
[#18752] fix: The W/O address shouldn't be in account selection

### DIFF
--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -31,13 +31,13 @@
              :token  (:symbol balance)))))
 
 (defn- account-item
-  [{:keys [customization-color address name emoji]} _ _ [selected-addresses community-id]]
+  [{:keys [color address name emoji]} _ _ [selected-addresses community-id]]
   (let [balances (rf/sub [:communities/permissioned-balances-by-address community-id address])]
     [quo/account-permissions
      {:account         {:name                name
                         :address             address
                         :emoji               emoji
-                        :customization-color customization-color}
+                        :customization-color color}
       :token-details   (balances->components-props balances)
       :checked?        (contains? selected-addresses address)
       :on-change       #(rf/dispatch [:communities/toggle-selected-permission-address
@@ -51,7 +51,7 @@
     (fn []
       (let [{:keys [name color images]}       (rf/sub [:communities/community id])
             {:keys [highest-permission-role]} (rf/sub [:community/token-gated-overview id])
-            accounts                          (rf/sub [:wallet/accounts-with-customization-color])
+            accounts                          (rf/sub [:wallet/accounts-without-watched-accounts])
             selected-addresses                (rf/sub [:communities/selected-permission-addresses id])
             highest-role-text                 (when highest-permission-role
                                                 (i18n/label (communities.utils/role->translation-key

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -370,7 +370,7 @@
 (re-frame/reg-sub
  :communities/selected-permission-accounts
  (fn [[_ community-id]]
-   [(re-frame/subscribe [:wallet/accounts-with-customization-color])
+   [(re-frame/subscribe [:wallet/accounts-without-watched-accounts])
     (re-frame/subscribe [:communities/selected-permission-addresses community-id])])
  (fn [[accounts selected-permission-addresses]]
    (filter #(contains? selected-permission-addresses (:address %)) accounts)))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -190,7 +190,7 @@
 
 (rf/reg-sub
  :wallet/accounts-without-watched-accounts
- :<- [:wallet/accounts]
+ :<- [:wallet/accounts-with-customization-color]
  (fn [accounts]
    (remove #(:watch-only? %) accounts)))
 

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -367,52 +367,55 @@
            (assoc-in [:wallet :accounts] accounts)
            (assoc-in [:wallet :networks] network-data)))
     (is
-     (= (list
-         {:path                      "m/44'/60'/0'/0/0"
-          :emoji                     "😃"
-          :key-uid                   "0x2f5ea39"
-          :address                   "0x1"
-          :wallet                    false
-          :name                      "Account One"
-          :type                      :generated
-          :watch-only?               false
-          :chat                      false
-          :test-preferred-chain-ids  #{5 420 421613}
-          :color                     :blue
-          :hidden                    false
-          :prod-preferred-chain-ids  #{1 10 42161}
-          :network-preferences-names #{:ethereum :arbitrum :optimism}
-          :position                  0
-          :clock                     1698945829328
-          :created-at                1698928839000
-          :operable                  "fully"
-          :mixedcase-address         "0x7bcDfc75c431"
-          :public-key                "0x04371e2d9d66b82f056bc128064"
-          :removed                   false
-          :tokens                    tokens-0x1}
-         {:path                      "m/44'/60'/0'/0/1"
-          :emoji                     "💎"
-          :key-uid                   "0x2f5ea39"
-          :address                   "0x2"
-          :wallet                    false
-          :name                      "Account Two"
-          :type                      :generated
-          :watch-only?               false
-          :chat                      false
-          :test-preferred-chain-ids  #{5 420 421613}
-          :color                     :purple
-          :hidden                    false
-          :prod-preferred-chain-ids  #{1 10 42161}
-          :network-preferences-names #{:ethereum :arbitrum :optimism}
-          :position                  1
-          :clock                     1698945829328
-          :created-at                1698928839000
-          :operable                  "fully"
-          :mixedcase-address         "0x7bcDfc75c431"
-          :public-key                "0x04371e2d9d66b82f056bc128064"
-          :removed                   false
-          :tokens                    tokens-0x2})
-        (rf/sub [sub-name])))))
+     (=
+      (list
+       {:path                      "m/44'/60'/0'/0/0"
+        :emoji                     "😃"
+        :key-uid                   "0x2f5ea39"
+        :address                   "0x1"
+        :wallet                    false
+        :name                      "Account One"
+        :type                      :generated
+        :watch-only?               false
+        :chat                      false
+        :test-preferred-chain-ids  #{5 420 421613}
+        :color                     :blue
+        :customization-color       :blue
+        :hidden                    false
+        :prod-preferred-chain-ids  #{1 10 42161}
+        :network-preferences-names #{:ethereum :arbitrum :optimism}
+        :position                  0
+        :clock                     1698945829328
+        :created-at                1698928839000
+        :operable                  "fully"
+        :mixedcase-address         "0x7bcDfc75c431"
+        :public-key                "0x04371e2d9d66b82f056bc128064"
+        :removed                   false
+        :tokens                    tokens-0x1}
+       {:path                      "m/44'/60'/0'/0/1"
+        :emoji                     "💎"
+        :key-uid                   "0x2f5ea39"
+        :address                   "0x2"
+        :wallet                    false
+        :name                      "Account Two"
+        :type                      :generated
+        :watch-only?               false
+        :chat                      false
+        :test-preferred-chain-ids  #{5 420 421613}
+        :color                     :purple
+        :customization-color       :purple
+        :hidden                    false
+        :prod-preferred-chain-ids  #{1 10 42161}
+        :network-preferences-names #{:ethereum :arbitrum :optimism}
+        :position                  1
+        :clock                     1698945829328
+        :created-at                1698928839000
+        :operable                  "fully"
+        :mixedcase-address         "0x7bcDfc75c431"
+        :public-key                "0x04371e2d9d66b82f056bc128064"
+        :removed                   false
+        :tokens                    tokens-0x2})
+      (rf/sub [sub-name])))))
 
 (h/deftest-sub :wallet/network-preference-details
   [sub-name]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.174.5",
-    "commit-sha1": "1ea2bd99d4c11f591df554c089aa9283b9742c59",
-    "src-sha256": "0b9411581gmxrrrbgbjk34db8xgz5qlhvrhp9hngggar1b7vmp1w"
+    "version": "v0.174.6",
+    "commit-sha1": "f95dd35d131f68645b7c4dc5fbcea955c16e25bd",
+    "src-sha256": "188chrifz4h3j6fpsrqq83v2vcnpp8y4282k9lhlrkkknfgwz5v2"
 }


### PR DESCRIPTION
fixes #18752

### Summary

We should not include watch-only addresses in account selection when joining a community

### Result

https://github.com/status-im/status-mobile/assets/71308738/177e4593-d7cc-4e2f-9adb-c5420873cec6

status: ready
