### PR TITLE
add integration test for send

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connection
 		"until [ -f $$SHADOW_OUTPUT_TO ] ; do sleep 1 ; done ; node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO --repl"
 
 test-unit: export SHADOW_OUTPUT_TO := target/unit_test/test.js
-test-unit: export SHADOW_NS_REGEXP := ^(?!tests\.integration-test)(?!tests-im\.contract-test).*-test$$
+test-unit: export SHADOW_NS_REGEXP := ^(?!tests\.integration-test)(?!tests\.contract-test).*-test$$
 test-unit: ##@test Run unit tests
 test-unit: _test-clojure
 

--- a/modules/react-native-status/nodejs/status.cpp
+++ b/modules/react-native-status/nodejs/status.cpp
@@ -670,6 +670,36 @@ void _ToChecksumAddress(const FunctionCallbackInfo<Value>& args) {
 
 }
 
+void _LoginAccount(const FunctionCallbackInfo<Value>& args) {
+	Isolate* isolate = args.GetIsolate();
+	 	Local<Context> context = isolate->GetCurrentContext();
+	
+	if (args.Length() != 1) {
+		// Throw an Error that is passed back to JavaScript
+		isolate->ThrowException(Exception::TypeError(
+			String::NewFromUtf8Literal(isolate, "Wrong number of arguments for Login")));
+		return;
+	}
+
+	// Check the argument types
+
+	if (!args[0]->IsString()) {
+		isolate->ThrowException(Exception::TypeError(
+			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'passwords'")));
+		return;
+	}
+
+	String::Utf8Value arg0Obj(isolate, args[0]->ToString(context).ToLocalChecked());
+	char *arg0 = *arg0Obj;
+
+	// Call exported Go function, which returns a C string
+	char *c = LoginAccount(arg0);
+
+	Local<String> ret = String::NewFromUtf8(isolate, c).ToLocalChecked();
+	args.GetReturnValue().Set(ret);
+	delete c;
+}
+
 void _Logout(const FunctionCallbackInfo<Value>& args) {
 	Isolate* isolate = args.GetIsolate();
 
@@ -842,6 +872,36 @@ void _CreateAccountAndLogin(const FunctionCallbackInfo<Value>& args) {
 	args.GetReturnValue().Set(ret);
 	delete c;
 
+}
+
+void _RestoreAccountAndLogin(const FunctionCallbackInfo<Value>& args) {
+	Isolate* isolate = args.GetIsolate();
+        Local<Context> context = isolate->GetCurrentContext();
+
+	if (args.Length() != 1) {
+		// Throw an Error that is passed back to JavaScript
+		isolate->ThrowException(Exception::TypeError(
+			String::NewFromUtf8Literal(isolate, "Wrong number of arguments for RestoreAccountAndLogin")));
+		return;
+	}
+
+	// Check the argument types
+
+	if (!args[0]->IsString()) {
+		isolate->ThrowException(Exception::TypeError(
+			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'RestoreAccountAndLogin'")));
+		return;
+	}
+
+	String::Utf8Value arg0Obj(isolate, args[0]->ToString(context).ToLocalChecked());
+	char *arg0 = *arg0Obj;
+
+	// Call exported Go function, which returns a C string
+	char *c = RestoreAccountAndLogin(arg0);
+
+	Local<String> ret = String::NewFromUtf8(isolate, c).ToLocalChecked();
+	args.GetReturnValue().Set(ret);
+	delete c;
 }
 
 void _ValidateMnemonic(const FunctionCallbackInfo<Value>& args) {
@@ -1911,11 +1971,13 @@ void init(Local<Object> exports) {
 	NODE_SET_METHOD(exports, "isAddress", _IsAddress);
 	NODE_SET_METHOD(exports, "sha3", _Sha3);
 	NODE_SET_METHOD(exports, "toChecksumAddress", _ToChecksumAddress);
+	NODE_SET_METHOD(exports, "loginAccount", _LoginAccount);
 	NODE_SET_METHOD(exports, "logout", _Logout);
 	NODE_SET_METHOD(exports, "hashMessage", _HashMessage);
 	NODE_SET_METHOD(exports, "resetChainData", _ResetChainData);
 	NODE_SET_METHOD(exports, "saveAccountAndLogin", _SaveAccountAndLogin);
 	NODE_SET_METHOD(exports, "createAccountAndLogin", _CreateAccountAndLogin);
+	NODE_SET_METHOD(exports, "restoreAccountAndLogin", _RestoreAccountAndLogin);
 	NODE_SET_METHOD(exports, "validateMnemonic", _ValidateMnemonic);
 	NODE_SET_METHOD(exports, "multiformatSerializePublicKey", _MultiformatSerializePublicKey);
 	NODE_SET_METHOD(exports, "saveAccountAndLoginWithKeycard", _SaveAccountAndLoginWithKeycard);

--- a/src/mocks/js_dependencies.cljs
+++ b/src/mocks/js_dependencies.cljs
@@ -2,7 +2,7 @@
   (:require-macros [legacy.status-im.utils.slurp :refer [slurp]])
   (:require
     [legacy.status-im.fleet.default-fleet :refer (default-fleets)])
-  (:require [legacy.status-im.utils.test :as utils.test]))
+  (:require [tests.test-utils :as utils.test]))
 
 ;; to generate a js Proxy at js/__STATUS_MOBILE_JS_IDENTITY_PROXY__ that accept any (.xxx) call and
 ;; return itself

--- a/src/react_native/keychain.cljs
+++ b/src/react_native/keychain.cljs
@@ -80,5 +80,5 @@
 
 (defn reset-credentials
   [server]
-  (-> (.resetInternetCredentials ^js react-native-keychain (string/lower-case server))
+  (-> (.resetInternetCredentials ^js react-native-keychain (when server (string/lower-case server)))
       (.then #(when-not % (log/error (str "Error while clearing saved password."))))))

--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -9,7 +9,7 @@
 
 (defn enabled? [v] (= "1" v))
 
-(goog-define INFURA_TOKEN "")
+(goog-define INFURA_TOKEN "d7aaebc4a3584b5198682ced53801cd3")
 (goog-define POKT_TOKEN "3ef2018191814b7e1009b8d9")
 (goog-define OPENSEA_API_KEY "")
 (goog-define RARIBLE_MAINNET_API_KEY "")
@@ -167,5 +167,5 @@
 
 (def default-kdf-iterations 3200)
 
-(def community-accounts-selection-enabled? true)
+(def community-accounts-selection-enabled? (enabled? (get-config :ACCOUNT_SELECTION_ENABLED "0")))
 (def fetch-messages-enabled? (enabled? (get-config :FETCH_MESSAGES_ENABLED "1")))

--- a/src/test_helpers/integration.clj
+++ b/src/test_helpers/integration.clj
@@ -5,7 +5,7 @@
 (defmacro with-app-initialized
   [& body]
   `(do
-     (legacy.status-im.utils.test/init!)
+     (tests.test/init!)
      (if (test-helpers.integration/app-initialized)
        (do ~@body)
        (do
@@ -20,5 +20,17 @@
      (do
        (test-helpers.integration/create-multiaccount!)
        (rf-test/wait-for [:messenger-started]
+         (test-helpers.integration/assert-messenger-started)
+         ~@body))))
+
+(defmacro with-recovered-account
+  [& body]
+  `(if (test-helpers.integration/messenger-started)
+     (do ~@body)
+     (do
+       (test-helpers.integration/recover-multiaccount!)
+       (rf-test/wait-for
+         [:messenger-started]
+         (test-helpers.integration/enable-testnet!)
          (test-helpers.integration/assert-messenger-started)
          ~@body))))

--- a/src/test_helpers/integration.clj
+++ b/src/test_helpers/integration.clj
@@ -5,7 +5,7 @@
 (defmacro with-app-initialized
   [& body]
   `(do
-     (tests.test/init!)
+     (tests.test-utils/init!)
      (if (test-helpers.integration/app-initialized)
        (do ~@body)
        (do

--- a/src/test_helpers/integration.cljs
+++ b/src/test_helpers/integration.cljs
@@ -59,8 +59,6 @@
   []
   (rf/dispatch [:profile.settings/profile-update :test-networks-enabled?
                 true {}])
-  ; can be removed soon
-  (rf/dispatch [:profile.settings/profile-update :is-sepolia-enabled? true {}])
   (rf/dispatch [:wallet/initialize]))
 
 (defn app-initialized

--- a/src/test_helpers/integration.cljs
+++ b/src/test_helpers/integration.cljs
@@ -84,7 +84,6 @@
   []
   (is (= @(rf/subscribe [:communities/create]) constants/community)))
 
-
 (defn logout
   []
   (rf/dispatch [:logout]))

--- a/src/tests/contract_test/core_test.cljs
+++ b/src/tests/contract_test/core_test.cljs
@@ -5,12 +5,12 @@
     legacy.status-im.events
     [legacy.status-im.multiaccounts.logout.core :as logout]
     legacy.status-im.subs.root
-    [legacy.status-im.utils.test :as utils.test]
     [re-frame.core :as rf]
     status-im.events
     status-im.navigation.core
     status-im.subs.root
-    [test-helpers.integration :as h]))
+    [test-helpers.integration :as h]
+    [tests.test-utils :as utils.test]))
 
 (deftest initialize-app-test
   (h/log-headline :initialize-app-test)

--- a/src/tests/integration_test/constants.cljs
+++ b/src/tests/integration_test/constants.cljs
@@ -5,3 +5,11 @@
 (def community {:membership 1 :name "foo" :description "bar"})
 
 (def account-name "account-abc")
+
+
+(def recovery-account
+  {:name        "wallet-abc"
+   :seed-phrase "destroy end torch puzzle develop note wise island disease chaos kind bus"
+   :key-uid     "0x6827f3d1e21ae723a24e0dcbac1853b5ed4d651c821a2326492ce8f2367ec905"
+   :public-key  "0x48b8b9e2a8f71e1beae729d83bcd385ffc6af0d5"
+  })

--- a/src/tests/integration_test/constants.cljs
+++ b/src/tests/integration_test/constants.cljs
@@ -6,7 +6,6 @@
 
 (def account-name "account-abc")
 
-
 (def recovery-account
   {:name        "wallet-abc"
    :seed-phrase "destroy end torch puzzle develop note wise island disease chaos kind bus"

--- a/src/tests/integration_test/core_test.cljs
+++ b/src/tests/integration_test/core_test.cljs
@@ -5,12 +5,12 @@
     legacy.status-im.events
     [legacy.status-im.multiaccounts.logout.core :as logout]
     legacy.status-im.subs.root
-    [legacy.status-im.utils.test :as utils.test]
     [re-frame.core :as rf]
     status-im.events
     status-im.navigation.core
     status-im.subs.root
-    [test-helpers.integration :as h]))
+    [test-helpers.integration :as h]
+    [tests.test-utils :as utils.test]))
 
 (deftest initialize-app-test
   (h/log-headline :initialize-app-test)

--- a/src/tests/integration_test/profile_test.cljs
+++ b/src/tests/integration_test/profile_test.cljs
@@ -3,9 +3,9 @@
     [cljs.test :refer [deftest is]]
     [day8.re-frame.test :as rf-test]
     [legacy.status-im.multiaccounts.logout.core :as logout]
-    [legacy.status-im.utils.test :as utils.test]
     [status-im.contexts.profile.utils :as profile.utils]
     [test-helpers.integration :as h]
+    [tests.test-utils :as test-utils]
     [utils.re-frame :as rf]))
 
 (deftest edit-profile-name-test
@@ -28,7 +28,7 @@
 (deftest edit-profile-picture-test
   (h/log-headline :edit-profile-picture-test)
   (let [mock-image    "resources/images/mock2/monkey.png"
-        absolute-path (.resolve utils.test/path mock-image)]
+        absolute-path (.resolve test-utils/path mock-image)]
     (rf-test/run-test-async
      (h/with-app-initialized
       (h/with-account

--- a/src/tests/integration_test/wallet_test.cljs
+++ b/src/tests/integration_test/wallet_test.cljs
@@ -23,44 +23,44 @@
   (h/log-headline :wallet-send-test)
   (rf-test/run-test-async
    (h/with-app-initialized
-    (h/with-recovered-account
-     (rf-test/wait-for
-       [:wallet/get-wallet-token]
-       (let [accs            (rf/sub [:wallet/accounts])
-             default-account (get-default-account accs)
-             address         (:address default-account)]
-         ;; navigate to account page
-         (rf/dispatch [:wallet/navigate-to-account (:address default-account)])
-         (rf-test/wait-for [:wallet/navigate-to-account]
-           ;; set the receipient address (same address as sender to avoid token loss)
-           (rf/dispatch [:wallet/select-send-address
-                         {:address    address
-                          :token      true
-                          :receipient address
-                          :stack-id   :wallet-select-address}])
-           (let [filtered-tokens (rf/sub [:wallet/tokens-filtered "eth"])]
+     (h/with-recovered-account
+       (rf-test/wait-for
+        [:wallet/get-wallet-token]
+        (let [accs            (rf/sub [:wallet/accounts])
+              default-account (get-default-account accs)
+              address         (:address default-account)]
+          ;; navigate to account page
+          (rf/dispatch [:wallet/navigate-to-account (:address default-account)])
+          (rf-test/wait-for [:wallet/navigate-to-account]
+                            ;; set the receipient address (same address as sender to avoid token loss)
+                            (rf/dispatch [:wallet/select-send-address
+                                          {:address    address
+                                           :token      true
+                                           :receipient address
+                                           :stack-id   :wallet-select-address}])
+                            (let [filtered-tokens (rf/sub [:wallet/tokens-filtered "eth"])]
 
-             (rf/dispatch [:wallet/send-select-token
-                           {:token    (first filtered-tokens)
-                            :stack-id :wallet-select-asset}])
-             (rf-test/wait-for
-               [:wallet/clean-suggested-routes]
-               (rf/dispatch
-                [:wallet/get-suggested-routes {:amount send-amount}]))
-             (rf-test/wait-for
-               [:wallet/suggested-routes-success]
-               (let [route (rf/sub [:wallet/wallet-send-route])]
-                 (is (true? (some? route)))
-                 (rf/dispatch [:wallet/send-select-amount
-                               {:amount   send-amount
-                                :stack-id :wallet-send-input-amount}])
-                 (rf/dispatch
-                  [:wallet/send-transaction
-                   (security/safe-unmask-data (security/hash-masked-password
-                                               (security/mask-data test-constants/password)))])
-                 (rf-test/wait-for [:wallet/pending-transaction-status-changed-received]
-                   (let [transaction-details (rf/sub [:wallet/send-transaction-progress])]
-                     (is (= :confirmed (-> transaction-details vals first :status)))
-                     (h/logout)
-                     (rf-test/wait-for
-                       [::logout/logout-method])))))))))))))
+                              (rf/dispatch [:wallet/send-select-token
+                                            {:token    (first filtered-tokens)
+                                             :stack-id :wallet-select-asset}])
+                              (rf-test/wait-for
+                               [:wallet/clean-suggested-routes]
+                               (rf/dispatch
+                                [:wallet/get-suggested-routes {:amount send-amount}])
+                               (rf-test/wait-for
+                                [:wallet/suggested-routes-success]
+                                (let [route (rf/sub [:wallet/wallet-send-route])]
+                                  (is (true? (some? route)))
+                                  (rf/dispatch [:wallet/send-select-amount
+                                                {:amount   send-amount
+                                                 :stack-id :wallet-send-input-amount}])
+                                  (rf/dispatch
+                                   [:wallet/send-transaction
+                                    (security/safe-unmask-data (security/hash-masked-password
+                                                                (security/mask-data test-constants/password)))])
+                                  (rf-test/wait-for [:wallet/pending-transaction-status-changed-received]
+                                                    (let [transaction-details (rf/sub [:wallet/send-transaction-progress])]
+                                                      (is (= :confirmed (-> transaction-details vals first :status)))
+                                                      (h/logout)
+                                                      (rf-test/wait-for
+                                                       [::logout/logout-method]))))))))))))))

--- a/src/tests/integration_test/wallet_test.cljs
+++ b/src/tests/integration_test/wallet_test.cljs
@@ -1,0 +1,64 @@
+(ns tests.integration-test.wallet-test
+  (:require
+    [cljs.test :refer [deftest is]]
+    [day8.re-frame.test :as rf-test]
+    legacy.status-im.events
+    legacy.status-im.subs.root
+    status-im.events
+    status-im.navigation.core
+    status-im.subs.root
+    [test-helpers.integration :as h]
+    [tests.integration-test.constants :as test-constants]
+    [utils.re-frame :as rf]
+    [utils.security.core :as security]))
+
+(defn get-default-account
+  [accounts]
+  (first (filter :wallet accounts)))
+
+(def send-amount "0.00001")
+
+(deftest wallet-send-test
+  (h/log-headline :wallet-send-test)
+  (rf-test/run-test-async
+   (h/with-app-initialized
+    (h/with-recovered-account
+     (rf-test/wait-for
+       [:wallet/get-wallet-token]
+       (let [accs            (rf/sub [:wallet/accounts])
+             default-account (get-default-account accs)
+             address         (:address default-account)]
+         ;; navigate to account page
+         (rf/dispatch [:wallet/navigate-to-account (:address default-account)])
+         (rf-test/wait-for [:wallet/navigate-to-account]
+           ;; set the receipient address (same address as sender to avoid token loss)
+           (rf/dispatch [:wallet/select-send-address
+                         {:address    address
+                          :token      true
+                          :receipient address
+                          :stack-id   :wallet-select-address}])
+           (let [filtered-tokens (rf/sub [:wallet/tokens-filtered "eth"])]
+             (rf/dispatch [:wallet/send-select-token
+                           {:token    (first filtered-tokens)
+                            :stack-id :wallet-select-asset}])
+             (rf-test/wait-for
+               [:wallet/clean-suggested-routes]
+               (rf/dispatch
+                [:wallet/get-suggested-routes send-amount]))
+             (rf-test/wait-for
+               [:wallet/suggested-routes-success]
+               (let [route (rf/sub [:wallet/wallet-send-route])]
+                 (is (true? (some? route)))
+                 (rf/dispatch [:wallet/send-select-amount
+                               {:amount   send-amount
+                                :stack-id :wallet-send-input-amount}])
+                 (rf/dispatch
+                  [:wallet/send-transaction
+                   (security/safe-unmask-data (security/hash-masked-password
+                                               (security/mask-data test-constants/password)))])
+                 (rf-test/wait-for [:wallet/pending-transaction-status-changed-received]
+                   (let [transaction-details (rf/sub [:wallet/send-transaction-progress])]
+                     (is (= :confirmed (-> transaction-details vals first :status)))
+                     (h/logout)
+                     (rf-test/wait-for
+                       [:legacy.status-im.multiaccounts.logout.core/logout-method])))))))))))))

--- a/src/tests/integration_test/wallet_test.cljs
+++ b/src/tests/integration_test/wallet_test.cljs
@@ -23,44 +23,41 @@
   (h/log-headline :wallet-send-test)
   (rf-test/run-test-async
    (h/with-app-initialized
-     (h/with-recovered-account
-       (rf-test/wait-for
-        [:wallet/get-wallet-token]
-        (let [accs            (rf/sub [:wallet/accounts])
-              default-account (get-default-account accs)
-              address         (:address default-account)]
-          ;; navigate to account page
-          (rf/dispatch [:wallet/navigate-to-account (:address default-account)])
-          (rf-test/wait-for [:wallet/navigate-to-account]
-                            ;; set the receipient address (same address as sender to avoid token loss)
-                            (rf/dispatch [:wallet/select-send-address
-                                          {:address    address
-                                           :token      true
-                                           :receipient address
-                                           :stack-id   :wallet-select-address}])
-                            (let [filtered-tokens (rf/sub [:wallet/tokens-filtered "eth"])]
-
-                              (rf/dispatch [:wallet/send-select-token
-                                            {:token    (first filtered-tokens)
-                                             :stack-id :wallet-select-asset}])
-                              (rf-test/wait-for
-                               [:wallet/clean-suggested-routes]
-                               (rf/dispatch
-                                [:wallet/get-suggested-routes {:amount send-amount}])
-                               (rf-test/wait-for
-                                [:wallet/suggested-routes-success]
-                                (let [route (rf/sub [:wallet/wallet-send-route])]
-                                  (is (true? (some? route)))
-                                  (rf/dispatch [:wallet/send-select-amount
-                                                {:amount   send-amount
-                                                 :stack-id :wallet-send-input-amount}])
-                                  (rf/dispatch
-                                   [:wallet/send-transaction
-                                    (security/safe-unmask-data (security/hash-masked-password
-                                                                (security/mask-data test-constants/password)))])
-                                  (rf-test/wait-for [:wallet/pending-transaction-status-changed-received]
-                                                    (let [transaction-details (rf/sub [:wallet/send-transaction-progress])]
-                                                      (is (= :confirmed (-> transaction-details vals first :status)))
-                                                      (h/logout)
-                                                      (rf-test/wait-for
-                                                       [::logout/logout-method]))))))))))))))
+    (h/with-recovered-account
+     (rf-test/wait-for
+       [:wallet/get-wallet-token]
+       (let [accs            (rf/sub [:wallet/accounts])
+             default-account (get-default-account accs)
+             address         (:address default-account)]
+         (rf/dispatch [:wallet/navigate-to-account (:address default-account)])
+         (rf-test/wait-for [:wallet/navigate-to-account]
+           (rf/dispatch [:wallet/select-send-address
+                         {:address    address
+                          :token      true
+                          :receipient address
+                          :stack-id   :wallet-select-address}])
+           (let [filtered-tokens (rf/sub [:wallet/tokens-filtered "eth"])]
+             (rf/dispatch [:wallet/send-select-token
+                           {:token    (first filtered-tokens)
+                            :stack-id :wallet-select-asset}])
+             (rf-test/wait-for
+               [:wallet/clean-suggested-routes]
+               (rf/dispatch
+                [:wallet/get-suggested-routes {:amount send-amount}])
+               (rf-test/wait-for
+                 [:wallet/suggested-routes-success]
+                 (let [route (rf/sub [:wallet/wallet-send-route])]
+                   (is (true? (some? route)))
+                   (rf/dispatch [:wallet/send-select-amount
+                                 {:amount   send-amount
+                                  :stack-id :wallet-send-input-amount}])
+                   (rf/dispatch
+                    [:wallet/send-transaction
+                     (security/safe-unmask-data (security/hash-masked-password
+                                                 (security/mask-data test-constants/password)))])
+                   (rf-test/wait-for [:wallet/pending-transaction-status-changed-received]
+                     (let [transaction-details (rf/sub [:wallet/send-transaction-progress])]
+                       (is (= :confirmed (-> transaction-details vals first :status)))
+                       (h/logout)
+                       (rf-test/wait-for
+                         [::logout/logout-method]))))))))))))))

--- a/src/tests/integration_test/wallet_test.cljs
+++ b/src/tests/integration_test/wallet_test.cljs
@@ -16,7 +16,7 @@
   [accounts]
   (first (filter :wallet accounts)))
 
-(def send-amount "0.00001")
+(def send-amount "0.0001")
 
 (deftest wallet-send-test
   (h/log-headline :wallet-send-test)
@@ -38,13 +38,14 @@
                           :receipient address
                           :stack-id   :wallet-select-address}])
            (let [filtered-tokens (rf/sub [:wallet/tokens-filtered "eth"])]
+
              (rf/dispatch [:wallet/send-select-token
                            {:token    (first filtered-tokens)
                             :stack-id :wallet-select-asset}])
              (rf-test/wait-for
                [:wallet/clean-suggested-routes]
                (rf/dispatch
-                [:wallet/get-suggested-routes send-amount]))
+                [:wallet/get-suggested-routes {:amount send-amount}]))
              (rf-test/wait-for
                [:wallet/suggested-routes-success]
                (let [route (rf/sub [:wallet/wallet-send-route])]

--- a/src/tests/integration_test/wallet_test.cljs
+++ b/src/tests/integration_test/wallet_test.cljs
@@ -3,6 +3,7 @@
     [cljs.test :refer [deftest is]]
     [day8.re-frame.test :as rf-test]
     legacy.status-im.events
+    [legacy.status-im.multiaccounts.logout.core :as logout]
     legacy.status-im.subs.root
     status-im.events
     status-im.navigation.core
@@ -62,4 +63,4 @@
                      (is (= :confirmed (-> transaction-details vals first :status)))
                      (h/logout)
                      (rf-test/wait-for
-                       [:legacy.status-im.multiaccounts.logout.core/logout-method])))))))))))))
+                       [::logout/logout-method])))))))))))))

--- a/src/tests/test_utils.cljs
+++ b/src/tests/test_utils.cljs
@@ -1,4 +1,4 @@
-(ns legacy.status-im.utils.test
+(ns tests.test-utils
   (:require
     [legacy.status-im.utils.deprecated-types :as types]
     [re-frame.core :as re-frame]))
@@ -70,6 +70,12 @@
       (callback (.openAccounts native-status test-dir)))
     :createAccountAndLogin
     (fn [request] (.createAccountAndLogin native-status request))
+    :restoreAccountAndLogin
+    (fn [request]
+      (prn native-status)
+      (.restoreAccountAndLogin native-status request))
+    :loginAccount
+    (fn [request] (.loginAccount native-status request))
     :logout
     (fn [] (.logout native-status))
     :multiAccountImportMnemonic
@@ -128,3 +134,4 @@
     (fn [] (.fleets native-status))
     :startLocalNotifications
     identity}))
+


### PR DESCRIPTION
This test is to cover the basic send flow.

In this test it:
recover account with balance
enable testnet

navigates through the send flow happy path and sends a small transaction to itself.

The balance diminished should be very low, I will keep adding test eth to this account daily,
an alternative is to also test using on arbitrum or optimism as fees will naturally be lower.