### PR TITLE
[Feature] Wallet - Handle blockchain status

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -425,6 +425,9 @@
 (def ^:const optimism-goerli-chain-id 420)
 (def ^:const optimism-sepolia-chain-id 11155420)
 
+(def ^:const mainnet-chain-ids
+  #{ethereum-mainnet-chain-id arbitrum-mainnet-chain-id optimism-mainnet-chain-id})
+
 (def ^:const mainnet-short-name "eth")
 (def ^:const optimism-short-name "opt")
 (def ^:const arbitrum-short-name "arb1")

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -60,8 +60,7 @@
                         :color                    :colorId})
       (update :prodPreferredChainIds chain-ids-set->string)
       (update :testPreferredChainIds chain-ids-set->string)
-      (dissoc :watch-only?)
-      (dissoc :default-account?)))
+      (dissoc :watch-only? :default-account? :tokens :collectibles)))
 
 (defn- rpc->balances-per-chain
   [token]

--- a/src/status_im/contexts/wallet/signals.cljs
+++ b/src/status_im/contexts/wallet/signals.cljs
@@ -2,12 +2,13 @@
   (:require
     [oops.core :as oops]
     [taoensso.timbre :as log]
-    [utils.re-frame :as rf]))
+    [utils.re-frame :as rf]
+    [utils.transforms :as transforms]))
 
 (rf/reg-event-fx
  :wallet/pending-transaction-status-changed-received
  (fn [{:keys [db]} [{:keys [message]}]]
-   (let [details (js->clj (js/JSON.parse message) :keywordize-keys true)
+   (let [details (transforms/json->clj message)
          tx-hash (:hash details)]
      {:db (update-in db [:wallet :transactions tx-hash] assoc :status :confirmed :blocks 1)})))
 
@@ -25,22 +26,17 @@
        "pending-transaction-status-changed"       {:fx
                                                    [[:dispatch
                                                      [:wallet/pending-transaction-status-changed-received
-                                                      (js->clj event-js
-                                                               :keywordize-keys
-                                                               true)]]]}
+                                                      (transforms/js->clj event-js)]]]}
        "wallet-owned-collectibles-filtering-done" {:fx [[:dispatch
                                                          [:wallet/owned-collectibles-filtering-done
-                                                          (js->clj event-js
-                                                                   :keywordize-keys
-                                                                   true)]]]}
+                                                          (transforms/js->clj event-js)]]]}
        "wallet-get-collectibles-details-done"     {:fx [[:dispatch
                                                          [:wallet/get-collectible-details-done
-                                                          (js->clj event-js
-                                                                   :keywordize-keys
-                                                                   true)]]]}
+                                                          (transforms/js->clj event-js)]]]}
        "wallet-tick-reload"                       {:fx [[:dispatch [:wallet/reload]]]}
+       "wallet-blockchain-status-changed"         {:fx [[:dispatch
+                                                         [:wallet/blockchain-status-changed
+                                                          (transforms/js->clj event-js)]]]}
        (log/debug ::unknown-wallet-event
-                  :type  type
-                  :event (js->clj event-js
-                                  :keywordize-keys
-                                  true))))))
+                  :type  event-type
+                  :event (transforms/js->clj event-js))))))

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -213,9 +213,13 @@
   "Add with defaults, this version is able to receive `nil` and takes them as 0."
   (fnil add* (bignumber 0) (bignumber 0)))
 
-(defn mul
+(defn- mul*
   [bn1 bn2]
   (.mul ^js bn1 bn2))
+
+(def mul
+  "Multiply with defaults, this version is able to receive `nil` and takes them as 0."
+  (fnil mul* (bignumber 0) (bignumber 0)))
 
 (defn mul-and-round
   [bn1 bn2]

--- a/translations/en.json
+++ b/translations/en.json
@@ -2514,5 +2514,6 @@
     "keypair-name-input-placeholder": "Collectibles account, Old vault....",
     "goerli-testnet-toggle-confirmation": "Are you sure you want to toggle Goerli? This will log you out and you will have to login again.",
     "bridged-to": "Bridged to {{network}}",
-    "slide-to-bridge": "Slide to bridge"
+    "slide-to-bridge": "Slide to bridge",
+    "provider-is-down": "The provider for the following chain(s) is down: {{chains}}"
 }


### PR DESCRIPTION
fixes #18826 

### Summary

This PR adds the feature to handle blockchain status signals from the `status-go` and shows a toast if the provider for any of the blockchains is down.

Additionally, this PR refactors a few areas of the wallet.

<img width="300" src="https://github.com/status-im/status-mobile/assets/19339952/d95ec944-0da1-4d85-b7b4-06f07e74f0f5" />

### Testing notes

To simulate the chains down, we need to create a test branch in status-go with completely wrong network RPC URLs and use it. I will create it when we start testing.

A regression test on the wallet is appreciated as this PR refactors a few areas of the Wallet.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Login to your profile
- Verify that toast is shown if any of the blockchains is down

status: ready 
