### PR TITLE
hide eligibility when checking

### DIFF
--- a/src/quo/components/drawers/bottom_actions/view.cljs
+++ b/src/quo/components/drawers/bottom_actions/view.cljs
@@ -53,7 +53,7 @@
         :style {:color (colors/theme-colors colors/danger-50 colors/danger-60 theme)}}
        error-message]])
 
-   (when (= description :top)
+   (when (and (= description :top) role)
      [rn/view
       {:style style/description-top}
       [text/text

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -61,7 +61,8 @@
     (rf/dispatch [:communities/get-permissioned-balances id])
     (fn []
       (let [{:keys [name color images]}       (rf/sub [:communities/community id])
-            {:keys [highest-permission-role]} (rf/sub [:community/token-gated-overview id])
+            {:keys [checking?
+                    highest-permission-role]} (rf/sub [:community/token-gated-overview id])
             accounts                          (rf/sub [:wallet/accounts-without-watched-accounts])
             selected-addresses                (rf/sub [:communities/selected-permission-addresses id])
             share-all-addresses?              (rf/sub [:communities/share-all-addresses? id])
@@ -105,7 +106,8 @@
           {:actions          :two-actions
            :button-one-label (i18n/label :t/confirm-changes)
            :button-one-props {:customization-color color
-                              :disabled?           (or (empty? selected-addresses)
+                              :disabled?           (or checking?
+                                                       (empty? selected-addresses)
                                                        (not highest-permission-role)
                                                        (not unsaved-address-changes?))
                               :on-press            (fn []
@@ -123,9 +125,10 @@
                                      (not highest-permission-role))
                                :top-error
                                :top)
-           :role             (role-keyword highest-permission-role)
+           :role             (when-not checking? (role-keyword highest-permission-role))
            :error-message    (cond
                                (empty? selected-addresses)   (i18n/label :t/no-addresses-selected)
                                (not highest-permission-role) (i18n/label
                                                               :t/addresses-dont-contain-tokens-needed)
                                :else                         nil)}]]))))
+

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -330,6 +330,7 @@
          highest-permission-role (:type highest-role)
          can-request-access?     (and (boolean highest-permission-role) (not networks-not-supported?))]
      {:can-request-access?     can-request-access?
+      :checking?               checking?
       :highest-permission-role highest-permission-role
       :networks-not-supported? networks-not-supported?
       :no-member-permission?   (and highest-permission-role


### PR DESCRIPTION
When checking permissions, we should not show previous results

depends on https://github.com/status-im/status-mobile/pull/18870 check only last commit

Fixes https://github.com/status-im/status-mobile/issues/18859