### PR TITLE
fix(style): :resize-method is not avaliable on ios

### DIFF
--- a/src/react_native/core.cljs
+++ b/src/react_native/core.cljs
@@ -25,10 +25,15 @@
 
 (defn image
   [{:keys [source] :as props}]
-  [image-native
-   (if (string? source)
-     (assoc props :source {:uri source})
-     props)])
+  (let [props (cond-> props
+                platform/ios?
+                (dissoc :resize-method)
+                (and (:style props) platform/ios?)
+                (update :style dissoc :resize-method))]
+    [image-native
+     (if (string? source)
+       (assoc props :source {:uri source})
+       props)]))
 
 (defn image-get-size
   [uri]


### PR DESCRIPTION
### Summary

react native doc at https://reactnative.dev/docs/image#resizemethod-android
got below error at in onboarding flow

``` text
 ERROR  Warning: Failed prop type: Invalid props.style key `resizeMethod` supplied to `Image`.
Bad object: {
  "resizeMode": "stretch",
  "resizeMethod": "scale",
  "width": 390,
  "marginTop": 12,
  "marginBottom": 4
}
Valid keys: [
  "alignContent",
  "alignItems",
  "alignSelf",
  "aspectRatio",
  "borderBottomWidth",
  "borderEndWidth",
  "borderLeftWidth",
  "borderRightWidth",
  "borderStartWidth",
  "borderTopWidth",
  "borderWidth",
  "bottom",
  "columnGap",
  "direction",
  "display",
  "end",
  "flex",
  "flexBasis",
  "flexDirection",
  "flexGrow",
  "flexShrink",
  "flexWrap",
  "gap",
  "height",
  "inset",
  "insetBlock",
  "insetBlockEnd",
  "insetBlockStart",
  "insetInline",
  "insetInlineEnd",
  "insetInlineStart",
  "justifyContent",
  "left",
  "margin",
  "marginBlock",
  "marginBlockEnd",
  "marginBlockStart",
  "marginBottom",
  "marginEnd",
  "marginHorizontal",
  "marginInline",
  "marginInlineEnd",
  "marginInlineStart",
  "marginLeft",
  "marginRight",
  "marginStart",
  "marginTop",
  "marginVertical",
  "maxHeight",
  "maxWidth",
  "minHeight",
  "minWidth",
  "overflow",
  "padding",
  "paddingBlock",
  "paddingBlockEnd",
  "paddingBlockStart",
  "paddingBottom",
  "paddingEnd",
  "paddingHorizontal",
  "paddingInline",
  "paddingInlineEnd",
  "paddingInlineStart",
  "paddingLeft",
  "paddingRight",
  "paddingStart",
  "paddingTop",
  "paddingVertical",
  "position",
  "right",
  "rowGap",
  "start",
  "top",
  "width",
  "zIndex",
  "shadowColor",
  "shadowOffset",
  "shadowOpacity",
  "shadowRadius",
  "transform",
  "backfaceVisibility",
  "backgroundColor",
  "borderBottomLeftRadius",
  "borderBottomRightRadius",
  "borderColor",
  "borderRadius",
  "borderTopLeftRadius",
  "borderTopRightRadius",
  "objectFit",
  "opacity",
  "overlayColor",
  "tintColor",
  "resizeMode"
]
BaseImage@http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=im.status.ethereum.debug:90508:106
    in react_native.core.image (created by status_im.contexts.onboarding.welcome.view.view)
    in RCTView (created by View)
    in View (created by status_im.contexts.onboarding.welcome.view.view)
    in status_im.contexts.onboarding.welcome.view.view (created by quo.theme.provider)
    in RCTView (created by View)
    in View (created by quo.theme.provider)
    in quo.theme.provider (created by reagent17)
    in reagent17 (created by gestureHandlerRootHOC(reagent17))
```
### Testing notes
illustration images style in onboarding flow should be the same

status: ready <!-- Can be ready or wip -->