### PR TITLE
Sort communities by currently active tab

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/link_preview/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/link_preview/view.cljs
@@ -81,7 +81,9 @@
       (fn []
         (when-not cached-preview-data
           (let [community-id (community-id-from-link community-link)]
-            (rf/dispatch [:communities/fetch-community community-id]))))
+            (rf/dispatch [:communities/fetch-community
+                          {:community-id           community-id
+                           :update-last-opened-at? false}]))))
       :reagent-render
       (fn []
         (when cached-preview-data

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -338,7 +338,11 @@
    [:catn
     [:cofx :schema.re-frame/cofx]
     [:args
-     [:schema [:catn [:community-id [:? :string]]]]]]
+     [:schema
+      [:catn
+       [:map
+        [:community-id [:? :string]]
+        [:update-last-opened-at? [:? :boolean]]]]]]]
    [:maybe
     [:map
      [:db map?]
@@ -383,11 +387,7 @@
    [:catn
     [:cofx :schema.re-frame/cofx]
     [:args
-     [:schema
-      [:catn
-       [:map
-        [:community-id [:? :string]]
-        [:update-last-opened-at? [:? :boolean]]]]]]]
+     [:schema [:catn [:community-id [:? :string]]]]]]
    [:maybe
     [:map
      [:db map?]

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -302,6 +302,7 @@
   (when community
     {:db (update db :communities/fetching-community dissoc community-id)
      :fx [[:dispatch [:communities/handle-community community]]
+          [:dispatch [:communities/update-last-opened-at community-id]]
           [:dispatch
            [:chat.ui/cache-link-preview-data (link-preview.events/community-link community-id)
             community]]]}))
@@ -315,7 +316,7 @@
 (rf/reg-event-fx :chat.ui/community-failed-to-fetch community-failed-to-fetch)
 
 (defn fetch-community
-  [{:keys [db]} [community-id]]
+  [{:keys [db]} [{:keys [community-id update-last-opened-at?]}]]
   (when (and community-id (not (get-in db [:communities/fetching-community community-id])))
     {:db            (assoc-in db [:communities/fetching-community community-id] true)
      :json-rpc/call [{:method     "wakuext_fetchCommunity"
@@ -323,6 +324,8 @@
                                     :TryDatabase     true
                                     :WaitForResponse true}]
                       :on-success (fn [community]
+                                    (when update-last-opened-at?
+                                      (rf/dispatch [:communities/update-last-opened-at community-id]))
                                     (rf/dispatch [:chat.ui/community-fetched community-id community]))
                       :on-error   (fn [err]
                                     (rf/dispatch [:chat.ui/community-failed-to-fetch community-id])
@@ -380,7 +383,11 @@
    [:catn
     [:cofx :schema.re-frame/cofx]
     [:args
-     [:schema [:catn [:community-id [:? :string]]]]]]
+     [:schema
+      [:catn
+       [:map
+        [:community-id [:? :string]]
+        [:update-last-opened-at? [:? :boolean]]]]]]]
    [:maybe
     [:map
      [:db map?]
@@ -403,17 +410,21 @@
      (navigate-to-serialized-community cofx deserialized-key)
      (rf/merge
       cofx
-      {:fx [[:dispatch [:communities/fetch-community deserialized-key]]
-            [:dispatch [:navigate-to :community-overview deserialized-key]]
-            [:dispatch [:communities/update-last-opened-at deserialized-key]]]}
+      {:fx [[:dispatch
+             [:communities/fetch-community
+              {:community-id           deserialized-key
+               :update-last-opened-at? true}]]
+            [:dispatch [:navigate-to :community-overview deserialized-key]]]}
       (navigation/pop-to-root :shell-stack)))))
 
 (rf/reg-event-fx :communities/navigate-to-community-chat
  (fn [{:keys [db]} [chat-id pop-to-root?]]
    (let [{:keys [community-id]} (get-in db [:chats chat-id])]
      {:fx [(when community-id
-             [:dispatch [:communities/fetch-community community-id]]
-             [:dispatch [:communities/update-last-opened-at community-id]])
+             [:dispatch
+              [:communities/fetch-community
+               {:community-id           community-id
+                :update-last-opened-at? true}]])
            (if pop-to-root?
              [:dispatch [:chat/pop-to-root-and-navigate-to-chat chat-id]]
              [:dispatch [:chat/navigate-to-chat chat-id]])]})))

--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -113,7 +113,7 @@
                              :params [{:CommunityKey    community-id
                                        :TryDatabase     true
                                        :WaitForResponse true}]}]}
-           (events/fetch-community {} [community-id])))))
+           (events/fetch-community {} [{:community-id community-id}])))))
   (testing "with no community id"
     (testing "do nothing"
       (is (match?

--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -106,7 +106,7 @@
     (testing "update fetching indicator in db"
       (is (match?
            {:db {:communities/fetching-community {community-id true}}}
-           (events/fetch-community {} [community-id]))))
+           (events/fetch-community {} [{:community-id community-id}]))))
     (testing "call the fetch community rpc method with correct community id"
       (is (match?
            {:json-rpc/call [{:method "wakuext_fetchCommunity"

--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -143,6 +143,7 @@
         (testing "dispatch fxs"
           (is (match?
                {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
+                     [:dispatch [:communities/update-last-opened-at community-id]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
                        {:id community-id}]]]}
@@ -153,6 +154,7 @@
         (testing "dispatch fxs, do not spectate community"
           (is (match?
                {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
+                     [:dispatch [:communities/update-last-opened-at community-id]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
                        {:id community-id}]]]}
@@ -163,6 +165,7 @@
         (testing "dispatch fxs, do not spectate community"
           (is (match?
                {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
+                     [:dispatch [:communities/update-last-opened-at community-id]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
                        {:id community-id}]]]}

--- a/src/status_im/contexts/communities/home/view.cljs
+++ b/src/status_im/contexts/communities/home/view.cljs
@@ -100,7 +100,10 @@
              :header                            [common.header-spacing/view]
              :render-fn                         item-render
              :style                             {:margin-top -1}
-             :data                              selected-items
+             :data                              (sort-by (fn [{:keys [last-opened-at joined-at]}]
+                                                           (or last-opened-at joined-at))
+                                                         #(compare %2 %1)
+                                                         selected-items)
              :scroll-event-throttle             8
              :content-container-style           {:padding-bottom
                                                  jump-to.constants/floating-shell-button-height}

--- a/src/status_im/contexts/communities/home/view.cljs
+++ b/src/status_im/contexts/communities/home/view.cljs
@@ -100,10 +100,7 @@
              :header                            [common.header-spacing/view]
              :render-fn                         item-render
              :style                             {:margin-top -1}
-             :data                              (sort-by (fn [{:keys [last-opened-at joined-at]}]
-                                                           (or last-opened-at joined-at))
-                                                         #(compare %2 %1)
-                                                         selected-items)
+             :data                              selected-items
              :scroll-event-throttle             8
              :content-container-style           {:padding-bottom
                                                  jump-to.constants/floating-shell-button-height}

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -113,7 +113,10 @@
                                              pending? (update acc :pending conj community)
                                              :else    (update acc :opened conj community))))
                                        {:joined [] :pending [] :opened []}
-                                       (vals communities))]
+                                       (sort-by (fn [{:keys [last-opened-at joined-at]}]
+                                                  (or last-opened-at joined-at))
+                                                #(compare %2 %1)
+                                                (vals communities)))]
        (reset! memo-communities-stack-items grouped-communities)
        grouped-communities)
      @memo-communities-stack-items)))

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -115,7 +115,7 @@
                                     vals
                                     (sort-by (fn [{:keys [requested-to-join-at last-opened-at
                                                           joined-at]}]
-                                               (or requested-to-join-at last-opened-at joined-at))
+                                               (or last-opened-at (max requested-to-join-at joined-at)))
                                              #(compare %2 %1))
                                     (group-by #(group-communities-by-status requests %)))]
        (reset! memo-communities-stack-items grouped-communities)

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -113,8 +113,8 @@
    (if (or (empty? @memo-communities-stack-items) (= view-id :communities-stack))
      (let [grouped-communities (->> communities
                                     vals
-                                    (sort-by (fn [{:keys [last-opened-at joined-at]}]
-                                               (or last-opened-at joined-at))
+                                    (sort-by (fn [{:keys [requested-to-join-at last-opened-at joined-at]}]
+                                               (or requested-to-join-at last-opened-at joined-at))
                                              #(compare %2 %1))
                                     (group-by #(group-communities-by-status requests %)))]
        (reset! memo-communities-stack-items grouped-communities)

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -95,8 +95,8 @@
 (def memo-communities-stack-items (atom nil))
 
 (defn- merge-opened-communities
-  [{:keys [joined] :as assorted-communities}]
-  (update assorted-communities :opened concat joined))
+  [{:keys [joined pending] :as assorted-communities}]
+  (update assorted-communities :opened concat joined pending))
 
 (defn- group-communities-by-status
   [requests

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -1,11 +1,11 @@
 (ns status-im.subs.communities
   (:require
-   [clojure.string :as string]
-   [legacy.status-im.ui.screens.profile.visibility-status.utils :as visibility-status-utils]
-   [re-frame.core :as re-frame]
-   [status-im.constants :as constants]
-   [status-im.contexts.wallet.common.utils :as wallet.utils]
-   [utils.i18n :as i18n]))
+    [clojure.string :as string]
+    [legacy.status-im.ui.screens.profile.visibility-status.utils :as visibility-status-utils]
+    [re-frame.core :as re-frame]
+    [status-im.constants :as constants]
+    [status-im.contexts.wallet.common.utils :as wallet.utils]
+    [utils.i18n :as i18n]))
 
 (re-frame/reg-sub
  :communities/fetching-community
@@ -208,10 +208,10 @@
  :<- [:communities/requests-to-join]
  (fn [requests [_ community-id]]
    (->>
-    (get requests community-id {})
-    vals
-    (filter (fn [{:keys [state]}]
-              (= state constants/request-to-join-pending-state))))))
+     (get requests community-id {})
+     vals
+     (filter (fn [{:keys [state]}]
+               (= state constants/request-to-join-pending-state))))))
 
 (re-frame/reg-sub
  :community/categories
@@ -381,9 +381,9 @@
    (get-in communities [community-id :intro-message])))
 
 (re-frame/reg-sub :communities/permissioned-balances-by-address
-                  :<- [:communities/permissioned-balances]
-                  (fn [balances [_ community-id account-address]]
-                    (get-in balances [community-id (keyword account-address)])))
+ :<- [:communities/permissioned-balances]
+ (fn [balances [_ community-id account-address]]
+   (get-in balances [community-id (keyword account-address)])))
 
 (re-frame/reg-sub
  :communities/selected-permission-addresses

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -113,7 +113,8 @@
    (if (or (empty? @memo-communities-stack-items) (= view-id :communities-stack))
      (let [grouped-communities (->> communities
                                     vals
-                                    (sort-by (fn [{:keys [requested-to-join-at last-opened-at joined-at]}]
+                                    (sort-by (fn [{:keys [requested-to-join-at last-opened-at
+                                                          joined-at]}]
                                                (or requested-to-join-at last-opened-at joined-at))
                                              #(compare %2 %1))
                                     (group-by #(group-communities-by-status requests %)))]

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -96,12 +96,10 @@
 
 (defn- group-communities-by-status
   [requests {:keys [id] :as community}]
-  (let [joined?  (:joined community)
-        pending? (boolean (get requests id))]
-    (cond
-      joined?  :joined
-      pending? :pending
-      :else    :opened)))
+  (cond
+    (:joined community)         :joined
+    (boolean (get requests id)) :pending
+    :else                       :opened))
 
 (re-frame/reg-sub
  :communities/grouped-by-status


### PR DESCRIPTION
fixes #17337

### Summary

Sorts communities by last-opened-at property, And falls back to joined-at property if last-opened-at doesn't exist.

status: ready
