### PR TITLE
fix: we need to tunnel 8081 for connected devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ endif
 export TMPDIR = /tmp/tmp-status-mobile-$(BUILD_TAG)
 # This has to be specified for both the Node.JS server process and the Qt process.
 export REACT_SERVER_PORT ?= 5001
+# Default metro port used by scripts/run-android.sh.
+export RCT_METRO_PORT ?= 8081
 # Fix for ERR_OSSL_EVP_UNSUPPORTED error.
 export NODE_OPTIONS += --openssl-legacy-provider
 # The path can be anything, but home is usually safest.

--- a/scripts/run-android.sh
+++ b/scripts/run-android.sh
@@ -13,8 +13,10 @@ export BUILD_TYPE=debug
 
 # Install the APK on running emulator or android device.
 installAndLaunchApp() {
-  adb install ./result/app-debug.apk > "${ADB_INSTALL_LOG_FILE}" 2>&1
+  adb install -r ./result/app-debug.apk > "${ADB_INSTALL_LOG_FILE}" 2>&1
   "${GIT_ROOT}/scripts/wait-for-metro-port.sh" 2>&1
+  # connected android devices need this port to be exposed for metro
+  adb reverse "tcp:${RCT_METRO_PORT}" "tcp:${RCT_METRO_PORT}"
   adb shell monkey -p im.status.ethereum.debug 1 > "${ADB_SHELL_MONKEY_LOG_FILE}" 2>&1
 }
 


### PR DESCRIPTION
## Summary

`make run-android` would fail for connected Android devices because the android device was not able to talk to metro bundler.
This was discovered by @J-Son89 
This was easily fixed by reverse tcping port 8081.

## Review notes
connect Android device by USB or Wifi
- `make run-clojure`
- `make run-android`
status app must run without any errors on the connected Android device.

## Platforms
- Android

status: ready
