### PR TITLE
chore: don't auto focus create account input

### DIFF
--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -102,7 +102,6 @@
          :max-length          constants/wallet-account-name-max-length
          :blur?               true
          :disabled?           false
-         :auto-focus          true
          :default-value       @account-name
          :container-style     style/title-input-container}]
        [quo/divider-line]


### PR DESCRIPTION
fixes #18876

## Summary

The keyboard won't auto open now when navigating to create wallet account UI.
This used to happen because of auto-focus prop set as true on the text input on this screen.

## Testing notes
@qoqobolo : do check if this fixes the original issue for you.

#### Platforms
- Android
- iOS

status: ready
