### PR TITLE
chore: fix few outdated things in docs & readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ project dependencies, coding guidelines and testing procedures.
 Check out our [coding guidelines](doc/new-guidelines.md).
 
 - **Community Management**
-Metcalfe's law states that the value of a network is proportional to the square of the number of connected users of the system - without community Status is meaningless. We're looking to create a positive, fun environment to explore new ideas, experiment and grow the Status community. Building a community takes a lot of work but the people you'll meet and the long-lasting relationships you form will be well worth it, check out our [Mission and Community Principles](https://status.im/about)
+Metcalfe's law states that the value of a network is proportional to the square of the number of connected users of the system - without community Status is meaningless. We're looking to create a positive, fun environment to explore new ideas, experiment and grow the Status community. Building a community takes a lot of work but the people you'll meet and the long-lasting relationships you form will be well worth it, check out our [Mission and Community Principles](https://status.app/manifesto)
 
 - **Specification / Documentation**
 John Dewey once said, "Education is not preparation for life; education is life *itself* ". Developers and Designers need guidance and it all starts from documentation and specifications. Our software is only as good as its documentation, check out our [docs](doc/) and see how you can improve what we have.
@@ -53,10 +53,10 @@ Status is a visual interface to make permanent changes on the Blockchain, it han
 
 - **Evangelism**
 Help us spread the word! Tell a friend *right now*, in fact, tell **everyone** - yell from a mountain if you have to, every person counts! If you've got a great story to tell or have some interesting way you've spread the word about Status let us know about it in our [chat](https://join.status.im/chat/public/status)
-
+  
 ## Give me Binaries!
 
-You can get our Beta builds for both Android and iOS on our [website](https://status.im), through our [nightly builds](https://status.im/nightly/), or by [building it yourself](https://status.im/technical/build_status/).
+You can get our Beta builds for both Android and iOS on our [website](https://status.app), through our [nightly builds](https://status.im/nightly/), or by [building it yourself](doc/starting-guide.md).
 
 ## Core Contributors
 

--- a/doc/starting-guide.md
+++ b/doc/starting-guide.md
@@ -4,21 +4,41 @@ This document provides information on how to start developing Status App.
 
 # Getting Started
 
-To start developing start a shell for the platform you are interested in.
+To start developing clone the status-mobile repo in the directory of your choice. 
 ```
-make shell TARGET=android
+git clone https://github.com/status-im/status-mobile.git
 ```
-This step will take a while the first time as it will download all dependencies.
 
-# Development
+Then open a terminal and cd into this directory. 
 
-There are three steps necessary to start development, in this case for Android:
+```
+cd status-mobile
+```
 
-1. `make run-clojure` - Compiles Clojure into JavaScript, watches for changes on cljs files, and hot-reloads code in the app.
-2. `make run-android` or `make run-ios` - Builds the Android/iOS app, starts it on the device and starts metro bundler.
+Then build the clojure terminal 
 
-The first two will continue watching for changes and keep re-building the app. They need to be ready first.
-The last one will exit once the app is up and ready.
+```
+make run-clojure
+```
+
+note: ⚠️ This might take a while if this is your first time.
+
+This command installs `nix` and pulls in all the dependencies.
+Do answer with "Y" to all the prompts and press "Enter" when `nix` setup asks you to Acknowledge.
+This command builds the `jsbundle` and then compiles `Clojure` into `JavaScript`, watches for changes on `cljs` files, and hot-reloads code in the app.
+
+wait till you see the following message :
+
+```
+[:mobile] Build completed. (1801 files, 52 compiled, 0 warnings, 9.52s)
+```
+
+Once the clojure terminal is running you need to run the appropriate command next for your platform in a separate terminal :
+
+`make run-android` or `make run-ios`
+
+These commands will build the app, start a metro bundler and deploy the app on your simulator OR connected device (android only). For building and deploying to connected iPhones use `make run-ios-device` instead of `make run-ios`
+Also check [developing on a physical iOS Device](#Additional-requirements-for-developing-on-physical-ios-device).
 
 ## Simulators and Devices
 ### Android
@@ -45,12 +65,8 @@ Running `make run-ios` will target `iPhone 13` by default.
 
 If you need to run on any other simulator, you can specify the simulator type by adding the `SIMULATOR` flag:
 ```sh
-make run-ios SIMULATOR="iPhone 13"
+make run-ios SIMULATOR="iPhone 15"
 ```
-
-#### Running on a physical device
-
-Some manual steps are necessary for [developing on a physical iOS Device](#physical-ios-device).
 
 # Build release
 
@@ -101,16 +117,15 @@ Steps:
 3. [Setup Git to sign commits](https://help.github.com/en/github/authenticating-to-github/signing-commits)
 4. [Setup GitHub to validate commits](https://help.github.com/en/github/authenticating-to-github/adding-a-new-gpg-key-to-your-github-account)
 
-## Physical iOS Device
+## Additional requirements for developing on Physical iOS Device
 
 To use a physical iPhone your device UDID must be added to provisioning profiles and your Apple account invited as Developer to Status team.
 
 1. [Get your UDID of your iPhone.](https://www.extentia.com/post/finding-the-udid-of-an-ios-device)
 2. Request from someone with access like @cammellos or @jakubgs to
-  - Add the UDID to development devices on Apple Developer Portal.
-  - Invite your Apple account to be Developer in Status team.
-3. Run a build in XCode using the project from `status-mobile/ios` directory.
-  - You might see error: `Select a development team in the Signing & Capabilities editor`
-  - Select `Status Research & Development GmbH` as the development team and rebuild again.
-
-Once build finishes Status should start on your iPhone with its logs in terminal running `make run-metro`.
+- Add the UDID to development devices on Apple Developer Portal.
+- Invite your Apple account to be Developer in Status team.
+3. Open XCode using the project from `status-mobile/ios` directory.
+- You might see error: `Select a development team in the Signing & Capabilities editor`
+- Select `Status Research & Development GmbH` as the development team.
+4. In a new terminal execute `make clean` and then `make xcode-clean` 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -2,13 +2,11 @@
 
 ## Unit & integration tests
 
-To run tests:
+To run all tests:
 
 ```
 make test
 ```
-
-
 
 Also test watcher can be launched. It will re-run the entire test suite when any file is modified
 
@@ -51,18 +49,46 @@ Here I'm showing a terminal-only experience using Tmux (left pane Emacs, right p
 
 [2022-12-19 13-17.webm](https://user-images.githubusercontent.com/46027/208471199-1909c446-c82d-42a0-9350-0c15ca562713.webm)
 
-## Component tests
+## Component tests only
 
 To run tests:
 
 ```
-   make component-test
+make component-test
 ```
 
 Also test watcher can be launched. It will re-run the entire test suite when any file is modified
 
 ```
-   make component-test-watch
+make component-test-watch
 ```
 
 Check [component tests doc](./component-tests-overview.md) for more.
+
+## Unit tests only
+
+To run unit tests:
+
+```
+make test-unit
+```
+
+Also test watcher can be launched. It will re-run the entire test suite when any file is modified
+
+```
+make test-unit WATCH=true
+```
+
+## Integration tests only
+
+To run integration tests:
+
+```
+make test-integration
+```
+
+Also test watcher can be launched. It will re-run the entire test suite when any file is modified
+
+```
+make test-integration WATCH=true
+```

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -88,6 +88,7 @@ info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this 
 Update yarn.lock file. In order to do this, perform the following steps on a clean `status-mobile` repo:
 ```
 cd status-mobile
+make shell
 yarn install
 ```
 and don't forget to commit updated `yarn.lock` together with `package.json`.
@@ -127,23 +128,3 @@ Status-mobile uses `shadow-cljs` for hot reloading changes and uses its own [rel
 
 ### Solution
 Open react native's [In-App Developer Menu](https://reactnative.dev/docs/debugging#accessing-the-in-app-developer-menu) and press "Disable Fast Refresh" or "Disable Hot Reloading"
-
-## App Crashes after few reloads
-
-### Cause
-For x86 CPU architecture Android Devices, Hermes is creating the issue and the app crashes after a few reloads.
-([Original Issue](https://github.com/status-im/status-mobile/issues/14031))
-
-<details>
-  <summary>How to Find CPU architecture</summary>
-
-  CPU architecture of android device can be found using
-  - `adb shell uname -m` or
-  - `adb shell getprop ro.product.cpu.abilist`
-
-</details>
-
-### Solution
-Disable Hermes while building the app
-
-`make run-android DISABLE_HERMES=true`


### PR DESCRIPTION
## Summary

In this PR we brings docs upto speed on a few things : 
- remove technical doc link from old website
- update steps on how to build the app for physical iOS device
- update steps on new workflow to build app without needing `make run-metro`
- remove info about disabling `hermes`
- Add information about running integration and unit tests separately
- update getting started steps

## Review
To review open these links in a new window 
- https://github.com/status-im/status-mobile/blob/update-docs-and-main-readme/README.md
- https://github.com/status-im/status-mobile/blob/update-docs-and-main-readme/doc/starting-guide.md
- https://github.com/status-im/status-mobile/blob/update-docs-and-main-readme/doc/testing.md
- https://github.com/status-im/status-mobile/blob/update-docs-and-main-readme/doc/troubleshooting.md

status: ready
