### PR TITLE
chore: improve android & iOS build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ lefthook.yml
 
 ## metro server logs
 metro-server-logs.log
+
+## debug build time logs
+logs/

--- a/scripts/run-android.sh
+++ b/scripts/run-android.sh
@@ -1,37 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -m # needed to access jobs
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
-
-# We run Metro in background while calling adb.
-cleanupMetro() {
-    pkill -f run-metro.sh
-    rm -f metro-server-logs.log
-}
-
-# Using function gives a neater jobspec name.
-runMetro() {
-   nohup "${GIT_ROOT}/scripts/run-metro.sh" 2>&1 \
-        | tee metro-server-logs.log
-}
-
-waitForMetro() {
-    set +e # Allow grep command to fail in the loop.
-    TIMEOUT=5
-    echo "Waiting for Metro server..." >&2
-    while ! grep -q "Welcome to Metro" metro-server-logs.log; do
-      echo -n "." >&2
-      sleep 1
-      if ((TIMEOUT == 0)); then
-        echo -e "\nMetro server timed out, exiting" >&2
-        set -e # Restore errexit for rest of script.
-        return 1
-      fi
-      ((TIMEOUT--))
-    done
-    set -e # Restore errexit for rest of script.
-}
+ADB_INSTALL_LOG_FILE="${GIT_ROOT}/logs/adb_install.log"
+ADB_SHELL_MONKEY_LOG_FILE="${GIT_ROOT}/logs/adb_shell_monkey.log"
 
 # Generate android debug build.
 export ANDROID_ABI_INCLUDE=$("${GIT_ROOT}/scripts/adb_devices_abis.sh")
@@ -40,14 +12,17 @@ export BUILD_TYPE=debug
 "${GIT_ROOT}/scripts/build-android.sh"
 
 # Install the APK on running emulator or android device.
-adb install ./result/app-debug.apk
+installAndLaunchApp() {
+  adb install ./result/app-debug.apk > "${ADB_INSTALL_LOG_FILE}" 2>&1
+  "${GIT_ROOT}/scripts/wait-for-metro-port.sh" 2>&1
+  adb shell monkey -p im.status.ethereum.debug 1 > "${ADB_SHELL_MONKEY_LOG_FILE}" 2>&1
+}
 
-trap cleanupMetro EXIT ERR INT QUIT
-runMetro &
-waitForMetro
+showAdbLogs() {
+  cat "${ADB_INSTALL_LOG_FILE}" >&2;
+  cat "${ADB_SHELL_MONKEY_LOG_FILE}" >&2;
+}
 
-# Start the installed app.
-adb shell monkey -p im.status.ethereum.debug 1
-
-# bring metro job to foreground
-fg 'runMetro'
+trap showAdbLogs EXIT ERR INT QUIT
+installAndLaunchApp &
+exec "${GIT_ROOT}/scripts/run-metro.sh" 2>&1

--- a/scripts/wait-for-metro-port.sh
+++ b/scripts/wait-for-metro-port.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TIMEOUT=10 # Metro should not take this long to start.
+
+while [ "${TIMEOUT}" -gt 0 ]; do
+  if ! lsof -i:8081 &> /dev/null; then
+    echo "."
+    sleep 1
+    ((TIMEOUT--))
+  else
+    break
+  fi
+done


### PR DESCRIPTION
fixes #18888

## Summary
`make run-android` was sometimes flaky because we used to send metro to background via `nohup` and then bring it back to foreground after we read metro logs.

Now we do not send metro to background.
The new workflow should now be less flaky.

## Review notes
`make run-clojure`
`make run-android` OR `make run-ios` should just work 

#### Platforms
- Android
- iOS

status: ready
