### PR TITLE
feat: update transaction confirmation page to support bridging txs

### DIFF
--- a/src/quo/components/wallet/summary_info/view.cljs
+++ b/src/quo/components/wallet/summary_info/view.cljs
@@ -30,8 +30,8 @@
 (defn networks
   [values theme]
   (let [{:keys [ethereum optimism arbitrum]} values
-        show-optimism?                       (pos? optimism)
-        show-arbitrum?                       (pos? arbitrum)]
+        show-optimism?                       (and optimism (pos? (:amount optimism)))
+        show-arbitrum?                       (and arbitrum (pos? (:amount arbitrum)))]
     [rn/view
      {:style               style/networks-container
       :accessibility-label :networks}

--- a/src/quo/foundations/resources.cljs
+++ b/src/quo/foundations/resources.cljs
@@ -35,6 +35,7 @@
 (def ^:private networks
   {:arbitrum (js/require "../resources/images/networks/Arbitrum.png")
    :ethereum (js/require "../resources/images/networks/Ethereum.png")
+   :mainnet  (js/require "../resources/images/networks/Ethereum.png")
    :gnosis   (js/require "../resources/images/networks/Gnosis.png")
    :hermez   (js/require "../resources/images/networks/Hermez.png")
    :optimism (js/require "../resources/images/networks/Optimism.png")

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -429,7 +429,11 @@
 (def ^:const optimism-short-name "opt")
 (def ^:const arbitrum-short-name "arb1")
 
-(def ^:const mainnet-network-name :ethereum)
+(def ^:const mainnet-abbreviated-name "Eth.")
+(def ^:const optimism-abbreviated-name "Opt.")
+(def ^:const arbitrum-abbreviated-name "Arb1.")
+
+(def ^:const mainnet-network-name :mainnet)
 (def ^:const optimism-network-name :optimism)
 (def ^:const arbitrum-network-name :arbitrum)
 

--- a/src/status_im/contexts/wallet/account/bridge_send/view.cljs
+++ b/src/status_im/contexts/wallet/account/bridge_send/view.cljs
@@ -11,9 +11,10 @@
   []
   [rn/view {:style style/bridge-send-wrapper}
    [input-amount/view
-    {:button-one-label (i18n/label :t/confirm-bridge)
-     :button-one-props {:icon-left :i/bridge}
-     :on-navigate-back (fn []
-                         (rf/dispatch [:navigate-back-within-stack :wallet-bridge-send]))}]])
+    {:current-screen-id :wallet-bridge-send
+     :button-one-label  (i18n/label :t/confirm-bridge)
+     :button-one-props  {:icon-left :i/bridge}
+     :on-navigate-back  (fn []
+                          (rf/dispatch [:navigate-back-within-stack :wallet-bridge-send]))}]])
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/common/utils/send.cljs
+++ b/src/status_im/contexts/wallet/common/utils/send.cljs
@@ -16,3 +16,7 @@
       (let [gas-price     (money/bignumber (get gas-fees :gas-price))
             total-gas-fee (money/mul gas-amount gas-price)]
         (money/with-precision (money/div total-gas-fee billion) 10)))))
+
+(defn calculate-full-route-gas-fee
+  [route]
+  (reduce money/add (map calculate-gas-fee route)))

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -43,14 +43,14 @@
                                                   :total-balance              100
                                                   :market-values-per-currency {:usd {:price 10}}}
    :wallet/wallet-send-loading-suggested-routes? false
-   :wallet/wallet-send-route                     {:from       {:chainid                1
-                                                               :native-currency-symbol "ETH"}
-                                                  :to         {:chain-id               1
-                                                               :native-currency-symbol "ETH"}
-                                                  :gas-amount "23487"
-                                                  :gas-fees   {:base-fee                 "32.325296406"
-                                                               :max-priority-fee-per-gas "0.011000001"
-                                                               :eip1559-enabled          true}}
+   :wallet/wallet-send-route                     [{:from       {:chainid                1
+                                                                :native-currency-symbol "ETH"}
+                                                   :to         {:chain-id               1
+                                                                :native-currency-symbol "ETH"}
+                                                   :gas-amount "23487"
+                                                   :gas-fees   {:base-fee                 "32.325296406"
+                                                                :max-priority-fee-per-gas "0.011000001"
+                                                                :eip1559-enabled          true}}]
    :wallet/wallet-send-suggested-routes          {:candidates []}
    :wallet/wallet-send-selected-networks         []
    :navigation/current-screen-id                 :wallet-send-input-amount

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -131,6 +131,7 @@
                          (rf/dispatch [:wallet/clean-scanned-address])
                          (rf/dispatch [:wallet/clean-local-suggestions])
                          (rf/dispatch [:wallet/clean-selected-token])
+                         (rf/dispatch [:wallet/clean-selected-collectible])
                          (rf/dispatch [:wallet/clean-send-address])
                          (rf/dispatch [:wallet/select-address-tab nil])
                          (rf/dispatch [:navigate-back]))

--- a/src/status_im/contexts/wallet/send/send_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/send_amount/view.cljs
@@ -8,9 +8,11 @@
 (defn- view-internal
   []
   [input-amount/view
-   {:button-one-label (i18n/label :t/confirm)
-    :on-navigate-back (fn []
-                        (rf/dispatch [:wallet/clean-selected-token])
-                        (rf/dispatch [:navigate-back-within-stack :wallet-send-input-amount]))}])
+   {:current-screen-id :wallet-send-input-amount
+    :button-one-label  (i18n/label :t/confirm)
+    :on-navigate-back  (fn []
+                         (rf/dispatch [:wallet/clean-selected-token])
+                         (rf/dispatch [:wallet/clean-selected-collectible])
+                         (rf/dispatch [:navigate-back-within-stack :wallet-send-input-amount]))}])
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -1,7 +1,9 @@
 (ns status-im.contexts.wallet.send.transaction-confirmation.view
   (:require
     [clojure.string :as string]
+    [legacy.status-im.utils.hex :as utils.hex]
     [legacy.status-im.utils.utils :as utils]
+    [native-module.core :as native-module]
     [quo.core :as quo]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
@@ -10,73 +12,168 @@
     [status-im.common.standard-authentication.core :as standard-auth]
     [status-im.contexts.wallet.send.transaction-confirmation.style :as style]
     [utils.i18n :as i18n]
+    [utils.money :as money]
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
 
 (defn- transaction-title
-  [{:keys [token-symbol amount account to-address image-url collectible?]}]
-  [rn/view {:style style/content-container}
-   [rn/view {:style {:flex-direction :row}}
-    [quo/text
-     {:size                :heading-1
-      :weight              :semi-bold
-      :style               style/title-container
-      :accessibility-label :send-label}
-     (i18n/label :t/send)]
-    [quo/summary-tag
-     {:token        (if collectible? "" token-symbol)
-      :label        (str amount " " token-symbol)
-      :type         (if collectible? :collectible :token)
-      :image-source (if collectible? image-url :eth)}]]
-   [rn/view
-    {:style {:flex-direction :row
-             :margin-top     4}}
-    [quo/text
-     {:size                :heading-1
-      :weight              :semi-bold
-      :style               style/title-container
-      :accessibility-label :send-label}
-     (i18n/label :t/from)]
-    [quo/summary-tag
-     {:label               (:name account)
-      :type                :account
-      :emoji               (:emoji account)
-      :customization-color (:color account)}]]
-   [rn/view
-    {:style {:flex-direction :row
-             :margin-top     4}}
-    [quo/text
-     {:size                :heading-1
-      :weight              :semi-bold
-      :style               style/title-container
-      :accessibility-label :send-label}
-     (i18n/label :t/to)]
-    [quo/summary-tag
-     {:type  :address
-      :label (utils/get-shortened-address to-address)}]]])
+  [{:keys [token-symbol amount account to-address route to-network image-url transaction-type
+           collectible?]}]
+  (let [to-network-name  (:network-name to-network)
+        to-network-color (if (= to-network-name :mainnet) :ethereum to-network-name)]
+    [rn/view {:style style/content-container}
+     [rn/view {:style {:flex-direction :row}}
+      [quo/text
+       {:size                :heading-1
+        :weight              :semi-bold
+        :style               style/title-container
+        :accessibility-label :send-label}
+       (if (= transaction-type :bridge)
+         (i18n/label :t/bridge)
+         (i18n/label :t/send))]
+      [quo/summary-tag
+       {:token        (if collectible? "" token-symbol)
+        :label        (str amount " " token-symbol)
+        :type         (if collectible? :collectible :token)
+        :image-source (if collectible? image-url :eth)}]]
+     (if (= transaction-type :bridge)
+       (map-indexed
+        (fn [idx path]
+          (let [from-network             (:from path)
+                chain-id                 (:chain-id from-network)
+                network                  (rf/sub [:wallet/network-details-by-chain-id
+                                                  chain-id])
+                network-name             (:network-name network)
+                network-name-text        (name network-name)
+                network-name-capitalized (when (seq network-name-text)
+                                           (string/capitalize network-name-text))
+                network-color            (if (= network-name :mainnet) :ethereum network-name)]
+            [rn/view
+             {:style {:flex-direction :row
+                      :margin-top     4}}
+             (if (zero? idx)
+               [:<>
+                [quo/text
+                 {:size                :heading-1
+                  :weight              :semi-bold
+                  :style               style/title-container
+                  :accessibility-label :send-label}
+                 (i18n/label :t/from)]
+                [quo/summary-tag
+                 {:label               network-name-capitalized
+                  :type                :network
+                  :image-source        (:source network)
+                  :customization-color network-color}]]
+               [:<>
+                [quo/text
+                 {:size                :heading-1
+                  :weight              :semi-bold
+                  :style               style/title-container
+                  :accessibility-label :send-label}
+                 (str (i18n/label :t/and) " ")]
+                [quo/summary-tag
+                 {:label               network-name-capitalized
+                  :type                :network
+                  :image-source        (:source network)
+                  :customization-color network-color}]])]))
+        route)
+       [rn/view
+        {:style {:flex-direction :row
+                 :margin-top     4}}
+        [quo/text
+         {:size                :heading-1
+          :weight              :semi-bold
+          :style               style/title-container
+          :accessibility-label :send-label}
+         (i18n/label :t/from)]
+        [quo/summary-tag
+         {:label               (:name account)
+          :type                :account
+          :emoji               (:emoji account)
+          :customization-color (:color account)}]])
+     [rn/view
+      {:style {:flex-direction :row
+               :margin-top     4}}
+      [quo/text
+       {:size                :heading-1
+        :weight              :semi-bold
+        :style               style/title-container
+        :accessibility-label :send-label}
+       (i18n/label :t/to)]
+      (if (= transaction-type :bridge)
+        [quo/summary-tag
+         {:type                :network
+          :image-source        (:source to-network)
+          :label               (string/capitalize (name (:network-name to-network)))
+          :customization-color to-network-color}]
+        [quo/summary-tag
+         {:type  :address
+          :label (utils/get-shortened-address to-address)}])]
+     (when (= transaction-type :bridge)
+       [rn/view
+        {:style {:flex-direction :row
+                 :margin-top     4}}
+        [quo/text
+         {:size                :heading-1
+          :weight              :semi-bold
+          :style               style/title-container
+          :accessibility-label :send-label}
+         (i18n/label :t/in)]
+        [quo/summary-tag
+         {:label               (:name account)
+          :type                :account
+          :emoji               (:emoji account)
+          :customization-color (:color account)}]])]))
 
 (defn- user-summary
-  [{:keys [amount token-symbol account-props theme label accessibility-label summary-type]}]
-  [rn/view
-   {:style {:padding-horizontal 20
-            :padding-bottom     16}}
-   [quo/text
-    {:size                :paragraph-2
-     :weight              :medium
-     :style               (style/section-label theme)
-     :accessibility-label accessibility-label}
-    label]
-   [quo/summary-info
-    {:type          summary-type
-     :networks?     true
-     :values        {:ethereum {:amount       amount
-                                :token-symbol token-symbol}}
-     :account-props account-props}]])
+  [{:keys [token-symbol token-decimals account-props route to? theme label accessibility-label
+           summary-type]}]
+  (letfn [(merge-sum [a b]
+            (merge-with money/add a b))]
+    (let [network-amounts
+          (reduce (fn [acc path]
+                    (let [network         (if to? (:to path) (:from path))
+                          chain-id        (:chain-id network)
+                          amount-hex      (if to? (:amount-in path) (:amount-out path))
+                          amount-units    (native-module/hex-to-number
+                                           (utils.hex/normalize-hex amount-hex))
+                          amount          (money/with-precision
+                                           (if (= token-symbol "ETH")
+                                             (money/wei->ether amount-units)
+                                             (money/token->unit amount-units
+                                                                token-decimals))
+                                           6)
+                          network-details (rf/sub [:wallet/network-details-by-chain-id chain-id])
+                          network-name    (:network-name network-details)
+                          network-name    (if (= network-name :mainnet) :ethereum network-name)]
+                      (merge-sum acc {network-name amount})))
+                  {}
+                  route)
+          network-values
+          (reduce-kv (fn [acc k v]
+                       (assoc acc k {:amount v :token-symbol token-symbol}))
+                     {}
+                     network-amounts)]
+      [rn/view
+       {:style {:padding-horizontal 20
+                :padding-bottom     16}}
+       [quo/text
+        {:size                :paragraph-2
+         :weight              :medium
+         :style               (style/section-label theme)
+         :accessibility-label accessibility-label}
+        label]
+       [quo/summary-info
+        {:type          summary-type
+         :networks?     true
+         :values        network-values
+         :account-props account-props}]])))
 
 (defn- transaction-details
-  [{:keys [estimated-time-min max-fees token-symbol amount to-address route theme]}]
+  [{:keys [estimated-time-min max-fees token-symbol amount to-address to-network route transaction-type
+           theme]}]
   (let [currency-symbol           (rf/sub [:profile/currency-symbol])
-        route-loaded?             (some? route)
+        route-loaded?             (and route (seq route))
         loading-suggested-routes? (rf/sub [:wallet/wallet-send-loading-suggested-routes?])]
     [rn/view
      {:style style/details-title-container}
@@ -129,7 +226,10 @@
            :label           :none
            :status          :default
            :size            :small
-           :title           (i18n/label :t/user-gets {:name (utils/get-shortened-address to-address)})
+           :title           (if (= transaction-type :bridge)
+                              (i18n/label :t/bridged-to
+                                          {:network (:abbreviated-name to-network)})
+                              (i18n/label :t/user-gets {:name (utils/get-shortened-address to-address)}))
            :subtitle        (str amount " " token-symbol)}]]
         :else
         [quo/text {:style {:align-self :center}}
@@ -137,7 +237,10 @@
 
 (defn- view-internal
   [_]
-  (let [on-close #(rf/dispatch [:navigate-back-within-stack :wallet-select-asset])]
+  (let [on-close (fn []
+                   (rf/dispatch [:navigate-back-within-stack :wallet-transaction-confirmation])
+                   (rf/dispatch [:wallet/clean-suggested-routes])
+                   (rf/dispatch [:wallet/clean-selected-collectible]))]
     (fn [{:keys [theme]}]
       (let [send-transaction-data (rf/sub [:wallet/wallet-send])
             token                 (:token send-transaction-data)
@@ -151,14 +254,19 @@
                                             [(:name collectible-data)
                                              (str (:name collection-data) " #" collectible-id)]))
                                     (:symbol token))
+            token-decimals        (if collectible 0 (:decimals token))
             image-url             (when collectible (:image-url collectible-data))
             amount                (:amount send-transaction-data)
             route                 (:route send-transaction-data)
-            estimated-time-min    (:estimated-time route)
+            transaction-type      (:type send-transaction-data)
+            estimated-time-min    (reduce + (map :estimated-time route))
             max-fees              "-"
             to-address            (:to-address send-transaction-data)
             account               (rf/sub [:wallet/current-viewing-account])
             account-color         (:color account)
+            bridge-to-chain-id    (:bridge-to-chain-id send-transaction-data)
+            bridge-to-network     (when bridge-to-chain-id
+                                    (rf/sub [:wallet/network-details-by-chain-id bridge-to-chain-id]))
             from-account-props    {:customization-color account-color
                                    :size                32
                                    :emoji               (:emoji account)
@@ -176,15 +284,13 @@
                                        :on-press            on-close
                                        :margin-top          (safe-area/get-top)
                                        :background          :blur
-                                       :accessibility-label :top-bar
-                                       :right-side          [{:icon-name           :i/advanced
-                                                              :on-press            #(js/alert
-                                                                                     "to be implemented")
-                                                              :accessibility-label :advanced-options}]}]
-           :footer                   (when route
+                                       :accessibility-label :top-bar}]
+           :footer                   (when (and route (seq route))
                                        [standard-auth/slide-button
                                         {:size                :size-48
-                                         :track-text          (i18n/label :t/slide-to-send)
+                                         :track-text          (if (= transaction-type :bridge)
+                                                                (i18n/label :t/slide-to-bridge)
+                                                                (i18n/label :t/slide-to-send))
                                          :container-style     {:z-index 2}
                                          :customization-color account-color
                                          :on-auth-success     #(rf/dispatch
@@ -196,27 +302,38 @@
            :customization-color      (:color account)}
           [rn/view
            [transaction-title
-            {:token-symbol token-symbol
-             :amount       amount
-             :account      account
-             :to-address   to-address
-             :image-url    image-url
-             :collectible? (some? collectible)}]
+            {:token-symbol     token-symbol
+             :amount           amount
+             :account          account
+             :to-address       to-address
+             :route            route
+             :to-network       bridge-to-network
+             :image-url        image-url
+             :transaction-type transaction-type
+             :collectible?     (some? collectible)}]
            [user-summary
-            {:amount              amount
-             :token-symbol        token-symbol
+            {:token-symbol        token-symbol
+             :token-decimals      token-decimals
              :summary-type        :status-account
              :accessibility-label :summary-from-label
              :label               (i18n/label :t/from-capitalized)
+             :route               route
+             :to?                 false
              :account-props       from-account-props
              :theme               theme}]
            [user-summary
-            {:amount              amount
-             :token-symbol        token-symbol
-             :summary-type        :account
+            {:token-symbol        token-symbol
+             :token-decimals      token-decimals
+             :summary-type        (if (= transaction-type :bridge)
+                                    :status-account
+                                    :account)
              :accessibility-label :summary-to-label
              :label               (i18n/label :t/to-capitalized)
-             :account-props       user-props
+             :account-props       (if (= transaction-type :bridge)
+                                    from-account-props
+                                    user-props)
+             :route               route
+             :to?                 true
              :theme               theme}]
            [transaction-details
             {:estimated-time-min estimated-time-min
@@ -224,7 +341,9 @@
              :token-symbol       token-symbol
              :amount             amount
              :to-address         to-address
+             :to-network         bridge-to-network
              :theme              theme
-             :route              route}]]]]))))
+             :route              route
+             :transaction-type   transaction-type}]]]]))))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/subs/wallet/networks.cljs
+++ b/src/status_im/subs/wallet/networks.cljs
@@ -16,19 +16,22 @@
    (get networks (if test-networks-enabled? :test :prod))))
 
 (def mainnet-network-details
-  {:source       (resources/get-network constants/mainnet-network-name)
-   :short-name   constants/mainnet-short-name
-   :network-name constants/mainnet-network-name})
+  {:source           (resources/get-network constants/mainnet-network-name)
+   :short-name       constants/mainnet-short-name
+   :network-name     constants/mainnet-network-name
+   :abbreviated-name constants/mainnet-abbreviated-name})
 
 (def arbitrum-network-details
-  {:source       (resources/get-network constants/arbitrum-network-name)
-   :short-name   constants/arbitrum-short-name
-   :network-name constants/arbitrum-network-name})
+  {:source           (resources/get-network constants/arbitrum-network-name)
+   :short-name       constants/arbitrum-short-name
+   :network-name     constants/arbitrum-network-name
+   :abbreviated-name constants/arbitrum-abbreviated-name})
 
 (def optimism-network-details
-  {:source       (resources/get-network constants/optimism-network-name)
-   :short-name   constants/optimism-short-name
-   :network-name constants/optimism-network-name})
+  {:source           (resources/get-network constants/optimism-network-name)
+   :short-name       constants/optimism-short-name
+   :network-name     constants/optimism-network-name
+   :abbreviated-name constants/optimism-abbreviated-name})
 
 (defn get-network-details
   [chain-id]

--- a/src/status_im/subs/wallet/networks_test.cljs
+++ b/src/status_im/subs/wallet/networks_test.cljs
@@ -10,7 +10,8 @@
 (def network-data
   {:test [{:test?            true
            :short-name       "eth"
-           :network-name     :ethereum
+           :network-name     :mainnet
+           :abbreviated-name "Eth."
            :related-chain-id 1
            :chain-id         3
            :layer            1}
@@ -41,16 +42,20 @@
   [sub-name]
   (testing "returns data with prod"
     (swap! rf-db/app-db assoc-in [:wallet :networks] network-data)
-    (is (= [{:network-name :ethereum
-             :short-name   "eth"
-             :chain-id     1
-             :layer        1}
-            {:network-name :arbitrum
-             :short-name   "arb1"
-             :chain-id     42161
-             :layer        2}
-            {:network-name :optimism
-             :short-name   "opt"
-             :chain-id     10
-             :layer        2}]
-           (map #(dissoc % :source :related-chain-id) (rf/sub [sub-name]))))))
+    (is
+     (= [{:network-name     :mainnet
+          :short-name       "eth"
+          :chain-id         1
+          :abbreviated-name "Eth."
+          :layer            1}
+         {:network-name     :arbitrum
+          :short-name       "arb1"
+          :abbreviated-name "Arb1."
+          :chain-id         42161
+          :layer            2}
+         {:network-name     :optimism
+          :short-name       "opt"
+          :abbreviated-name "Opt."
+          :chain-id         10
+          :layer            2}]
+        (map #(dissoc % :source :related-chain-id) (rf/sub [sub-name]))))))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -89,6 +89,11 @@
  :-> :suggested-routes)
 
 (rf/reg-sub
+ :wallet/wallet-bridge-to-chain-id
+ :<- [:wallet/wallet-send]
+ :-> :bridge-to-chain-id)
+
+(rf/reg-sub
  :wallet/watch-address-activity-state
  :<- [:wallet/ui]
  :-> :watch-address-activity-state)

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -183,7 +183,7 @@
              :color                     :blue
              :hidden                    false
              :prod-preferred-chain-ids  #{1 10 42161}
-             :network-preferences-names #{:ethereum :arbitrum :optimism}
+             :network-preferences-names #{:mainnet :arbitrum :optimism}
              :position                  0
              :clock                     1698945829328
              :created-at                1698928839000
@@ -205,7 +205,7 @@
              :color                     :purple
              :hidden                    false
              :prod-preferred-chain-ids  #{1 10 42161}
-             :network-preferences-names #{:ethereum :arbitrum :optimism}
+             :network-preferences-names #{:mainnet :arbitrum :optimism}
              :position                  1
              :clock                     1698945829328
              :created-at                1698928839000
@@ -269,7 +269,7 @@
            :color                     :blue
            :hidden                    false
            :prod-preferred-chain-ids  #{1 10 42161}
-           :network-preferences-names #{:ethereum :arbitrum :optimism}
+           :network-preferences-names #{:mainnet :arbitrum :optimism}
            :position                  0
            :clock                     1698945829328
            :created-at                1698928839000
@@ -326,7 +326,7 @@
           :color                     :blue
           :hidden                    false
           :prod-preferred-chain-ids  #{1 10 42161}
-          :network-preferences-names #{:ethereum :arbitrum :optimism}
+          :network-preferences-names #{:mainnet :arbitrum :optimism}
           :position                  0
           :clock                     1698945829328
           :created-at                1698928839000
@@ -383,7 +383,7 @@
         :customization-color       :blue
         :hidden                    false
         :prod-preferred-chain-ids  #{1 10 42161}
-        :network-preferences-names #{:ethereum :arbitrum :optimism}
+        :network-preferences-names #{:mainnet :arbitrum :optimism}
         :position                  0
         :clock                     1698945829328
         :created-at                1698928839000
@@ -406,7 +406,7 @@
         :customization-color       :purple
         :hidden                    false
         :prod-preferred-chain-ids  #{1 10 42161}
-        :network-preferences-names #{:ethereum :arbitrum :optimism}
+        :network-preferences-names #{:mainnet :arbitrum :optimism}
         :position                  1
         :clock                     1698945829328
         :created-at                1698928839000
@@ -427,17 +427,20 @@
            (assoc-in [:wallet :networks] network-data)))
     (is
      (match? [{:short-name       "eth"
-               :network-name     :ethereum
+               :network-name     :mainnet
+               :abbreviated-name "Eth."
                :chain-id         1
                :related-chain-id nil
                :layer            1}
               {:short-name       "arb1"
                :network-name     :arbitrum
+               :abbreviated-name "Arb1."
                :chain-id         42161
                :related-chain-id nil
                :layer            2}
               {:short-name       "opt"
                :network-name     :optimism
+               :abbreviated-name "Opt."
                :chain-id         10
                :related-chain-id nil
                :layer            2}]
@@ -474,11 +477,11 @@
      (= [(-> accounts
              (get "0x1")
              (assoc :customization-color :blue)
-             (assoc :network-preferences-names #{:ethereum :arbitrum :optimism}))
+             (assoc :network-preferences-names #{:mainnet :arbitrum :optimism}))
          (-> accounts
              (get "0x2")
              (assoc :customization-color :purple)
-             (assoc :network-preferences-names #{:ethereum :arbitrum :optimism}))
+             (assoc :network-preferences-names #{:mainnet :arbitrum :optimism}))
          (-> accounts
              (get "0x3")
              (assoc :customization-color :magenta)

--- a/translations/en.json
+++ b/translations/en.json
@@ -2519,5 +2519,7 @@
     "keypair-name": "Keypair name",
     "keypair-name-description": "Name keypair for your own personal reference",
     "keypair-name-input-placeholder": "Collectibles account, Old vault....",
-    "goerli-testnet-toggle-confirmation": "Are you sure you want to toggle Goerli? This will log you out and you will have to login again."
+    "goerli-testnet-toggle-confirmation": "Are you sure you want to toggle Goerli? This will log you out and you will have to login again.",
+    "bridged-to": "Bridged to {{network}}",
+    "slide-to-bridge": "Slide to bridge"
 }


### PR DESCRIPTION
fixes #18590 

### Summary

Update transaction confirmation page to support Bridge transactions and show the correct UI for displaying the transaction summary and confirming the transaction. Some minor bugs were detected and fixed during the process to properly implement this.

The logic of actually bridging will be implemented in #18938, this issue just for UI implementation.

<img width="300" src="https://github.com/status-im/status-mobile/assets/18485527/bec15463-b760-4231-ae95-b043bdc652b1"> 
<img width="300" src="https://github.com/status-im/status-mobile/assets/18485527/6cf6d456-359e-4ef3-b470-48046604e704">

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Login with an account with same tokens on different networks (ETH, DAI, etc)
- Go to account
- Go to Bridge
- Select a token
- Select network to bridge to
- Go to transaction confirmation page
- Verify UI is displayed correctly

status: ready