### PR TITLE
Account selection: Use bottom sheet component

### DIFF
--- a/src/quo/components/settings/category/reorder/view.cljs
+++ b/src/quo/components/settings/category/reorder/view.cljs
@@ -16,9 +16,9 @@
   (reagent/flush))
 
 (defn- reorder-category-internal
-  [{:keys [label data blur? theme]}]
+  [{:keys [label data blur? theme container-style]}]
   (reagent/with-let [atom-data (reagent/atom data)]
-    [rn/view {:style style/container}
+    [rn/view {:style (merge (style/container label) container-style)}
      [text/text
       {:weight :medium
        :size   :paragraph-2

--- a/src/status_im/common/bottom_sheet/style.cljs
+++ b/src/status_im/common/bottom_sheet/style.cljs
@@ -31,8 +31,8 @@
    :bottom           0})
 
 (defn sheet-content
-  [{:keys [theme padding-bottom shell? max-height]}]
-  {:max-height              max-height
+  [{:keys [theme padding-bottom shell?]}]
+  {:overflow                :scroll
    :padding-bottom          padding-bottom
    :border-top-left-radius  sheet-border-radius
    :border-top-right-radius sheet-border-radius

--- a/src/status_im/common/bottom_sheet/style.cljs
+++ b/src/status_im/common/bottom_sheet/style.cljs
@@ -3,18 +3,18 @@
     [quo.foundations.colors :as colors]
     [react-native.platform :as platform]))
 
+(def ^:private sheet-border-radius 20)
+
 (defn sheet
-  [{:keys [top]} window-height selected-item]
+  [{:keys [max-height]}]
   {:position                :absolute
-   :max-height              (- window-height top)
-   :z-index                 1
    :bottom                  0
    :left                    0
    :right                   0
-   :border-top-left-radius  20
-   :border-top-right-radius 20
-   :overflow                (when-not selected-item :hidden)
-   :flex                    1})
+   :z-index                 1
+   :max-height              max-height
+   :border-top-left-radius  sheet-border-radius
+   :border-top-right-radius sheet-border-radius})
 
 (def gradient-bg
   {:position :absolute
@@ -31,10 +31,11 @@
    :bottom           0})
 
 (defn sheet-content
-  [theme padding-bottom-override {:keys [bottom]} shell? bottom-margin]
-  {:border-top-left-radius  20
-   :border-top-right-radius 20
-   :padding-bottom          (or padding-bottom-override (+ bottom bottom-margin))
+  [{:keys [theme padding-bottom shell? max-height]}]
+  {:max-height              max-height
+   :padding-bottom          padding-bottom
+   :border-top-left-radius  sheet-border-radius
+   :border-top-right-radius sheet-border-radius
    :background-color        (if shell?
                               :transparent
                               (colors/theme-colors colors/white colors/neutral-95 theme))})

--- a/src/status_im/common/bottom_sheet/view.cljs
+++ b/src/status_im/common/bottom_sheet/view.cljs
@@ -130,9 +130,7 @@
         {:on-layout set-sheet-height
          :style     (style/sheet-content {:theme          theme
                                           :shell?         shell?
-                                          :padding-bottom content-padding-bottom
-                                          :max-height     (- sheet-max-height
-                                                             content-padding-bottom)})}
+                                          :padding-bottom content-padding-bottom})}
         (when (and gradient-cover? customization-color)
           [rn/view {:style style/gradient-bg}
            [quo/gradient-cover

--- a/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
@@ -5,81 +5,92 @@
     [react-native.gesture :as gesture]
     [status-im.common.password-authentication.view :as password-authentication]
     [status-im.contexts.communities.actions.accounts-selection.style :as style]
+    [status-im.contexts.communities.actions.addresses-for-permissions.view :as addresses-for-permissions]
+    [status-im.contexts.communities.actions.airdrop-addresses.view :as airdrop-addresses]
     [status-im.contexts.communities.actions.community-rules.view :as community-rules]
     [status-im.contexts.communities.utils :as communities.utils]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn- join-community-and-navigate-back
-  [id]
-  (rf/dispatch [:password-authentication/show {:content (fn [] [password-authentication/view])}
-                {:label    (i18n/label :t/join-open-community)
-                 :on-press #(rf/dispatch [:communities/request-to-join-with-addresses
-                                          {:community-id id :password %}])}])
-  (rf/dispatch [:navigate-back]))
-
 (defn view
   []
-  (let [{id :community-id}                (rf/sub [:get-screen-params])
-        {:keys [name color images]}       (rf/sub [:communities/community id])
-        airdrop-account                   (rf/sub [:communities/airdrop-account id])
-        selected-accounts                 (rf/sub [:communities/selected-permission-accounts id])
-        {:keys [highest-permission-role]} (rf/sub [:community/token-gated-overview id])
-        highest-role-text                 (i18n/label (communities.utils/role->translation-key
-                                                       highest-permission-role
-                                                       :t/member))]
-    [rn/safe-area-view {:style style/container}
-     [quo/page-nav
-      {:text-align          :left
-       :icon-name           :i/close
-       :on-press            #(rf/dispatch [:navigate-back])
-       :accessibility-label :back-button}]
-     [quo/page-top
-      {:title       (i18n/label :t/request-to-join)
-       :description :context-tag
-       :context-tag {:type           :community
-                     :size           24
-                     :community-logo (get-in images [:thumbnail :uri])
-                     :community-name name}}]
-     [gesture/scroll-view
-      [:<>
-       [quo/text
-        {:style               style/section-title
-         :accessibility-label :community-rules-title
-         :weight              :semi-bold
-         :size                :paragraph-1}
-        (i18n/label :t/address-to-share)]
-       [quo/category
-        {:list-type :settings
-         :data      [{:title             (i18n/label :t/join-as-a {:role highest-role-text})
-                      :on-press          #(rf/dispatch [:open-modal :addresses-for-permissions
-                                                        {:community-id id}])
-                      :description       :text
-                      :action            :arrow
-                      :label             :preview
-                      :label-props       {:type :accounts
-                                          :data selected-accounts}
-                      :description-props {:text (i18n/label :t/all-addresses)}}
-                     {:title             (i18n/label :t/for-airdrops)
-                      :on-press          #(rf/dispatch [:open-modal :airdrop-addresses
-                                                        {:community-id id}])
-                      :description       :text
-                      :action            :arrow
-                      :label             :preview
-                      :label-props       {:type :accounts
-                                          :data [airdrop-account]}
-                      :description-props {:text (:name airdrop-account)}}]}]
-       [quo/text
-        {:style               style/section-title
-         :accessibility-label :community-rules-title
-         :weight              :semi-bold
-         :size                :paragraph-1}
-        (i18n/label :t/community-rules)]
-       [community-rules/view id]]]
-     [rn/view {:style (style/bottom-actions)}
-      [quo/slide-button
-       {:size                :size-48
-        :track-text          (i18n/label :t/slide-to-request-to-join)
-        :track-icon          :i/face-id
-        :customization-color color
-        :on-complete         #(join-community-and-navigate-back id)}]]]))
+  (let [{id :community-id}             (rf/sub [:get-screen-params])
+        show-addresses-for-permissions (fn []
+                                         (rf/dispatch [:show-bottom-sheet
+                                                       {:community-id id
+                                                        :content      addresses-for-permissions/view}]))
+        show-airdrop-addresses         (fn []
+                                         (rf/dispatch [:show-bottom-sheet
+                                                       {:community-id id
+                                                        :content      airdrop-addresses/view}]))
+        navigate-back                  #(rf/dispatch [:navigate-back])
+        join-and-go-back               (fn []
+                                         (rf/dispatch [:password-authentication/show
+                                                       {:content (fn [] [password-authentication/view])}
+                                                       {:label (i18n/label :t/join-open-community)
+                                                        :on-press
+                                                        #(rf/dispatch
+                                                          [:communities/request-to-join-with-addresses
+                                                           {:community-id id :password %}])}])
+                                         (navigate-back))]
+    (fn []
+      (let [{:keys [name color images]}       (rf/sub [:communities/community id])
+            airdrop-account                   (rf/sub [:communities/airdrop-account id])
+            selected-accounts                 (rf/sub [:communities/selected-permission-accounts id])
+            {:keys [highest-permission-role]} (rf/sub [:community/token-gated-overview id])
+            highest-role-text                 (i18n/label (communities.utils/role->translation-key
+                                                           highest-permission-role
+                                                           :t/member))]
+        [rn/safe-area-view {:style style/container}
+         [quo/page-nav
+          {:text-align          :left
+           :icon-name           :i/close
+           :on-press            navigate-back
+           :accessibility-label :back-button}]
+         [quo/page-top
+          {:title       (i18n/label :t/request-to-join)
+           :description :context-tag
+           :context-tag {:type           :community
+                         :size           24
+                         :community-logo (get-in images [:thumbnail :uri])
+                         :community-name name}}]
+         [gesture/scroll-view
+          [:<>
+           [quo/text
+            {:style               style/section-title
+             :accessibility-label :community-rules-title
+             :weight              :semi-bold
+             :size                :paragraph-1}
+            (i18n/label :t/address-to-share)]
+           [quo/category
+            {:list-type :settings
+             :data      [{:title             (i18n/label :t/join-as-a {:role highest-role-text})
+                          :on-press          show-addresses-for-permissions
+                          :description       :text
+                          :action            :arrow
+                          :label             :preview
+                          :label-props       {:type :accounts
+                                              :data selected-accounts}
+                          :description-props {:text (i18n/label :t/all-addresses)}}
+                         {:title             (i18n/label :t/for-airdrops)
+                          :on-press          show-airdrop-addresses
+                          :description       :text
+                          :action            :arrow
+                          :label             :preview
+                          :label-props       {:type :accounts
+                                              :data [airdrop-account]}
+                          :description-props {:text (:name airdrop-account)}}]}]
+           [quo/text
+            {:style               style/section-title
+             :accessibility-label :community-rules-title
+             :weight              :semi-bold
+             :size                :paragraph-1}
+            (i18n/label :t/community-rules)]
+           [community-rules/view id]]]
+         [rn/view {:style (style/bottom-actions)}
+          [quo/slide-button
+           {:size                :size-48
+            :track-text          (i18n/label :t/slide-to-request-to-join)
+            :track-icon          :i/face-id
+            :customization-color color
+            :on-complete         join-and-go-back}]]]))))

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/style.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/style.cljs
@@ -1,3 +1,0 @@
-(ns status-im.contexts.communities.actions.addresses-for-permissions.style)
-
-(def container {:flex 1})

--- a/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
+++ b/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
@@ -1,7 +1,7 @@
 (ns status-im.contexts.communities.actions.airdrop-addresses.view
   (:require
     [quo.core :as quo]
-    [react-native.core :as rn]
+    [react-native.gesture :as gesture]
     [status-im.common.not-implemented :as not-implemented]
     [status-im.contexts.communities.actions.airdrop-addresses.style :as style]
     [utils.i18n :as i18n]
@@ -14,7 +14,7 @@
     :state         (when (= airdrop-address (:address item)) :selected)
     :on-press      (fn []
                      (rf/dispatch [:communities/set-airdrop-address (:address item) community-id])
-                     (rf/dispatch [:navigate-back]))
+                     (rf/dispatch [:hide-bottom-sheet]))
     :emoji         (:emoji item)}])
 
 (defn view
@@ -33,7 +33,7 @@
        :on-button-press     not-implemented/alert
        :community-logo      (get-in images [:thumbnail :uri])
        :customization-color color}]
-     [rn/flat-list
+     [gesture/flat-list
       {:data                    selected-accounts
        :render-fn               render-item
        :render-data             [airdrop-address id]

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -13,9 +13,6 @@
     [status-im.contexts.chat.messenger.messages.view :as chat]
     [status-im.contexts.chat.messenger.photo-selector.view :as photo-selector]
     [status-im.contexts.communities.actions.accounts-selection.view :as communities.accounts-selection]
-    [status-im.contexts.communities.actions.addresses-for-permissions.view :as
-     addresses-for-permissions]
-    [status-im.contexts.communities.actions.airdrop-addresses.view :as airdrop-addresses]
     [status-im.contexts.communities.actions.request-to-join.view :as join-menu]
     [status-im.contexts.communities.actions.share-community-channel.view :as share-community-channel]
     [status-im.contexts.communities.discover.view :as communities.discover]
@@ -125,14 +122,6 @@
     {:name      :community-account-selection
      :options   {:sheet? true}
      :component communities.accounts-selection/view}
-
-    {:name      :addresses-for-permissions
-     :options   {:sheet? true}
-     :component addresses-for-permissions/view}
-
-    {:name      :airdrop-addresses
-     :options   {:sheet? true}
-     :component airdrop-addresses/view}
 
     {:name      :lightbox
      :options   options/lightbox


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/18617
Fixes https://github.com/status-im/status-mobile/issues/18619

### Summary

Use bottom sheet component as designed in [Figma](https://www.figma.com/file/h9wo4GipgZURbqqr1vShFN/Communities-for-Mobile?type=design&node-id=16409-98076&mode=design&t=jrVNb3JnWNurJwP8-0).

Additionally

- [x] Fixed incorrect code passing a function instance to a style prop, which leads to incorrect appearance for `settings.category.reorder.view/view`.
- [x] Optimized Reagent a little bit by extracting functions that need to close over the community ID to the mount phase. That way, we avoid regenerating function instances on every re-render and Reagent can avoid a bit of re-work.

### Review notes

The challenge for this PR was to make the scrollable content work inside a bottom sheet, while supporting the designs for a fixed (always visible) header and footer. Using `:flex 1` (as is today) in the bottom sheet `content` wrapper doesn't work. We need to tell the bottom sheet `content` to have a max height.

### Demo

As expected, the bottom sheet component auto adjusts to its content. Also, notice when the "Cancel" button is pressed, there's an animation (which on Android & `develop` doesn't currently happen to me).

[feature-correct.webm](https://github.com/status-im/status-mobile/assets/46027/5aa2784a-d07e-40e0-8749-da69c1a79179)

#### Platforms

- Android
- iOS

### Steps to test

Besides the two bugs being fixed by this PR, it's recommended to check how other bottom sheets are being displayed. I checked (on Android) usages of other bottom sheets and couldn't find any regression. Special care for iOS should be taken because I can't test in it.

status: ready
