### PR TITLE
FIX: Addresses for permissions info button bg color

### DIFF
--- a/src/quo/components/drawers/drawer_top/view.cljs
+++ b/src/quo/components/drawers/drawer_top/view.cljs
@@ -137,7 +137,8 @@
       :description description}]))
 
 (defn- right-icon
-  [{:keys [theme type on-button-press on-button-long-press button-disabled? button-icon]}]
+  [{:keys [theme type on-button-press on-button-long-press button-disabled? button-icon button-type]
+    :or   {button-type :primary}}]
   (cond
     (= :info type)
     [icons/icon
@@ -153,7 +154,7 @@
       :on-press            on-button-press
       :on-long-press       on-button-long-press
       :disabled?           button-disabled?
-      :type                :primary
+      :type                button-type
       :size                24
       :icon-only?          true}
      button-icon]))
@@ -182,7 +183,7 @@
 
 (defn- view-internal
   [{:keys [title title-icon type theme description blur? community-name community-logo button-icon
-           account-name emoji context-tag-type
+           account-name emoji context-tag-type button-type
            on-button-press
            on-button-long-press
            button-disabled? account-avatar-emoji account-avatar-type customization-color icon-avatar
@@ -221,6 +222,7 @@
    [right-icon
     {:theme                theme
      :type                 type
+     :button-type          button-type
      :on-button-press      on-button-press
      :on-button-long-press on-button-long-press
      :button-disabled?     button-disabled?

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -69,6 +69,7 @@
            :context-tag-type    :community
            :community-name      name
            :button-icon         :i/info
+           :button-type         :grey
            :on-button-press     not-implemented/alert
            :community-logo      (get-in images [:thumbnail :uri])
            :customization-color color}]


### PR DESCRIPTION
fixes #18616 

#### Areas that maybe impacted
- Addresses for permissions screen
- Drawer/drawer-top component

status: ready <!-- Can be ready or wip -->
