### PR TITLE
fix: duplicate sub key :communities/fetching-community

### DIFF
--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -398,7 +398,7 @@
                                  :community-id community-id})}})
 
 (rf/reg-event-fx :communities/navigate-to-community-overview
- (fn [cofx [deserialized-key]]
+ (fn [{:keys [db] :as cofx} [deserialized-key]]
    (if (string/starts-with? deserialized-key constants/serialization-key)
      (navigate-to-serialized-community cofx deserialized-key)
      (rf/merge
@@ -407,7 +407,9 @@
              [:communities/fetch-community
               {:community-id           deserialized-key
                :update-last-opened-at? true}]]
-            [:dispatch [:navigate-to :community-overview deserialized-key]]]}
+            [:dispatch [:navigate-to :community-overview deserialized-key]]
+            (when (get-in db [:communities deserialized-key :joined])
+              [:dispatch [:activity-center.notifications/dismiss-community-overview deserialized-key]])]}
       (navigation/pop-to-root :shell-stack)))))
 
 (rf/reg-event-fx :communities/navigate-to-community-chat

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -293,7 +293,7 @@
 (defn community-fetched
   [{:keys [db]} [community-id community]]
   (when community
-    {:db (update db :communities/fetching-community dissoc community-id)
+    {:db (update db :communities/fetching-communities dissoc community-id)
      :fx [[:dispatch [:communities/handle-community community]]
           [:dispatch [:communities/update-last-opened-at community-id]]
           [:dispatch
@@ -304,14 +304,14 @@
 
 (defn community-failed-to-fetch
   [{:keys [db]} [community-id]]
-  {:db (update db :communities/fetching-community dissoc community-id)})
+  {:db (update db :communities/fetching-communities dissoc community-id)})
 
 (rf/reg-event-fx :chat.ui/community-failed-to-fetch community-failed-to-fetch)
 
 (defn fetch-community
   [{:keys [db]} [{:keys [community-id update-last-opened-at?]}]]
-  (when (and community-id (not (get-in db [:communities/fetching-community community-id])))
-    {:db            (assoc-in db [:communities/fetching-community community-id] true)
+  (when (and community-id (not (get-in db [:communities/fetching-communities community-id])))
+    {:db            (assoc-in db [:communities/fetching-communities community-id] true)
      :json-rpc/call [{:method     "wakuext_fetchCommunity"
                       :params     [{:CommunityKey    community-id
                                     :TryDatabase     true

--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -104,7 +104,7 @@
   (testing "with community id"
     (testing "update fetching indicator in db"
       (is (match?
-           {:db {:communities/fetching-community {community-id true}}}
+           {:db {:communities/fetching-communities {community-id true}}}
            (events/fetch-community {} [{:community-id community-id}]))))
     (testing "call the fetch community rpc method with correct community id"
       (is (match?
@@ -124,21 +124,21 @@
     (testing "remove community id from fetching indicator in db"
       (is (match?
            nil
-           (get-in (events/community-failed-to-fetch {:db {:communities/fetching-community
+           (get-in (events/community-failed-to-fetch {:db {:communities/fetching-communities
                                                            {community-id true}}}
                                                      [community-id])
-                   [:db :communities/fetching-community community-id]))))))
+                   [:db :communities/fetching-communities community-id]))))))
 
 (deftest community-fetched
   (with-redefs [link-preview.events/community-link (fn [id] (str "community-link+" id))]
     (testing "given a community"
-      (let [cofx {:db {:communities/fetching-community {community-id true}}}
+      (let [cofx {:db {:communities/fetching-communities {community-id true}}}
             arg  [community-id {:id community-id}]]
         (testing "remove community id from fetching indicator in db"
           (is (match?
                nil
                (get-in (events/community-fetched cofx arg)
-                       [:db :communities/fetching-community community-id]))))
+                       [:db :communities/fetching-communities community-id]))))
         (testing "dispatch fxs"
           (is (match?
                {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
@@ -148,7 +148,7 @@
                        {:id community-id}]]]}
                (events/community-fetched cofx arg))))))
     (testing "given a joined community"
-      (let [cofx {:db {:communities/fetching-community {community-id true}}}
+      (let [cofx {:db {:communities/fetching-communities {community-id true}}}
             arg  [community-id {:id community-id :joined true}]]
         (testing "dispatch fxs, do not spectate community"
           (is (match?
@@ -159,7 +159,7 @@
                        {:id community-id}]]]}
                (events/community-fetched cofx arg))))))
     (testing "given a token-gated community"
-      (let [cofx {:db {:communities/fetching-community {community-id true}}}
+      (let [cofx {:db {:communities/fetching-communities {community-id true}}}
             arg  [community-id {:id community-id :tokenPermissions [1]}]]
         (testing "dispatch fxs, do not spectate community"
           (is (match?

--- a/src/status_im/contexts/communities/overview/style.cljs
+++ b/src/status_im/contexts/communities/overview/style.cljs
@@ -21,6 +21,13 @@
    :align-items    :center
    :margin-top     20})
 
+(def fetching-placeholder
+  {:align-items     :center
+   :justify-content :center
+   :flex            1})
+
+(def fetching-text {:color :red})
+
 (def blur-channel-header
   {:position :absolute
    :top      100

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -7,6 +7,7 @@
     [react-native.core :as rn]
     [reagent.core :as reagent]
     [status-im.common.home.actions.view :as actions]
+    [status-im.common.not-implemented :as not-implemented]
     [status-im.common.scroll-page.style :as scroll-page.style]
     [status-im.common.scroll-page.view :as scroll-page]
     [status-im.config :as config]
@@ -176,7 +177,6 @@
          :disabled?           (not can-request-access?)
          :icon-left           (if can-request-access? :i/unlocked :i/locked)}
         (i18n/label :t/join-open-community)]])))
-
 
 (defn- join-community
   [{:keys [id joined permissions role-permissions? can-join?] :as community}]
@@ -366,14 +366,28 @@
            ;; might have been removed.
            on-first-channel-height-changed}]]))))
 
+(defn- community-fetching-placeholder
+  [id]
+  (let [fetching? (rf/sub [:communities/fetching-community id])]
+    [rn/view
+     {:style               style/fetching-placeholder
+      :accessibility-label (if fetching?
+                             :fetching-community-overview
+                             :failed-to-fetch-community-overview)}
+     [not-implemented/not-implemented
+      [rn/text
+       {:style style/fetching-text}
+       (if fetching?
+         "Fetching community..."
+         "Failed to fetch community")]]]))
+
 (defn- community-card-page-view
   [id]
-  (let [{:keys [id joined name images]
+  (let [{:keys [joined name images]
          :as   community} (rf/sub [:communities/community id])]
-    (when community
-      (when joined
-        (rf/dispatch [:activity-center.notifications/dismiss-community-overview id]))
-      [community-scroll-page id joined name images])))
+    (if community
+      [community-scroll-page id joined name images]
+      [community-fetching-placeholder id])))
 
 (defn view
   [id]

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -9,7 +9,7 @@
 
 (re-frame/reg-sub
  :communities/fetching-community
- :<- [:communities/fetching-community]
+ :<- [:communities/fetching-communities]
  (fn [info [_ id]]
    (get info id)))
 

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -143,7 +143,7 @@
 (reg-root-key-sub :communities/create-channel :communities/create-channel)
 (reg-root-key-sub :communities/requests-to-join :communities/requests-to-join)
 (reg-root-key-sub :communities/community-id-input :communities/community-id-input)
-(reg-root-key-sub :communities/fetching-community :communities/fetching-community)
+(reg-root-key-sub :communities/fetching-communities :communities/fetching-communities)
 (reg-root-key-sub :communities/my-pending-requests-to-join :communities/my-pending-requests-to-join)
 (reg-root-key-sub :communities/collapsed-categories :communities/collapsed-categories)
 (reg-root-key-sub :communities/selected-tab :communities/selected-tab)


### PR DESCRIPTION
### Summary

1. rename the root sub :communities/fetching-community to :communities/fetching-communities
1. add a not-implemented fetching and failed to fetch screen for community overview

related to #18624

https://github.com/status-im/status-mobile/assets/15090582/bb48238d-f8a7-490e-a924-05c2f9658317

![CleanShot 2024-02-19 at 14 28 59](https://github.com/status-im/status-mobile/assets/15090582/19bdea58-e460-4b5b-87a1-4c92bee4d686)

### Testing notes

1. the rename in 1 doesn't affect anything since the sub is not used anywhere before this PR
1. there will now be a fetching and failed to fetch screen when open links of a not fetched community

status: ready <!-- Can be ready or wip -->