### PR TITLE
fix: iOS build stage to install app on simulator

### DIFF
--- a/scripts/run-ios.sh
+++ b/scripts/run-ios.sh
@@ -58,8 +58,15 @@ xcrun simctl boot "$UUID"
 # start the simulator
 open -a Simulator --args -CurrentDeviceUDID "$UUID"
 
+BUILD_DIR="${GIT_ROOT}/build"
+
 #iOS build of debug scheme
-xcodebuild -workspace "ios/StatusIm.xcworkspace" -configuration Debug -scheme StatusIm -destination id="$UUID" | xcbeautify
+xcodebuild -workspace "ios/StatusIm.xcworkspace" -configuration Debug -scheme StatusIm -destination id="$UUID" -derivedDataPath "${BUILD_DIR}" | xcbeautify
+
+APP_PATH="${BUILD_DIR}/Build/Products/Debug-iphonesimulator/StatusIm.app"
+
+# Install on the simulator
+xcrun simctl install "$UUID" "$APP_PATH"
 
 trap cleanupMetro EXIT ERR INT QUIT
 runMetro &


### PR DESCRIPTION
fixes #18836

## Summary

While introducing https://github.com/status-im/status-mobile/pull/18784 I missed out on adding an install step to `run-ios.sh` script.

`make run-ios` would work fine for simulators that already have the app installed but would fail for new emulators.
@flexsurfer  discovered this problem.

This PR fixes that by adding an install step to the script.

## Review notes
- `make run-clojure`
- `make run-ios` 
should just work.

## Platforms
- iOS

status: ready 
