### PR TITLE
fix: sync qr code not visible

### DIFF
--- a/src/status_im/common/qr_codes/view.cljs
+++ b/src/status_im/common/qr_codes/view.cljs
@@ -33,7 +33,7 @@
   (let [qr-media-server-uri (image-server/get-qr-image-uri-for-any-url
                              {:url         url
                               :port        (rf/sub [:mediaserver/port])
-                              :qr-size     (or (int size) 400)
+                              :qr-size     (or (and size (int size)) 400)
                               :error-level :highest})]
     [quo/qr-code
      (assoc props


### PR DESCRIPTION
the cause of #18940 is value of `size` maybe nil.

this PR fixes #18940 

status: ready <!-- Can be ready or wip -->
