### PR TITLE
fix: improve iOS simulator selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,6 @@ metro-server-logs.log
 
 ## debug build time logs
 logs/
+
+## available iOS simulators
+ios_simulators_list.json

--- a/scripts/run-ios.sh
+++ b/scripts/run-ios.sh
@@ -8,9 +8,9 @@ XCRUN_LAUNCH_LOG_FILE="${GIT_ROOT}/logs/xcrun_launch.log"
 
 # Install on the simulator
 installAndLaunchApp() {
-  xcrun simctl install "$UUID" "$APP_PATH" > "${XCRUN_INSTALL_LOG_FILE}" 2>&1
+  xcrun simctl install "$UDID" "$APP_PATH" > "${XCRUN_INSTALL_LOG_FILE}" 2>&1
   "${GIT_ROOT}/scripts/wait-for-metro-port.sh"  2>&1
-  xcrun simctl launch "$UUID" im.status.ethereum.debug > "${XCRUN_LAUNCH_LOG_FILE}" 2>&1
+  xcrun simctl launch "$UDID" im.status.ethereum.debug > "${XCRUN_LAUNCH_LOG_FILE}" 2>&1
 
 }
 
@@ -25,29 +25,41 @@ if [ -z "${1-}" ]; then
     exit 1
 fi
 
+# fetch available iOS Simulators
+xcrun simctl list devices -j > ios_simulators_list.json
+
 SIMULATOR=${1}
 
-# get our desired UUID
-UUID=$(xcrun simctl list devices | grep -E "$SIMULATOR \(" | head -n 1 | awk -F '[()]' '{print $2}')
+# get the first available UDID for Simulators that match the name
+read -r UDID SIMULATOR_STATE IS_AVAILABLE < <(jq --raw-output --arg simulator "${SIMULATOR}" '
+  [ .devices[] | .[] | select(.name == $simulator) ] |
+  map(select(.isAvailable)) + map(select(.isAvailable | not)) |
+  first |
+  "\(.udid) \(.state) \(.isAvailable)"
+' ios_simulators_list.json)
 
-# get simulator status
-SIMULATOR_STATE=$(xcrun simctl list devices | grep -E "$SIMULATOR \(" | head -n 1 | awk '{print $NF}')
+if [ "${IS_AVAILABLE}" == false ] || [ "${UDID}" == null ]; then
+    echo "Error: Simulator ${SIMULATOR} is not available, Please find and install them."
+    echo "For help please refer"
+    echo "https://developer.apple.com/documentation/safari-developer-tools/adding-additional-simulators#Add-and-remove-Simulators " >&2
+    exit 1
+fi
 
 # sometimes a simulator is already running, shut it down to avoid errors
-if [ "$SIMULATOR_STATE" != "(Shutdown)" ]; then
-    xcrun simctl shutdown "$UUID"
+if [ "${SIMULATOR_STATE}" != "Shutdown" ]; then
+    xcrun simctl shutdown "${UDID}"
 fi
 
 # boot up iOS for simulator
-xcrun simctl boot "$UUID"
+xcrun simctl boot "${UDID}"
 
 # start the simulator
-open -a Simulator --args -CurrentDeviceUDID "$UUID"
+open -a Simulator --args -CurrentDeviceUDID "${UDID}"
 
 BUILD_DIR="${GIT_ROOT}/build"
 
 #iOS build of debug scheme
-xcodebuild -workspace "ios/StatusIm.xcworkspace" -configuration Debug -scheme StatusIm -destination id="$UUID" -derivedDataPath "${BUILD_DIR}" | xcbeautify
+xcodebuild -workspace "ios/StatusIm.xcworkspace" -configuration Debug -scheme StatusIm -destination id="${UDID}" -derivedDataPath "${BUILD_DIR}" -verbose | xcbeautify
 
 APP_PATH="${BUILD_DIR}/Build/Products/Debug-iphonesimulator/StatusIm.app"
 


### PR DESCRIPTION
## Summary

Improve iOS Simulator selection via `make run-ios` command.
Currently : `make run-ios SIMULATOR="iPhone SE (3rd generation)"` would fail because of our scripts inability to deal with this kind of a pattern.

This PR fixes that and makes this script more robust by storing output of `xcrun simctl list devices` in a json file `ios_simulators_list.json` and then using `jq` to properly get `UDIDs` of those simulators.

This script will now also prompt you to download a simulator image if you do not already have it.

The file `ios_simulators_list.json` will also help in future debugging when we want to check a quick summary of iOS simulator status of devs in the future.

We also append `-verbose` to `xcodebuild` for debug `iOS` builds, this helps debugging.

## Review notes
try such options -> `make run-ios SIMULATOR="iPhone SE (3rd generation)"`

## Platform 
- iOS

status: ready
