### PR TITLE
[Feature] Enable Sepolia testnet by default

### DIFF
--- a/src/legacy/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/legacy/status_im/ui/screens/advanced_settings/views.cljs
@@ -20,7 +20,7 @@
            current-fleet
            webview-debug
            test-networks-enabled?
-           is-sepolia-enabled?]}]
+           is-goerli-enabled?]}]
   (keep
    identity
    [{:size :small
@@ -112,13 +112,13 @@
      :accessory :switch
      :active test-networks-enabled?}
     {:size :small
-     :title "Enable Sepolia as test network"
+     :title "Enable Goerli as test network"
      :accessibility-label :enable-sepolia-as-test-network
      :container-margin-bottom 8
      :on-press
-     #(re-frame/dispatch [:profile.settings/toggle-sepolia-test-network])
+     #(re-frame/dispatch [:profile.settings/toggle-goerli-test-network])
      :accessory :switch
-     :active is-sepolia-enabled?}
+     :active is-goerli-enabled?}
     {:size                :small
      :title               (i18n/label :t/set-currency)
      :accessibility-label :wallet-change-currency
@@ -139,7 +139,7 @@
 (views/defview advanced-settings
   []
   (views/letsubs [test-networks-enabled?           [:profile/test-networks-enabled?]
-                  is-sepolia-enabled?              [:profile/is-sepolia-enabled?]
+                  is-goerli-enabled?               [:profile/is-goerli-enabled?]
                   light-client-enabled?            [:profile/light-client-enabled?]
                   webview-debug                    [:profile/webview-debug]
                   network-name                     [:network-name]
@@ -156,6 +156,6 @@
                    :dev-mode?                        false
                    :webview-debug                    webview-debug
                    :test-networks-enabled?           test-networks-enabled?
-                   :is-sepolia-enabled?              is-sepolia-enabled?})
+                   :is-goerli-enabled?               is-goerli-enabled?})
       :key-fn    (fn [_ i] (str i))
       :render-fn render-item}]))

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -415,14 +415,14 @@
 (def ^:const ens-action-type-set-pub-key 2)
 
 ;; wallet
-(def ^:const ethereum-chain-id 1)
-(def ^:const goerli-chain-id 5)
-(def ^:const arbitrum-chain-id 42161)
-(def ^:const arbitrum-testnet-chain-id 421613)
-(def ^:const optimism-chain-id 10)
-(def ^:const optimism-testnet-chain-id 420)
+(def ^:const ethereum-mainnet-chain-id 1)
+(def ^:const ethereum-goerli-chain-id 5)
 (def ^:const ethereum-sepolia-chain-id 11155111)
+(def ^:const arbitrum-mainnet-chain-id 42161)
+(def ^:const arbitrum-goerli-chain-id 421613)
 (def ^:const arbitrum-sepolia-chain-id 421614)
+(def ^:const optimism-mainnet-chain-id 10)
+(def ^:const optimism-goerli-chain-id 420)
 (def ^:const optimism-sepolia-chain-id 11155420)
 
 (def ^:const mainnet-short-name "eth")

--- a/src/status_im/contexts/profile/settings/events.cljs
+++ b/src/status_im/contexts/profile/settings/events.cljs
@@ -70,14 +70,16 @@
                                        {:on-success on-success}])
              :on-cancel nil}]]})))
 
-(rf/reg-event-fx :profile.settings/toggle-sepolia-test-network
+(rf/reg-event-fx :profile.settings/toggle-goerli-test-network
  (fn [{:keys [db]}]
-   (let [value      (get-in db [:profile/profile :is-sepolia-enabled?])
-         on-success #(rf/dispatch [:wallet/initialize])]
-     {:fx [[:dispatch
-            [:profile.settings/profile-update :is-sepolia-enabled?
-             (not value)
-             {:on-success on-success}]]]})))
+   (let [value      (get-in db [:profile/profile :is-goerli-enabled?])
+         on-success #(rf/dispatch [:logout])]
+     {:fx [[:ui/show-confirmation
+            {:content   (i18n/label :t/goerli-testnet-toggle-confirmation)
+             :on-accept #(rf/dispatch [:profile.settings/profile-update :is-goerli-enabled?
+                                       (not value)
+                                       {:on-success on-success}])
+             :on-cancel nil}]]})))
 
 (rf/defn change-preview-privacy-flag
   {:events [:profile.settings/change-preview-privacy]}

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -191,29 +191,37 @@
     address))
 
 (def id->network
-  {constants/ethereum-chain-id         :ethereum
-   constants/goerli-chain-id           :ethereum
+  {constants/ethereum-mainnet-chain-id :ethereum
+   constants/ethereum-goerli-chain-id  :ethereum
    constants/ethereum-sepolia-chain-id :ethereum
-   constants/optimism-chain-id         :optimism
-   constants/optimism-testnet-chain-id :optimism
+   constants/optimism-mainnet-chain-id :optimism
+   constants/optimism-goerli-chain-id  :optimism
    constants/optimism-sepolia-chain-id :optimism
-   constants/arbitrum-chain-id         :arbitrum
-   constants/arbitrum-testnet-chain-id :arbitrum
+   constants/arbitrum-mainnet-chain-id :arbitrum
+   constants/arbitrum-goerli-chain-id  :arbitrum
    constants/arbitrum-sepolia-chain-id :arbitrum})
 
 (defn- get-chain-id
-  [test-net?]
-  (if test-net?
-    {:eth  constants/goerli-chain-id
-     :opt  constants/optimism-testnet-chain-id
-     :arb1 constants/arbitrum-testnet-chain-id}
-    {:eth  constants/ethereum-chain-id
-     :opt  constants/optimism-chain-id
-     :arb1 constants/arbitrum-chain-id}))
+  [testnet-enabled? goerli-enabled?]
+  (cond
+    (and testnet-enabled? goerli-enabled?)
+    {:eth  constants/ethereum-goerli-chain-id
+     :opt  constants/optimism-goerli-chain-id
+     :arb1 constants/arbitrum-goerli-chain-id}
+
+    testnet-enabled?
+    {:eth  constants/ethereum-sepolia-chain-id
+     :opt  constants/optimism-sepolia-chain-id
+     :arb1 constants/arbitrum-sepolia-chain-id}
+
+    :else
+    {:eth  constants/ethereum-mainnet-chain-id
+     :opt  constants/optimism-mainnet-chain-id
+     :arb1 constants/arbitrum-mainnet-chain-id}))
 
 (defn short-name->id
-  [short-name test-net?]
-  (let [chain-id-map (get-chain-id test-net?)]
+  [short-name testnet-enabled? goerli-enabled?]
+  (let [chain-id-map (get-chain-id testnet-enabled? goerli-enabled?)]
     (get chain-id-map short-name)))
 
 (defn get-standard-fiat-format

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -63,10 +63,11 @@
  (fn [{:keys [db]} [{:keys [address token recipient stack-id]}]]
    (let [[prefix to-address] (utils/split-prefix-and-address address)
          test-net?           (get-in db [:profile/profile :test-networks-enabled?])
+         goerli-enabled?     (get-in db [:profile/profile :is-goerli-enabled?])
          prefix-seq          (string/split prefix #":")
          selected-networks   (->> prefix-seq
                                   (remove string/blank?)
-                                  (mapv #(utils/short-name->id (keyword %) test-net?)))]
+                                  (mapv #(utils/short-name->id (keyword %) test-net? goerli-enabled?)))]
      {:db (-> db
               (assoc-in [:wallet :ui :send :recipient] (or recipient address))
               (assoc-in [:wallet :ui :send :to-address] to-address)

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -107,10 +107,10 @@
    (:test-networks-enabled? profile)))
 
 (re-frame/reg-sub
- :profile/is-sepolia-enabled?
+ :profile/is-goerli-enabled?
  :<- [:profile/profile]
  (fn [profile]
-   (:is-sepolia-enabled? profile)))
+   (:is-goerli-enabled? profile)))
 
 (re-frame/reg-sub
  :multiaccount/contact

--- a/src/status_im/subs/wallet/networks.cljs
+++ b/src/status_im/subs/wallet/networks.cljs
@@ -33,16 +33,16 @@
 (defn get-network-details
   [chain-id]
   (case chain-id
-    (constants/ethereum-chain-id constants/goerli-chain-id
-                                 constants/ethereum-sepolia-chain-id)
+    (constants/ethereum-mainnet-chain-id constants/ethereum-goerli-chain-id
+                                         constants/ethereum-sepolia-chain-id)
     mainnet-network-details
 
-    (constants/arbitrum-chain-id constants/arbitrum-testnet-chain-id
-                                 constants/arbitrum-sepolia-chain-id)
+    (constants/arbitrum-mainnet-chain-id constants/arbitrum-goerli-chain-id
+                                         constants/arbitrum-sepolia-chain-id)
     arbitrum-network-details
 
-    (constants/optimism-chain-id constants/optimism-testnet-chain-id
-                                 constants/optimism-sepolia-chain-id)
+    (constants/optimism-mainnet-chain-id constants/optimism-goerli-chain-id
+                                         constants/optimism-sepolia-chain-id)
     optimism-network-details
 
     nil))

--- a/src/tests/contract_test/wallet_test.cljs
+++ b/src/tests/contract_test/wallet_test.cljs
@@ -66,12 +66,12 @@
 (defn assert-ethereum-chains
   [response]
   (is (= number-of-networks (count response)))
-  (is (some #(= constants/ethereum-chain-id (get-in % [:Prod :chainId])) response))
-  (is (some #(= constants/optimism-chain-id (get-in % [:Prod :chainId])) response))
-  (is (some #(= constants/arbitrum-chain-id (get-in % [:Prod :chainId])) response))
-  (is (some #(= constants/goerli-chain-id (get-in % [:Test :chainId])) response))
-  (is (some #(= constants/arbitrum-testnet-chain-id (get-in % [:Test :chainId])) response))
-  (is (some #(= constants/optimism-testnet-chain-id (get-in % [:Test :chainId])) response)))
+  (is (some #(= constants/ethereum-mainnet-chain-id (get-in % [:Prod :chainId])) response))
+  (is (some #(= constants/optimism-mainnet-chain-id (get-in % [:Prod :chainId])) response))
+  (is (some #(= constants/arbitrum-mainnet-chain-id (get-in % [:Prod :chainId])) response))
+  (is (some #(= constants/ethereum-sepolia-chain-id (get-in % [:Test :chainId])) response))
+  (is (some #(= constants/arbitrum-sepolia-chain-id (get-in % [:Test :chainId])) response))
+  (is (some #(= constants/optimism-sepolia-chain-id (get-in % [:Test :chainId])) response)))
 
 (deftest accounts-get-chains-contract
   (h/log-headline :contract/wallet_get-ethereum-chains)

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.175.3",
-    "commit-sha1": "23ee898754f71341dc53e71657ef0633165f7bd3",
-    "src-sha256": "0zabdfpplzwi0dmb650cdvhrn3z7zqz70f261b3cyaxc68hc117w"
+    "version": "feat/sepolia-default",
+    "commit-sha1": "fa0e662cc9edd51e1f3f5235bbb83ebdc8c96725",
+    "src-sha256": "02p9fgar10aq6s4ff28vdppv5rvfvimfafgn9x47y82wn8iaw6s5"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "feat/sepolia-default",
-    "commit-sha1": "fa0e662cc9edd51e1f3f5235bbb83ebdc8c96725",
-    "src-sha256": "02p9fgar10aq6s4ff28vdppv5rvfvimfafgn9x47y82wn8iaw6s5"
+    "version": "v0.175.4",
+    "commit-sha1": "5304406079a5e3e1cfea285fef892ac56f2c3aad",
+    "src-sha256": "08xprnmpw0nz2zjm1wp8ypjhdyfvgmh7pqrlk69prgr23xa31ady"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -2517,5 +2517,6 @@
     "generating-keypair": "Generating keypair...",
     "keypair-name": "Keypair name",
     "keypair-name-description": "Name keypair for your own personal reference",
-    "keypair-name-input-placeholder": "Collectibles account, Old vault...."
+    "keypair-name-input-placeholder": "Collectibles account, Old vault....",
+    "goerli-testnet-toggle-confirmation": "Are you sure you want to toggle Goerli? This will log you out and you will have to login again."
 }


### PR DESCRIPTION
### Summary

This PR 
- enables Sepolia test network by default
- adds a toggle to switch to the Goerli test network

status-go PR: https://github.com/status-im/status-go/pull/4770

### Testing notes

A complete testing of Wallet is appreciated.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to `Profile > Advanced`
- Enable `Testnet mode` (Make sure the toggle `Enable Goerli as test network` is OFF)
- Navigate to the Wallet tab
- Verify assets from the Sepolia test network are shown
- Enable `Enable Goerli as test network` toggle
- Verify assets from the Goerli test network are shown

status: ready