### PR TITLE
[#18929] fix: no bottom space under the join button

### DIFF
--- a/src/status_im/contexts/communities/actions/accounts_selection/style.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/style.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.communities.actions.accounts-selection.style
   (:require
-    [quo.foundations.colors :as colors]
-    [react-native.safe-area :as safe-area]))
+    [quo.foundations.colors :as colors]))
 
 (def screen-horizontal-padding 20)
 
@@ -15,7 +14,6 @@
 
 (defn bottom-actions
   []
-  {:padding-top        12
+  {:padding-vertical   12
    :padding-horizontal screen-horizontal-padding
-   :background-color   (colors/theme-colors colors/white colors/neutral-95)
-   :padding-bottom     (+ (safe-area/get-bottom) 12)})
+   :background-color   (colors/theme-colors colors/white colors/neutral-95)})

--- a/src/status_im/contexts/communities/actions/accounts_selection/style.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/style.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.communities.actions.accounts-selection.style
   (:require
-    [quo.foundations.colors :as colors]))
+    [quo.foundations.colors :as colors]
+    [react-native.safe-area :as safe-area]))
 
 (def screen-horizontal-padding 20)
 
@@ -16,4 +17,5 @@
   []
   {:padding-top        12
    :padding-horizontal screen-horizontal-padding
-   :background-color   (colors/theme-colors colors/white colors/neutral-95)})
+   :background-color   (colors/theme-colors colors/white colors/neutral-95)
+   :padding-bottom     (+ (safe-area/get-bottom) 12)})


### PR DESCRIPTION
fixes #18929
fixes #18997

### Summary

No bottom space under the 'Slide to request to join' button

#### Platforms

- Android
- iOS (SE)

### Result
<img src="https://github.com/status-im/status-mobile/assets/71308738/58e82dce-b617-4f1a-b03d-74fcc38fc821" width="390px"/>


status: ready
