### PR TITLE
fix: use blacklist for parallax

### DIFF
--- a/src/status_im/common/parallax/blacklist.cljs
+++ b/src/status_im/common/parallax/blacklist.cljs
@@ -2,16 +2,16 @@
   (:require
     [native-module.core :as native-module]))
 
-(def ^:const device-id (:device-id (native-module/get-device-model-info)))
+(def ^:private device-id (:device-id (native-module/get-device-model-info)))
 
-(defn get-model-code
+(defn- get-model-code
   [model]
   (let [match (re-find #"iPhone(\d+)" model)]
     (if match
       (js/parseInt (second match))
       0)))
 
-(def ^:const minimum-device-code 11)
+(def ^:private minimum-device-code 11)
 
 (def blacklisted?
   (-> device-id

--- a/src/status_im/common/parallax/blacklist.cljs
+++ b/src/status_im/common/parallax/blacklist.cljs
@@ -6,10 +6,9 @@
 
 (defn- get-model-code
   [model]
-  (let [[_ code] (re-find #"iPhone(\d+)" model)]
-    (if code
-      (js/parseInt code)
-      0)))
+  (if-let [[_ code] (and model (re-find #"iPhone(\d+)" model))]
+    (js/parseInt code 10)
+    0))
 
 (def ^:private minimum-device-code 11)
 

--- a/src/status_im/common/parallax/blacklist.cljs
+++ b/src/status_im/common/parallax/blacklist.cljs
@@ -6,9 +6,9 @@
 
 (defn- get-model-code
   [model]
-  (let [match (re-find #"iPhone(\d+)" model)]
-    (if match
-      (js/parseInt (second match))
+  (let [[_ code] (re-find #"iPhone(\d+)" model)]
+    (if code
+      (js/parseInt code)
       0)))
 
 (def ^:private minimum-device-code 11)

--- a/src/status_im/common/parallax/blacklist.cljs
+++ b/src/status_im/common/parallax/blacklist.cljs
@@ -1,0 +1,19 @@
+(ns status-im.common.parallax.blacklist
+  (:require
+    [native-module.core :as native-module]))
+
+(def ^:const device-id (:device-id (native-module/get-device-model-info)))
+
+(defn get-model-code
+  [model]
+  (let [match (re-find #"iPhone(\d+)" model)]
+    (if match
+      (js/parseInt (second match))
+      0)))
+
+(def ^:const minimum-device-code 11)
+
+(def blacklisted?
+  (-> device-id
+      get-model-code
+      (< minimum-device-code)))

--- a/src/status_im/common/parallax/whitelist.cljs
+++ b/src/status_im/common/parallax/whitelist.cljs
@@ -1,6 +1,0 @@
-(ns status-im.common.parallax.whitelist
-  (:require
-    [status-im.common.parallax.blacklist :as blacklist]))
-
-(def whitelisted?
-  (not blacklist/blacklisted?))

--- a/src/status_im/common/parallax/whitelist.cljs
+++ b/src/status_im/common/parallax/whitelist.cljs
@@ -1,13 +1,6 @@
 (ns status-im.common.parallax.whitelist
   (:require
-    [clojure.string :as string]
-    [native-module.core :as native-module]))
-
-(def ^:const device-id (:device-id (native-module/get-device-model-info)))
-
-;; iPhone 14 is 15 for some reason
-(def ^:const whitelist #{"iPhone11" "iPhone12" "iPhone13" "iPhone14" "iPhone15"})
+    [status-im.common.parallax.blacklist :as blacklist]))
 
 (def whitelisted?
-  (let [device-type (first (string/split (str device-id) ","))]
-    (whitelist device-type)))
+  (not blacklist/blacklisted?))

--- a/src/status_im/contexts/onboarding/enable_biometrics/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_biometrics/view.cljs
@@ -4,8 +4,8 @@
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [status-im.common.biometric.events :as biometric]
+    [status-im.common.parallax.blacklist :as blacklist]
     [status-im.common.parallax.view :as parallax]
-    [status-im.common.parallax.whitelist :as whitelist]
     [status-im.common.resources :as resources]
     [status-im.contexts.onboarding.enable-biometrics.style :as style]
     [status-im.navigation.state :as state]
@@ -71,9 +71,9 @@
   (let [insets (safe-area/get-insets)]
     [rn/view {:style (style/page-container insets)}
      [page-title]
-     (if whitelist/whitelisted?
-       [enable-biometrics-parallax]
-       [enable-biometrics-simple])
+     (if blacklist/blacklisted?
+       [enable-biometrics-simple]
+       [enable-biometrics-parallax])
      [enable-biometrics-buttons insets]]))
 
 (defn view

--- a/src/status_im/contexts/onboarding/enable_notifications/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_notifications/view.cljs
@@ -4,8 +4,8 @@
     [react-native.core :as rn]
     [react-native.platform :as platform]
     [react-native.safe-area :as safe-area]
+    [status-im.common.parallax.blacklist :as blacklist]
     [status-im.common.parallax.view :as parallax]
-    [status-im.common.parallax.whitelist :as whitelist]
     [status-im.common.resources :as resources]
     [status-im.contexts.onboarding.enable-notifications.style :as style]
     [status-im.contexts.shell.jump-to.utils :as shell.utils]
@@ -78,9 +78,9 @@
         :icon-name  :i/arrow-left
         :on-press   #(rf/dispatch [:navigate-back-within-stack :enable-biometrics])}]
       [page-title]]
-     (if whitelist/whitelisted?
-       [enable-notifications-parallax]
-       [enable-notifications-simple])
+     (if blacklist/blacklisted?
+       [enable-notifications-simple]
+       [enable-notifications-parallax])
      [enable-notification-buttons {:insets insets}]]))
 
 (defn view

--- a/src/status_im/contexts/onboarding/generating_keys/view.cljs
+++ b/src/status_im/contexts/onboarding/generating_keys/view.cljs
@@ -4,8 +4,8 @@
     [react-native.core :as rn]
     [react-native.reanimated :as reanimated]
     [react-native.safe-area :as safe-area]
+    [status-im.common.parallax.blacklist :as blacklist]
     [status-im.common.parallax.view :as parallax]
-    [status-im.common.parallax.whitelist :as whitelist]
     [status-im.common.resources :as resources]
     [status-im.contexts.onboarding.generating-keys.style :as style]
     [utils.i18n :as i18n]))
@@ -149,9 +149,9 @@
   []
   (let [insets (safe-area/get-insets)]
     [rn/view {:style (style/page-container insets)}
-     (if whitelist/whitelisted?
-       [parallax-page insets]
-       [:f> f-simple-page insets])]))
+     (if blacklist/blacklisted?
+       [:f> f-simple-page insets]
+       [parallax-page insets])]))
 
 (defn generating-keys
   []


### PR DESCRIPTION
Use blacklist for determining device to show parallax animation to.

This solves the issue as noted here https://discord.com/channels/1103692771585433630/1103692773363810317/1210598484076535838 which was earlier raised by John

status: ready <!-- Can be ready or wip -->
