### PR TITLE
feat: make bridging transactions work after sliding to confirm the transaction

### DIFF
--- a/src/quo/components/wallet/summary_info/view.cljs
+++ b/src/quo/components/wallet/summary_info/view.cljs
@@ -32,10 +32,10 @@
   (let [{:keys [ethereum optimism arbitrum]} values
         show-optimism?                       (and optimism
                                                   (or (pos? (:amount optimism))
-                                                      (= (:amount optimism) "<0.00")))
+                                                      (= (:amount optimism) "<0.01")))
         show-arbitrum?                       (and arbitrum
                                                   (or (pos? (:amount arbitrum))
-                                                      (= (:amount arbitrum) "<0.00")))]
+                                                      (= (:amount arbitrum) "<0.01")))]
     [rn/view
      {:style               style/networks-container
       :accessibility-label :networks}

--- a/src/quo/components/wallet/summary_info/view.cljs
+++ b/src/quo/components/wallet/summary_info/view.cljs
@@ -30,8 +30,12 @@
 (defn networks
   [values theme]
   (let [{:keys [ethereum optimism arbitrum]} values
-        show-optimism?                       (and optimism (pos? (:amount optimism)))
-        show-arbitrum?                       (and arbitrum (pos? (:amount arbitrum)))]
+        show-optimism?                       (and optimism
+                                                  (or (pos? (:amount optimism))
+                                                      (= (:amount optimism) "<0.00")))
+        show-arbitrum?                       (and arbitrum
+                                                  (or (pos? (:amount arbitrum))
+                                                      (= (:amount arbitrum) "<0.00")))]
     [rn/view
      {:style               style/networks-container
       :accessibility-label :networks}

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -478,6 +478,7 @@
 
 (def ^:const bridge-name-transfer "Transfer")
 (def ^:const bridge-name-erc-721-transfer "ERC721Transfer")
+(def ^:const bridge-name-hop "Hop")
 
 (def ^:const alert-banner-height 40)
 

--- a/src/status_im/contexts/wallet/account/bridge_to/view.cljs
+++ b/src/status_im/contexts/wallet/account/bridge_to/view.cljs
@@ -31,7 +31,7 @@
         :fiat-value    fiat-formatted
         :on-press      #(rf/dispatch [:wallet/select-bridge-network
                                       {:network-chain-id chain-id
-                                       :stack-id         :wallet-bridge}])}])))
+                                       :stack-id         :screen/wallet.bridge-to}])}])))
 
 (defn- view-internal
   []

--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -7,7 +7,6 @@
     [status-im.contexts.wallet.account.tabs.view :as tabs]
     [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im.contexts.wallet.common.temp :as temp]
-    [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 

--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -55,8 +55,7 @@
              :receive-action #(rf/dispatch [:open-modal :screen/wallet.share-address {:status :receive}])
              :buy-action     #(rf/dispatch [:show-bottom-sheet
                                             {:content buy-drawer}])
-             :bridge-action  #(ff/alert ::ff/wallet.bridge-token
-                                        (fn [] (rf/dispatch [:wallet/start-bridge])))}])
+             :bridge-action  #(rf/dispatch [:wallet/start-bridge])}])
          [quo/tabs
           {:style            style/tabs
            :size             32

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -244,7 +244,7 @@
 
 (rf/reg-event-fx :wallet/start-bridge
  (fn [{:keys [db]}]
-   {:db (assoc-in db [:wallet :ui :send :type] :bridge)
+   {:db (assoc-in db [:wallet :ui :send :tx-type] :bridge)
     :fx [[:dispatch [:open-modal :screen/wallet.bridge]]]}))
 
 (rf/reg-event-fx :wallet/select-bridge-network

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -90,24 +90,24 @@
 
 (rf/reg-event-fx :wallet/clean-selected-token
  (fn [{:keys [db]}]
-   {:db (assoc-in db [:wallet :ui :send :token] nil)}))
+   {:db (update-in db [:wallet :ui :send] dissoc :token :tx-type)}))
 
 (rf/reg-event-fx :wallet/clean-selected-collectible
  (fn [{:keys [db]}]
-   (let [type (get-in db [:wallet :ui :send :type])]
+   (let [transaction-type (get-in db [:wallet :ui :send :tx-type])]
      {:db (update-in db
                      [:wallet :ui :send]
                      dissoc
                      :collectible
                      :amount
-                     (when (= type :collecible) :type))})))
+                     (when (= transaction-type :collecible) :tx-type))})))
 
 (rf/reg-event-fx :wallet/send-select-collectible
  (fn [{:keys [db]} [{:keys [collectible stack-id]}]]
    {:db (-> db
             (update-in [:wallet :ui :send] dissoc :token)
             (assoc-in [:wallet :ui :send :collectible] collectible)
-            (assoc-in [:wallet :ui :send :type] :collectible)
+            (assoc-in [:wallet :ui :send :tx-type] :collectible)
             (assoc-in [:wallet :ui :send :amount] 1))
     :fx [[:dispatch [:wallet/get-suggested-routes {:amount 1}]]
          [:navigate-to-within-stack [:screen/wallet.transaction-confirmation stack-id]]]}))
@@ -121,7 +121,7 @@
  (fn [{:keys [db now]} [{:keys [amount]}]]
    (let [wallet-address          (get-in db [:wallet :current-viewing-account-address])
          token                   (get-in db [:wallet :ui :send :token])
-         transaction-type        (get-in db [:wallet :ui :send :type])
+         transaction-type        (get-in db [:wallet :ui :send :tx-type])
          collectible             (get-in db [:wallet :ui :send :collectible])
          to-address              (get-in db [:wallet :ui :send :to-address])
          test-networks-enabled?  (get-in db [:profile/profile :test-networks-enabled?])
@@ -192,46 +192,71 @@
    {:fx [[:dispatch [:dismiss-modal :screen/wallet.transaction-progress]]]}))
 
 (defn- build-transaction-path
-  [{:keys [from-address from-chain-id to-address token-id token-address route data eth-transfer?]}]
-  (let [{:keys [bridge-name amount-out gas-amount
-                gas-fees]}                 route
-        eip-1559-enabled?                  (:eip-1559-enabled gas-fees)
+  [{:keys [from-address to-address token-id token-address route data
+           eth-transfer?]}]
+  (let [{:keys [bridge-name amount-in gas-amount
+                gas-fees bonder-fees from to]} route
+        eip-1559-enabled?                      (:eip-1559-enabled gas-fees)
         {:keys [gas-price max-fee-per-gas-medium
-                max-priority-fee-per-gas]} gas-fees
-        transfer-tx                        (cond-> {:From  from-address
-                                                    :To    (or token-address to-address)
-                                                    :Gas   (money/to-hex gas-amount)
-                                                    :Value (when eth-transfer? amount-out)
-                                                    :Nonce nil
-                                                    :Input ""
-                                                    :Data  (or data "0x")}
-                                             eip-1559-enabled?       (assoc :TxType "0x02"
-                                                                            :MaxFeePerGas
-                                                                            (money/to-hex
-                                                                             (money/->wei
-                                                                              :gwei
-                                                                              max-fee-per-gas-medium))
-                                                                            :MaxPriorityFeePerGas
-                                                                            (money/to-hex
-                                                                             (money/->wei
-                                                                              :gwei
-                                                                              max-priority-fee-per-gas)))
-                                             (not eip-1559-enabled?) (assoc :TxType   "0x00"
-                                                                            :GasPrice (money/to-hex
-                                                                                       (money/->wei
-                                                                                        :gwei
-                                                                                        gas-price))))]
+                max-priority-fee-per-gas]}     gas-fees
+        tx-data                                (cond-> {:From  from-address
+                                                        :To    (or token-address to-address)
+                                                        :Gas   (money/to-hex gas-amount)
+                                                        :Value (when eth-transfer? amount-in)
+                                                        :Nonce nil
+                                                        :Input ""
+                                                        :Data  (or data "0x")}
+                                                 eip-1559-enabled?       (assoc
+                                                                          :TxType "0x02"
+                                                                          :MaxFeePerGas
+                                                                          (money/to-hex
+                                                                           (money/->wei
+                                                                            :gwei
+                                                                            max-fee-per-gas-medium))
+                                                                          :MaxPriorityFeePerGas
+                                                                          (money/to-hex
+                                                                           (money/->wei
+                                                                            :gwei
+                                                                            max-priority-fee-per-gas)))
+                                                 (not eip-1559-enabled?) (assoc :TxType "0x00"
+                                                                                :GasPrice
+                                                                                (money/to-hex
+                                                                                 (money/->wei
+                                                                                  :gwei
+                                                                                  gas-price))))
+        to-chain-id                            (:chain-id to)
+        from-chain-id                          (:chain-id from)]
     (cond-> {:BridgeName bridge-name
              :ChainID    from-chain-id}
 
       (= bridge-name constants/bridge-name-erc-721-transfer)
       (assoc :ERC721TransferTx
-             (assoc transfer-tx
+             (assoc tx-data
                     :Recipient to-address
-                    :TokenID   token-id))
+                    :TokenID   token-id
+                    :ChainID   to-chain-id))
 
       (= bridge-name constants/bridge-name-transfer)
-      (assoc :TransferTx transfer-tx))))
+      (assoc :TransferTx tx-data)
+
+      (= bridge-name constants/bridge-name-hop)
+      (assoc :HopTx
+             (assoc tx-data
+                    :ChainID   to-chain-id
+                    :Symbol    token-id
+                    :Recipient to-address
+                    :Amount    amount-in
+                    :BonderFee bonder-fees))
+
+      (not (or (= bridge-name constants/bridge-name-erc-721-transfer)
+               (= bridge-name constants/bridge-name-transfer)
+               (= bridge-name constants/bridge-name-hop)))
+      (assoc :CbridgeTx
+             (assoc tx-data
+                    :ChainID   to-chain-id
+                    :Symbol    token-id
+                    :Recipient to-address
+                    :Amount    amount-in)))))
 
 (defn- multi-transaction-command
   [{:keys [from-address to-address from-asset to-asset amount-out transfer-type]
@@ -248,6 +273,11 @@
    (let [routes (get-in db [:wallet :ui :send :route])
          first-route (first routes)
          from-address (get-in db [:wallet :current-viewing-account-address])
+         transaction-type (get-in db [:wallet :ui :send :tx-type])
+         transaction-type-param (case transaction-type
+                                  :collectible constants/send-type-erc-721-transfer
+                                  :bridge      constants/send-type-bridge
+                                  constants/send-type-transfer)
          token (get-in db [:wallet :ui :send :token])
          collectible (get-in db [:wallet :ui :send :collectible])
          first-route-from-chain-id (get-in first-route [:from :chain-id])
@@ -263,29 +293,29 @@
                              (get-in token [:balances-per-chain first-route-from-chain-id :address]))
          to-address (get-in db [:wallet :ui :send :to-address])
          transaction-paths (mapv (fn [route]
-                                   (let [data          (when erc20-transfer?
-                                                         (native-module/encode-transfer
-                                                          (address/normalized-hex to-address)
-                                                          (:amount-out route)))
-                                         from-chain-id (get-in first-route [:from :chain-id])]
+                                   (let [data (when erc20-transfer?
+                                                (native-module/encode-transfer
+                                                 (address/normalized-hex to-address)
+                                                 (:amount-in route)))]
                                      (build-transaction-path {:to-address    to-address
                                                               :from-address  from-address
                                                               :route         route
-                                                              :from-chain-id from-chain-id
                                                               :token-address token-address
-                                                              :token-id      (when collectible
+                                                              :token-id      (if collectible
                                                                                (money/to-hex (js/parseInt
-                                                                                              token-id)))
+                                                                                              token-id))
+                                                                               token-id)
                                                               :data          data
                                                               :eth-transfer? eth-transfer?})))
                                  routes)
          request-params
          [(multi-transaction-command
-           {:from-address from-address
-            :to-address   to-address
-            :from-asset   token-id
-            :to-asset     token-id
-            :amount-out   (if eth-transfer? (:amount-out first-route) "0x0")})
+           {:from-address  from-address
+            :to-address    to-address
+            :from-asset    token-id
+            :to-asset      token-id
+            :amount-out    (if eth-transfer? (:amount-out first-route) "0x0")
+            :transfer-type transaction-type-param})
           transaction-paths
           sha3-pwd]]
      {:json-rpc/call [{:method     "wallet_createMultiTransaction"

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -10,8 +10,7 @@
     [utils.address :as address]
     [utils.money :as money]
     [utils.number]
-    [utils.re-frame :as rf]
-    [utils.transforms :as transforms]))
+    [utils.re-frame :as rf]))
 
 (rf/reg-event-fx :wallet/clean-send-data
  (fn [{:keys [db]}]

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -340,4 +340,8 @@
                                      (log/error "failed to send transaction"
                                                 {:event  :wallet/send-transaction
                                                  :error  error
-                                                 :params request-params}))}]})))
+                                                 :params request-params})
+                                     (rf/dispatch [:toasts/upsert
+                                                   {:id   :send-transaction-error
+                                                    :type :negative
+                                                    :text (:message error)}]))}]})))

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -10,7 +10,8 @@
     [utils.address :as address]
     [utils.money :as money]
     [utils.number]
-    [utils.re-frame :as rf]))
+    [utils.re-frame :as rf]
+    [utils.transforms :as transforms]))
 
 (rf/reg-event-fx :wallet/clean-send-data
  (fn [{:keys [db]}]

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -206,6 +206,7 @@
             conversion-rate           (-> token :market-values-per-currency :usd :price)
             loading-routes?           (rf/sub [:wallet/wallet-send-loading-suggested-routes?])
             suggested-routes          (rf/sub [:wallet/wallet-send-suggested-routes])
+            best-routes               (when suggested-routes (or (:best suggested-routes) []))
             route                     (rf/sub [:wallet/wallet-send-route])
             to-address                (rf/sub [:wallet/wallet-send-to-address])
             on-confirm                (or default-on-confirm handle-on-confirm)
@@ -280,7 +281,7 @@
                                    :limit-crypto crypto-limit})}]
          [routes/view
           {:amount       amount-text
-           :routes       suggested-routes
+           :routes       best-routes
            :token        token
            :input-value  @input-value
            :fetch-routes #(fetch-routes % (current-limit))}]

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -122,9 +122,8 @@
   (let [selected-networks         (rf/sub [:wallet/wallet-send-selected-networks])
         loading-networks          (find-affordable-networks token input-value selected-networks)
         loading-suggested-routes? (rf/sub [:wallet/wallet-send-loading-suggested-routes?])
-        best-routes               (:best routes)
-        data                      (if loading-suggested-routes? loading-networks best-routes)]
-    (if (or (and (not-empty loading-networks) loading-suggested-routes?) (not-empty best-routes))
+        data                      (if loading-suggested-routes? loading-networks routes)]
+    (if (or (and (not-empty loading-networks) loading-suggested-routes?) (not-empty routes))
       [rn/flat-list
        {:data                    (if (and (< (count data) 3) (pos? (count data)))
                                    (concat data [{:status :add}])
@@ -154,7 +153,7 @@
                                                      (utils/id->network (get-in item
                                                                                 [:to :chain-id])))}])}]
       [rn/view {:style style/empty-container}
-       (when (and (not (nil? best-routes)) (not loading-suggested-routes?))
+       (when (and (not (nil? routes)) (not loading-suggested-routes?))
          [quo/text (i18n/label :t/no-routes-found)])])))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -158,7 +158,7 @@
                                          (map (fn [[k v]]
                                                 [k
                                                  (if (money/equal-to (v :amount) 0)
-                                                   (assoc v :amount "<0.00")
+                                                   (assoc v :amount "<0.01")
                                                    v)])
                                               network-values))]
       [rn/view

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -153,7 +153,14 @@
           (reduce-kv (fn [acc k v]
                        (assoc acc k {:amount v :token-symbol token-symbol}))
                      {}
-                     network-amounts)]
+                     network-amounts)
+          network-values-sanitized (into {}
+                                         (map (fn [[k v]]
+                                                [k
+                                                 (if (money/equal-to (v :amount) 0)
+                                                   (assoc v :amount "<0.00")
+                                                   v)])
+                                              network-values))]
       [rn/view
        {:style {:padding-horizontal 20
                 :padding-bottom     16}}
@@ -166,7 +173,7 @@
        [quo/summary-info
         {:type          summary-type
          :networks?     true
-         :values        network-values
+         :values        network-values-sanitized
          :account-props account-props}]])))
 
 (defn- transaction-details
@@ -258,7 +265,7 @@
             image-url             (when collectible (:image-url collectible-data))
             amount                (:amount send-transaction-data)
             route                 (:route send-transaction-data)
-            transaction-type      (:type send-transaction-data)
+            transaction-type      (:tx-type send-transaction-data)
             estimated-time-min    (reduce + (map :estimated-time route))
             max-fees              "-"
             to-address            (:to-address send-transaction-data)

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -11,7 +11,6 @@
 (defonce ^:private feature-flags-config
   (reagent/atom
    {::wallet.edit-default-keypair      (enabled-in-env? :FLAG_EDIT_DEFAULT_KEYPAIR)
-    ::wallet.bridge-token              (enabled-in-env? :FLAG_BRIDGE_TOKEN_ENABLED)
     ::wallet.edit-derivation-path      (enabled-in-env? :FLAG_EDIT_DERIVATION_PATH)
     ::wallet.remove-account            (enabled-in-env? :FLAG_REMOVE_ACCOUNT_ENABLED)
     ::wallet.network-filter            (enabled-in-env? :FLAG_NETWORK_FILTER_ENABLED)

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.176.9",
-    "commit-sha1": "a3ad05db58b8af20bf6b7ab852f8603212abac4e",
-    "src-sha256": "10c05kgihczbams3i8fkfm1mh5m61bnsjh255c22m4awc073rg12"
+    "version": "v0.176.10",
+    "commit-sha1": "f69ee07593e8e35bb029f62de670b5554d71c932",
+    "src-sha256": "1icm7l1lhqdz5zbfvagxb051rw3hdm8zvwcxwaizyd1lhbx4v8h5"
 }


### PR DESCRIPTION
fixes #18938 

### Summary

This PR is a follow up of #18887. Here we are implementing the logic to send the Bridge transactions to the network through the `createMultiTransaction` status-go endpoint. Implementing this implies making some refactoring to `:wallet/send-transaction` event to support multi-routes transactions, removes logic that forced to use only the first route in the routes array so we can allow bridging from more than one network and allow Bridge routes. This will also allow in the future to send multi transactions that involve multiple transfers and bridging in the same transaction.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Login with an account with same tokens on different networks (ETH, DAI, etc)
- Go to account
- Go to Bridge
- Select a token
- Select network to bridge to
- Enter an amount and wait for routes to be loaded successfully
- Go to transaction confirmation page
- Slide the "Slide to bridge" slider
- Verify transaction is correctly executed 

Note: Check with the team which tokens are supported to be bridged, and how long does it take to reach transaction finality and see the balances reflected on the new chain.

status: ready