### PR TITLE
[Fix] Broken wallet account emoji when syncing devices

### DIFF
--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -22,6 +22,15 @@
   [account]
   (assoc account :watch-only? (= (:type account) :watch)))
 
+(defn- sanitize-emoji
+  "As Desktop uses Twemoji, the emoji received can be an img tag 
+   with raw emoji in alt attribute. This function help us to extract 
+   the emoji from it as mobile doesn't support HTML rendering and Twemoji"
+  [emoji]
+  (if (string/starts-with? emoji "<img")
+    (-> (re-find #"alt=\"(.*?)\"" emoji) last)
+    emoji))
+
 (defn rpc->account
   [account]
   (-> account
@@ -33,6 +42,7 @@
       (update :test-preferred-chain-ids chain-ids-string->set)
       (update :type keyword)
       (update :color #(if (seq %) (keyword %) constants/account-default-customization-color))
+      (update :emoji sanitize-emoji)
       (assoc :default-account? (:wallet account))
       add-keys-to-account))
 


### PR DESCRIPTION
fixes #18640

### Summary

This PR fixes the broken wallet account emoji when syncing devices by adding a sanitization method for the wallet account emoji. The desktop can handle both variants (raw emoji and img tag) and this PR adds the same for mobile. 

### Review notes

Since the Desktop uses Twemoji, it is used to save the account emoji in img tag in status-go. It was fixed to save only the emoji instead of img tag. Somehow, the img tag is still propagated from the desktop. It will be debugged by the desktop team later (as this issue is not a priority at this moment). Additionally, this fix (sanitization) would help prevent such issues from happening from backup restore in mobile.

### Platforms

- Android
- iOS

### Steps to test

#### Prerequisite: Create a user in Desktop

- Open Status
- Sync the mobile app with the Desktop for the newly created user
- Verify the account emojis displayed across the application are not broken (or displaying an HTML img tag)

status: ready 
