### PR TITLE
Fix: slide button

### DIFF
--- a/src/quo/components/buttons/slide_button/view.cljs
+++ b/src/quo/components/buttons/slide_button/view.cljs
@@ -13,7 +13,6 @@
     [react-native.gesture :as gesture]
     [react-native.reanimated :as reanimated]))
 
-<<<<<<< HEAD
 (defn drag-gesture
   [x-pos gestures-disabled? set-gestures-disabled disabled? track-width sliding-complete?
    set-sliding-complete
@@ -37,90 +36,6 @@
                                 reached-end?  (>= x-translation track-width)]
                             (when (not reached-end?)
                               (animations/reset-track-position x-pos))))))))
-=======
-(defn- f-slider
-  [{:keys [disabled?]}]
-  (let [track-width        (reagent/atom nil)
-        sliding-complete?  (reagent/atom false)
-        on-track-layout    (fn [evt]
-                             (let [width (oops/oget evt "nativeEvent.layout.width")]
-                               (reset! track-width width)))
-        gestures-disabled? (reagent/atom disabled?)]
-    (fn [{:keys [on-reset
-                 on-complete
-                 track-text
-                 track-icon
-                 disabled?
-                 customization-color
-                 size
-                 container-style
-                 theme
-                 type
-                 blur?]}]
-      (let [x-pos             (reanimated/use-shared-value 0)
-            dimensions        (partial utils/get-dimensions
-                                       (or @track-width constants/default-width)
-                                       size)
-            interpolate-track (partial animations/interpolate-track
-                                       x-pos
-                                       (dimensions :usable-track)
-                                       (dimensions :thumb))
-            custom-color      (if (= type :danger) :danger customization-color)]
-        (rn/use-effect #(reset! gestures-disabled? disabled?) [disabled?])
-        (rn/use-effect (fn []
-                         (when @sliding-complete?
-                           (on-complete)))
-                       [@sliding-complete?])
-        (rn/use-effect (fn []
-                         (when on-reset
-                           (reset! sliding-complete? false)
-                           (reset! gestures-disabled? false)
-                           (animations/reset-track-position x-pos)
-                           (on-reset)))
-                       [on-reset])
-        [gesture/gesture-detector
-         {:gesture (animations/drag-gesture x-pos
-                                            gestures-disabled?
-                                            disabled?
-                                            (dimensions :usable-track)
-                                            sliding-complete?)}
-         [reanimated/view
-          {:test-ID   :slide-button-track
-           :style     (merge (style/track {:disabled?           disabled?
-                                           :customization-color custom-color
-                                           :height              (dimensions :track-height)
-                                           :blur?               blur?})
-                             container-style)
-           :on-layout (when-not (some? @track-width)
-                        on-track-layout)}
-          [reanimated/view {:style (style/track-cover interpolate-track)}
-           [rn/view {:style (style/track-cover-text-container @track-width)}
-            [icon/icon track-icon
-             {:color (utils/text-color custom-color theme blur?)
-              :size  20}]
-            [rn/view {:width 4}]
-            [text/text
-             {:weight :medium
-              :size   :paragraph-1
-              :style  (style/track-text custom-color theme blur?)}
-             track-text]]]
-          [reanimated/view
-           {:style (style/thumb-container {:interpolate-track   interpolate-track
-                                           :thumb-size          (dimensions :thumb)
-                                           :customization-color custom-color
-                                           :theme               theme
-                                           :blur?               blur?})}
-           [reanimated/view {:style (style/arrow-icon-container interpolate-track)}
-            [icon/icon :arrow-right
-             {:color colors/white
-              :size  20}]]
-           [reanimated/view
-            {:style (style/action-icon interpolate-track
-                                       (dimensions :thumb))}
-            [icon/icon track-icon
-             {:color colors/white
-              :size  20}]]]]]))))
->>>>>>> d9ad786bd (fix slide button)
 
 (defn view
   "Options

--- a/src/quo/components/buttons/slide_button/view.cljs
+++ b/src/quo/components/buttons/slide_button/view.cljs
@@ -39,12 +39,13 @@
                               (animations/reset-track-position x-pos))))))))
 =======
 (defn- f-slider
-  []
+  [{:keys [disabled?]}]
   (let [track-width        (reagent/atom nil)
         sliding-complete?  (reagent/atom false)
         on-track-layout    (fn [evt]
                              (let [width (oops/oget evt "nativeEvent.layout.width")]
-                               (reset! track-width width)))]
+                               (reset! track-width width)))
+        gestures-disabled? (reagent/atom disabled?)]
     (fn [{:keys [on-reset
                  on-complete
                  track-text
@@ -56,8 +57,7 @@
                  theme
                  type
                  blur?]}]
-      (let [gestures-disabled? (reagent/atom disabled?)
-            x-pos             (reanimated/use-shared-value 0)
+      (let [x-pos             (reanimated/use-shared-value 0)
             dimensions        (partial utils/get-dimensions
                                        (or @track-width constants/default-width)
                                        size)
@@ -66,6 +66,7 @@
                                        (dimensions :usable-track)
                                        (dimensions :thumb))
             custom-color      (if (= type :danger) :danger customization-color)]
+        (rn/use-effect #(reset! gestures-disabled? disabled?) [disabled?])
         (rn/use-effect (fn []
                          (when @sliding-complete?
                            (on-complete)))

--- a/src/quo/components/buttons/slide_button/view.cljs
+++ b/src/quo/components/buttons/slide_button/view.cljs
@@ -86,7 +86,6 @@
                                                                   on-complete
                                                                   reset-fn)
                                                    [gestures-disabled? sliding-complete? disabled?])]
-    (rn/use-effect #(set-gestures-disabled disabled?) [disabled?])
     [gesture/gesture-detector
      {:gesture gesture}
      [reanimated/view

--- a/src/quo/components/buttons/slide_button/view.cljs
+++ b/src/quo/components/buttons/slide_button/view.cljs
@@ -17,24 +17,23 @@
   [x-pos disabled? track-width sliding-complete?
    set-sliding-complete
    on-complete reset-fn]
-  (let [gestures-enabled? (not disabled?)]
-    (-> (gesture/gesture-pan)
-        (gesture/with-test-ID :slide-button-gestures)
-        (gesture/enabled gestures-enabled?)
-        (gesture/min-distance 0)
-        (gesture/on-update (fn [event]
-                             (let [x-translation (oops/oget event "translationX")
-                                   clamped-x     (utils/clamp-value x-translation 0 track-width)
-                                   reached-end?  (>= clamped-x track-width)]
-                               (reanimated/set-shared-value x-pos clamped-x)
-                               (when (and reached-end? (not sliding-complete?))
-                                 (set-sliding-complete true)
-                                 (when on-complete (on-complete reset-fn))))))
-        (gesture/on-end (fn [event]
-                          (let [x-translation (oops/oget event "translationX")
-                                reached-end?  (>= x-translation track-width)]
-                            (when (not reached-end?)
-                              (animations/reset-track-position x-pos))))))))
+  (-> (gesture/gesture-pan)
+      (gesture/with-test-ID :slide-button-gestures)
+      (gesture/enabled (not disabled?))
+      (gesture/min-distance 0)
+      (gesture/on-update (fn [event]
+                           (let [x-translation (oops/oget event "translationX")
+                                 clamped-x     (utils/clamp-value x-translation 0 track-width)
+                                 reached-end?  (>= clamped-x track-width)]
+                             (reanimated/set-shared-value x-pos clamped-x)
+                             (when (and reached-end? (not sliding-complete?))
+                               (set-sliding-complete true)
+                               (when on-complete (on-complete reset-fn))))))
+      (gesture/on-end (fn [event]
+                        (let [x-translation (oops/oget event "translationX")
+                              reached-end?  (>= x-translation track-width)]
+                          (when (not reached-end?)
+                            (animations/reset-track-position x-pos)))))))
 
 (defn view
   "Options

--- a/src/quo/components/buttons/slide_button/view.cljs
+++ b/src/quo/components/buttons/slide_button/view.cljs
@@ -86,6 +86,7 @@
                                                                   on-complete
                                                                   reset-fn)
                                                    [gestures-disabled? sliding-complete? disabled?])]
+    (rn/use-effect #(set-gestures-disabled disabled?) [disabled?])
     [gesture/gesture-detector
      {:gesture gesture}
      [reanimated/view

--- a/src/quo/components/buttons/slide_button/view.cljs
+++ b/src/quo/components/buttons/slide_button/view.cljs
@@ -13,6 +13,7 @@
     [react-native.gesture :as gesture]
     [react-native.reanimated :as reanimated]))
 
+<<<<<<< HEAD
 (defn drag-gesture
   [x-pos gestures-disabled? set-gestures-disabled disabled? track-width sliding-complete?
    set-sliding-complete
@@ -36,6 +37,89 @@
                                 reached-end?  (>= x-translation track-width)]
                             (when (not reached-end?)
                               (animations/reset-track-position x-pos))))))))
+=======
+(defn- f-slider
+  []
+  (let [track-width        (reagent/atom nil)
+        sliding-complete?  (reagent/atom false)
+        on-track-layout    (fn [evt]
+                             (let [width (oops/oget evt "nativeEvent.layout.width")]
+                               (reset! track-width width)))]
+    (fn [{:keys [on-reset
+                 on-complete
+                 track-text
+                 track-icon
+                 disabled?
+                 customization-color
+                 size
+                 container-style
+                 theme
+                 type
+                 blur?]}]
+      (let [gestures-disabled? (reagent/atom disabled?)
+            x-pos             (reanimated/use-shared-value 0)
+            dimensions        (partial utils/get-dimensions
+                                       (or @track-width constants/default-width)
+                                       size)
+            interpolate-track (partial animations/interpolate-track
+                                       x-pos
+                                       (dimensions :usable-track)
+                                       (dimensions :thumb))
+            custom-color      (if (= type :danger) :danger customization-color)]
+        (rn/use-effect (fn []
+                         (when @sliding-complete?
+                           (on-complete)))
+                       [@sliding-complete?])
+        (rn/use-effect (fn []
+                         (when on-reset
+                           (reset! sliding-complete? false)
+                           (reset! gestures-disabled? false)
+                           (animations/reset-track-position x-pos)
+                           (on-reset)))
+                       [on-reset])
+        [gesture/gesture-detector
+         {:gesture (animations/drag-gesture x-pos
+                                            gestures-disabled?
+                                            disabled?
+                                            (dimensions :usable-track)
+                                            sliding-complete?)}
+         [reanimated/view
+          {:test-ID   :slide-button-track
+           :style     (merge (style/track {:disabled?           disabled?
+                                           :customization-color custom-color
+                                           :height              (dimensions :track-height)
+                                           :blur?               blur?})
+                             container-style)
+           :on-layout (when-not (some? @track-width)
+                        on-track-layout)}
+          [reanimated/view {:style (style/track-cover interpolate-track)}
+           [rn/view {:style (style/track-cover-text-container @track-width)}
+            [icon/icon track-icon
+             {:color (utils/text-color custom-color theme blur?)
+              :size  20}]
+            [rn/view {:width 4}]
+            [text/text
+             {:weight :medium
+              :size   :paragraph-1
+              :style  (style/track-text custom-color theme blur?)}
+             track-text]]]
+          [reanimated/view
+           {:style (style/thumb-container {:interpolate-track   interpolate-track
+                                           :thumb-size          (dimensions :thumb)
+                                           :customization-color custom-color
+                                           :theme               theme
+                                           :blur?               blur?})}
+           [reanimated/view {:style (style/arrow-icon-container interpolate-track)}
+            [icon/icon :arrow-right
+             {:color colors/white
+              :size  20}]]
+           [reanimated/view
+            {:style (style/action-icon interpolate-track
+                                       (dimensions :thumb))}
+            [icon/icon track-icon
+             {:color colors/white
+              :size  20}]]]]]))))
+>>>>>>> d9ad786bd (fix slide button)
 
 (defn view
   "Options

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -62,7 +62,7 @@
                                                      :auth-button-label     auth-button-label})
          :track-icon          (if biometric-auth? :i/face-id :password)
          :track-text          track-text
-         :disabled? disabled?}]])))
+         :disabled?           disabled?}]])))
 
 (def view (quo.theme/with-theme view-internal))
 >>>>>>> d9ad786bd (fix slide button)

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -13,6 +13,7 @@
     :or   {container-style {:flex 1}}}]
   (let [theme           (quo.theme/use-theme-value)
         auth-method     (rf/sub [:auth-method])
+<<<<<<< HEAD
         biometric-auth? (= auth-method constants/auth-method-biometric)
         on-complete     (rn/use-callback
                          (fn [reset]
@@ -32,3 +33,36 @@
       :on-complete         on-complete
       :track-icon          (if biometric-auth? :i/face-id :password)
       :track-text          track-text}]))
+=======
+        biometric-auth? (= auth-method constants/auth-method-biometric)]
+    (fn [{:keys [track-text
+                 customization-color
+                 auth-button-label
+                 on-auth-success
+                 on-auth-fail
+                 auth-button-icon-left
+                 size
+                 theme
+                 blur?
+                 disabled?
+                 container-style]
+          :or   {container-style {:flex 1}}}]
+      [rn/view {:style container-style}
+       [quo/slide-button
+        {:size                size
+         :customization-color customization-color
+         :on-reset            (when @reset-slider? #(reset! reset-slider? false))
+         :on-complete         #(authorize/authorize {:on-close              on-close
+                                                     :auth-button-icon-left auth-button-icon-left
+                                                     :theme                 theme
+                                                     :blur?                 blur?
+                                                     :biometric-auth?       biometric-auth?
+                                                     :on-auth-success       on-auth-success
+                                                     :on-auth-fail          on-auth-fail
+                                                     :auth-button-label     auth-button-label})
+         :track-icon          (if biometric-auth? :i/face-id :password)
+         :track-text          track-text
+         :disabled? disabled?}]])))
+
+(def view (quo.theme/with-theme view-internal))
+>>>>>>> d9ad786bd (fix slide button)

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -13,7 +13,6 @@
     :or   {container-style {:flex 1}}}]
   (let [theme           (quo.theme/use-theme-value)
         auth-method     (rf/sub [:auth-method])
-<<<<<<< HEAD
         biometric-auth? (= auth-method constants/auth-method-biometric)
         on-complete     (rn/use-callback
                          (fn [reset]
@@ -33,36 +32,3 @@
       :on-complete         on-complete
       :track-icon          (if biometric-auth? :i/face-id :password)
       :track-text          track-text}]))
-=======
-        biometric-auth? (= auth-method constants/auth-method-biometric)]
-    (fn [{:keys [track-text
-                 customization-color
-                 auth-button-label
-                 on-auth-success
-                 on-auth-fail
-                 auth-button-icon-left
-                 size
-                 theme
-                 blur?
-                 disabled?
-                 container-style]
-          :or   {container-style {:flex 1}}}]
-      [rn/view {:style container-style}
-       [quo/slide-button
-        {:size                size
-         :customization-color customization-color
-         :on-reset            (when @reset-slider? #(reset! reset-slider? false))
-         :on-complete         #(authorize/authorize {:on-close              on-close
-                                                     :auth-button-icon-left auth-button-icon-left
-                                                     :theme                 theme
-                                                     :blur?                 blur?
-                                                     :biometric-auth?       biometric-auth?
-                                                     :on-auth-success       on-auth-success
-                                                     :on-auth-fail          on-auth-fail
-                                                     :auth-button-label     auth-button-label})
-         :track-icon          (if biometric-auth? :i/face-id :password)
-         :track-text          track-text
-         :disabled?           disabled?}]])))
-
-(def view (quo.theme/with-theme view-internal))
->>>>>>> d9ad786bd (fix slide button)

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -32,4 +32,4 @@
       :on-complete         on-complete
       :track-icon          (if biometric-auth? :i/face-id :password)
       :track-text          track-text
-      :disabled? disabled?}]))
+      :disabled?           disabled?}]))

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -9,7 +9,7 @@
 
 (defn view
   [{:keys [track-text customization-color auth-button-label on-auth-success on-auth-fail
-           auth-button-icon-left size blur? container-style]
+           auth-button-icon-left size blur? container-style disabled?]
     :or   {container-style {:flex 1}}}]
   (let [theme           (quo.theme/use-theme-value)
         auth-method     (rf/sub [:auth-method])
@@ -31,4 +31,5 @@
       :customization-color customization-color
       :on-complete         on-complete
       :track-icon          (if biometric-auth? :i/face-id :password)
-      :track-text          track-text}]))
+      :track-text          track-text
+      :disabled? disabled?}]))

--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -65,7 +65,6 @@
                                                      public-key]))
         {window-width :width}        (rn/get-window)]
     (fn [{:keys [theme]}]
-<<<<<<< HEAD
       (let [{:keys [new-keypair]} (rf/sub [:wallet/create-account])]
         (rn/use-unmount #(rf/dispatch [:wallet/clear-new-keypair]))
         [rn/view {:style {:flex 1}}
@@ -143,91 +142,17 @@
                                                       @derivation-path})}])
                                     (rf/dispatch [:wallet/derive-address-and-add-account
                                                   {:sha3-pwd     (security/safe-unmask-data
-                                                                  entered-password)
+                                                                   entered-password)
                                                    :emoji        @emoji
                                                    :color        @account-color
                                                    :path         @derivation-path
                                                    :account-name @account-name}])))
            :auth-button-label   (i18n/label :t/confirm)
-           ;; TODO (@rende11) Add this property when sliding button issue will fixed
-           ;; https://github.com/status-im/status-mobile/pull/18683#issuecomment-1941564785
-           ;; :disabled?           (empty? @account-name)
+           :disabled?           (empty? @account-name)
            :container-style     (style/slide-button-container bottom)}]]))))
 
 (defn- view-internal
   []
   [:f> f-view])
-=======
-      [rn/view {:style {:flex 1}}
-       [quo/page-nav
-        {:type       :no-title
-         :background :blur
-         :right-side [{:icon-name :i/info
-                       :on-press  #(rf/dispatch [:show-bottom-sheet
-                                                 {:content account-origin/view}])}]
-         :icon-name  :i/close
-         :on-press   #(rf/dispatch [:navigate-back])}]
-       [quo/gradient-cover
-        {:customization-color @account-color
-         :container-style     (style/gradient-cover-container top)}]
-       [rn/view
-        {:style style/account-avatar-container}
-        [quo/account-avatar
-         {:customization-color @account-color
-          :size                80
-          :emoji               @emoji
-          :type                :default}]
-        [quo/button
-         {:size            32
-          :type            :grey
-          :background      :photo
-          :icon-only?      true
-          :on-press        #(rf/dispatch [:emoji-picker/open
-                                          {:on-select (fn [selected-emoji]
-                                                        (reset! emoji selected-emoji))}])
-          :container-style style/reaction-button-container} :i/reaction]]
-       [quo/title-input
-        {:customization-color @account-color
-         :placeholder         placeholder
-         :on-change-text      on-change-text
-         :max-length          constants/wallet-account-name-max-length
-         :blur?               true
-         :disabled?           false
-         :auto-focus          true
-         :default-value       @account-name
-         :container-style     style/title-input-container}]
-       [quo/divider-line]
-       [rn/view
-        {:style style/color-picker-container}
-        [quo/text
-         {:size   :paragraph-2
-          :weight :medium
-          :style  (style/color-label theme)}
-         (i18n/label :t/colour)]
-        [quo/color-picker
-         {:default-selected @account-color
-          :on-change        #(reset! account-color %)
-          :container-style  {:padding-vertical 12
-                             :padding-left     (iphone-11-Pro-20-pixel-from-width window-width)}}]]
-       [quo/divider-line]
-       [quo/category
-        {:list-type :settings
-         :label     (i18n/label :t/origin)
-         :data      (get-keypair-data primary-name @derivation-path @account-color)}]
-       [standard-auth/slide-button
-        {:size                :size-48
-         :track-text          (i18n/label :t/slide-to-create-account)
-         :customization-color @account-color
-         :on-auth-success     (fn [entered-password]
-                                (rf/dispatch [:wallet/derive-address-and-add-account
-                                              {:sha3-pwd     (security/safe-unmask-data entered-password)
-                                               :emoji        @emoji
-                                               :color        @account-color
-                                               :path         @derivation-path
-                                               :account-name @account-name}]))
-         :auth-button-label   (i18n/label :t/confirm)
-         :disabled?           (empty? @account-name)
-         :container-style     (style/slide-button-container bottom)}]])))
->>>>>>> 8c10e641f (fix slide button)
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -65,6 +65,7 @@
                                                      public-key]))
         {window-width :width}        (rn/get-window)]
     (fn [{:keys [theme]}]
+<<<<<<< HEAD
       (let [{:keys [new-keypair]} (rf/sub [:wallet/create-account])]
         (rn/use-unmount #(rf/dispatch [:wallet/clear-new-keypair]))
         [rn/view {:style {:flex 1}}
@@ -156,5 +157,77 @@
 (defn- view-internal
   []
   [:f> f-view])
+=======
+      [rn/view {:style {:flex 1}}
+       [quo/page-nav
+        {:type       :no-title
+         :background :blur
+         :right-side [{:icon-name :i/info
+                       :on-press  #(rf/dispatch [:show-bottom-sheet
+                                                 {:content account-origin/view}])}]
+         :icon-name  :i/close
+         :on-press   #(rf/dispatch [:navigate-back])}]
+       [quo/gradient-cover
+        {:customization-color @account-color
+         :container-style     (style/gradient-cover-container top)}]
+       [rn/view
+        {:style style/account-avatar-container}
+        [quo/account-avatar
+         {:customization-color @account-color
+          :size                80
+          :emoji               @emoji
+          :type                :default}]
+        [quo/button
+         {:size            32
+          :type            :grey
+          :background      :photo
+          :icon-only?      true
+          :on-press        #(rf/dispatch [:emoji-picker/open
+                                          {:on-select (fn [selected-emoji]
+                                                        (reset! emoji selected-emoji))}])
+          :container-style style/reaction-button-container} :i/reaction]]
+       [quo/title-input
+        {:customization-color @account-color
+         :placeholder         placeholder
+         :on-change-text      on-change-text
+         :max-length          constants/wallet-account-name-max-length
+         :blur?               true
+         :disabled?           false
+         :auto-focus          true
+         :default-value       @account-name
+         :container-style     style/title-input-container}]
+       [quo/divider-line]
+       [rn/view
+        {:style style/color-picker-container}
+        [quo/text
+         {:size   :paragraph-2
+          :weight :medium
+          :style  (style/color-label theme)}
+         (i18n/label :t/colour)]
+        [quo/color-picker
+         {:default-selected @account-color
+          :on-change        #(reset! account-color %)
+          :container-style  {:padding-vertical 12
+                             :padding-left     (iphone-11-Pro-20-pixel-from-width window-width)}}]]
+       [quo/divider-line]
+       [quo/category
+        {:list-type :settings
+         :label     (i18n/label :t/origin)
+         :data      (get-keypair-data primary-name @derivation-path @account-color)}]
+       [standard-auth/slide-button
+        {:size                :size-48
+         :track-text          (i18n/label :t/slide-to-create-account)
+         :customization-color @account-color
+         :on-auth-success     (fn [entered-password]
+                                (rf/dispatch [:wallet/derive-address-and-add-account
+                                              {:sha3-pwd     (security/safe-unmask-data entered-password)
+                                               :emoji        @emoji
+                                               :color        @account-color
+                                               :path         @derivation-path
+                                               :account-name @account-name}]))
+         :auth-button-label   (i18n/label :t/confirm)
+         :disabled?           (empty? @account-name)
+         :container-style     (style/slide-button-container bottom)}]])))
+>>>>>>> 8c10e641f (fix slide button)
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -142,7 +142,7 @@
                                                       @derivation-path})}])
                                     (rf/dispatch [:wallet/derive-address-and-add-account
                                                   {:sha3-pwd     (security/safe-unmask-data
-                                                                   entered-password)
+                                                                  entered-password)
                                                    :emoji        @emoji
                                                    :color        @account-color
                                                    :path         @derivation-path


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/18894

This PR fixes the `disabled?` prop for the slide button where the slide button wouldn't slide after changing `disabled?` from true to false


Parts affected: 
- Wallet account creation page. Demo below:

https://github.com/status-im/status-mobile/assets/29354102/78feb76f-ab34-4501-84bf-b918e358fcaf

