### PR TITLE
Fix chat UI element colors

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -167,10 +167,9 @@
                                                                          muted?)))}]}]))
 
 (defn f-list-footer
-  [{:keys [chat distance-from-list-top theme community-color]}]
+  [{:keys [chat distance-from-list-top theme customization-color]}]
   (let [{:keys [chat-id chat-name emoji chat-type
-                group-chat color]} chat
-        chat-color           (or color community-color)
+                group-chat]} chat
         display-name         (cond
                                (= chat-type constants/one-to-one-chat-type)
                                (first (rf/sub [:contacts/contact-two-names-by-identity chat-id]))
@@ -186,8 +185,8 @@
                                 messages.constants/top-bar-height
                                 messages.constants/header-container-top-margin)
         background-color     (colors/theme-colors
-                              (colors/resolve-color chat-color theme 20)
-                              (colors/resolve-color chat-color theme 40)
+                              (colors/resolve-color customization-color theme 20)
+                              (colors/resolve-color customization-color theme 40)
                               theme)
         border-radius        (reanimated/interpolate
                               distance-from-list-top
@@ -225,7 +224,7 @@
       (when bio
         [quo/text {:style style/bio}
          bio])
-      [actions chat-id chat-color]]]))
+      [actions chat-id customization-color]]]))
 
 (defn list-footer
   [props]
@@ -290,7 +289,11 @@
            chat-screen-layout-calculations-complete? chat-list-scroll-y]}]
   (let [theme                    (quo.theme/use-theme-value)
         chat                     (rf/sub [:chats/current-chat-chat-view])
-        community-color          (rf/sub [:communities/community-color (:community-id chat)])
+        community-channel?       (= constants/community-chat-type (:chat-type chat))
+        customization-color      (if community-channel?
+                                   (or (:color chat)
+                                       (rf/sub [:communities/community-color (:community-id chat)]))
+                                   :turquoise)
         {:keys [keyboard-shown]} (hooks/use-keyboard)
         {window-height :height}  (rn/get-window)
         context                  (rf/sub [:chats/current-chat-message-list-view-context])
@@ -312,7 +315,7 @@
                                              :chat                   chat
                                              :window-height          window-height
                                              :distance-from-list-top distance-from-list-top
-                                             :community-color        community-color}]
+                                             :customization-color    customization-color}]
         :data                              messages
         :render-data                       {:theme           theme
                                             :context         context

--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -167,9 +167,10 @@
                                                                          muted?)))}]}]))
 
 (defn f-list-footer
-  [{:keys [chat distance-from-list-top cover-bg-color theme]}]
+  [{:keys [chat distance-from-list-top theme community-color]}]
   (let [{:keys [chat-id chat-name emoji chat-type
-                group-chat]} chat
+                group-chat color]} chat
+        chat-color           (or color community-color)
         display-name         (cond
                                (= chat-type constants/one-to-one-chat-type)
                                (first (rf/sub [:contacts/contact-two-names-by-identity chat-id]))
@@ -185,8 +186,8 @@
                                 messages.constants/top-bar-height
                                 messages.constants/header-container-top-margin)
         background-color     (colors/theme-colors
-                              (colors/custom-color cover-bg-color 50 20)
-                              (colors/custom-color cover-bg-color 50 40)
+                              (colors/custom-color chat-color 50 20)
+                              (colors/custom-color chat-color 50 40)
                               theme)
         border-radius        (reanimated/interpolate
                               distance-from-list-top
@@ -224,7 +225,7 @@
       (when bio
         [quo/text {:style style/bio}
          bio])
-      [actions chat-id cover-bg-color]]]))
+      [actions chat-id chat-color]]]))
 
 (defn list-footer
   [props]
@@ -285,10 +286,11 @@
     (reset! distance-atom new-distance)))
 
 (defn f-messages-list-content
-  [{:keys [insets distance-from-list-top content-height layout-height cover-bg-color distance-atom
+  [{:keys [insets distance-from-list-top content-height layout-height distance-atom
            chat-screen-layout-calculations-complete? chat-list-scroll-y]}]
   (let [theme                    (quo.theme/use-theme-value)
         chat                     (rf/sub [:chats/current-chat-chat-view])
+        community-color          (rf/sub [:communities/community-color (:community-id chat)])
         {:keys [keyboard-shown]} (hooks/use-keyboard)
         {window-height :height}  (rn/get-window)
         context                  (rf/sub [:chats/current-chat-message-list-view-context])
@@ -310,7 +312,7 @@
                                              :chat                   chat
                                              :window-height          window-height
                                              :distance-from-list-top distance-from-list-top
-                                             :cover-bg-color         cover-bg-color}]
+                                             :community-color        community-color}]
         :data                              messages
         :render-data                       {:theme           theme
                                             :context         context

--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -186,8 +186,8 @@
                                 messages.constants/top-bar-height
                                 messages.constants/header-container-top-margin)
         background-color     (colors/theme-colors
-                              (colors/custom-color chat-color 50 20)
-                              (colors/custom-color chat-color 50 40)
+                              (colors/resolve-color chat-color theme 20)
+                              (colors/resolve-color chat-color theme 40)
                               theme)
         border-radius        (reanimated/interpolate
                               distance-from-list-top

--- a/src/status_im/contexts/chat/messenger/messages/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/view.cljs
@@ -34,8 +34,7 @@
        :distance-atom                             distance-atom
        :chat-screen-layout-calculations-complete? chat-screen-layout-calculations-complete?
        :distance-from-list-top                    distance-from-list-top
-       :chat-list-scroll-y                        chat-list-scroll-y
-       :cover-bg-color                            :turquoise}]
+       :chat-list-scroll-y                        chat-list-scroll-y}]
      [composer.view/composer
       {:insets                                    insets
        :chat-screen-layout-calculations-complete? chat-screen-layout-calculations-complete?

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -37,6 +37,12 @@
    (get-in communities [id :chats])))
 
 (re-frame/reg-sub
+ :communities/community-color
+ :<- [:communities]
+ (fn [communities [_ id]]
+   (get-in communities [id :color])))
+
+(re-frame/reg-sub
  :communities/community-members
  :<- [:communities]
  (fn [communities [_ id]]

--- a/src/status_im/subs/communities_test.cljs
+++ b/src/status_im/subs/communities_test.cljs
@@ -496,3 +496,12 @@
                   :network-preferences-names #{}
                   :name                      "account3"}]
                 (rf/sub [sub-name community-id])))))
+
+(h/deftest-sub :communities/community-color
+  [sub-name]
+  (testing "returns the community color"
+    (let [community-color "#FEFEFE"]
+      (swap! rf-db/app-db assoc
+        :communities
+        {community-id {:color community-color}})
+      (is (match? community-color (rf/sub [sub-name community-id]))))))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #18830 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR attempts resolve the issue described in #18830 where the mobile chat UI uses the incorrect color for chat/channels when viewing the chat/channel messages. The cause of the issue seems to be related to a color constant being passed around instead of the correct chat/channel color or community color.

### Testing notes

This PR attempts to use the community color as a fallback color when the chat color may not be present. However, I'm not sure how to create a channel without a color, so I'm not able to manually test that scenario. But the code has been written to support using the community color if the chat color is missing, which aligns with the suggested behavior described in #18830.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- community chats
- 1-on-1 chats
- other chats?

### Steps to test

A few pieces are needed to setup the test scenario for this PR. The steps for reproducing the issue are based on the ones in #18830.

1. Create a Community on Status desktop (and choose a community color)
2. Create a chat/channel on Status desktop (and choose a chat color)
3. Invite the Status mobile user to the created community and join the community on mobile
4. Open community on mobile and view the created community chat/channel

### Before and after screenshots comparison

The attached screen captures will showcase an existing community with a configured color, and some existing chat/channels with their own configured colors. Note, there may be an unrelated bug when displaying the community chat-list view where the colors don't match their channel colors. If this is a bug, I will create a separate issue for it soon.

#### Before Chat Color Fixes

https://github.com/status-im/status-mobile/assets/2845768/19ab919c-8450-4585-9875-b9b030264677

#### After Chat Color Fixes 

https://github.com/status-im/status-mobile/assets/2845768/869d2f38-2e01-4c5f-a1aa-2d1d21be3f5b

status: ready
