### PR TITLE
Updated placeholder for no pinned messages in chat

### DIFF
--- a/src/status_im/contexts/chat/messenger/menus/pinned_messages/view.cljs
+++ b/src/status_im/contexts/chat/messenger/menus/pinned_messages/view.cljs
@@ -26,15 +26,13 @@
   [message/message message context (atom false)])
 
 (defn empty-pinned-messages-state
-  [{:keys [theme community?]}]
+  [{:keys [theme]}]
   [rn/view {:style style/no-pinned-messages-container}
    [quo/empty-state
     {:blur?       false
      :image       (resources/get-themed-image :no-pinned-messages theme)
      :title       (i18n/label :t/no-pinned-messages)
-     :description (i18n/label (if community?
-                                :t/no-pinned-messages-community-desc
-                                :t/no-pinned-messages-desc))}]])
+     :description (i18n/label :t/no-pinned-messages-desc)}]])
 
 (defn f-pinned-messages
   [{:keys [theme chat-id]}]
@@ -77,8 +75,7 @@
          :key-fn      list-key-fn
          :separator   [quo/separator {:style {:margin-vertical 8}}]}]
        [empty-pinned-messages-state
-        {:community? (boolean community)
-         :theme      theme}])]))
+        {:theme theme}])]))
 
 (defn- internal-pinned-messages
   [params]

--- a/translations/en.json
+++ b/translations/en.json
@@ -2053,8 +2053,7 @@
     "you-must-always-hold": "You must always hold:",
     "shell-placeholder-title": "Your open tabs will be here",
     "shell-placeholder-subtitle": "Jump between your communities, messages,\nwallet accounts and browser tabs",
-    "no-pinned-messages-desc": "This chat doesn’t have any\npinned messages.",
-    "no-pinned-messages-community-desc": "Just keep pinning, just keep pinning \nWhat do we do? We pin, pin, pin",
+    "no-pinned-messages-desc": "Just keep pinning, just keep pinning \nWhat do we do? We pin, pin, pin",
     "invite-friends-to-status": "Invite friends to Status",
     "share-invite-link": "Share an invite link",
     "pending-requests": "Pending requests",

--- a/translations/en.json
+++ b/translations/en.json
@@ -2053,7 +2053,7 @@
     "you-must-always-hold": "You must always hold:",
     "shell-placeholder-title": "Your open tabs will be here",
     "shell-placeholder-subtitle": "Jump between your communities, messages,\nwallet accounts and browser tabs",
-    "no-pinned-messages-desc": "Just keep pinning, just keep pinning \nWhat do we do? We pin, pin, pin",
+    "no-pinned-messages-desc": "Just keep pinning, just keep pinning\nWhat do we do? We pin, pin, pin",
     "invite-friends-to-status": "Invite friends to Status",
     "share-invite-link": "Share an invite link",
     "pending-requests": "Pending requests",


### PR DESCRIPTION
fixes #18792 

### Summary

Updated the text for the chat's no pinned messages placeholder


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Create a profile
- Add a contact
- Open chat with your contact
- Tap on pinned messages while chat is empty

status: ready