### PR TITLE
Migrate reagent atom part 1

### DIFF
--- a/src/quo/components/buttons/composer_button/view.cljs
+++ b/src/quo/components/buttons/composer_button/view.cljs
@@ -3,28 +3,24 @@
     [quo.components.buttons.composer-button.style :as style]
     [quo.components.icon :as quo.icons]
     [quo.theme :as theme]
-    [react-native.core :as rn]
-    [reagent.core :as reagent]))
+    [react-native.core :as rn]))
 
-(defn- view-internal
-  [_ _]
-  (let [pressed? (reagent/atom false)]
-    (fn
-      [{:keys [on-press on-long-press disabled? theme blur? icon accessibility-label container-style]}]
-      [rn/pressable
-       {:accessibility-label (or accessibility-label :composer-button)
-        :on-press            on-press
-        :on-press-in         #(reset! pressed? true)
-        :on-press-out        #(reset! pressed? nil)
-        :on-long-press       on-long-press
-        :disabled            disabled?
-        :style               (merge (style/main {:pressed?  @pressed?
-                                                 :blur?     blur?
-                                                 :theme     theme
-                                                 :disabled? disabled?})
-                                    container-style)}
-       [quo.icons/icon icon
-        {:color (style/get-label-color {:blur? blur?
-                                        :theme theme})}]])))
-
-(def view (theme/with-theme view-internal))
+(defn view
+  [{:keys [on-press on-long-press disabled? blur? icon accessibility-label container-style]}]
+  (let [[pressed? set-pressed] (rn/use-state false)
+        theme                  (theme/use-theme-value)
+        on-press-in            (rn/use-callback #(set-pressed true))
+        on-press-out           (rn/use-callback #(set-pressed nil))]
+    [rn/pressable
+     {:accessibility-label (or accessibility-label :composer-button)
+      :on-press            on-press
+      :on-press-in         on-press-in
+      :on-press-out        on-press-out
+      :on-long-press       on-long-press
+      :disabled            disabled?
+      :style               (merge (style/main {:pressed?  pressed?
+                                               :blur?     blur?
+                                               :theme     theme
+                                               :disabled? disabled?})
+                                  container-style)}
+     [quo.icons/icon icon {:color (style/get-label-color {:blur? blur? :theme theme})}]]))

--- a/src/quo/components/buttons/logout_button/view.cljs
+++ b/src/quo/components/buttons/logout_button/view.cljs
@@ -6,29 +6,25 @@
     [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
-    [reagent.core :as reagent]
     [utils.i18n :as i18n]))
 
-(defn- view-internal
-  [_]
-  (let [pressed?     (reagent/atom false)
-        on-press-in  #(reset! pressed? true)
-        on-press-out #(reset! pressed? nil)]
-    (fn
-      [{:keys [on-press on-long-press disabled? theme container-style]}]
-      [rn/pressable
-       {:accessibility-label :log-out-button
-        :on-press            on-press
-        :on-press-in         on-press-in
-        :on-press-out        on-press-out
-        :on-long-press       on-long-press
-        :disabled            disabled?
-        :style               (merge (style/main {:pressed?  @pressed?
-                                                 :theme     theme
-                                                 :disabled? disabled?})
-                                    container-style)}
-       [icon/icon :i/log-out {:color (if pressed? colors/white-opa-40 colors/white-opa-70)}]
-       [text/text {:weight :medium :size :paragraph-1}
-        (i18n/label :t/logout)]])))
-
-(def view (quo.theme/with-theme view-internal))
+(defn view
+  [{:keys [on-press on-long-press disabled? container-style]}]
+  (let [theme                  (quo.theme/use-theme-value)
+        [pressed? set-pressed] (rn/use-state false)
+        on-press-in            (rn/use-callback #(set-pressed true))
+        on-press-out           (rn/use-callback #(set-pressed nil))]
+    [rn/pressable
+     {:accessibility-label :log-out-button
+      :on-press            on-press
+      :on-press-in         on-press-in
+      :on-press-out        on-press-out
+      :on-long-press       on-long-press
+      :disabled            disabled?
+      :style               (merge (style/main {:pressed?  pressed?
+                                               :theme     theme
+                                               :disabled? disabled?})
+                                  container-style)}
+     [icon/icon :i/log-out {:color (if pressed? colors/white-opa-40 colors/white-opa-70)}]
+     [text/text {:weight :medium :size :paragraph-1}
+      (i18n/label :t/logout)]]))

--- a/src/quo/components/buttons/slide_button/animations.cljs
+++ b/src/quo/components/buttons/slide_button/animations.cljs
@@ -1,9 +1,5 @@
 (ns quo.components.buttons.slide-button.animations
-  (:require
-    [oops.core :as oops]
-    [quo.components.buttons.slide-button.utils :as utils]
-    [react-native.gesture :as gesture]
-    [react-native.reanimated :as reanimated]))
+  (:require [react-native.reanimated :as reanimated]))
 
 (def ^:private extrapolation
   {:extrapolateLeft  "clamp"
@@ -66,36 +62,6 @@
                                                 :damping   30
                                                 :stiffness 400}))
 
-(defn- complete-animation
-  [sliding-complete?]
-  (reset! sliding-complete? true))
-
 (defn reset-track-position
   [x-pos]
   (animate-spring x-pos 0))
-
-;; Gestures
-(defn drag-gesture
-  [x-pos
-   gestures-disabled?
-   disabled?
-   track-width
-   sliding-complete?]
-  (let [gestures-enabled? (not (or disabled? @gestures-disabled?))]
-    (-> (gesture/gesture-pan)
-        (gesture/with-test-ID :slide-button-gestures)
-        (gesture/enabled gestures-enabled?)
-        (gesture/min-distance 0)
-        (gesture/on-update (fn [event]
-                             (let [x-translation (oops/oget event "translationX")
-                                   clamped-x     (utils/clamp-value x-translation 0 track-width)
-                                   reached-end?  (>= clamped-x track-width)]
-                               (reanimated/set-shared-value x-pos clamped-x)
-                               (when (and reached-end? (not @sliding-complete?))
-                                 (reset! gestures-disabled? true)
-                                 (complete-animation sliding-complete?)))))
-        (gesture/on-end (fn [event]
-                          (let [x-translation (oops/oget event "translationX")
-                                reached-end?  (>= x-translation track-width)]
-                            (when (not reached-end?)
-                              (reset-track-position x-pos))))))))

--- a/src/quo/components/buttons/slide_button/view.cljs
+++ b/src/quo/components/buttons/slide_button/view.cljs
@@ -11,94 +11,35 @@
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
-    [react-native.reanimated :as reanimated]
-    [reagent.core :as reagent]))
+    [react-native.reanimated :as reanimated]))
 
-(defn- f-slider
-  [{:keys [disabled?]}]
-  (let [track-width        (reagent/atom nil)
-        sliding-complete?  (reagent/atom false)
-        gestures-disabled? (reagent/atom disabled?)
-        on-track-layout    (fn [evt]
-                             (let [width (oops/oget evt "nativeEvent.layout.width")]
-                               (reset! track-width width)))]
-    (fn [{:keys [on-reset
-                 on-complete
-                 track-text
-                 track-icon
-                 disabled?
-                 customization-color
-                 size
-                 container-style
-                 theme
-                 type
-                 blur?]}]
-      (let [x-pos             (reanimated/use-shared-value 0)
-            dimensions        (partial utils/get-dimensions
-                                       (or @track-width constants/default-width)
-                                       size)
-            interpolate-track (partial animations/interpolate-track
-                                       x-pos
-                                       (dimensions :usable-track)
-                                       (dimensions :thumb))
-            custom-color      (if (= type :danger) :danger customization-color)]
-        (rn/use-effect (fn []
-                         (when @sliding-complete?
-                           (on-complete)))
-                       [@sliding-complete?])
-        (rn/use-effect (fn []
-                         (when on-reset
-                           (reset! sliding-complete? false)
-                           (reset! gestures-disabled? false)
-                           (animations/reset-track-position x-pos)
-                           (on-reset)))
-                       [on-reset])
-        [gesture/gesture-detector
-         {:gesture (animations/drag-gesture x-pos
-                                            gestures-disabled?
-                                            disabled?
-                                            (dimensions :usable-track)
-                                            sliding-complete?)}
-         [reanimated/view
-          {:test-ID   :slide-button-track
-           :style     (merge (style/track {:disabled?           disabled?
-                                           :customization-color custom-color
-                                           :height              (dimensions :track-height)
-                                           :blur?               blur?})
-                             container-style)
-           :on-layout (when-not (some? @track-width)
-                        on-track-layout)}
-          [reanimated/view {:style (style/track-cover interpolate-track)}
-           [rn/view {:style (style/track-cover-text-container @track-width)}
-            [icon/icon track-icon
-             {:color (utils/text-color custom-color theme blur?)
-              :size  20}]
-            [rn/view {:width 4}]
-            [text/text
-             {:weight :medium
-              :size   :paragraph-1
-              :style  (style/track-text custom-color theme blur?)}
-             track-text]]]
-          [reanimated/view
-           {:style (style/thumb-container {:interpolate-track   interpolate-track
-                                           :thumb-size          (dimensions :thumb)
-                                           :customization-color custom-color
-                                           :theme               theme
-                                           :blur?               blur?})}
-           [reanimated/view {:style (style/arrow-icon-container interpolate-track)}
-            [icon/icon :arrow-right
-             {:color colors/white
-              :size  20}]]
-           [reanimated/view
-            {:style (style/action-icon interpolate-track
-                                       (dimensions :thumb))}
-            [icon/icon track-icon
-             {:color colors/white
-              :size  20}]]]]]))))
+(defn drag-gesture
+  [x-pos gestures-disabled? set-gestures-disabled disabled? track-width sliding-complete?
+   set-sliding-complete
+   on-complete reset-fn]
+  (let [gestures-enabled? (not (or disabled? gestures-disabled?))]
+    (-> (gesture/gesture-pan)
+        (gesture/with-test-ID :slide-button-gestures)
+        (gesture/enabled gestures-enabled?)
+        (gesture/min-distance 0)
+        (gesture/on-update (fn [event]
+                             (let [x-translation (oops/oget event "translationX")
+                                   clamped-x     (utils/clamp-value x-translation 0 track-width)
+                                   reached-end?  (>= clamped-x track-width)]
+                               (reanimated/set-shared-value x-pos clamped-x)
+                               (when (and reached-end? (not sliding-complete?))
+                                 (set-gestures-disabled true)
+                                 (set-sliding-complete true)
+                                 (when on-complete (on-complete reset-fn))))))
+        (gesture/on-end (fn [event]
+                          (let [x-translation (oops/oget event "translationX")
+                                reached-end?  (>= x-translation track-width)]
+                            (when (not reached-end?)
+                              (animations/reset-track-position x-pos))))))))
 
-(defn- view-internal
+(defn view
   "Options
-  - `on-complete`         Callback called when the sliding is complete
+  - `on-complete`         Callback called when the sliding is complete, returns reset fn as a parameter
   - `disabled?`           Boolean that disables the button
                           (_and gestures_)
   - `size`                :size/s-40`/`:size/s-48`
@@ -106,9 +47,78 @@
   - `track-icon`          Key of the icon shown on the track
                           (e.g. `:face-id`)
   - `customization-color` Customization color
-  - `on-reset`            A callback which can be used to reset the component and run required functionality
   "
-  [props]
-  [:f> f-slider props])
-
-(def view (quo.theme/with-theme view-internal))
+  [{:keys [on-complete track-text track-icon disabled? customization-color size
+           container-style type blur?]}]
+  (let [theme                         (quo.theme/use-theme-value)
+        x-pos                         (reanimated/use-shared-value 0)
+        [track-width set-track-width] (rn/use-state nil)
+        [sliding-complete?
+         set-sliding-complete]        (rn/use-state false)
+        [gestures-disabled?
+         set-gestures-disabled]       (rn/use-state disabled?)
+        on-track-layout               (rn/use-callback
+                                       #(set-track-width (oops/oget % "nativeEvent.layout.width")))
+        reset-fn                      (rn/use-callback
+                                       (fn []
+                                         (set-sliding-complete false)
+                                         (set-gestures-disabled false)
+                                         (animations/reset-track-position x-pos)))
+        dimensions                    (rn/use-callback
+                                       (partial utils/get-dimensions
+                                                (or track-width constants/default-width)
+                                                size)
+                                       [track-width])
+        interpolate-track             (rn/use-callback
+                                       (partial animations/interpolate-track
+                                                x-pos
+                                                (dimensions :usable-track)
+                                                (dimensions :thumb))
+                                       [dimensions])
+        custom-color                  (if (= type :danger) :danger customization-color)
+        gesture                       (rn/use-memo #(drag-gesture x-pos
+                                                                  gestures-disabled?
+                                                                  set-gestures-disabled
+                                                                  disabled?
+                                                                  (dimensions :usable-track)
+                                                                  sliding-complete?
+                                                                  set-sliding-complete
+                                                                  on-complete
+                                                                  reset-fn)
+                                                   [gestures-disabled? sliding-complete? disabled?])]
+    [gesture/gesture-detector
+     {:gesture gesture}
+     [reanimated/view
+      {:test-ID   :slide-button-track
+       :style     (merge (style/track {:disabled?           disabled?
+                                       :customization-color custom-color
+                                       :height              (dimensions :track-height)
+                                       :blur?               blur?})
+                         container-style)
+       :on-layout on-track-layout}
+      [reanimated/view {:style (style/track-cover interpolate-track)}
+       [rn/view {:style (style/track-cover-text-container track-width)}
+        [icon/icon track-icon
+         {:color (utils/text-color custom-color theme blur?)
+          :size  20}]
+        [rn/view {:width 4}]
+        [text/text
+         {:weight :medium
+          :size   :paragraph-1
+          :style  (style/track-text custom-color theme blur?)}
+         track-text]]]
+      [reanimated/view
+       {:style (style/thumb-container {:interpolate-track   interpolate-track
+                                       :thumb-size          (dimensions :thumb)
+                                       :customization-color custom-color
+                                       :theme               theme
+                                       :blur?               blur?})}
+       [reanimated/view {:style (style/arrow-icon-container interpolate-track)}
+        [icon/icon :arrow-right
+         {:color colors/white
+          :size  20}]]
+       [reanimated/view
+        {:style (style/action-icon interpolate-track (dimensions :thumb))}
+        [icon/icon track-icon
+         {:color colors/white
+          :size  20}]]]]]))

--- a/src/quo/components/buttons/wallet_button/view.cljs
+++ b/src/quo/components/buttons/wallet_button/view.cljs
@@ -4,26 +4,24 @@
     [quo.components.icon :as quo.icons]
     [quo.foundations.colors :as colors]
     [quo.theme :as theme]
-    [react-native.core :as rn]
-    [reagent.core :as reagent]))
+    [react-native.core :as rn]))
 
-(defn- view-internal
-  []
-  (let [pressed? (reagent/atom false)]
-    (fn
-      [{:keys [on-press on-long-press disabled? icon accessibility-label container-style theme]}]
-      [rn/pressable
-       {:accessibility-label (or accessibility-label :wallet-button)
-        :on-press            on-press
-        :on-press-in         #(reset! pressed? true)
-        :on-press-out        #(reset! pressed? nil)
-        :on-long-press       on-long-press
-        :disabled            disabled?
-        :style               (merge (style/main {:pressed?  @pressed?
-                                                 :theme     theme
-                                                 :disabled? disabled?})
-                                    container-style)}
-       [quo.icons/icon icon
-        {:color (colors/theme-colors colors/neutral-100 colors/white theme)}]])))
-
-(def view (theme/with-theme view-internal))
+(defn view
+  [{:keys [on-press on-long-press disabled? icon accessibility-label container-style]}]
+  (let [theme                  (theme/use-theme-value)
+        [pressed? set-pressed] (rn/use-state false)
+        on-press-in            (rn/use-callback #(set-pressed true))
+        on-press-out           (rn/use-callback #(set-pressed nil))]
+    [rn/pressable
+     {:accessibility-label (or accessibility-label :wallet-button)
+      :on-press            on-press
+      :on-press-in         on-press-in
+      :on-press-out        on-press-out
+      :on-long-press       on-long-press
+      :disabled            disabled?
+      :style               (merge (style/main {:pressed?  pressed?
+                                               :theme     theme
+                                               :disabled? disabled?})
+                                  container-style)}
+     [quo.icons/icon icon
+      {:color (colors/theme-colors colors/neutral-100 colors/white theme)}]]))

--- a/src/status_im/common/bottom_sheet/view.cljs
+++ b/src/status_im/common/bottom_sheet/view.cljs
@@ -9,7 +9,6 @@
     [react-native.gesture :as gesture]
     [react-native.hooks :as hooks]
     [react-native.reanimated :as reanimated]
-    [reagent.core :as reagent]
     [status-im.common.bottom-sheet.style :as style]
     [utils.re-frame :as rf]))
 
@@ -57,83 +56,77 @@
            (show translate-y bg-opacity)
            (hide translate-y bg-opacity window-height on-close))))))
 
-(defn- f-view
-  [_ _]
-  (let [sheet-height (reagent/atom 0)
-        item-height  (reagent/atom 0)]
-    (fn [{:keys [hide? insets theme]}
-         {:keys [content selected-item padding-bottom-override border-radius on-close shell?
-                 gradient-cover? customization-color hide-handle? blur-radius]
-          :or   {border-radius 12}}]
-      (let [{window-height :height}           (rn/get-window)
-            bg-opacity                        (reanimated/use-shared-value 0)
-            translate-y                       (reanimated/use-shared-value window-height)
-            sheet-gesture                     (get-sheet-gesture translate-y
-                                                                 bg-opacity
-                                                                 window-height
-                                                                 on-close)
-            selected-item-smaller-than-sheet? (< @item-height
-                                                 (- window-height
-                                                    @sheet-height
-                                                    (:top insets)
-                                                    (:bottom insets)
-                                                    bottom-margin))
-            top                               (- window-height (:top insets) @sheet-height)
-            bottom                            (if selected-item-smaller-than-sheet?
-                                                (+ @sheet-height bottom-margin)
-                                                (:bottom insets))]
-        (rn/use-effect
-         #(if hide?
-            (hide translate-y bg-opacity window-height on-close)
-            (show translate-y bg-opacity))
-         [hide?])
-        (hooks/use-back-handler (fn []
-                                  (when (fn? on-close)
-                                    (on-close))
-                                  (rf/dispatch [:hide-bottom-sheet])
-                                  true))
-        [rn/view {:style {:flex 1}}
-         ;; backdrop
-         [rn/pressable
-          {:on-press #(rf/dispatch [:hide-bottom-sheet])
-           :style    {:flex 1}}
-          [reanimated/view
-           {:style (reanimated/apply-animations-to-style
-                    {:opacity bg-opacity}
-                    {:flex 1 :background-color colors/neutral-100-opa-70})}]]
-         ;; sheet
-         [gesture/gesture-detector {:gesture sheet-gesture}
-          [reanimated/view
-           {:style (reanimated/apply-animations-to-style
-                    {:transform [{:translateY translate-y}]}
-                    (style/sheet insets window-height selected-item))}
-           (when shell?
-             [blur/ios-view
-              {:style         style/shell-bg
-               :blur-radius   (or blur-radius 20)
-               :blur-type     :transparent
-               :overlay-color :transparent}])
-           (when selected-item
-             [rn/view
-              {:on-layout #(reset! item-height (.-nativeEvent.layout.height ^js %))
-               :style
-               (style/selected-item theme top bottom selected-item-smaller-than-sheet? border-radius)}
-              [selected-item]])
+(defn view
+  [{:keys [hide? insets]}
+   {:keys [content selected-item padding-bottom-override border-radius on-close shell?
+           gradient-cover? customization-color hide-handle? blur-radius]
+    :or   {border-radius 12}}]
+  (let [theme                             (quo.theme/use-theme-value)
+        sheet-height                      (rn/use-ref-atom 0)
+        item-height                       (rn/use-ref-atom 0)
+        {window-height :height}           (rn/get-window)
+        bg-opacity                        (reanimated/use-shared-value 0)
+        translate-y                       (reanimated/use-shared-value window-height)
+        sheet-gesture                     (get-sheet-gesture translate-y
+                                                             bg-opacity
+                                                             window-height
+                                                             on-close)
+        selected-item-smaller-than-sheet? (< @item-height
+                                             (- window-height
+                                                @sheet-height
+                                                (:top insets)
+                                                (:bottom insets)
+                                                bottom-margin))
+        top                               (- window-height (:top insets) @sheet-height)
+        bottom                            (if selected-item-smaller-than-sheet?
+                                            (+ @sheet-height bottom-margin)
+                                            (:bottom insets))]
+    (rn/use-effect
+     #(if hide?
+        (hide translate-y bg-opacity window-height on-close)
+        (show translate-y bg-opacity))
+     [hide?])
+    (hooks/use-back-handler (fn []
+                              (when (fn? on-close)
+                                (on-close))
+                              (rf/dispatch [:hide-bottom-sheet])
+                              true))
+    [rn/view {:style {:flex 1}}
+     ;; backdrop
+     [rn/pressable
+      {:on-press #(rf/dispatch [:hide-bottom-sheet])
+       :style    {:flex 1}}
+      [reanimated/view
+       {:style (reanimated/apply-animations-to-style
+                {:opacity bg-opacity}
+                {:flex 1 :background-color colors/neutral-100-opa-70})}]]
+     ;; sheet
+     [gesture/gesture-detector {:gesture sheet-gesture}
+      [reanimated/view
+       {:style (reanimated/apply-animations-to-style
+                {:transform [{:translateY translate-y}]}
+                (style/sheet insets window-height selected-item))}
+       (when shell?
+         [blur/ios-view
+          {:style         style/shell-bg
+           :blur-radius   (or blur-radius 20)
+           :blur-type     :transparent
+           :overlay-color :transparent}])
+       (when selected-item
+         [rn/view
+          {:on-layout #(reset! item-height (.-nativeEvent.layout.height ^js %))
+           :style
+           (style/selected-item theme top bottom selected-item-smaller-than-sheet? border-radius)}
+          [selected-item]])
 
-           [rn/view
-            {:style     (style/sheet-content theme padding-bottom-override insets shell? bottom-margin)
-             :on-layout #(reset! sheet-height (.-nativeEvent.layout.height ^js %))}
-            (when (and gradient-cover? customization-color)
-              [rn/view {:style style/gradient-bg}
-               [quo/gradient-cover
-                {:customization-color customization-color
-                 :opacity             0.4}]])
-            (when-not hide-handle?
-              [quo/drawer-bar])
-            [content]]]]]))))
-
-(defn- internal-view
-  [args sheet]
-  [:f> f-view args sheet])
-
-(def view (quo.theme/with-theme internal-view))
+       [rn/view
+        {:style     (style/sheet-content theme padding-bottom-override insets shell? bottom-margin)
+         :on-layout #(reset! sheet-height (.-nativeEvent.layout.height ^js %))}
+        (when (and gradient-cover? customization-color)
+          [rn/view {:style style/gradient-bg}
+           [quo/gradient-cover
+            {:customization-color customization-color
+             :opacity             0.4}]])
+        (when-not hide-handle?
+          [quo/drawer-bar])
+        [content]]]]]))

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -3,45 +3,32 @@
     [quo.core :as quo]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
-    [reagent.core :as reagent]
     [status-im.common.standard-authentication.standard-auth.authorize :as authorize]
     [status-im.constants :as constants]
     [utils.re-frame :as rf]))
 
-(defn- view-internal
-  [_]
-  (let [reset-slider?   (reagent/atom false)
-        on-close        (fn []
-                          (js/setTimeout
-                           #(reset! reset-slider? true)
-                           200))
+(defn view
+  [{:keys [track-text customization-color auth-button-label on-auth-success on-auth-fail
+           auth-button-icon-left size blur? container-style]
+    :or   {container-style {:flex 1}}}]
+  (let [theme           (quo.theme/use-theme-value)
         auth-method     (rf/sub [:auth-method])
-        biometric-auth? (= auth-method constants/auth-method-biometric)]
-    (fn [{:keys [track-text
-                 customization-color
-                 auth-button-label
-                 on-auth-success
-                 on-auth-fail
-                 auth-button-icon-left
-                 size
-                 theme
-                 blur?
-                 container-style]
-          :or   {container-style {:flex 1}}}]
-      [rn/view {:style container-style}
-       [quo/slide-button
-        {:size                size
-         :customization-color customization-color
-         :on-reset            (when @reset-slider? #(reset! reset-slider? false))
-         :on-complete         #(authorize/authorize {:on-close              on-close
-                                                     :auth-button-icon-left auth-button-icon-left
-                                                     :theme                 theme
-                                                     :blur?                 blur?
-                                                     :biometric-auth?       biometric-auth?
-                                                     :on-auth-success       on-auth-success
-                                                     :on-auth-fail          on-auth-fail
-                                                     :auth-button-label     auth-button-label})
-         :track-icon          (if biometric-auth? :i/face-id :password)
-         :track-text          track-text}]])))
-
-(def view (quo.theme/with-theme view-internal))
+        biometric-auth? (= auth-method constants/auth-method-biometric)
+        on-complete     (rn/use-callback
+                         (fn [reset]
+                           (authorize/authorize {:on-close              #(js/setTimeout reset 200)
+                                                 :auth-button-icon-left auth-button-icon-left
+                                                 :theme                 theme
+                                                 :blur?                 blur?
+                                                 :biometric-auth?       biometric-auth?
+                                                 :on-auth-success       on-auth-success
+                                                 :on-auth-fail          on-auth-fail
+                                                 :auth-button-label     auth-button-label}))
+                         [theme])]
+    [quo/slide-button
+     {:container-style     container-style
+      :size                size
+      :customization-color customization-color
+      :on-complete         on-complete
+      :track-icon          (if biometric-auth? :i/face-id :password)
+      :track-text          track-text}]))

--- a/src/status_im/contexts/preview/quo/buttons/slide_button.cljs
+++ b/src/status_im/contexts/preview/quo/buttons/slide_button.cljs
@@ -48,7 +48,7 @@
            :disabled?           (:disabled? @state)
            :blur?               @blur?
            :type                (:type @state)
-           :on-complete         (fn []
+           :on-complete         (fn [_]
                                   (js/setTimeout (fn [] (reset! complete? true))
                                                  1000)
                                   (js/alert "I don't wanna slide anymore"))}]


### PR DESCRIPTION

This PR is the first step in migrating from reagent atom to react state, also it changes theme context usage and use-callback for anon functions 

slide button is a good example of how components can be simplified and improved https://github.com/status-im/status-mobile/pull/18901/files#diff-0ad4df96fe272774e325a17c8b955035d50f1f9ec6802c1aae5f52dd763fae52

two effects have been eliminated