### PR TITLE
[Fix] Wallet - Routes not fetched on scanned address

### DIFF
--- a/src/status_im/contexts/wallet/add_address_to_watch/confirm_address/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/confirm_address/view.cljs
@@ -14,7 +14,7 @@
 
 (defn view
   []
-  (let [{:keys [address]}  (rf/sub [:get-screen-params])
+  (let [address            (rf/sub [:wallet/address-to-watch])
         number-of-accounts (count (rf/sub [:wallet/watch-only-accounts]))
         account-name       (reagent/atom "")
         placeholder        (i18n/label :t/default-watched-address-placeholder

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -64,7 +64,8 @@
       {:type            :outline
        :on-press        (fn []
                           (rn/dismiss-keyboard!)
-                          (rf/dispatch [:open-modal :scan-address]))
+                          (rf/dispatch [:navigate-to-within-stack
+                                        [:scan-address :add-address-to-watch]]))
        :container-style style/scan
        :size            40
        :icon-only?      true}
@@ -127,9 +128,10 @@
                    :disabled?           (or (string/blank? @input-value)
                                             (some? (validate @input-value)))
                    :on-press            (fn []
-                                          (rf/dispatch [:navigate-to
-                                                        :confirm-address-to-watch
-                                                        {:address @input-value}])
+                                          (rf/dispatch [:wallet/add-address-to-watch @input-value])
+                                          (rf/dispatch [:navigate-to-within-stack
+                                                        [:confirm-address-to-watch
+                                                         :add-address-to-watch]])
                                           (clear-input))
                    :container-style     {:z-index 2}}
                   (i18n/label :t/continue)]}

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -46,6 +46,16 @@
     :fx [[:dispatch [:pop-to-root :shell-stack]]]}))
 
 (rf/reg-event-fx
+ :wallet/add-address-to-watch
+ (fn [{:keys [db]} [address]]
+   {:db (assoc-in db [:wallet :ui :address-to-watch] address)}))
+
+(rf/reg-event-fx
+ :wallet/clean-address-to-watch
+ (fn [{:keys [db]}]
+   {:db (update db [:wallet :ui] dissoc :address-to-watch)}))
+
+(rf/reg-event-fx
  :wallet/get-accounts-success
  (fn [{:keys [db]} [accounts]]
    (let [wallet-accounts     (filter #(not (:chat %)) accounts)
@@ -170,7 +180,8 @@
                 :wallet              assoc
                 :navigate-to-account address
                 :new-account?        true)
-    :fx [[:dispatch [:wallet/get-accounts]]]}))
+    :fx [[:dispatch [:wallet/get-accounts]]
+         [:dispatch [:wallet/clean-address-to-watch]]]}))
 
 (rf/reg-event-fx :wallet/add-account
  (fn [{:keys [db]}

--- a/src/status_im/contexts/wallet/home/view.cljs
+++ b/src/status_im/contexts/wallet/home/view.cljs
@@ -23,7 +23,7 @@
       :accessibility-label :add-a-contact
       :label               (i18n/label :t/add-address)
       :sub-label           (i18n/label :t/add-address-description)
-      :on-press            #(rf/dispatch [:navigate-to :add-address-to-watch])
+      :on-press            #(rf/dispatch [:open-modal :add-address-to-watch])
       :add-divider?        true}]]])
 
 (defn- new-account-card-data

--- a/src/status_im/contexts/wallet/scan_account/view.cljs
+++ b/src/status_im/contexts/wallet/scan_account/view.cljs
@@ -2,7 +2,8 @@
   (:require [status-im.common.scan-qr-code.view :as scan-qr-code]
             [status-im.constants :as constants]
             [utils.debounce :as debounce]
-            [utils.i18n :as i18n]))
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]))
 
 (defn- contains-address?
   [s]
@@ -15,10 +16,11 @@
 (defn view
   []
   [scan-qr-code/view
-   {:title           (i18n/label :t/scan-qr)
-    :subtitle        (i18n/label :t/scan-an-account-qr-code)
-    :error-message   (i18n/label :t/oops-this-qr-does-not-contain-an-address)
-    :validate-fn     #(contains-address? %)
-    :on-success-scan #(debounce/debounce-and-dispatch [:wallet/scan-address-success
-                                                       (extract-address %)]
-                                                      300)}])
+   {:title            (i18n/label :t/scan-qr)
+    :subtitle         (i18n/label :t/scan-an-account-qr-code)
+    :error-message    (i18n/label :t/oops-this-qr-does-not-contain-an-address)
+    :validate-fn      #(contains-address? %)
+    :on-success-scan  #(debounce/debounce-and-dispatch [:wallet/scan-address-success
+                                                        (extract-address %)]
+                                                       300)
+    :navigate-back-fn #(rf/dispatch [:navigate-back-within-stack :scan-address])}])

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -38,7 +38,8 @@
         :on-scan               (fn []
                                  (rn/dismiss-keyboard!)
                                  (rf/dispatch [:wallet/clean-scanned-address])
-                                 (rf/dispatch [:open-modal :scan-address]))
+                                 (rf/dispatch [:navigate-to-within-stack
+                                               [:scan-address :wallet-select-address]]))
         :ens-regex             constants/regx-ens
         :scanned-value         (or (when recipient-plain-address? send-address) scanned-address)
         :address-regex         constants/regx-multichain-address

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -331,7 +331,8 @@
      :component wallet-edit-account/view}
 
     {:name      :add-address-to-watch
-     :options   {:insets {:top? true}}
+     :options   {:insets                 {:top? true}
+                 :modalPresentationStyle :overCurrentContext}
      :component add-address-to-watch/view}
 
     {:name      :confirm-address-to-watch

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -89,6 +89,11 @@
  :-> :watch-address-activity-state)
 
 (rf/reg-sub
+ :wallet/address-to-watch
+ :<- [:wallet/ui]
+ :-> :address-to-watch)
+
+(rf/reg-sub
  :wallet/accounts
  :<- [:wallet]
  :<- [:wallet/network-details]


### PR DESCRIPTION
fixes #18652 (for the second time and hopefully last)

### Summary

This PR fixes routes not fetched for scanned addresses.

### Review notes

The issue doesn't state it is caused only by scanned addresses. This was discovered on https://github.com/status-im/status-mobile/pull/18850#issuecomment-1948041140. 

This bug is caused as a regression by the [introduction](https://github.com/status-im/status-mobile/pull/18593) of `:modal-view-ids` (to app-db) to store the screen list and to prevent some key data lost on re-render (during development).

In the send flow, the first screen (`wallet-select-address`) is opened in a modal (`:open-modal`) and the screens after that are navigated with the help of the `:navigate-to-within-stack` event. **BUT**, The `scan-address` screen is opened with `:open-modal` (resets `:modal-view-ids` ) and on successful scan or on navigating back by tapping on the `X` icon, the `:modal-view-ids` is removed from app-db (because the `navigate-back` event clears it) and makes the following condition to fail and not to fetch the route:
https://github.com/status-im/status-mobile/blob/be2c697b7cf245f91d593dfda18d0554214ceb3b/src/status_im/contexts/wallet/send/input_amount/view.cljs#L179

We can make the `open-modal` robust by checking if any `:modal-view-ids` exists and `conj` the view-id to it. This would keep the `:modal-view-ids` intact but may introduce other unwanted bugs as the old data would persist. 

So, the proper fix is to add the `:scan-address` screen in the stack flow on the send flow and the add watch address flow separately. Since the scanner view is common, we need to handle the `:navigate-back` event as well (to not affect other screens). Hence, we introduce a custom navigation function prop to fix it. 


### Testing notes

Regression testing on the whole application is appreciated as this PR updates the common scanner screen.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Log in to your profile
- Navigate to the Wallet tab
- Tap on any account
- Tap on the Send button
- Scan any address
- Select any asset to send
- Enter any amount (below the limit)
- Verify the routes are fetched

#### Additionally, verify the add address to watch flow with the scanner is working as expected

status: ready 
