### PR TITLE
fix: ask for push notification permissions on toggle in settings if skipped during onboarding

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,12 +1,25 @@
-# Resolve react_native_pods.rb with node to allow for hoisting
-require Pod::Executable.execute_command('node', ['-p',
-  'require.resolve(
-    "react-native/scripts/react_native_pods.rb",
-    {paths: [process.argv[1]]},
-  )', __dir__]).strip
+def node_require(script)
+   # Resolve script with node to allow for hoisting
+   require Pod::Executable.execute_command('node', ['-p',
+     "require.resolve(
+       '#{script}',
+       {paths: [process.argv[1]]},
+     )", __dir__]).strip
+end
+
+node_require('react-native/scripts/react_native_pods.rb')
+node_require('react-native-permissions/scripts/setup.rb')
 
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
+
+setup_permissions([
+  'Camera',
+  'Microphone',
+  'FaceID',
+  'MediaLibrary',
+  'PhotoLibrary',
+])
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil
@@ -40,12 +53,7 @@ abstract_target 'Status' do
 
   pod 'react-native-image-resizer', :path => '../node_modules/react-native-image-resizer'
   pod 'react-native-config', :path => '../node_modules/react-native-config'
-
   pod 'SSZipArchive', '2.4.3'
-
-  permissions_path = '../node_modules/react-native-permissions/ios'
-  pod 'Permission-Microphone', :path => "#{permissions_path}/Microphone/Permission-Microphone.podspec"
-  pod 'Permission-Camera', :path => "#{permissions_path}/Camera/Permission-Camera.podspec"
   pod "react-native-status-keycard", path: "../node_modules/react-native-status-keycard"
   pod "react-native-status", path: "../modules/react-native-status"
   pod "Keycard", git: "https://github.com/status-im/Keycard.swift.git"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -28,10 +28,6 @@ PODS:
   - libwebp/mux (1.2.4):
     - libwebp/demux
   - libwebp/webp (1.2.4)
-  - Permission-Camera (3.8.0):
-    - RNPermissions
-  - Permission-Microphone (3.8.0):
-    - RNPermissions
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -495,7 +491,7 @@ PODS:
     - React-Core
   - RNLanguages (3.0.2):
     - React
-  - RNPermissions (3.8.0):
+  - RNPermissions (4.1.1):
     - React-Core
   - RNReactNativeHapticFeedback (1.9.0):
     - React
@@ -529,8 +525,6 @@ DEPENDENCIES:
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - Keycard (from `https://github.com/status-im/Keycard.swift.git`)
-  - Permission-Camera (from `../node_modules/react-native-permissions/ios/Camera/Permission-Camera.podspec`)
-  - Permission-Microphone (from `../node_modules/react-native-permissions/ios/Microphone/Permission-Microphone.podspec`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
@@ -633,10 +627,6 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   Keycard:
     :git: https://github.com/status-im/Keycard.swift.git
-  Permission-Camera:
-    :path: "../node_modules/react-native-permissions/ios/Camera/Permission-Camera.podspec"
-  Permission-Microphone:
-    :path: "../node_modules/react-native-permissions/ios/Microphone/Permission-Microphone.podspec"
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -793,19 +783,17 @@ CHECKOUT OPTIONS:
     :submodules: true
 
 SPEC CHECKSUMS:
-  boost: 64032b9e9b938fda23325e68a3771f0fabf414dc
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   BVLinearGradient: 612a04ff38e8480291f3379ee5b5a2c571f03fe0
   CryptoSwift: c4f2debceb38bf44c80659afe009f71e23e4a082
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 71803c074f6325f10b5ec891c443b6bbabef0ca7
   FBReactNativeSpec: 448e08a759d29a96e15725ae532445bf4343567c
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: cf171f517b828fdde711287b723e348da1ea0fc3
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   Keycard: ac6df4d91525c3c82635ac24d4ddd9a80aca5fc8
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
-  Permission-Camera: e6d142d7d8b714afe0a83e5e6ae17eb949f1e3e9
-  Permission-Microphone: 644b1de8bcc2afcaf934e09a22bee507a95796a7
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: df81ab637d35fac9e6eb94611cfd20f0feb05455
   RCTTypeSafety: 4636e4a36c7c2df332bda6d59b19b41c443d4287
@@ -870,7 +858,7 @@ SPEC CHECKSUMS:
   RNImageCropPicker: 486e2f7e2b0461ce24321f751410dce1b3b49e6d
   RNKeychain: a65256b6ca6ba6976132cc4124b238a5b13b3d9c
   RNLanguages: 962e562af0d34ab1958d89bcfdb64fafc37c513e
-  RNPermissions: 215c54462104b3925b412b0fb3c9c497b21c358b
+  RNPermissions: 9531f8dd275d9f56df1c452ef36c488bfd48fb1e
   RNReactNativeHapticFeedback: 2566b468cc8d0e7bb2f84b23adc0f4614594d071
   RNReanimated: fdbaa9c964bbab7fac50c90862b6cc5f041679b9
   RNShare: d82e10f6b7677f4b0048c23709bd04098d5aee6c
@@ -884,6 +872,6 @@ SPEC CHECKSUMS:
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   Yoga: 86fed2e4d425ee4c6eab3813ba1791101ee153c6
 
-PODFILE CHECKSUM: 3f98ce893757dfa17e609ef7cd24fa41635b73a6
+PODFILE CHECKSUM: d49001f1a40944ca42bd5604b6873ad879720e3c
 
 COCOAPODS: 1.12.0

--- a/nix/deps/gradle/deps.json
+++ b/nix/deps/gradle/deps.json
@@ -8064,16 +8064,16 @@
   },
 
   {
-    "path": "commons-codec/commons-codec/1.16.0",
+    "path": "commons-codec/commons-codec/1.16.1",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "commons-codec-1.16.0.pom": {
-        "sha1": "d1dacb885ae5c943234addcc73f473e609ca1248",
-        "sha256": "sha256-bLWVeBnfOTlW/TEaOgw/XuwevEm6Wy0J8/ROYWf6PnQ="
+      "commons-codec-1.16.1.pom": {
+        "sha1": "fdca64157d8fd070e24bd7d4ae9b8851d9ed9c0e",
+        "sha256": "sha256-uCbd2S+dfMZDcaAvoIMMFU1nyYNw6lSi0ZbnLrWQrSg="
       },
-      "commons-codec-1.16.0.jar": {
-        "sha1": "4e3eb3d79888d76b54e28b350915b5dc3919c9de",
-        "sha256": "sha256-VllfsgsLhbyR0NUD2tULt/G5r8Du1d/6bLslkpAASE0="
+      "commons-codec-1.16.1.jar": {
+        "sha1": "47bd4d333fba53406f6c6c51884ddbca435c8862",
+        "sha256": "sha256-7Ie/tV8iy9GyHiGQ7toosrMS7SpDHuSfvcwBgS0EpeQ="
       }
     }
   },
@@ -10724,16 +10724,16 @@
   },
 
   {
-    "path": "com/google/errorprone/error_prone_annotations/2.24.1",
+    "path": "com/google/errorprone/error_prone_annotations/2.25.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "error_prone_annotations-2.24.1.pom": {
-        "sha1": "e36d508134193b5b782a79cd834fef22f96850ea",
-        "sha256": "sha256-dW0LPDkGWZ2XMUDuziZuDej08ZKvFLGQBq8Un+kO+NU="
+      "error_prone_annotations-2.25.0.pom": {
+        "sha1": "1b4e6331c408121a28dc206201a34fc357369237",
+        "sha256": "sha256-tY153uGWjVjc6cWwPkIQbX3UwH9weOs5PGceWPI79hE="
       },
-      "error_prone_annotations-2.24.1.jar": {
-        "sha1": "32b299e45105aa9b0df8279c74dc1edfcf313ff0",
-        "sha256": "sha256-Gf4vcVXSDqCTFoUnmZ2pgQgQPuVG0ei3JrxLJ8MaPDA="
+      "error_prone_annotations-2.25.0.jar": {
+        "sha1": "2785894515fe631ca74ec5ccaeffe02aa7e8f065",
+        "sha256": "sha256-R9kcFB79ax2SMaMi3sqPTDLayOlAxsONdos2rdIhcA0="
       }
     }
   },
@@ -10827,12 +10827,12 @@
   },
 
   {
-    "path": "com/google/errorprone/error_prone_parent/2.24.1",
+    "path": "com/google/errorprone/error_prone_parent/2.25.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "error_prone_parent-2.24.1.pom": {
-        "sha1": "20bcb755b5f180723ef1b055f34a1834b7410f54",
-        "sha256": "sha256-y589WAUC7OXhJCnX96x1/kerhdat91zd+G+lokrvpI8="
+      "error_prone_parent-2.25.0.pom": {
+        "sha1": "8bb7eee325b64624640214388c824b2613089d62",
+        "sha256": "sha256-VnU95L6nogwp1plmfynylyfAu61c9plzqZQJRxjadcU="
       }
     }
   },
@@ -11344,12 +11344,12 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-bom/4.26.0-RC1",
+    "path": "com/google/protobuf/protobuf-bom/4.26.0-RC2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-bom-4.26.0-RC1.pom": {
-        "sha1": "95b890ee6f318b67514a9d3573c78aebfd8cf4c1",
-        "sha256": "sha256-rGscgQUEAvrvFw6SnyMSbIw7N0J6SEgo4bo8nmAbO04="
+      "protobuf-bom-4.26.0-RC2.pom": {
+        "sha1": "aeb31331e40cd3dc4e6cd425060b954836cc2c2a",
+        "sha256": "sha256-3f0uTDk61XKNx4f3CHni0CkURGNGaaBzmlzbd+TjTUM="
       }
     }
   },
@@ -11520,16 +11520,16 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-java/4.26.0-RC1",
+    "path": "com/google/protobuf/protobuf-java/4.26.0-RC2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-java-4.26.0-RC1.pom": {
-        "sha1": "9b053265705abd2eb8dd06831b4728ed19e8f79a",
-        "sha256": "sha256-cexXywR1/FPS885SUYezfvvww1TAjy6gAtAmxJVxn0Y="
+      "protobuf-java-4.26.0-RC2.pom": {
+        "sha1": "e80ddf7c903d9b539bee9fd2da2fa8eb9f0a6dce",
+        "sha256": "sha256-F22KJgv1xKm/gVwMYzcBS0BnXV2LdBYOUMrDrl6OS0Q="
       },
-      "protobuf-java-4.26.0-RC1.jar": {
-        "sha1": "a4718e6e4943736bb27aa3c7f8ef3c0a851c35b1",
-        "sha256": "sha256-cgTa51zMiegEQa2I9pyGy9psCQ5tPJU9MfMoC8DyDDg="
+      "protobuf-java-4.26.0-RC2.jar": {
+        "sha1": "1605d3b9a515f35d7d22c74d056febfb3d045793",
+        "sha256": "sha256-6aLoVu8x6q/Cd4ccTjLNGOAsqKCmoLyL2YOSz9uOLNM="
       }
     }
   },
@@ -11627,38 +11627,38 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-parent/4.26.0-RC1",
+    "path": "com/google/protobuf/protobuf-parent/4.26.0-RC2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-parent-4.26.0-RC1.pom": {
-        "sha1": "80963cafb79bc1b0f5dd2c1c82c67016c2362ad4",
-        "sha256": "sha256-n+4hEMufYvUwFQts4WiDUYKyGGnivQQhyc2bS7fODMs="
+      "protobuf-parent-4.26.0-RC2.pom": {
+        "sha1": "5b59bd23ed83183cc674a9ba65abd61d8dcc7c73",
+        "sha256": "sha256-almnkUtZHD69gSlBOOdnpAq+tR9VdRHcFi/G6mQL2Qk="
       }
     }
   },
 
   {
-    "path": "com/google/truth/truth-parent/1.4.0",
+    "path": "com/google/truth/truth-parent/1.4.1",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "truth-parent-1.4.0.pom": {
-        "sha1": "08b3f870d82e4e34caa1aa94ca03c29d9b40d3d2",
-        "sha256": "sha256-K+3ssiZ3EYKh/sxgh3NFLyTPuMEjreDzymb4pmmU3Gs="
+      "truth-parent-1.4.1.pom": {
+        "sha1": "2a40f89aec5545089a58012388e73d2eb03e53c4",
+        "sha256": "sha256-OubzkUkobHtq8UV9EwLiOhdmw/XsuNJpcxRWaVxkO2w="
       }
     }
   },
 
   {
-    "path": "com/google/truth/truth/1.4.0",
+    "path": "com/google/truth/truth/1.4.1",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "truth-1.4.0.pom": {
-        "sha1": "6ff4bdfe8a3758a755b52ad894b7d983c88e4850",
-        "sha256": "sha256-v4+lYqfRXWNEU9f/LidC/eACm2VNhwtK0uejf89mTnY="
+      "truth-1.4.1.pom": {
+        "sha1": "607152bb2cd37e548dc77878313302df762e0622",
+        "sha256": "sha256-k2rr1WZHd1ANtUYSZASZwDF89Tc0Sq4d36BdvzCGaEA="
       },
-      "truth-1.4.0.jar": {
-        "sha1": "2a9475ed8cf2081b859fda8f9c860d5c449cd9ed",
-        "sha256": "sha256-I1wo6W7mcBqwHMhS+ylMsPNHVvY2qBVLmu8I+xIVu8Q="
+      "truth-1.4.1.jar": {
+        "sha1": "212d306fd6b3f1157b5293ebcdb90224bbb5c24a",
+        "sha256": "sha256-N7xA+9mCndzmtOuHCgnUmV/9nBhx8LR9WWiAjXv+nEE="
       }
     }
   },
@@ -11882,20 +11882,20 @@
   },
 
   {
-    "path": "com/squareup/okio/okio-jvm/3.7.0",
+    "path": "com/squareup/okio/okio-jvm/3.8.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "okio-jvm-3.7.0.pom": {
-        "sha1": "14382d2a63e8b742f3d38c80479b7136e263ab58",
-        "sha256": "sha256-d07LnSsHlLT7J+eeCHYMpWC39U+qlRm5GDxn/rRfLJc="
+      "okio-jvm-3.8.0.pom": {
+        "sha1": "8712c5a431dd86a901bc890613202ab4c35f495c",
+        "sha256": "sha256-v4QMb2WRo8f9f092ya++HwXg0a2M1RaDpSko9p1RyUs="
       },
-      "okio-jvm-3.7.0.jar": {
-        "sha1": "276b999b41f7dcde00054848fc53af338d86b349",
-        "sha256": "sha256-2LNa3Ch2j0OuWv5qfRqiqHi6UeC5ak8wiBHzsfWxPlU="
+      "okio-jvm-3.8.0.jar": {
+        "sha1": "856593a7eb4dc94f9fe27b4a4d14624a8db9ffa7",
+        "sha256": "sha256-iPt59v4aRirPCjvSV2uhUlwp8pgl7+zuxwp0esHG/JA="
       },
-      "okio-jvm-3.7.0.module": {
-        "sha1": "39db5f722d75bf6f974e9448ccc136d559d65162",
-        "sha256": "sha256-b64CAbCuSKGWBt4Ab/6YQtjQ/CoeQ04Hhc7Ni3Wr5HQ="
+      "okio-jvm-3.8.0.module": {
+        "sha1": "b9cfc198ac2ad8bde3d6488ccab4ccbab536ba1c",
+        "sha256": "sha256-2GYvXpeluYF/0S0pFA410KOiPNdN4UU6jXyifVBlWck="
       }
     }
   },
@@ -12036,20 +12036,20 @@
   },
 
   {
-    "path": "com/squareup/okio/okio/3.7.0",
+    "path": "com/squareup/okio/okio/3.8.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "okio-3.7.0.pom": {
-        "sha1": "941b51284181fddbc2f25ca4c8a9a68232d59bf8",
-        "sha256": "sha256-H2KMRSg726uM4DwHps+3akeLjdrhgL2PNKusJz5Id24="
+      "okio-3.8.0.pom": {
+        "sha1": "199f67e2aff32a03363c15773d8f7ce01ced9675",
+        "sha256": "sha256-/vASWBErw/3ff18z2ewD6Q23hhv6QIPYHPDOTa1pnLo="
       },
-      "okio-3.7.0.jar": {
-        "sha1": "e4ccc4133d4657e86b7824a44a85c09319ecab11",
-        "sha256": "sha256-bvOnJZNuIlJB1K0SavmnyWgOS0r8G8Xtnn3TXwaJpNw="
+      "okio-3.8.0.jar": {
+        "sha1": "5f829888bf843b27297cab4fd2f678be4bd1bdb6",
+        "sha256": "sha256-bjtCC74nFctVSFCaguTOZ+syCq091h0LHBi0C126Ywc="
       },
-      "okio-3.7.0.module": {
-        "sha1": "c9fca4b848f14db865254f70a23b62283212fb30",
-        "sha256": "sha256-88rgCfC2yEL7vFLOd1QsGdGdVu6ZpeVVZH8Lr8nVDPo="
+      "okio-3.8.0.module": {
+        "sha1": "361643950bd41cd3e5bee81e79ef21cba52a1300",
+        "sha256": "sha256-ZqlWWun0Hir9D8mwL/OXYvkHeQPXq9ZfR37bnpfOB+Q="
       }
     }
   },
@@ -14345,17 +14345,6 @@
   },
 
   {
-    "path": "org/apache/apache/29",
-    "repo": "https://repo.maven.apache.org/maven2",
-    "files": {
-      "apache-29.pom": {
-        "sha1": "57991491045c9a37a3113f24bf29a41a4ceb1459",
-        "sha256": "sha256-PkkDcXSCC70N9jQgqXclWIY5iVTCoGKR+mH3J6w1s3c="
-      }
-    }
-  },
-
-  {
     "path": "org/apache/apache/31",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
@@ -14563,23 +14552,23 @@
   },
 
   {
-    "path": "org/apache/commons/commons-parent/58",
-    "repo": "https://repo.maven.apache.org/maven2",
-    "files": {
-      "commons-parent-58.pom": {
-        "sha1": "26758faad5d4d692a3cee724c42605d2ee9d5284",
-        "sha256": "sha256-LUsS4YiZBjq9fHUni1+pejcp2Ah4zuy2pA2UbpwNVZA="
-      }
-    }
-  },
-
-  {
     "path": "org/apache/commons/commons-parent/65",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
       "commons-parent-65.pom": {
         "sha1": "a5e6a3fd684242815f2ffd77ed8b316d549ed01b",
         "sha256": "sha256-bPNJX8LmrJE6K38uA/tZCPs/Ip+wbTNY3EVnjVrz424="
+      }
+    }
+  },
+
+  {
+    "path": "org/apache/commons/commons-parent/66",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-66.pom": {
+        "sha1": "24cf85c9d30c5ca5a2f48d806e93d8328b622a8c",
+        "sha256": "sha256-SP1tyEblax9AhmDRY+dTAPnjhLtjvkgqgIKiHXKo25w="
       }
     }
   },
@@ -17512,16 +17501,16 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-reflect/2.0.0-Beta3",
+    "path": "org/jetbrains/kotlin/kotlin-reflect/2.0.0-Beta4",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-reflect-2.0.0-Beta3.pom": {
-        "sha1": "dc97aad46542eaa0cb64120911ac1013483969ac",
-        "sha256": "sha256-NnPskjZQvqH3zdWL94mDT/EMvy51senYGEbKjz+ya64="
+      "kotlin-reflect-2.0.0-Beta4.pom": {
+        "sha1": "6834744376fbc0c42dbfe08ab4da5d85d2c9a4cb",
+        "sha256": "sha256-64jmvJJL3W2pNLma4vyOY/S3vMwT/1Vrvwp67/G5rPg="
       },
-      "kotlin-reflect-2.0.0-Beta3.jar": {
-        "sha1": "6915153788502bdccc98753f41dcbd5bf7c7e128",
-        "sha256": "sha256-k4zOXYaKP8MBwjWAOLuEt0ahsLlSHtdnldJma/o0e2Y="
+      "kotlin-reflect-2.0.0-Beta4.jar": {
+        "sha1": "bf5a66348110bc0139dbf1f4e146f3e694a5dcda",
+        "sha256": "sha256-uKPeNQr3jAqSqMWaeU53OBqssY4sSGwOuUThc3y9RV4="
       }
     }
   },
@@ -18769,28 +18758,28 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/2.0.0-Beta3",
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/2.0.0-Beta4",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-stdlib-2.0.0-Beta3.pom": {
-        "sha1": "1005b3f259dffb93f972e5227eb18fc579b71811",
-        "sha256": "sha256-2qxjaqrwUBME9CbB4lpEKGV4qi2VGn8USteyCSZ8lq4="
+      "kotlin-stdlib-2.0.0-Beta4.pom": {
+        "sha1": "45487dfd8dfba273251afd0ddf7b58d1df30b864",
+        "sha256": "sha256-zPRp0yjWK+zWExaRp+wOJ6Wnkzk2SrnAjroptmNdmeg="
       },
-      "kotlin-stdlib-2.0.0-Beta3-all.jar": {
-        "sha1": "845c7a75152307a41522e800bb9706a58e02b228",
-        "sha256": "sha256-YwNHMM8zT64dAULHPNt+zLXQ5xTeAvtP/HKybthMDWI="
+      "kotlin-stdlib-2.0.0-Beta4-all.jar": {
+        "sha1": "b00b6c228abd69d305eeda3b4bf67f07a9c3ce77",
+        "sha256": "sha256-QXgmSNaBXY9bucRBarhywPIhoOwBt23SijQvt74ESeY="
       },
-      "kotlin-stdlib-2.0.0-Beta3-common.jar": {
-        "sha1": "e0224f6b9468655e1feffe789ab7ebd4965a9431",
-        "sha256": "sha256-ikItp8AZFxM/bokvCF68e2Q+oNGbbJxTILtPDnj7uMI="
+      "kotlin-stdlib-2.0.0-Beta4-common.jar": {
+        "sha1": "f37c50e38e7190bbe0123658dfd05e47ef25c07d",
+        "sha256": "sha256-hh6hY0GyabJUvh+oSaIhtr2QNMfwy6XHjUdDdhg1FNk="
       },
-      "kotlin-stdlib-2.0.0-Beta3.jar": {
-        "sha1": "9982637ebb69602015ed823cceca7054d2ab8bbe",
-        "sha256": "sha256-1+6KuGuMgmiuPLpxx+cJSZ3/pnVOMmLdtzmk3mwB0ro="
+      "kotlin-stdlib-2.0.0-Beta4.jar": {
+        "sha1": "a586d3149d30177032b6d1aeae312fd6e62a5cac",
+        "sha256": "sha256-cQymYm/6T4avBVqk8+v2PdQ4pHjHzuQykORlBs7O35o="
       },
-      "kotlin-stdlib-2.0.0-Beta3.module": {
-        "sha1": "5026675037ebf81e108eb3cc581a24570ec7ceb2",
-        "sha256": "sha256-rlVFQM89Ga0h57LsViIgT8iSdE18G0rd/TN7/u9UKrU="
+      "kotlin-stdlib-2.0.0-Beta4.module": {
+        "sha1": "cf8b777ca443856f3dd39575629388623594928d",
+        "sha256": "sha256-4hE48x2ywQoJQFPCri5VaaWa10Z40KsdPPM+AI/QOyA="
       }
     }
   },
@@ -18995,16 +18984,16 @@
   },
 
   {
-    "path": "org/json/json/20231013",
+    "path": "org/json/json/20240205",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "json-20231013.pom": {
-        "sha1": "e96348a6a6d298fa54380d714a8bbdc4399cc008",
-        "sha256": "sha256-xQBAI9OfVGNbNbvrQOIaKtVR/KDy41Cxzje9DnyypGY="
+      "json-20240205.pom": {
+        "sha1": "f0008ac56b261c434f50ab988e45a9ff85cffe90",
+        "sha256": "sha256-rl9XLISkLFuXMdP4IYdOTusS8139wHDMKzlbFDkeKEw="
       },
-      "json-20231013.jar": {
-        "sha1": "e22e0c040fe16f04ffdb85d851d77b07fc05ea52",
-        "sha256": "sha256-DxgZLfKJEU4XqhoNCn+DcsyfXH5Pfjmtz4kG/nFPp9M="
+      "json-20240205.jar": {
+        "sha1": "c8498148ba08ba5bb25339dfb70c44fb09ed4670",
+        "sha256": "sha256-6J32FGbwgH+KhtsOiAWoN+WUYsjKR8Z3huQyEzxJCso="
       }
     }
   },

--- a/nix/deps/gradle/deps.urls
+++ b/nix/deps/gradle/deps.urls
@@ -506,7 +506,7 @@ https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.6/commons-cod
 https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.pom
 https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.10/commons-codec-1.10.pom
 https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.11/commons-codec-1.11.pom
-https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.16.0/commons-codec-1.16.0.pom
+https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.16.1/commons-codec-1.16.1.pom
 https://repo.maven.apache.org/maven2/commons-io/commons-io/2.4/commons-io-2.4.pom
 https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.pom
 https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.pom
@@ -670,7 +670,7 @@ https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotatio
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.4.0/error_prone_annotations-2.4.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.7.1/error_prone_annotations-2.7.1.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.9.0/error_prone_annotations-2.9.0.pom
-https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.24.1/error_prone_annotations-2.24.1.pom
+https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.25.0/error_prone_annotations-2.25.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.0.18/error_prone_parent-2.0.18.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.2.0/error_prone_parent-2.2.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.3.1/error_prone_parent-2.3.1.pom
@@ -679,7 +679,7 @@ https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.4.0/error_prone_parent-2.4.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.7.1/error_prone_parent-2.7.1.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.9.0/error_prone_parent-2.9.0.pom
-https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.24.1/error_prone_parent-2.24.1.pom
+https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.25.0/error_prone_parent-2.25.0.pom
 https://repo.maven.apache.org/maven2/com/google/flatbuffers/flatbuffers-java/1.12.0/flatbuffers-java-1.12.0.pom
 https://repo.maven.apache.org/maven2/com/google/google/1/google-1.pom
 https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom
@@ -718,7 +718,7 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.7.1/prot
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.10.0/protobuf-bom-3.10.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.13.0/protobuf-bom-3.13.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.17.2/protobuf-bom-3.17.2.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/4.26.0-RC1/protobuf-bom-4.26.0-RC1.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/4.26.0-RC2/protobuf-bom-4.26.0-RC2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-javalite/3.17.2/protobuf-javalite-3.17.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java-util/3.4.0/protobuf-java-util-3.4.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java-util/3.10.0/protobuf-java-util-3.10.0.pom
@@ -730,7 +730,7 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.7.1/pro
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.10.0/protobuf-java-3.10.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.13.0/protobuf-java-3.13.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.17.2/protobuf-java-3.17.2.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/4.26.0-RC1/protobuf-java-4.26.0-RC1.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/4.26.0-RC2/protobuf-java-4.26.0-RC2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-lite/3.0.1/protobuf-lite-3.0.1.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.0.0/protobuf-parent-3.0.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.4.0/protobuf-parent-3.4.0.pom
@@ -739,9 +739,9 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.7.1/p
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.10.0/protobuf-parent-3.10.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.13.0/protobuf-parent-3.13.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.17.2/protobuf-parent-3.17.2.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/4.26.0-RC1/protobuf-parent-4.26.0-RC1.pom
-https://repo.maven.apache.org/maven2/com/google/truth/truth-parent/1.4.0/truth-parent-1.4.0.pom
-https://repo.maven.apache.org/maven2/com/google/truth/truth/1.4.0/truth-1.4.0.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/4.26.0-RC2/protobuf-parent-4.26.0-RC2.pom
+https://repo.maven.apache.org/maven2/com/google/truth/truth-parent/1.4.1/truth-parent-1.4.1.pom
+https://repo.maven.apache.org/maven2/com/google/truth/truth/1.4.1/truth-1.4.1.pom
 https://repo.maven.apache.org/maven2/com/ibm/icu/icu4j/53.1/icu4j-53.1.pom
 https://repo.maven.apache.org/maven2/com/intellij/annotations/12.0/annotations-12.0.pom
 https://repo.maven.apache.org/maven2/com/parse/bolts/bolts-tasks/1.4.0/bolts-tasks-1.4.0.pom
@@ -756,7 +756,7 @@ https://repo.maven.apache.org/maven2/com/squareup/okhttp3/okhttp/3.12.1/okhttp-3
 https://repo.maven.apache.org/maven2/com/squareup/okhttp3/okhttp/4.9.2/okhttp-4.9.2.pom
 https://repo.maven.apache.org/maven2/com/squareup/okhttp3/parent/3.9.1/parent-3.9.1.pom
 https://repo.maven.apache.org/maven2/com/squareup/okhttp3/parent/3.12.1/parent-3.12.1.pom
-https://repo.maven.apache.org/maven2/com/squareup/okio/okio-jvm/3.7.0/okio-jvm-3.7.0.pom
+https://repo.maven.apache.org/maven2/com/squareup/okio/okio-jvm/3.8.0/okio-jvm-3.8.0.pom
 https://repo.maven.apache.org/maven2/com/squareup/okio/okio-metadata/2.8.0/okio-metadata-2.8.0.pom
 https://repo.maven.apache.org/maven2/com/squareup/okio/okio-parent/1.13.0/okio-parent-1.13.0.pom
 https://repo.maven.apache.org/maven2/com/squareup/okio/okio-parent/1.15.0/okio-parent-1.15.0.pom
@@ -766,7 +766,7 @@ https://repo.maven.apache.org/maven2/com/squareup/okio/okio/1.15.0/okio-1.15.0.p
 https://repo.maven.apache.org/maven2/com/squareup/okio/okio/1.17.4/okio-1.17.4.pom
 https://repo.maven.apache.org/maven2/com/squareup/okio/okio/2.8.0/okio-2.8.0.pom
 https://repo.maven.apache.org/maven2/com/squareup/okio/okio/2.9.0/okio-2.9.0.pom
-https://repo.maven.apache.org/maven2/com/squareup/okio/okio/3.7.0/okio-3.7.0.pom
+https://repo.maven.apache.org/maven2/com/squareup/okio/okio/3.8.0/okio-3.8.0.pom
 https://repo.maven.apache.org/maven2/com/sun/activation/all/1.2.0/all-1.2.0.pom
 https://repo.maven.apache.org/maven2/com/sun/activation/all/1.2.1/all-1.2.1.pom
 https://repo.maven.apache.org/maven2/com/sun/activation/all/1.2.2/all-1.2.2.pom
@@ -933,7 +933,6 @@ https://repo.maven.apache.org/maven2/org/apache/apache/15/apache-15.pom
 https://repo.maven.apache.org/maven2/org/apache/apache/16/apache-16.pom
 https://repo.maven.apache.org/maven2/org/apache/apache/18/apache-18.pom
 https://repo.maven.apache.org/maven2/org/apache/apache/21/apache-21.pom
-https://repo.maven.apache.org/maven2/org/apache/apache/29/apache-29.pom
 https://repo.maven.apache.org/maven2/org/apache/apache/31/apache-31.pom
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.8.1/commons-compress-1.8.1.pom
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.12/commons-compress-1.12.pom
@@ -951,8 +950,8 @@ https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/35/common
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/39/commons-parent-39.pom
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/42/commons-parent-42.pom
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/48/commons-parent-48.pom
-https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/58/commons-parent-58.pom
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/65/commons-parent-65.pom
+https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/66/commons-parent-66.pom
 https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.1.1/httpclient-4.1.1.pom
 https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.2.6/httpclient-4.2.6.pom
 https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2.pom
@@ -1146,7 +1145,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.20/kotlin-reflect-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.7.10/kotlin-reflect-1.7.10.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.7.22/kotlin-reflect-1.7.22.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.0.0-Beta3/kotlin-reflect-2.0.0-Beta3.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.0.0-Beta4/kotlin-reflect-2.0.0-Beta4.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.6.20/kotlin-scripting-common-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.7.22/kotlin-scripting-common-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.9.0/kotlin-scripting-common-1.9.0.pom
@@ -1229,7 +1228,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.7.10/k
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.7.22/kotlin-stdlib-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.0/kotlin-stdlib-1.9.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.21/kotlin-stdlib-1.9.21.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.0.0-Beta3/kotlin-stdlib-2.0.0-Beta3.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.0.0-Beta4/kotlin-stdlib-2.0.0-Beta4.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/1.7.22/kotlin-tooling-core-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/1.9.0/kotlin-tooling-core-1.9.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-metadata/1.6.20/kotlin-tooling-metadata-1.6.20.pom
@@ -1243,7 +1242,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/markdown-jvm/0.2.1/markdown-j
 https://repo.maven.apache.org/maven2/org/jetbrains/markdown/0.2.1/markdown-0.2.1.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824.pom
 https://repo.maven.apache.org/maven2/org/json/json/20180813/json-20180813.pom
-https://repo.maven.apache.org/maven2/org/json/json/20231013/json-20231013.pom
+https://repo.maven.apache.org/maven2/org/json/json/20240205/json-20240205.pom
 https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.13.1/jsoup-1.13.1.pom
 https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.2/junit-bom-5.9.2.pom
 https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-native-mail": "git+https://github.com/status-im/react-native-mail.git#refs/tags/v6.1.2-status",
     "react-native-navigation": "7.37.0",
     "react-native-orientation-locker": "^1.5.0",
-    "react-native-permissions": "3.8.0",
+    "react-native-permissions": "4.1.1",
     "react-native-randombytes": "^3.6.1",
     "react-native-reanimated": "3.6.1",
     "react-native-redash": "18.1.0",

--- a/src/legacy/status_im/ui/screens/notifications_settings/views.cljs
+++ b/src/legacy/status_im/ui/screens/notifications_settings/views.cljs
@@ -5,6 +5,7 @@
     [legacy.status-im.ui.components.list.item :as list.item]
     [legacy.status-im.ui.components.react :as react]
     [react-native.platform :as platform]
+    [taoensso.timbre :as log]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -56,7 +57,14 @@
        :accessibility-label :local-notifications-settings-button
        :subtitle            (i18n/label :t/local-notifications-subtitle)
        :active              notifications-enabled?
-       :on-press            #(rf/dispatch [:push-notifications/switch (not notifications-enabled?)])
+       :on-press            (fn []
+                              (rf/dispatch
+                               [:request-permissions
+                                {:permissions [:post-notifications]
+                                 :on-allowed  #(rf/dispatch [:push-notifications/switch
+                                                             (not notifications-enabled?)])
+                                 :on-denied   #(log/error
+                                                "user denied push notification permissions")}]))
        :accessory           :switch}]]))
 
 (defn notifications-settings

--- a/yarn.lock
+++ b/yarn.lock
@@ -7865,13 +7865,6 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pkg-dir@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
-  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
-  dependencies:
-    find-up "^5.0.0"
-
 pngjs@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
@@ -8316,13 +8309,10 @@ react-native-orientation-locker@^1.5.0:
   resolved "https://registry.yarnpkg.com/react-native-orientation-locker/-/react-native-orientation-locker-1.5.0.tgz#324853937eed4835ecd1c8613ab2206135d908ac"
   integrity sha512-4XOCGmNN4BXg5JUFjUuXpsfhPJmbA3LkQilJO1ed+6vL97teTdG2w5IEevKiqL9/hPjeWE8YYtX/YW+yp53hkg==
 
-react-native-permissions@3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.8.0.tgz#7c1f75ae126c7d0b863eec9d2f5cd93ff8ad8310"
-  integrity sha512-BfZ7ksgdpGchHZH8M/kxCGZbWeACANbnPmb3hNjVOMDQusc4PWlPpobX3eBqYMSKbpi7bMECeV9BVU4QuwAf9A==
-  dependencies:
-    picocolors "^1.0.0"
-    pkg-dir "^5.0.0"
+react-native-permissions@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-4.1.1.tgz#6c185f9ec45069fa14cf8992bed6b67fc8981478"
+  integrity sha512-wdIHMwmDZ6pRVsgAgF7mn/pJEuJd5wJDGENqvFDJs2lW4BSZeN++ZFsA6FgOqUs/2276Oj7rslQgVaxdOsi6yw==
 
 react-native-randombytes@^3.5.1, react-native-randombytes@^3.6.1:
   version "3.6.1"


### PR DESCRIPTION
related to  #18251

## Summary

The Android app would not ask for permissions to show push notifications if the permissions were skipped during login but later enabled via settings.
This PR fixes that.
We also take this opportunity to upgrade `react-native-permissions` library to `4.1.1`
 
## Testing notes
- Create fresh account.
- Don't give notification permissions during onboarding.
- Go to Profile > Notifications.
- Enable "Local Notifications" switch.
- You would now get a permissions prompt on Android 13 and above.

## Platforms
- Android

## Screenshot
<img width="515" alt="Screenshot 2024-02-18 at 2 41 42 AM" src="https://github.com/status-im/status-mobile/assets/64726664/81ce31e2-488b-41c2-8ff8-b3ce98874264">


status: ready
