### PR TITLE
[#18865] fix: separate edit bio and set bio, update number of profile name characters

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -106,7 +106,7 @@
 (def ^:const command-state-transaction-sent 7)
 
 (def ^:const profile-default-color :blue)
-(def ^:const profile-name-max-length 24)
+(def ^:const profile-name-max-length 20)
 (def ^:const profile-bio-max-length 240)
 (def ^:const profile-default-currency :usd)
 

--- a/src/status_im/contexts/profile/edit/bio/events.cljs
+++ b/src/status_im/contexts/profile/edit/bio/events.cljs
@@ -1,22 +1,26 @@
 (ns status-im.contexts.profile.edit.bio.events
-  (:require [utils.i18n :as i18n]
+  (:require [clojure.string :as string]
+            [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
 (rf/reg-event-fx :profile/edit-profile-bio-success
- (fn [_]
+ (fn [_ [added?]]
    {:fx [[:dispatch [:navigate-back]]
          [:dispatch
           [:toasts/upsert
            {:type  :positive
             :theme :dark
-            :text  (i18n/label :t/bio-added)}]]]}))
+            :text  (if added?
+                     (i18n/label :t/bio-added)
+                     (i18n/label :t/bio-updated))}]]]}))
 
 (defn edit-profile-bio
-  [{:keys [db]} [bio]]
-  {:db (assoc-in db [:profile/profile :bio] bio)
-   :fx [[:json-rpc/call
-         [{:method     "wakuext_setBio"
-           :params     [bio]
-           :on-success [:profile/edit-profile-bio-success]}]]]})
+  [{:keys [db]} [new-bio]]
+  (let [{:keys [bio]} (:profile/profile db)]
+    {:db (assoc-in db [:profile/profile :bio] new-bio)
+     :fx [[:json-rpc/call
+           [{:method     "wakuext_setBio"
+             :params     [new-bio]
+             :on-success [:profile/edit-profile-bio-success (string/blank? bio)]}]]]}))
 
 (rf/reg-event-fx :profile/edit-bio edit-profile-bio)

--- a/src/status_im/contexts/profile/edit/bio/events.cljs
+++ b/src/status_im/contexts/profile/edit/bio/events.cljs
@@ -4,8 +4,9 @@
             [utils.re-frame :as rf]))
 
 (rf/reg-event-fx :profile/edit-profile-bio-success
- (fn [_ [added?]]
-   {:fx [[:dispatch [:navigate-back]]
+ (fn [_ [{:keys [bio added?]}]]
+   {:fx [[:dispatch [:profile/save-local-profile-bio bio]]
+         [:dispatch [:navigate-back]]
          [:dispatch
           [:toasts/upsert
            {:type  :positive
@@ -14,13 +15,18 @@
                      (i18n/label :t/bio-added)
                      (i18n/label :t/bio-updated))}]]]}))
 
+(rf/reg-event-fx :profile/save-local-profile-bio
+ (fn [{:keys [db]} [bio]]
+   {:db (assoc-in db [:profile/profile :bio] bio)}))
+
 (defn edit-profile-bio
   [{:keys [db]} [new-bio]]
   (let [{:keys [bio]} (:profile/profile db)]
-    {:db (assoc-in db [:profile/profile :bio] new-bio)
-     :fx [[:json-rpc/call
+    {:fx [[:json-rpc/call
            [{:method     "wakuext_setBio"
              :params     [new-bio]
-             :on-success [:profile/edit-profile-bio-success (string/blank? bio)]}]]]}))
+             :on-success [:profile/edit-profile-bio-success
+                          {:bio    new-bio
+                           :added? (string/blank? bio)}]}]]]}))
 
 (rf/reg-event-fx :profile/edit-bio edit-profile-bio)

--- a/src/status_im/contexts/profile/edit/bio/events_test.cljs
+++ b/src/status_im/contexts/profile/edit/bio/events_test.cljs
@@ -10,6 +10,6 @@
                   :fx [[:json-rpc/call
                         [{:method     "wakuext_setBio"
                           :params     [new-bio]
-                          :on-success [:profile/edit-profile-bio-success]}]]]}]
+                          :on-success [:profile/edit-profile-bio-success false]}]]]}]
     (is (match? expected
                 (sut/edit-profile-bio cofx [new-bio])))))

--- a/src/status_im/contexts/profile/edit/bio/events_test.cljs
+++ b/src/status_im/contexts/profile/edit/bio/events_test.cljs
@@ -6,10 +6,11 @@
 (deftest edit-bio-test
   (let [new-bio  "New Bio text"
         cofx     {:db {:profile/profile {:bio "Old Bio text"}}}
-        expected {:db {:profile/profile {:bio new-bio}}
-                  :fx [[:json-rpc/call
+        expected {:fx [[:json-rpc/call
                         [{:method     "wakuext_setBio"
                           :params     [new-bio]
-                          :on-success [:profile/edit-profile-bio-success false]}]]]}]
+                          :on-success [:profile/edit-profile-bio-success
+                                       {:bio    new-bio
+                                        :added? false}]}]]]}]
     (is (match? expected
                 (sut/edit-profile-bio cofx [new-bio])))))

--- a/src/status_im/contexts/profile/edit/bio/view.cljs
+++ b/src/status_im/contexts/profile/edit/bio/view.cljs
@@ -67,5 +67,8 @@
            :customization-color customization-color
            :on-press            (fn []
                                   (rf/dispatch [:profile/edit-bio @unsaved-bio]))
-           :disabled?           (boolean (or @typing? (not (string/blank? @error-msg))))}
+           :disabled?           (boolean (or @typing?
+                                             (and (string/blank? profile-bio)
+                                                  (string/blank? @unsaved-bio))
+                                             (not (string/blank? @error-msg))))}
           (i18n/label :t/save-bio)]]]])))

--- a/src/tests/contract_test/profile_test.cljs
+++ b/src/tests/contract_test/profile_test.cljs
@@ -1,0 +1,25 @@
+(ns tests.contract-test.profile-test
+  (:require
+    [cljs.test :refer [deftest is]]
+    [day8.re-frame.test :as rf-test]
+    legacy.status-im.events
+    [legacy.status-im.multiaccounts.logout.core :as logout]
+    legacy.status-im.subs.root
+    status-im.events
+    status-im.navigation.core
+    status-im.subs.root
+    [test-helpers.integration :as h]
+    [tests.contract-test.utils :as contract-utils]))
+
+(deftest profile-set-bio-contract
+  (h/log-headline :contract/wakuext_setBio)
+  (rf-test/run-test-async
+   (h/with-app-initialized
+    (h/with-account
+     (contract-utils/call-rpc-endpoint
+      {:rpc-endpoint "wakuext_setBio"
+       :params       ["new bio"]
+       :on-error     #(is (nil? %) "Set bio RPC call should have succeeded")})
+     (h/logout)
+     (rf-test/wait-for
+       [::logout/logout-method])))))

--- a/translations/en.json
+++ b/translations/en.json
@@ -69,6 +69,7 @@
     "bio": "Bio",
     "bio-added": "Bio added",
     "bio-is-too-long": "Bio is too long",
+    "bio-updated": "Bio updated",
     "biometric-auth-android-sensor-desc": "Touch sensor",
     "biometric-auth-android-sensor-error-desc": "Failed",
     "biometric-auth-android-title": "Authentication Required",


### PR DESCRIPTION
fixes #18865
fixes #18788


### Summary

Separate the toast message for set bio and edit bio, and update character number in set profile name 


status: ready