### PR TITLE
Fix: don't run contract tests in test-unit target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connection
 		"until [ -f $$SHADOW_OUTPUT_TO ] ; do sleep 1 ; done ; node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO --repl"
 
 test-unit: export SHADOW_OUTPUT_TO := target/unit_test/test.js
-test-unit: export SHADOW_NS_REGEXP := ^(?!tests\.integration-test)(?!tests-im\.contract-test).*-test$$
+test-unit: export SHADOW_NS_REGEXP := ^(?!tests\.integration-test)(?!tests\.contract-test).*-test$$
 test-unit: ##@test Run unit tests
 test-unit: _test-clojure
 


### PR DESCRIPTION
### Summary

I noticed today a small regression from commit 9acf67dd5b974a82c2449a2fea37ffc8dfa8fab7, where we introduced contract tests. In `develop` we're now running contract tests whenever the `test-unit` target runs. This PR fixes the typo.

status: ready
