### PR TITLE
[#18608] Collectibles fetching performance

### DIFF
--- a/src/quo/components/profile/collectible/view.cljs
+++ b/src/quo/components/profile/collectible/view.cljs
@@ -1,9 +1,9 @@
 (ns quo.components.profile.collectible.view
   (:require
-   [clojure.string :as string]
-   [quo.components.markdown.text :as text]
-   [quo.components.profile.collectible.style :as style]
-   [react-native.core :as rn]))
+    [clojure.string :as string]
+    [quo.components.markdown.text :as text]
+    [quo.components.profile.collectible.style :as style]
+    [react-native.core :as rn]))
 
 (defn remaining-tiles
   [amount]
@@ -22,20 +22,22 @@
      (cond
        svg?
        [rn/view
-        {:style (assoc image-style :border-radius (:border-radius image-style)
-                                   :overflow :hidden
-                                   :justify-content :center
-                                   :align-items :center
-                                   :background-color :lightblue)}
+        {:style (assoc image-style
+                       :border-radius    (:border-radius image-style)
+                       :overflow         :hidden
+                       :justify-content  :center
+                       :align-items      :center
+                       :background-color :lightblue)}
         [text/text "SVG Content"]]
 
        (or (string/blank? resource) (string/blank? (:uri resource)))
        [rn/view
-        {:style (assoc image-style :border-radius (:border-radius image-style)
-                                   :overflow :hidden
-                                   :justify-content :center
-                                   :align-items :center
-                                   :background-color :lightgray)}
+        {:style (assoc image-style
+                       :border-radius    (:border-radius image-style)
+                       :overflow         :hidden
+                       :justify-content  :center
+                       :align-items      :center
+                       :background-color :lightgray)}
         [text/text "Missing image"]]
 
        :else

--- a/src/quo/components/profile/collectible/view.cljs
+++ b/src/quo/components/profile/collectible/view.cljs
@@ -1,9 +1,9 @@
 (ns quo.components.profile.collectible.view
   (:require
-    [quo.components.markdown.text :as text]
-    [quo.components.profile.collectible.style :as style]
-    [react-native.core :as rn]
-    [react-native.svg :as svg]))
+   [clojure.string :as string]
+   [quo.components.markdown.text :as text]
+   [quo.components.profile.collectible.style :as style]
+   [react-native.core :as rn]))
 
 (defn remaining-tiles
   [amount]
@@ -19,11 +19,26 @@
   (let [svg?        (and (map? resource) (:svg? resource))
         image-style (style/tile-style-by-size size)]
     [rn/view {:style style}
-     (if svg?
+     (cond
+       svg?
        [rn/view
-        {:style {:border-radius (:border-radius image-style)
-                 :overflow      :hidden}}
-        [svg/svg-uri (assoc image-style :uri (:uri resource))]]
+        {:style (assoc image-style :border-radius (:border-radius image-style)
+                                   :overflow :hidden
+                                   :justify-content :center
+                                   :align-items :center
+                                   :background-color :lightblue)}
+        [text/text "SVG Content"]]
+
+       (or (string/blank? resource) (string/blank? (:uri resource)))
+       [rn/view
+        {:style (assoc image-style :border-radius (:border-radius image-style)
+                                   :overflow :hidden
+                                   :justify-content :center
+                                   :align-items :center
+                                   :background-color :lightgray)}
+        [text/text "Missing image"]]
+
+       :else
        ;; NOTE: using react-native-fast-image here causes a crash on devices when used inside a
        ;; large flatlist. The library seems to have issues with memory consumption when used with
        ;; large images/GIFs.

--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -18,6 +18,7 @@
        :assets       [assets/view]
        :collectibles [collectibles/view
                       {:collectibles         collectible-list
+                       :on-end-reached       #(rf/dispatch [:wallet/request-collectibles-for-current-viewing-account])
                        :on-collectible-press (fn [{:keys [id]}]
                                                (rf/dispatch [:wallet/get-collectible-details id]))}]
        :activity     [activity/view]

--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -17,8 +17,9 @@
      (case selected-tab
        :assets       [assets/view]
        :collectibles [collectibles/view
-                      {:collectibles         collectible-list
-                       :on-end-reached       #(rf/dispatch [:wallet/request-collectibles-for-current-viewing-account])
+                      {:collectibles collectible-list
+                       :on-end-reached #(rf/dispatch
+                                         [:wallet/request-collectibles-for-current-viewing-account])
                        :on-collectible-press (fn [{:keys [id]}]
                                                (rf/dispatch [:wallet/get-collectible-details id]))}]
        :activity     [activity/view]

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -8,7 +8,7 @@
     [utils.i18n :as i18n]))
 
 (defn- view-internal
-  [{:keys [theme collectibles filtered? on-collectible-press]}]
+  [{:keys [theme collectibles filtered? on-collectible-press on-end-reached]}]
   (let [no-results-match-query? (and filtered? (empty? collectibles))]
     (cond
       no-results-match-query?
@@ -26,14 +26,17 @@
 
       :else
       [rn/flat-list
-       {:data                    collectibles
-        :style                   {:flex 1}
-        :content-container-style {:align-items :center}
-        :num-columns             2
-        :render-fn               (fn [{:keys [preview-url] :as collectible}]
-                                   [quo/collectible
-                                    {:images   [preview-url]
-                                     :on-press #(when on-collectible-press
-                                                  (on-collectible-press collectible))}])}])))
+       {:data                     collectibles
+        :style                    {:flex 1}
+        :content-container-style  {:align-items :center}
+        :window-size              11
+        :num-columns              2
+        :render-fn                (fn [{:keys [preview-url] :as collectible}]
+                                    [quo/collectible
+                                     {:images   [preview-url]
+                                      :on-press #(when on-collectible-press
+                                                   (on-collectible-press collectible))}])
+        :on-end-reached           on-end-reached
+        :on-end-reached-threshold 4}])))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -1,12 +1,12 @@
 (ns status-im.contexts.wallet.data-store
   (:require
-    [camel-snake-kebab.core :as csk]
     [camel-snake-kebab.extras :as cske]
     [clojure.set :as set]
     [clojure.string :as string]
     [status-im.constants :as constants]
     [utils.money :as money]
-    [utils.number :as utils.number]))
+    [utils.number :as utils.number]
+    [utils.transforms :as transforms]))
 
 (defn chain-ids-string->set
   [ids-string]
@@ -78,7 +78,7 @@
   [tokens]
   (-> tokens
       (update-keys name)
-      (update-vals #(cske/transform-keys csk/->kebab-case %))
+      (update-vals #(cske/transform-keys transforms/->kebab-case-keyword %))
       (update-vals remove-tokens-with-empty-values)
       (update-vals #(mapv rpc->balances-per-chain %))))
 

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -122,4 +122,4 @@
 (defn parse-keypairs
   [keypairs]
   (let [renamed-data (rename-color-id-in-data keypairs)]
-    (cske/transform-keys csk/->kebab-case-keyword renamed-data)))
+    (cske/transform-keys transforms/->kebab-case-keyword renamed-data)))

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -59,7 +59,7 @@
            [:wallet :accounts]
            (utils.collection/index-by :address (data-store/rpc->accounts wallet-accounts)))
       :fx [[:dispatch [:wallet/get-wallet-token]]
-           [:dispatch [:wallet/request-collectibles {:start-at-index 0 :new-request? true}]]
+           [:dispatch [:wallet/request-collectibles-for-all-accounts {:new-request? true}]]
            (when new-account?
              [:dispatch [:wallet/navigate-to-new-account navigate-to-account]])]})))
 

--- a/src/status_im/contexts/wallet/events/collectibles.cljs
+++ b/src/status_im/contexts/wallet/events/collectibles.cljs
@@ -77,7 +77,8 @@
 
 (defonce collectibles-request-ids (atom 0))
 
-(defn- get-unique-collectible-request-id [amount]
+(defn- get-unique-collectible-request-id
+  [amount]
   (let [initial-id (deref collectibles-request-ids)
         last-id    (+ initial-id amount)]
     (reset! collectibles-request-ids last-id)

--- a/src/status_im/contexts/wallet/events/collectibles.cljs
+++ b/src/status_im/contexts/wallet/events/collectibles.cljs
@@ -127,7 +127,7 @@
  :wallet/get-collectible-details
  (fn [_ [collectible-id]]
    (let [request-id               0
-         collectible-id-converted (cske/transform-keys csk/->PascalCaseKeyword collectible-id)
+         collectible-id-converted (cske/transform-keys transforms/->PascalCaseKeyword collectible-id)
          data-type                (collectible-data-types :details)
          request-params           [request-id [collectible-id-converted] data-type]]
      {:fx [[:json-rpc/call
@@ -142,8 +142,8 @@
 (rf/reg-event-fx
  :wallet/get-collectible-details-done
  (fn [_ [{:keys [message]}]]
-   (let [response               (cske/transform-keys csk/->kebab-case-keyword
-                                                     (types/json->clj message))
+   (let [response               (cske/transform-keys transforms/->kebab-case-keyword
+                                                     (transforms/json->clj message))
          {:keys [collectibles]} response
          collectible            (first collectibles)]
      (if collectible

--- a/src/status_im/contexts/wallet/events/collectibles.cljs
+++ b/src/status_im/contexts/wallet/events/collectibles.cljs
@@ -92,7 +92,7 @@
                                          :account    account
                                          :amount     collectibles-per-account}]])]
      {:db (cond-> db
-            :always (assoc-in [:wallet :ui :collectibles :pending-requests] num-accounts)
+            :always      (assoc-in [:wallet :ui :collectibles :pending-requests] num-accounts)
             new-request? (update-in [:wallet :accounts] update-vals #(dissoc % :collectibles)))
       :fx (map-indexed request-collectible-effect accounts)})))
 
@@ -101,20 +101,24 @@
  (fn [{:keys [db]} _]
    (let [current-viewing-account (-> db :wallet :current-viewing-account-address)]
      {:db (assoc-in db [:wallet :ui :collectibles :pending-requests] 1)
-      :fx [[:dispatch [:wallet/request-new-collectibles-for-account
-                       {:request-id 0
-                        :account    current-viewing-account
-                        :amount     collectibles-request-batch-size}]]]})))
+      :fx [[:dispatch
+            [:wallet/request-new-collectibles-for-account
+             {:request-id 0
+              :account    current-viewing-account
+              :amount     collectibles-request-batch-size}]]]})))
 
 (rf/reg-event-fx
  :wallet/owned-collectibles-filtering-done
  (fn [{:keys [db]} [{:keys [message]}]]
    (let [{:keys [offset ownershipStatus collectibles
                  hasMore]} (transforms/json->clj message)
-         collectibles     (cske/transform-keys transforms/->kebab-case-keyword collectibles)
-         owner-address    (->> ownershipStatus first key name)
-         pending-requests (dec (get-in db [:wallet :ui :collectibles :pending-requests]))
-         collectible-idx  (+ offset (count collectibles))]
+         collectibles      (cske/transform-keys transforms/->kebab-case-keyword collectibles)
+         owner-address     (->> ownershipStatus
+                                first
+                                key
+                                name)
+         pending-requests  (dec (get-in db [:wallet :ui :collectibles :pending-requests]))
+         collectible-idx   (+ offset (count collectibles))]
      {:db (-> db
               (assoc-in [:wallet :ui :collectibles :pending-requests] pending-requests)
               (assoc-in [:wallet :ui :collectibles :fetched owner-address] collectibles)

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -67,7 +67,8 @@
                          :ownership        [{:address "0x2"
                                              :balance "1"}]}
           db            {:wallet {:ui       {:collectibles {:pending-requests 0
-                                                            :fetched          {"0x1" [collectible-1 collectible-2]
+                                                            :fetched          {"0x1" [collectible-1
+                                                                                      collectible-2]
                                                                                "0x2" [collectible-3]}}}
                                   :accounts {"0x1" {}
                                              "0x3" {}}}}

--- a/src/status_im/contexts/wallet/home/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/view.cljs
@@ -9,13 +9,15 @@
 
 (defn view
   [{:keys [selected-tab]}]
-  (let [collectible-list (rf/sub [:wallet/all-collectibles-list])]
+  (let [collectible-list     (rf/sub [:wallet/all-collectibles-list])
+        request-collectibles #(rf/dispatch
+                               [:wallet/request-collectibles-for-all-accounts {}])]
     [rn/view {:style style/container}
      (case selected-tab
        :assets       [assets/view]
        :collectibles [collectibles/view
                       {:collectibles         collectible-list
-                       :on-end-reached       #(rf/dispatch [:wallet/request-collectibles-for-all-accounts {}])
+                       :on-end-reached       request-collectibles
                        :on-collectible-press (fn [{:keys [id]}]
                                                (rf/dispatch [:wallet/get-collectible-details id]))}]
        [activity/view])]))

--- a/src/status_im/contexts/wallet/home/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/view.cljs
@@ -9,12 +9,13 @@
 
 (defn view
   [{:keys [selected-tab]}]
-  (let [collectible-list (rf/sub [:wallet/all-collectibles])]
+  (let [collectible-list (rf/sub [:wallet/all-collectibles-list])]
     [rn/view {:style style/container}
      (case selected-tab
        :assets       [assets/view]
        :collectibles [collectibles/view
                       {:collectibles         collectible-list
+                       :on-end-reached       #(rf/dispatch [:wallet/request-collectibles-for-all-accounts {}])
                        :on-collectible-press (fn [{:keys [id]}]
                                                (rf/dispatch [:wallet/get-collectible-details id]))}]
        [activity/view])]))

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.wallet.send.events
   (:require
-    [camel-snake-kebab.core :as csk]
     [camel-snake-kebab.extras :as cske]
     [clojure.string :as string]
     [native-module.core :as native-module]
@@ -11,7 +10,8 @@
     [utils.address :as address]
     [utils.money :as money]
     [utils.number]
-    [utils.re-frame :as rf]))
+    [utils.re-frame :as rf]
+    [utils.transforms :as transforms]))
 
 (rf/reg-event-fx :wallet/clean-send-data
  (fn [{:keys [db]}]
@@ -24,7 +24,7 @@
 (rf/reg-event-fx :wallet/suggested-routes-success
  (fn [{:keys [db]} [suggested-routes timestamp]]
    (when (= (get-in db [:wallet :ui :send :suggested-routes-call-timestamp]) timestamp)
-     (let [suggested-routes-data (cske/transform-keys csk/->kebab-case suggested-routes)
+     (let [suggested-routes-data (cske/transform-keys transforms/->kebab-case-keyword suggested-routes)
            chosen-route          (:best suggested-routes-data)]
        {:db (-> db
                 (assoc-in [:wallet :ui :send :suggested-routes] suggested-routes-data)
@@ -90,7 +90,7 @@
 
 (rf/reg-event-fx :wallet/clean-selected-token
  (fn [{:keys [db]}]
-   {:db (update-in db [:wallet :ui :send] dissoc :token :type)}))
+   {:db (assoc-in db [:wallet :ui :send :token] nil)}))
 
 (rf/reg-event-fx :wallet/clean-selected-collectible
  (fn [{:keys [db]}]

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -33,6 +33,7 @@
     [collectibles-tab/view
      {:collectibles         collectibles
       :filtered?            search-performed?
+      :on-end-reached       #(rf/dispatch [:wallet/request-collectibles-for-current-viewing-account])
       :on-collectible-press #(rf/dispatch [:wallet/send-select-collectible
                                            {:collectible %
                                             :stack-id    :wallet-select-asset}])}]))

--- a/src/utils/transforms.cljs
+++ b/src/utils/transforms.cljs
@@ -1,6 +1,7 @@
 (ns utils.transforms
   (:refer-clojure :exclude [js->clj])
   (:require
+    [camel-snake-kebab.core :as csk]
     [cljs-bean.core :as clj-bean]
     [oops.core :as oops]
     [reagent.impl.template :as reagent.template]
@@ -19,6 +20,9 @@
   (when-not (= json "undefined")
     (try (js->clj (.parse js/JSON json))
          (catch js/Error _ (when (string? json) json)))))
+
+(def ->kebab-case-keyword (memoize csk/->kebab-case-keyword))
+(def ->PascalCaseKeyword (memoize csk/->PascalCaseKeyword))
 
 (defn json->js
   [json]


### PR DESCRIPTION
fixes #18608
fixes #18614

## Summary

This PR improves the performance of the collectible fetching and storing by changing the strategy to request them, it gives similar results in terms of UX.

Recorded in a development build, release should be even faster.

Before (UI freezed):

[Screencast from 2024-02-20 15-55-34.webm](https://github.com/status-im/status-mobile/assets/90291778/70f72372-0a00-453c-94af-9dcdf43bb8f1)



Now:

[Screencast from 2024-02-20 14-40-16.webm](https://github.com/status-im/status-mobile/assets/90291778/c850f2ed-0548-45ea-8ffa-81726220cb72)


## Details
(if you are interested)

This PR: 

1. Adds a memoized version of key transformation functions.

    I've tried several approaches, also implementing a custom key-value cache based on a JS object (similar to reagent's one). but I realized just memoizing is the best.

    I did some local measurements (not too strict), I was getting 38 - 45ms and now I'm getting 7 - 21 ms, so this is definitely  an improvement.

2. Remove the buggy SVG collectibles.
They've been too problematic, they fill the console with warnings, and don't properly understand the svgs received. I've seen React Native Skia, we can give it a try. Now I'm just showing a placeholder for these collectibles, as well as for the missing ones. We must implement a proper collectible component. 
![image](https://github.com/status-im/status-mobile/assets/90291778/ddfbdb46-85af-4714-be32-2ff44ffa9454)
![image](https://github.com/status-im/status-mobile/assets/90291778/a66c9842-7a2f-4b4f-96ab-6013481b917d)

3. Remove the `displayable-collectibles?` function.
According to designs, all collectibles should be displayed, but some of them aren't unsupported.
![Screenshot from 2024-02-20 13-37-32](https://github.com/status-im/status-mobile/assets/90291778/4d334617-e8ea-4ff7-9baf-591651ef1793)


4. (The actual issue) Instead of requesting all the owned collectibles by batches:
    1. Reduce the batch size (from 1000 to 25)
    2. Only request one batch when the user logs in, the remaining will be requested as the user scrolls the listings.
    3. Divides the batch size (25) by the number of accounts and perform individual request to get the collectibles for each account evenly. (e.g. 25 collectibles and 5 accounts mean 5 collectibles per account). This is only applied in home screen, when we visit an account, all those 25 collectibles are for the visited account.
    4. Stores the collectibles fetched per account in a separate re-frame key (`:ui :collectibles :fetched)`, once all requests have finished, writes the collectibles into their accounts. The reason is the view is subscribed, if we update each time we receive. we'll get many re-renders, besides performance, it doesn't look good in terms of UX.
    5.  Change the subscription to list all the collectibles in the home page:
    
        This is a listing:
      
        ![image](https://github.com/status-im/status-mobile/assets/90291778/8b46cfb8-636f-4b07-abf1-bda47eceffca)
      
        So we should add new received collectibles at the end of the listing to have a nice UX, also flat list behaves weird (jumps) if new items are added in the middle. Currently we are adding in the middle, this PR changes the sub to add at the end.
      
        E.g. Currently, if we have `account-1` and `account-2` collectibles, the list would look as:
      
        - `acc-1--coll-1`
        - `acc-1--coll-2`
        - `acc-1--coll-3`
        - `acc-2--coll-1`
        - `acc-2--coll-2`
        - `acc-2--coll-3`
     
        If we receive more collectibles, for each account then they will be inserted in the middle of the listing:
     
        -  `acc-1--coll-1`
        -  `acc-1--coll-2`
        - `acc-1--coll-3`
        - `acc-1--coll-4` <- Here!
        - `acc-2--coll-1` 
        - `acc-2--coll-2`
        - `acc-2--coll-3`
        - `acc-2--coll-4` <- Here!
     
        So this PR changes the sub to return:
     
        - `acc-1--coll-1`
        - `acc-2--coll-1`
        - `acc-1--coll-2`
        - `acc-2--coll-2`
        - `acc-1--coll-3`
        - `acc-2--coll-3`
     
        New collectibles will be added to the end, and don't worry, it properly handles accounts containing a different amount of collectibles.
     


## Testing notes

Make sure to add the mentioned addreses (in this PR's issue) to test the performance. Sometimes even if you added them, status-go doesn't return the collectibles, maybe you'll need to wait (idk for how long) after adding them.

#### Platforms

- Android
- iOS


##### Non-functional

- CPU performance / speed of the app

## Steps to test

- Open Status
- Go to Wallet
- Add the addresses listed in the related issue as watch only accounts
- Log out, log in (you may need to test this many times, Status go doesn't retrieve collectibles after adding the accounts, I waited for 1 day in an emulator).


status: ready
