### PR TITLE
ci: drop NIX_IGNORE_SYMLINK_STORE from Makefile and CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,6 @@ export _NIX_KEEP ?= TMPDIR,BUILD_ENV,\
 # Useful for Android release builds
 TMP_BUILD_NUMBER := $(shell ./scripts/version/gen_build_no.sh | cut -c1-10)
 
-# MacOS root is read-only, read nix/README.md for details
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-export NIX_IGNORE_SYMLINK_STORE=1
-endif
-
 #----------------
 # Nix targets
 #----------------

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -39,8 +39,6 @@ pipeline {
     LANGUAGE = "en_US.UTF-8"
     TARGET   = 'ios'
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
-    /* See nix/README.md */
-    NIX_IGNORE_SYMLINK_STORE = 1
     FASTLANE_DISABLE_COLORS = 1
     BUNDLE_PATH = "${HOME}/.bundle"
   }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -10,8 +10,6 @@ pipeline {
     LC_ALL    = 'en_US.UTF-8'
     TARGET    = 'ios'
     FASTLANE_DISABLE_COLORS = 1
-    /* See nix/README.md */
-    NIX_IGNORE_SYMLINK_STORE = 1
     /* avoid writing to r/o /nix */
     GEM_HOME  = '~/.rubygems'
   }

--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -18,8 +18,6 @@ pipeline {
   }
 
   environment {
-    /* See nix/README.md */
-    NIX_IGNORE_SYMLINK_STORE = 1
     /* we source .bash_profile to be able to use nix-store */
     NIX_SSHOPTS = "-oStrictHostKeyChecking=no"
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -10,8 +10,6 @@ pipeline {
     LC_ALL    = 'en_US.UTF-8'
     TARGET    = 'ios'
     FASTLANE_DISABLE_COLORS = 1
-    /* See nix/README.md */
-    NIX_IGNORE_SYMLINK_STORE = 1
     /* avoid writing to r/o /nix */
     GEM_HOME  = '~/.rubygems'
   }


### PR DESCRIPTION
This is a fix applied when upgrading to macOS Catalina in 2019:

* https://github.com/status-im/status-mobile/pull/9218

I do not believe it is necessary any longer.