### PR TITLE
disable `hermes` via `gradle` flag and other cleanup in build script of `Android`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ build-fdroid: ##@build Build release for F-Droid
 
 build-android: export BUILD_ENV ?= prod
 build-android: export BUILD_TYPE ?= nightly
-build-android: export BUILD_NUMBER ?= $(TMP_BUILD_NUMBER)
+build-android: export ORG_GRADLE_PROJECT_versionCode ?= $(TMP_BUILD_NUMBER)
 build-android: export ANDROID_ABI_SPLIT ?= false
 build-android: export ANDROID_ABI_INCLUDE ?= armeabi-v7a;arm64-v8a;x86
 build-android: ##@build Build unsigned Android APK

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.e2e-nightly
+++ b/ci/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 pipeline {
   agent { label params.AGENT_LABEL }
@@ -82,7 +82,7 @@ pipeline {
         env.NIXPKGS_SYSTEM_OVERRIDE = nixSysOverride(os, arch, 'android')
         /* Build/fetch deps required to build android release. */
         nix.build(
-          attr: 'targets.mobile.android.release.buildInputs',
+          attr: 'targets.mobile.android.build.buildInputs',
           sandbox: false,
           pure: false,
           link: false

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.5'
+library 'status-jenkins-lib@v1.8.7'
 
 pipeline {
   agent {

--- a/nix/DETAILS.md
+++ b/nix/DETAILS.md
@@ -61,7 +61,7 @@ We will use the `make jsbundle` target as an example of a derivation you can bui
 3. [`build.sh`](/nix/scripts/build.sh) calls `nix-build --attr targets.mobile.jsbundle` with extra arguments
 4. `nix-build` builds the derivation from [`nix/mobile/jsbundle/default.nix`](/nix/mobile/jsbundle/default.nix)
 
-The same can be done for other targets like `targets.mobile.android.release`.
+The same can be done for other targets like `targets.mobile.android.build`.
 Except in that case extra arguments are required which is why the [`scripts/release-android.sh`](/scripts/release-android.sh) is used in the `make release-android` target.
 
 If you run `make release-android` you'll see the `nix-build` command used:
@@ -71,14 +71,14 @@ nix-build \
   --fallback \
   --no-out-link \
   --show-trace \
-  --attr targets.mobile.android.release \
+  --attr targets.mobile.android.build \
   --argstr secrets-file '/tmp/tmp-status-mobile-559a3a441/tmp.xAnrPuNtAP' \
   --option extra-sandbox-paths '/home/joe/.gradle/status-im.keystore /tmp/tmp-status-mobile-559a3a441/tmp.xAnrPuNtAP' \
   default.nix
 ```
 Some of those are required which is why just calling:
 ```
-nix-build --attr targets.mobile.android.release
+nix-build --attr targets.mobile.android.build
 ```
 Would fail.
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -28,7 +28,7 @@ export STATUS_GO_IPFS_GATEWAY_URL="https://ipfs.status.im/"
 ```
 You can see the defaults in code:
 - [`nix/status-go/default.nix`](./status-go/default.nix)
-- [`nix/mobile/android/release.nix`](./mobile/android/release.nix)
+- [`nix/mobile/android/release.nix`](./mobile/android/build.nix)
 
 ## Shell
 

--- a/nix/deps/gradle/README.md
+++ b/nix/deps/gradle/README.md
@@ -6,7 +6,7 @@ This directory contains the tools and the data that allows Nix to manage Gradle 
 
 Simply calling `generate.sh` should result in a `deps.json` file which is used in the derivation that provides Gradle dependencies when building the Android app.
 
-You can see in [`nix/mobile/android/release.nix`](../../mobile/android/release.nix) that it's used via the `-Dmaven.repo.local='${deps.gradle}'` Gradle flag.
+You can see in [`nix/mobile/android/release.nix`](../../mobile/android/build.nix) that it's used via the `-Dmaven.repo.local='${deps.gradle}'` Gradle flag.
 
 # Files
 

--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -2,7 +2,7 @@
 , jsbundle, status-go, androidPkgs, androidShell }:
 
 rec {
-  release = callPackage ./release.nix {
+  build = callPackage ./build.nix {
     inherit jsbundle status-go;
   };
 
@@ -15,7 +15,7 @@ rec {
     ];
 
     inputsFrom = [
-      (release {})
+      (build {})
       androidShell
     ];
 

--- a/nix/scripts/build.sh
+++ b/nix/scripts/build.sh
@@ -45,7 +45,7 @@ if [[ -z "${TARGET}" ]]; then
 fi
 
 # Hack fix for missing Android SDK for aarch64 on Darwin. See systemOverride in `nix/pkgs.nix`.
-if [[ "${TARGET}" =~ ^(targets.status-go.mobile.android|targets.mobile.android.release)$ ]]; then
+if [[ "${TARGET}" =~ ^(targets.status-go.mobile.android|targets.mobile.android.build)$ ]]; then
   os=$(uname -s | tr '[:upper:]' '[:lower:]')
   export NIXPKGS_SYSTEM_OVERRIDE="x86_64-${os}"
 fi

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -21,8 +21,6 @@ function append_env_export() {
   VAR_VALUE=$(must_get_env "${VAR_NAME}")
   echo "export ${VAR_NAME}=\"${VAR_VALUE}\";" >> "${SECRETS_FILE_PATH}"
 }
-
-export COMMIT_HASH="$(git rev-parse --verify HEAD)"
 nixOpts=()
 
 # We create if now so the trap knows its location
@@ -73,4 +71,4 @@ else
 fi
 
 
-"${GIT_ROOT}/nix/scripts/build.sh" targets.mobile.android.release "${nixOpts[@]}"
+"${GIT_ROOT}/nix/scripts/build.sh" targets.mobile.android.build "${nixOpts[@]}"


### PR DESCRIPTION
fixes #18831

## Summary

We update the nix derivation to build android by passing `hermesEnabled` flag which checks the environment variable and if the environment variable is not set we default `hermesEnabled` to `true`.
This ensures that `hermes` is disabled for debug builds and enabled for release builds.

In this PR we also 
- rename `nix/mobile/android/release.nix` → `nix/mobile/android/build.nix` since that nix file no longer generates release only builds.
- cleanup 2 other env vars and use the `gradle` project format
- replace `BUILD_NUMBER` with `verisonCode` for consistency
- point to `status-jenkins-lib` branch for env vars change

## Platforms
- Android

status: ready
