### PR TITLE
Fix account edit confirmation button

### DIFF
--- a/src/status_im/common/floating_button_page/view.cljs
+++ b/src/status_im/common/floating_button_page/view.cljs
@@ -52,7 +52,7 @@
      :remove-listeners    remove-listeners}))
 
 (defn view
-  [{:keys [header footer customization-color footer-container-padding header-container-padding
+  [{:keys [header footer customization-color footer-container-padding header-container-style
            gradient-cover?]
     :or   {footer-container-padding (safe-area/get-top)}} &
    children]
@@ -88,7 +88,7 @@
        [rn/view {:style style/page-container}
         [rn/view
          {:on-layout set-header-height
-          :style     {:padding-top header-container-padding}}
+          :style     header-container-style}
          header]
         [rn/scroll-view
          {:on-scroll               set-content-y-scroll

--- a/src/status_im/common/floating_button_page/view.cljs
+++ b/src/status_im/common/floating_button_page/view.cljs
@@ -52,8 +52,10 @@
      :remove-listeners    remove-listeners}))
 
 (defn view
-  [{:keys [header footer customization-color footer-container-padding gradient-cover?]
-    :or   {footer-container-padding (safe-area/get-top)}} &
+  [{:keys [header footer customization-color footer-container-padding header-container-padding
+           gradient-cover?]
+    :or   {footer-container-padding (safe-area/get-top)
+           header-container-padding 0}} &
    children]
   (reagent/with-let [window-height                (:height (rn/get-window))
                      footer-container-height      (reagent/atom 0)
@@ -85,7 +87,9 @@
       [:<>
        (when gradient-cover? [quo/gradient-cover {:customization-color customization-color}])
        [rn/view {:style style/page-container}
-        [rn/view {:on-layout set-header-height}
+        [rn/view
+         {:on-layout set-header-height
+          :style     {:padding-top header-container-padding}}
          header]
         [rn/scroll-view
          {:on-scroll               set-content-y-scroll

--- a/src/status_im/common/floating_button_page/view.cljs
+++ b/src/status_im/common/floating_button_page/view.cljs
@@ -54,8 +54,7 @@
 (defn view
   [{:keys [header footer customization-color footer-container-padding header-container-padding
            gradient-cover?]
-    :or   {footer-container-padding (safe-area/get-top)
-           header-container-padding 0}} &
+    :or   {footer-container-padding (safe-area/get-top)}} &
    children]
   (reagent/with-let [window-height                (:height (rn/get-window))
                      footer-container-height      (reagent/atom 0)

--- a/src/status_im/contexts/wallet/add_address_to_watch/confirm_address/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/confirm_address/view.cljs
@@ -40,7 +40,6 @@
          :on-change-color     on-change-color
          :on-change-emoji     on-change-emoji
          :watch-only?         true
-         :bottom-action?      true
          :bottom-action-label :t/add-watched-address
          :bottom-action-props {:customization-color @account-color
                                :disabled?           (string/blank? @account-name)

--- a/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/style.cljs
+++ b/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/style.cljs
@@ -1,4 +1,5 @@
-(ns status-im.contexts.wallet.common.screen-base.create-or-edit-account.style)
+(ns status-im.contexts.wallet.common.screen-base.create-or-edit-account.style
+  (:require [quo.foundations.colors :as colors]))
 
 (defn root-container
   [top]
@@ -49,7 +50,8 @@
    :margin-bottom 12})
 
 (defn bottom-action
-  [bottom]
+  [{:keys [bottom theme]}]
   {:padding-horizontal 20
    :padding-vertical   12
+   :background-color   (colors/theme-colors colors/white colors/neutral-100 theme)
    :margin-bottom      bottom})

--- a/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -36,7 +36,7 @@
                                      (i18n/label bottom-action-label)]))
       :gradient-cover?          true
       :footer-container-padding 0
-      :header-container-padding (safe-area/get-top)
+      :header-container-style   {:padding-top (safe-area/get-top)}
       :customization-color      account-color}
      (into
       [:<>

--- a/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -12,7 +12,7 @@
   [{:keys [margin-top? page-nav-right-side placeholder account-name account-color account-emoji
            on-change-name
            on-change-color
-           on-change-emoji on-focus on-blur section-label bottom-action?
+           on-change-emoji on-focus on-blur section-label
            bottom-action-label bottom-action-props
            custom-bottom-action watch-only? theme]} & children]
   (let [{:keys [top bottom]}  (safe-area/get-insets)
@@ -75,17 +75,16 @@
           {:section         (i18n/label section-label)
            :container-style style/section-container}])]
       children)
-     (when bottom-action?
-       [rn/view
-        {:style (style/bottom-action {:theme  theme
-                                      :bottom bottom})}
-        (if custom-bottom-action
-          custom-bottom-action
-          [quo/button
-           (merge
-            {:size 40
-             :type :primary}
-            bottom-action-props)
-           (i18n/label bottom-action-label)])])]))
+     [rn/view
+      {:style (style/bottom-action {:theme  theme
+                                    :bottom bottom})}
+      (if custom-bottom-action
+        custom-bottom-action
+        [quo/button
+         (merge
+          {:size 40
+           :type :primary}
+          bottom-action-props)
+         (i18n/label bottom-action-label)])]]))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -1,6 +1,6 @@
 (ns status-im.contexts.wallet.common.screen-base.create-or-edit-account.view
   (:require [quo.core :as quo]
-            quo.theme
+            [quo.theme]
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
             [status-im.common.floating-button-page.view :as floating-button-page]
@@ -17,7 +17,16 @@
            hide-bottom-action?
            bottom-action-label bottom-action-props
            custom-bottom-action watch-only?]} & children]
-  (let [{window-width :width} (rn/get-window)]
+  (let [{window-width :width} (rn/get-window)
+        footer                (when-not hide-bottom-action?
+                                (if custom-bottom-action
+                                  custom-bottom-action
+                                  [quo/button
+                                   (merge
+                                    {:size 40
+                                     :type :primary}
+                                    bottom-action-props)
+                                   (i18n/label bottom-action-label)]))]
     [floating-button-page/view
      {:header                   [quo/page-nav
                                  {:type       :no-title
@@ -25,15 +34,7 @@
                                   :right-side page-nav-right-side
                                   :icon-name  :i/close
                                   :on-press   #(rf/dispatch [:navigate-back])}]
-      :footer                   (when-not hide-bottom-action?
-                                  (if custom-bottom-action
-                                    custom-bottom-action
-                                    [quo/button
-                                     (merge
-                                      {:size 40
-                                       :type :primary}
-                                      bottom-action-props)
-                                     (i18n/label bottom-action-label)]))
+      :footer                   footer
       :gradient-cover?          true
       :footer-container-padding 0
       :header-container-style   {:padding-top (safe-area/get-top)}

--- a/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.wallet.common.screen-base.create-or-edit-account.view
   (:require [quo.core :as quo]
+            quo.theme
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
             [status-im.constants :as constants]
@@ -7,13 +8,13 @@
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
-(defn view
+(defn view-internal
   [{:keys [margin-top? page-nav-right-side placeholder account-name account-color account-emoji
            on-change-name
            on-change-color
            on-change-emoji on-focus on-blur section-label bottom-action?
            bottom-action-label bottom-action-props
-           custom-bottom-action watch-only?]} & children]
+           custom-bottom-action watch-only? theme]} & children]
   (let [{:keys [top bottom]}  (safe-area/get-insets)
         margin-top            (if (false? margin-top?) 0 top)
         {window-width :width} (rn/get-window)]
@@ -30,7 +31,9 @@
       {:customization-color account-color
        :container-style     (style/gradient-cover-container margin-top)}]
      (into
-      [:<>
+      [rn/scroll-view
+       {:keyboard-should-persist-taps :always
+        :style                        {:flex 1}}
        [rn/view {:style style/account-avatar-container}
         [quo/account-avatar
          {:customization-color account-color
@@ -73,7 +76,9 @@
            :container-style style/section-container}])]
       children)
      (when bottom-action?
-       [rn/view {:style (style/bottom-action bottom)}
+       [rn/view
+        {:style (style/bottom-action {:theme  theme
+                                      :bottom bottom})}
         (if custom-bottom-action
           custom-bottom-action
           [quo/button
@@ -82,3 +87,5 @@
              :type :primary}
             bottom-action-props)
            (i18n/label bottom-action-label)])])]))
+
+(def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -12,7 +12,7 @@
   [{:keys [margin-top? page-nav-right-side placeholder account-name account-color account-emoji
            on-change-name
            on-change-color
-           on-change-emoji on-focus on-blur section-label
+           on-change-emoji section-label
            bottom-action-label bottom-action-props
            custom-bottom-action watch-only? theme]} & children]
   (let [{:keys [top bottom]}  (safe-area/get-insets)
@@ -55,9 +55,7 @@
          :default-value   account-name
          :auto-focus      true
          :on-change-text  on-change-name
-         :container-style style/title-input-container
-         :on-focus        on-focus
-         :on-blur         on-blur}]
+         :container-style style/title-input-container}]
        [quo/divider-line {:container-style style/divider-1}]
        [quo/section-label
         {:section         (i18n/label :t/colour)

--- a/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -3,86 +3,78 @@
             quo.theme
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
+            [status-im.common.floating-button-page.view :as floating-button-page]
             [status-im.constants :as constants]
             [status-im.contexts.wallet.common.screen-base.create-or-edit-account.style :as style]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
-(defn view-internal
-  [{:keys [margin-top? page-nav-right-side placeholder account-name account-color account-emoji
+(defn view
+  [{:keys [page-nav-right-side placeholder account-name account-color account-emoji
            on-change-name
            on-change-color
+           margin-top?
            on-change-emoji section-label
            bottom-action-label bottom-action-props
-           custom-bottom-action watch-only? theme]} & children]
-  (let [{:keys [top bottom]}  (safe-area/get-insets)
-        margin-top            (if (false? margin-top?) 0 top)
-        {window-width :width} (rn/get-window)]
-    [rn/keyboard-avoiding-view
-     {:style                    (style/root-container margin-top)
-      :keyboard-vertical-offset (- bottom)}
-     [quo/page-nav
-      {:type       :no-title
-       :background :blur
-       :right-side page-nav-right-side
-       :icon-name  :i/close
-       :on-press   #(rf/dispatch [:navigate-back])}]
-     [quo/gradient-cover
-      {:customization-color account-color
-       :container-style     (style/gradient-cover-container margin-top)}]
-     (into
-      [rn/scroll-view
-       {:keyboard-should-persist-taps :always
-        :style                        {:flex 1}}
-       [rn/view {:style style/account-avatar-container}
-        [quo/account-avatar
-         {:customization-color account-color
-          :size                80
-          :emoji               account-emoji
-          :type                (if watch-only? :watch-only :default)}]
-        [quo/button
-         {:size            32
-          :type            :grey
-          :background      :photo
-          :icon-only?      true
-          :on-press        #(rf/dispatch [:emoji-picker/open {:on-select on-change-emoji}])
-          :container-style style/reaction-button-container}
-         :i/reaction]]
-       [quo/title-input
-        {:placeholder     placeholder
-         :max-length      constants/wallet-account-name-max-length
-         :blur?           true
-         :default-value   account-name
-         :auto-focus      true
-         :on-change-text  on-change-name
-         :container-style style/title-input-container}]
-       [quo/divider-line {:container-style style/divider-1}]
-       [quo/section-label
-        {:section         (i18n/label :t/colour)
-         :container-style style/section-container}]
-       [rn/view
-        {:style style/color-picker-container}
-        [quo/color-picker
-         {:default-selected account-color
-          :on-change        on-change-color
-          :container-style  style/color-picker
-          :window-width     window-width}]]
-       [quo/divider-line {:container-style style/divider-2}]
-       (when section-label
-         [quo/section-label
-          {:section         (i18n/label section-label)
-           :container-style style/section-container}])]
-      children)
-     [rn/view
-      {:style (style/bottom-action {:theme  theme
-                                    :bottom bottom})}
-      (if custom-bottom-action
-        custom-bottom-action
-        [quo/button
-         (merge
-          {:size 40
-           :type :primary}
-          bottom-action-props)
-         (i18n/label bottom-action-label)])]]))
-
-(def view (quo.theme/with-theme view-internal))
+           custom-bottom-action watch-only?]} & children]
+  (let [{window-width :width} (rn/get-window)
+        {:keys [top]}         (safe-area/get-insets)
+        margin-top            (if (not margin-top?) 0 top)]
+    [floating-button-page/view
+     {:header                   [quo/page-nav
+                                 {:type       :no-title
+                                  :background :blur
+                                  :right-side page-nav-right-side
+                                  :icon-name  :i/close
+                                  :on-press   #(rf/dispatch [:navigate-back])}]
+      :footer                   (if custom-bottom-action
+                                  custom-bottom-action
+                                  [quo/button
+                                   (merge
+                                    {:size 40
+                                     :type :primary}
+                                    bottom-action-props)
+                                   (i18n/label bottom-action-label)])
+      :gradient-cover?          true
+      :footer-container-padding 0
+      :customization-color      account-color}
+     [:<>
+      [rn/view {:style style/account-avatar-container}
+       [quo/account-avatar
+        {:customization-color account-color
+         :size                80
+         :emoji               account-emoji
+         :type                (if watch-only? :watch-only :default)}]
+       [quo/button
+        {:size            32
+         :type            :grey
+         :background      :photo
+         :icon-only?      true
+         :on-press        #(rf/dispatch [:emoji-picker/open {:on-select on-change-emoji}])
+         :container-style style/reaction-button-container}
+        :i/reaction]]
+      [quo/title-input
+       {:placeholder     placeholder
+        :max-length      constants/wallet-account-name-max-length
+        :blur?           true
+        :default-value   account-name
+        :auto-focus      true
+        :on-change-text  on-change-name
+        :container-style style/title-input-container}]
+      [quo/divider-line {:container-style style/divider-1}]
+      [quo/section-label
+       {:section         (i18n/label :t/colour)
+        :container-style style/section-container}]
+      [rn/view
+       {:style style/color-picker-container}
+       [quo/color-picker
+        {:default-selected account-color
+         :on-change        on-change-color
+         :container-style  style/color-picker
+         :window-width     window-width}]]
+      [quo/divider-line {:container-style style/divider-2}]
+      (when section-label
+        [quo/section-label
+         {:section         (i18n/label section-label)
+          :container-style style/section-container}])
+      children]]))

--- a/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -2,6 +2,7 @@
   (:require [quo.core :as quo]
             quo.theme
             [react-native.core :as rn]
+            [react-native.safe-area :as safe-area]
             [status-im.common.floating-button-page.view :as floating-button-page]
             [status-im.constants :as constants]
             [status-im.contexts.wallet.common.screen-base.create-or-edit-account.style :as style]
@@ -35,44 +36,46 @@
                                      (i18n/label bottom-action-label)]))
       :gradient-cover?          true
       :footer-container-padding 0
+      :header-container-padding (safe-area/get-top)
       :customization-color      account-color}
-     [:<>
-      [rn/view {:style style/account-avatar-container}
-       [quo/account-avatar
-        {:customization-color account-color
-         :size                80
-         :emoji               account-emoji
-         :type                (if watch-only? :watch-only :default)}]
-       [quo/button
-        {:size            32
-         :type            :grey
-         :background      :photo
-         :icon-only?      true
-         :on-press        #(rf/dispatch [:emoji-picker/open {:on-select on-change-emoji}])
-         :container-style style/reaction-button-container}
-        :i/reaction]]
-      [quo/title-input
-       {:placeholder     placeholder
-        :max-length      constants/wallet-account-name-max-length
-        :blur?           true
-        :default-value   account-name
-        :auto-focus      true
-        :on-change-text  on-change-name
-        :container-style style/title-input-container}]
-      [quo/divider-line {:container-style style/divider-1}]
-      [quo/section-label
-       {:section         (i18n/label :t/colour)
-        :container-style style/section-container}]
-      [rn/view
-       {:style style/color-picker-container}
-       [quo/color-picker
-        {:default-selected account-color
-         :on-change        on-change-color
-         :container-style  style/color-picker
-         :window-width     window-width}]]
-      [quo/divider-line {:container-style style/divider-2}]
-      (when section-label
-        [quo/section-label
-         {:section         (i18n/label section-label)
-          :container-style style/section-container}])
-      children]]))
+     (into
+      [:<>
+       [rn/view {:style style/account-avatar-container}
+        [quo/account-avatar
+         {:customization-color account-color
+          :size                80
+          :emoji               account-emoji
+          :type                (if watch-only? :watch-only :default)}]
+        [quo/button
+         {:size            32
+          :type            :grey
+          :background      :photo
+          :icon-only?      true
+          :on-press        #(rf/dispatch [:emoji-picker/open {:on-select on-change-emoji}])
+          :container-style style/reaction-button-container}
+         :i/reaction]]
+       [quo/title-input
+        {:placeholder     placeholder
+         :max-length      constants/wallet-account-name-max-length
+         :blur?           true
+         :default-value   account-name
+         :auto-focus      true
+         :on-change-text  on-change-name
+         :container-style style/title-input-container}]
+       [quo/divider-line {:container-style style/divider-1}]
+       [quo/section-label
+        {:section         (i18n/label :t/colour)
+         :container-style style/section-container}]
+       [rn/view
+        {:style style/color-picker-container}
+        [quo/color-picker
+         {:default-selected account-color
+          :on-change        on-change-color
+          :container-style  style/color-picker
+          :window-width     window-width}]]
+       [quo/divider-line {:container-style style/divider-2}]
+       (when section-label
+         [quo/section-label
+          {:section         (i18n/label section-label)
+           :container-style style/section-container}])]
+      children)]))

--- a/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -13,6 +13,7 @@
            on-change-name
            on-change-color
            on-change-emoji section-label
+           hide-bottom-action?
            bottom-action-label bottom-action-props
            custom-bottom-action watch-only?]} & children]
   (let [{window-width :width} (rn/get-window)]
@@ -23,14 +24,15 @@
                                   :right-side page-nav-right-side
                                   :icon-name  :i/close
                                   :on-press   #(rf/dispatch [:navigate-back])}]
-      :footer                   (if custom-bottom-action
-                                  custom-bottom-action
-                                  [quo/button
-                                   (merge
-                                    {:size 40
-                                     :type :primary}
-                                    bottom-action-props)
-                                   (i18n/label bottom-action-label)])
+      :footer                   (when-not hide-bottom-action?
+                                  (if custom-bottom-action
+                                    custom-bottom-action
+                                    [quo/button
+                                     (merge
+                                      {:size 40
+                                       :type :primary}
+                                      bottom-action-props)
+                                     (i18n/label bottom-action-label)]))
       :gradient-cover?          true
       :footer-container-padding 0
       :customization-color      account-color}

--- a/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -2,7 +2,6 @@
   (:require [quo.core :as quo]
             quo.theme
             [react-native.core :as rn]
-            [react-native.safe-area :as safe-area]
             [status-im.common.floating-button-page.view :as floating-button-page]
             [status-im.constants :as constants]
             [status-im.contexts.wallet.common.screen-base.create-or-edit-account.style :as style]
@@ -13,13 +12,10 @@
   [{:keys [page-nav-right-side placeholder account-name account-color account-emoji
            on-change-name
            on-change-color
-           margin-top?
            on-change-emoji section-label
            bottom-action-label bottom-action-props
            custom-bottom-action watch-only?]} & children]
-  (let [{window-width :width} (rn/get-window)
-        {:keys [top]}         (safe-area/get-insets)
-        margin-top            (if (not margin-top?) 0 top)]
+  (let [{window-width :width} (rn/get-window)]
     [floating-button-page/view
      {:header                   [quo/page-nav
                                  {:type       :no-title

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -35,23 +35,22 @@
 
 (defn view
   []
-  (let [edited-account-name  (reagent/atom nil)
-        show-confirm-button? (reagent/atom false)
-        on-change-color      (fn [edited-color {:keys [color] :as account}]
-                               (when (not= edited-color color)
-                                 (save-account {:account     account
-                                                :updated-key :color
-                                                :new-value   edited-color})))
-        on-change-emoji      (fn [edited-emoji {:keys [emoji] :as account}]
-                               (when (not= edited-emoji emoji)
-                                 (save-account {:account     account
-                                                :updated-key :emoji
-                                                :new-value   edited-emoji})))
-        on-confirm-name      (fn [account]
-                               (rn/dismiss-keyboard!)
-                               (save-account {:account     account
-                                              :updated-key :name
-                                              :new-value   @edited-account-name}))]
+  (let [edited-account-name (reagent/atom nil)
+        on-change-color     (fn [edited-color {:keys [color] :as account}]
+                              (when (not= edited-color color)
+                                (save-account {:account     account
+                                               :updated-key :color
+                                               :new-value   edited-color})))
+        on-change-emoji     (fn [edited-emoji {:keys [emoji] :as account}]
+                              (when (not= edited-emoji emoji)
+                                (save-account {:account     account
+                                               :updated-key :emoji
+                                               :new-value   edited-emoji})))
+        on-confirm-name     (fn [account]
+                              (rn/dismiss-keyboard!)
+                              (save-account {:account     account
+                                             :updated-key :name
+                                             :new-value   @edited-account-name}))]
     (fn []
       (let [{:keys [name emoji address color watch-only? default-account?]
              :as   account}         (rf/sub [:wallet/current-viewing-account])
@@ -80,9 +79,7 @@
           :on-change-color     #(on-change-color % account)
           :on-change-emoji     #(on-change-emoji % account)
           :section-label       :t/account-info
-          :on-focus            #(reset! show-confirm-button? true)
-          :on-blur             #(reset! show-confirm-button? false)
-          :bottom-action?      @show-confirm-button?
+          :bottom-action?      true
           :bottom-action-label :t/update-account-name
           :bottom-action-props {:customization-color color
                                 :disabled?           button-disabled?

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -80,7 +80,7 @@
           :on-change-emoji     #(on-change-emoji % account)
           :section-label       :t/account-info
           :bottom-action?      true
-          :bottom-action-label :t/update-account-name
+          :bottom-action-label :t/confirm
           :bottom-action-props {:customization-color color
                                 :disabled?           button-disabled?
                                 :on-press            #(on-confirm-name account)}}

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -79,7 +79,6 @@
           :on-change-color     #(on-change-color % account)
           :on-change-emoji     #(on-change-emoji % account)
           :section-label       :t/account-info
-          :bottom-action?      true
           :bottom-action-label :t/confirm
           :bottom-action-props {:customization-color color
                                 :disabled?           button-disabled?

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.wallet.edit-account.view
   (:require [quo.core :as quo]
             [react-native.core :as rn]
+            [react-native.hooks :as hooks]
             [reagent.core :as reagent]
             [status-im.contexts.wallet.common.screen-base.create-or-edit-account.view
              :as create-or-edit-account]
@@ -33,7 +34,7 @@
                   {:account    edited-account-data
                    :on-success #(show-save-account-toast updated-key)}])))
 
-(defn view
+(defn- f-view
   []
   (let [edited-account-name (reagent/atom nil)
         on-change-color     (fn [edited-color {:keys [color] :as account}]
@@ -53,15 +54,16 @@
                                              :new-value   @edited-account-name}))]
     (fn []
       (let [{:keys [name emoji address color watch-only? default-account?]
-             :as   account}         (rf/sub [:wallet/current-viewing-account])
-            network-details         (rf/sub [:wallet/network-preference-details])
-            test-networks-enabled?  (rf/sub [:profile/test-networks-enabled?])
-            network-preferences-key (if test-networks-enabled?
-                                      :test-preferred-chain-ids
-                                      :prod-preferred-chain-ids)
-            account-name            (or @edited-account-name name)
-            button-disabled?        (or (nil? @edited-account-name)
-                                        (= name @edited-account-name))]
+             :as   account}          (rf/sub [:wallet/current-viewing-account])
+            network-details          (rf/sub [:wallet/network-preference-details])
+            test-networks-enabled?   (rf/sub [:profile/test-networks-enabled?])
+            network-preferences-key  (if test-networks-enabled?
+                                       :test-preferred-chain-ids
+                                       :prod-preferred-chain-ids)
+            account-name             (or @edited-account-name name)
+            button-disabled?         (or (nil? @edited-account-name)
+                                         (= name @edited-account-name))
+            {:keys [keyboard-shown]} (hooks/use-keyboard)]
         [create-or-edit-account/view
          {:page-nav-right-side [(when-not default-account?
                                   {:icon-name :i/delete
@@ -79,6 +81,7 @@
           :on-change-color     #(on-change-color % account)
           :on-change-emoji     #(on-change-emoji % account)
           :section-label       :t/account-info
+          :hide-bottom-action? (and button-disabled? (not keyboard-shown))
           :bottom-action-label :t/confirm
           :bottom-action-props {:customization-color color
                                 :disabled?           button-disabled?
@@ -110,3 +113,5 @@
                                                                   :new-value   chain-ids}))
                                                  :watch-only? watch-only?}])}]))
            :container-style style/data-item}]]))))
+
+(defn view [] [:f> f-view])

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -34,7 +34,7 @@
                   {:account    edited-account-data
                    :on-success #(show-save-account-toast updated-key)}])))
 
-(defn- f-view
+(defn view
   []
   (let [edited-account-name (reagent/atom nil)
         on-change-color     (fn [edited-color {:keys [color] :as account}]
@@ -113,5 +113,3 @@
                                                                   :new-value   chain-ids}))
                                                  :watch-only? watch-only?}])}]))
            :container-style style/data-item}]]))))
-
-(defn view [] [:f> f-view])


### PR DESCRIPTION
fixes #18834
fixes #18791

### Summary
On the account edit screen, always show the confirmation button, even if the input is focused. Also, fixed the issue with the text in the button.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- edit account

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Create a profile
- Navigate to the Wallet tab
- Open account
- Press account options
- Press edit account

### Demo

https://github.com/status-im/status-mobile/assets/21865759/3bce84dd-c274-4032-8dab-3aba0ba40d04

<!-- (PRs will only be accepted if squashed into single commit.) -->
status: ready <!-- Can be ready or wip -->
