### PR TITLE
Wallet: finalize kp

### DIFF
--- a/src/quo/components/wallet/keypair/component_spec.cljs
+++ b/src/quo/components/wallet/keypair/component_spec.cljs
@@ -55,7 +55,7 @@
                                     :action              :selector
                                     :details             other-details}]
                                   theme)
-    (h/is-truthy (h/get-by-label-text :radio-on)))
+    (h/is-truthy (h/get-by-label-text :radio-off)))
 
   (h/test "Options action renders"
     (h/render-with-theme-provider [keypair/view

--- a/src/quo/components/wallet/keypair/style.cljs
+++ b/src/quo/components/wallet/keypair/style.cljs
@@ -1,6 +1,7 @@
 (ns quo.components.wallet.keypair.style
   (:require
-    [quo.foundations.colors :as colors]))
+    [quo.foundations.colors :as colors]
+    [react-native.platform :as platform]))
 
 (defn container
   [{:keys [blur? customization-color theme selected?]}]
@@ -34,3 +35,8 @@
   {:color (if blur?
             colors/white-opa-40
             (colors/theme-colors colors/neutral-50 colors/neutral-40 theme))})
+
+(defn dot
+  [blur? theme]
+  (merge (subtitle blur? theme)
+         {:bottom (if platform/ios? 2 -2)}))

--- a/src/quo/components/wallet/keypair/view.cljs
+++ b/src/quo/components/wallet/keypair/view.cljs
@@ -11,7 +11,6 @@
     [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
-    [react-native.platform :as platform]
     [reagent.core :as reagent]
     [utils.i18n :as i18n]))
 
@@ -73,7 +72,7 @@
      (when (= type :default-keypair)
        [text/text
         {:size  :paragraph-2
-         :style (merge (style/subtitle blur? theme) {:bottom (if platform/ios? 2 -2)})}
+         :style (style/dot blur? theme)}
         " ∙ "])
      [text/text
       {:size  :paragraph-2

--- a/src/quo/components/wallet/keypair/view.cljs
+++ b/src/quo/components/wallet/keypair/view.cljs
@@ -60,7 +60,7 @@
           :accessibility-label :options-button}]])]))
 
 (defn details-view
-  [{:keys [details stored blur? theme]}]
+  [{:keys [details stored type blur? theme]}]
   (let [{:keys [address]} details]
     [rn/view
      {:style               {:flex-direction :row
@@ -70,10 +70,11 @@
       {:size  :paragraph-2
        :style (style/subtitle blur? theme)}
       address]
-     [text/text
-      {:size  :paragraph-2
-       :style (merge (style/subtitle blur? theme) {:bottom (if platform/ios? 2 -2)})}
-      " ∙ "]
+     (when (= type :default-keypair)
+       [text/text
+        {:size  :paragraph-2
+         :style (merge (style/subtitle blur? theme) {:bottom (if platform/ios? 2 -2)})}
+        " ∙ "])
      [text/text
       {:size  :paragraph-2
        :style (style/subtitle blur? theme)}
@@ -87,8 +88,8 @@
                    (colors/theme-colors colors/neutral-50 colors/neutral-40 theme))}]])]))
 
 (defn- view-internal
-  []
-  (let [selected? (reagent/atom true)]
+  [{:keys [default-selected?]}]
+  (let [selected? (reagent/atom default-selected?)]
     (fn [{:keys [accounts action container-style] :as props}]
       [rn/pressable
        {:style    (merge (style/container (merge props {:selected? @selected?})) container-style)

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -9,7 +9,7 @@
 
 (defn view
   [{:keys [track-text customization-color auth-button-label on-auth-success on-auth-fail
-           auth-button-icon-left size blur? container-style disabled?]
+           auth-button-icon-left size blur? container-style]
     :or   {container-style {:flex 1}}}]
   (let [theme           (quo.theme/use-theme-value)
         auth-method     (rf/sub [:auth-method])
@@ -31,5 +31,4 @@
       :customization-color customization-color
       :on-complete         on-complete
       :track-icon          (if biometric-auth? :i/face-id :password)
-      :track-text          track-text
-      :disabled?           disabled?}]))
+      :track-text          track-text}]))

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -9,7 +9,7 @@
 
 (defn view
   [{:keys [track-text customization-color auth-button-label on-auth-success on-auth-fail
-           auth-button-icon-left size blur? container-style]
+           auth-button-icon-left size blur? container-style disabled?]
     :or   {container-style {:flex 1}}}]
   (let [theme           (quo.theme/use-theme-value)
         auth-method     (rf/sub [:auth-method])
@@ -31,4 +31,5 @@
       :customization-color customization-color
       :on-complete         on-complete
       :track-icon          (if biometric-auth? :i/face-id :password)
-      :track-text          track-text}]))
+      :track-text          track-text
+      :disabled?           disabled?}]))

--- a/src/status_im/contexts/wallet/create_account/new_keypair/backup_recovery_phrase/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/new_keypair/backup_recovery_phrase/view.cljs
@@ -49,7 +49,7 @@
         secret-phrase       (reagent/atom [])
         random-phrase       (reagent/atom [])]
     (fn []
-      (rn/use-effect
+      (rn/use-mount
        (fn []
          (native-module/get-random-mnemonic #(reset! secret-phrase (string/split % #"\s")))
          (native-module/get-random-mnemonic #(reset! random-phrase (string/split % #"\s")))))

--- a/src/status_im/contexts/wallet/create_account/select_keypair/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/select_keypair/view.cljs
@@ -52,7 +52,7 @@
         color        (:customization-color main-account)
         accounts     (parse-accounts (:accounts item))]
     [quo/keypair
-     {:customization-color (if (not-empty (:customization-color main-account)) color :blue)
+     {:customization-color color
       :profile-picture     (when (zero? index) profile-picture)
       :status-indicator    false
       :type                (if (zero? index) :default-keypair :other)

--- a/src/status_im/contexts/wallet/create_account/utils.cljs
+++ b/src/status_im/contexts/wallet/create_account/utils.cljs
@@ -1,0 +1,19 @@
+(ns status-im.contexts.wallet.create-account.utils)
+
+(defn prepare-new-keypair
+  [{:keys [new-keypair address account-name account-color emoji derivation-path]}]
+  (assoc new-keypair
+         :name         (:keypair-name new-keypair)
+         :key-uid      (:keyUid new-keypair)
+         :type         :seed
+         :derived-from address
+         :accounts     [{:keypair-name (:keypair-name new-keypair)
+                         :key-uid      (:keyUid new-keypair)
+                         :seed-phrase  (:mnemonic new-keypair)
+                         :public-key   (:publicKey new-keypair)
+                         :name         account-name
+                         :type         :seed
+                         :emoji        emoji
+                         :colorID      account-color
+                         :path         derivation-path
+                         :address      (:address new-keypair)}]))

--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -19,6 +19,26 @@
     [utils.security.core :as security]
     [utils.string]))
 
+(defn prepare-new-keypair
+  [{:keys [new-keypair address account-name account-color emoji derivation-path]}]
+  (assoc
+   (assoc new-keypair
+          :name         (:keypair-name new-keypair)
+          :key-uid      (:keyUid new-keypair)
+          :type         :seed
+          :derived-from address)
+   :accounts
+   [{:keypair-name (:keypair-name new-keypair)
+     :key-uid      (:keyUid new-keypair)
+     :seed-phrase  (:mnemonic new-keypair)
+     :public-key   (:publicKey new-keypair)
+     :name         account-name
+     :type         :seed
+     :emoji        emoji
+     :colorID      account-color
+     :path         derivation-path
+     :address      (:address new-keypair)}]))
+
 (defn- get-keypair-data
   [primary-name derivation-path account-color {:keys [keypair-name]}]
   [{:title             (or keypair-name (i18n/label :t/keypair-title {:name primary-name}))
@@ -121,43 +141,34 @@
            :label     (i18n/label :t/origin)
            :data      (get-keypair-data primary-name @derivation-path @account-color new-keypair)}]
          [standard-auth/slide-button
-          {:size :size-48
-           :track-text (i18n/label :t/slide-to-create-account)
+          {:size                :size-48
+           :track-text          (i18n/label :t/slide-to-create-account)
            :customization-color @account-color
-           :on-auth-success (fn [entered-password]
-                              (if new-keypair
-                                (rf/dispatch
-                                 [:wallet/finalize-new-keypair
-                                  {:sha3-pwd    (security/safe-unmask-data
-                                                 entered-password)
-                                   :new-keypair (merge
-                                                 (merge new-keypair
-                                                        {:name         (:keypair-name new-keypair)
-                                                         :key-uid      (:keyUid new-keypair)
-                                                         :type         :seed
-                                                         :derived-from address})
-                                                 {:accounts [{:keypair-name (:keypair-name new-keypair)
-                                                              :key-uid      (:keyUid new-keypair)
-                                                              :seed-phrase  (:mnemonic new-keypair)
-                                                              :public-key   (:publicKey new-keypair)
-                                                              :name         @account-name
-                                                              :type         :seed
-                                                              :emoji        @emoji
-                                                              :colorID      @account-color
-                                                              :path         @derivation-path
-                                                              :address      (:address new-keypair)}]})}])
-                                (rf/dispatch [:wallet/derive-address-and-add-account
-                                              {:sha3-pwd     (security/safe-unmask-data
-                                                              entered-password)
-                                               :emoji        @emoji
-                                               :color        @account-color
-                                               :path         @derivation-path
-                                               :account-name @account-name}])))
-           :auth-button-label (i18n/label :t/confirm)
+           :on-auth-success     (fn [entered-password]
+                                  (if new-keypair
+                                    (rf/dispatch
+                                     [:wallet/finalize-new-keypair
+                                      {:sha3-pwd    (security/safe-unmask-data
+                                                     entered-password)
+                                       :new-keypair (prepare-new-keypair {:new-keypair new-keypair
+                                                                          :address address
+                                                                          :account-name @account-name
+                                                                          :account-color @account-color
+                                                                          :emoji @emoji
+                                                                          :derivation-path
+                                                                          @derivation-path})}])
+                                    (rf/dispatch [:wallet/derive-address-and-add-account
+                                                  {:sha3-pwd     (security/safe-unmask-data
+                                                                  entered-password)
+                                                   :emoji        @emoji
+                                                   :color        @account-color
+                                                   :path         @derivation-path
+                                                   :account-name @account-name}])))
+           :auth-button-label   (i18n/label :t/confirm)
            ;; TODO (@rende11) Add this property when sliding button issue will fixed
            ;; https://github.com/status-im/status-mobile/pull/18683#issuecomment-1941564785
            ;; :disabled?           (empty? @account-name)
-           :container-style (style/slide-button-container bottom)}]]))))
+           :container-style     (style/slide-button-container bottom)}]]))))
 
 (defn- view-internal
   []

--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -56,7 +56,7 @@
         account-name                 (reagent/atom "")
         placeholder                  (i18n/label :t/default-account-placeholder
                                                  {:number (inc number-of-accounts)})
-        derivation-path              (reagent/atom (utils/get-derivation-path (inc number-of-accounts)))
+        derivation-path              (reagent/atom (utils/get-derivation-path number-of-accounts))
         {:keys [public-key address]} (rf/sub [:profile/profile])
         on-change-text               #(reset! account-name %)
         primary-name                 (first (rf/sub [:contacts/contact-two-names-by-identity
@@ -64,7 +64,6 @@
         {window-width :width}        (rn/get-window)]
     (fn [{:keys [theme]}]
       (let [{:keys [new-keypair]} (rf/sub [:wallet/create-account])]
-        (println "qqq" address)
         (rn/use-effect (fn [] #(rf/dispatch [:wallet/clear-new-keypair])))
         [rn/view {:style {:flex 1}}
          [quo/page-nav
@@ -135,14 +134,14 @@
                                                  (merge new-keypair
                                                         {:name         (:keypair-name new-keypair)
                                                          :key-uid      (:keyUid new-keypair)
-                                                         :type         :generated
+                                                         :type         :seed
                                                          :derived-from address})
                                                  {:accounts [{:keypair-name (:keypair-name new-keypair)
                                                               :key-uid      (:keyUid new-keypair)
                                                               :seed-phrase  (:mnemonic new-keypair)
                                                               :public-key   (:publicKey new-keypair)
                                                               :name         @account-name
-                                                              :type         :generated
+                                                              :type         :seed
                                                               :emoji        @emoji
                                                               :colorID      @account-color
                                                               :path         @derivation-path

--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -66,7 +66,7 @@
         {window-width :width}        (rn/get-window)]
     (fn [{:keys [theme]}]
       (let [{:keys [new-keypair]} (rf/sub [:wallet/create-account])]
-        (rn/use-effect (fn [] #(rf/dispatch [:wallet/clear-new-keypair])))
+        (rn/use-unmount #(rf/dispatch [:wallet/clear-new-keypair]))
         [rn/view {:style {:flex 1}}
          [quo/page-nav
           {:type       :no-title

--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -13,31 +13,13 @@
     [status-im.contexts.wallet.common.sheets.account-origin.view :as account-origin]
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.create-account.style :as style]
+    [status-im.contexts.wallet.create-account.utils :as create-account.utils]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.responsiveness :refer [iphone-11-Pro-20-pixel-from-width]]
     [utils.security.core :as security]
     [utils.string]))
 
-(defn prepare-new-keypair
-  [{:keys [new-keypair address account-name account-color emoji derivation-path]}]
-  (assoc
-   (assoc new-keypair
-          :name         (:keypair-name new-keypair)
-          :key-uid      (:keyUid new-keypair)
-          :type         :seed
-          :derived-from address)
-   :accounts
-   [{:keypair-name (:keypair-name new-keypair)
-     :key-uid      (:keyUid new-keypair)
-     :seed-phrase  (:mnemonic new-keypair)
-     :public-key   (:publicKey new-keypair)
-     :name         account-name
-     :type         :seed
-     :emoji        emoji
-     :colorID      account-color
-     :path         derivation-path
-     :address      (:address new-keypair)}]))
 
 (defn- get-keypair-data
   [primary-name derivation-path account-color {:keys [keypair-name]}]
@@ -147,16 +129,17 @@
            :on-auth-success     (fn [entered-password]
                                   (if new-keypair
                                     (rf/dispatch
-                                     [:wallet/finalize-new-keypair
+                                     [:wallet/add-keypair-and-create-account
                                       {:sha3-pwd    (security/safe-unmask-data
                                                      entered-password)
-                                       :new-keypair (prepare-new-keypair {:new-keypair new-keypair
-                                                                          :address address
-                                                                          :account-name @account-name
-                                                                          :account-color @account-color
-                                                                          :emoji @emoji
-                                                                          :derivation-path
-                                                                          @derivation-path})}])
+                                       :new-keypair (create-account.utils/prepare-new-keypair
+                                                     {:new-keypair new-keypair
+                                                      :address address
+                                                      :account-name @account-name
+                                                      :account-color @account-color
+                                                      :emoji @emoji
+                                                      :derivation-path
+                                                      @derivation-path})}])
                                     (rf/dispatch [:wallet/derive-address-and-add-account
                                                   {:sha3-pwd     (security/safe-unmask-data
                                                                   entered-password)

--- a/src/status_im/contexts/wallet/create_account/view.cljs
+++ b/src/status_im/contexts/wallet/create_account/view.cljs
@@ -13,7 +13,6 @@
     [status-im.contexts.wallet.common.sheets.account-origin.view :as account-origin]
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.create-account.style :as style]
-    [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.responsiveness :refer [iphone-11-Pro-20-pixel-from-width]]
@@ -49,19 +48,20 @@
 
 (defn- f-view
   []
-  (let [top                (safe-area/get-top)
-        bottom             (safe-area/get-bottom)
-        account-color      (reagent/atom (rand-nth colors/account-colors))
-        emoji              (reagent/atom (emoji-picker.utils/random-emoji))
-        number-of-accounts (count (rf/sub [:wallet/accounts-without-watched-accounts]))
-        account-name       (reagent/atom "")
-        placeholder        (i18n/label :t/default-account-placeholder
-                                       {:number (inc number-of-accounts)})
-        derivation-path    (reagent/atom (utils/get-derivation-path (inc number-of-accounts)))
+  (let [top                          (safe-area/get-top)
+        bottom                       (safe-area/get-bottom)
+        account-color                (reagent/atom (rand-nth colors/account-colors))
+        emoji                        (reagent/atom (emoji-picker.utils/random-emoji))
+        number-of-accounts           (count (rf/sub [:wallet/accounts-without-watched-accounts]))
+        account-name                 (reagent/atom "")
+        placeholder                  (i18n/label :t/default-account-placeholder
+                                                 {:number (inc number-of-accounts)})
+        derivation-path              (reagent/atom (utils/get-derivation-path (inc number-of-accounts)))
         {:keys [public-key address]} (rf/sub [:profile/profile])
-        on-change-text     #(reset! account-name %)
-        primary-name       (first (rf/sub [:contacts/contact-two-names-by-identity public-key]))
-        {window-width :width} (rn/get-window)]
+        on-change-text               #(reset! account-name %)
+        primary-name                 (first (rf/sub [:contacts/contact-two-names-by-identity
+                                                     public-key]))
+        {window-width :width}        (rn/get-window)]
     (fn [{:keys [theme]}]
       (let [{:keys [new-keypair]} (rf/sub [:wallet/create-account])]
         (println "qqq" address)
@@ -122,39 +122,43 @@
            :label     (i18n/label :t/origin)
            :data      (get-keypair-data primary-name @derivation-path @account-color new-keypair)}]
          [standard-auth/slide-button
-          {:size                :size-48
-           :track-text          (i18n/label :t/slide-to-create-account)
+          {:size :size-48
+           :track-text (i18n/label :t/slide-to-create-account)
            :customization-color @account-color
-           :on-auth-success     (fn [entered-password]
-                                  (if new-keypair
-                                    (rf/dispatch [:wallet/finalize-new-keypair {:sha3-pwd    (security/safe-unmask-data
-                                                                                               entered-password)
-                                                                                :new-keypair (merge (merge new-keypair {:name         (:keypair-name new-keypair)
-                                                                                                                        :key-uid      (:keyUid new-keypair)
-                                                                                                                        :type         :generated
-                                                                                                                        :derived-from address})
-                                                                                                    {:accounts [{:keypair-name (:keypair-name new-keypair)
-                                                                                                                 :key-uid      (:keyUid new-keypair)
-                                                                                                                 :seed-phrase  (:mnemonic new-keypair)
-                                                                                                                 :public-key   (:publicKey new-keypair)
-                                                                                                                 :name         @account-name
-                                                                                                                 :type         :generated
-                                                                                                                 :emoji        @emoji
-                                                                                                                 :colorID     @account-color
-                                                                                                                 :path         @derivation-path
-                                                                                                                 :address      (:address new-keypair)}]})}])
-                                    (rf/dispatch [:wallet/derive-address-and-add-account
-                                                  {:sha3-pwd     (security/safe-unmask-data
-                                                                   entered-password)
-                                                   :emoji        @emoji
-                                                   :color        @account-color
-                                                   :path         @derivation-path
-                                                   :account-name @account-name}])))
-           :auth-button-label   (i18n/label :t/confirm)
+           :on-auth-success (fn [entered-password]
+                              (if new-keypair
+                                (rf/dispatch
+                                 [:wallet/finalize-new-keypair
+                                  {:sha3-pwd    (security/safe-unmask-data
+                                                 entered-password)
+                                   :new-keypair (merge
+                                                 (merge new-keypair
+                                                        {:name         (:keypair-name new-keypair)
+                                                         :key-uid      (:keyUid new-keypair)
+                                                         :type         :generated
+                                                         :derived-from address})
+                                                 {:accounts [{:keypair-name (:keypair-name new-keypair)
+                                                              :key-uid      (:keyUid new-keypair)
+                                                              :seed-phrase  (:mnemonic new-keypair)
+                                                              :public-key   (:publicKey new-keypair)
+                                                              :name         @account-name
+                                                              :type         :generated
+                                                              :emoji        @emoji
+                                                              :colorID      @account-color
+                                                              :path         @derivation-path
+                                                              :address      (:address new-keypair)}]})}])
+                                (rf/dispatch [:wallet/derive-address-and-add-account
+                                              {:sha3-pwd     (security/safe-unmask-data
+                                                              entered-password)
+                                               :emoji        @emoji
+                                               :color        @account-color
+                                               :path         @derivation-path
+                                               :account-name @account-name}])))
+           :auth-button-label (i18n/label :t/confirm)
            ;; TODO (@rende11) Add this property when sliding button issue will fixed
            ;; https://github.com/status-im/status-mobile/pull/18683#issuecomment-1941564785
            ;; :disabled?           (empty? @account-name)
-           :container-style     (style/slide-button-container bottom)}]]))))
+           :container-style (style/slide-button-container bottom)}]]))))
 
 (defn- view-internal
   []

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -23,8 +23,8 @@
   (assoc account :watch-only? (= (:type account) :watch)))
 
 (defn- sanitize-emoji
-  "As Desktop uses Twemoji, the emoji received can be an img tag 
-   with raw emoji in alt attribute. This function help us to extract 
+  "As Desktop uses Twemoji, the emoji received can be an img tag
+   with raw emoji in alt attribute. This function help us to extract
    the emoji from it as mobile doesn't support HTML rendering and Twemoji"
   [emoji]
   (if (string/starts-with? emoji "<img")
@@ -104,3 +104,19 @@
         :blockExplorerUrl       :block-explorer-url
         :nativeCurrencySymbol   :native-currency-symbol
         :nativeCurrencyName     :native-currency-symbol})))
+
+(defn rename-color-id-in-data
+  [data]
+  (map (fn [item]
+         (update item
+                 :accounts
+                 (fn [accounts]
+                   (map (fn [account]
+                          (set/rename-keys account {:color-id :customization-color}))
+                        accounts))))
+       data))
+
+(defn parse-keypairs
+  [keypairs]
+  (let [renamed-data (rename-color-id-in-data keypairs)]
+    (cske/transform-keys csk/->kebab-case-keyword renamed-data)))

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -112,7 +112,11 @@
                  :accounts
                  (fn [accounts]
                    (map (fn [account]
-                          (set/rename-keys account {:color-id :customization-color}))
+                          (let [renamed-account (set/rename-keys account
+                                                                 {:colorId :customization-color})]
+                            (if (contains? account :colorId)
+                              renamed-account
+                              (assoc renamed-account :customization-color :blue))))
                         accounts))))
        data))
 

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -202,29 +202,32 @@
                                     (first derived-address-details)]))]
      {:fx [[:dispatch [:wallet/create-derived-addresses account-details on-success]]]})))
 
-(rf/reg-event-fx
- :wallet/finalize-new-keypair
- (fn [_ [{:keys [sha3-pwd new-keypair]}]]
-   {:fx [[:json-rpc/call
-          [{:method     "accounts_addKeypair"
-            :params     [sha3-pwd new-keypair]
-            :on-success [:wallet/add-account-success (string/lower-case (:address new-keypair))]
-            :on-error   #(log/info "failed to create keypair " %)}]]]}))
+(defn finalize-new-keypair
+  [_ [{:keys [sha3-pwd new-keypair]}]]
+  {:fx [[:json-rpc/call
+         [{:method     "accounts_addKeypair"
+           :params     [sha3-pwd new-keypair]
+           :on-success [:wallet/add-account-success (string/lower-case (:address new-keypair))]
+           :on-error   #(log/info "failed to create keypair " %)}]]]})
 
-(rf/reg-event-fx
- :wallet/get-keypairs
- (fn [{:keys [db]}]
-   {:fx [[:json-rpc/call
-          [{:method     "accounts_getKeypairs"
-            :params     []
-            :on-success [:wallet/get-keypairs-success]
-            :on-error   #(log/info "failed to get keypairs " %)}]]]}))
+(rf/reg-event-fx :wallet/finalize-new-keypair finalize-new-keypair)
 
-(rf/reg-event-fx
- :wallet/get-keypairs-success
- (fn [{:keys [db]} [keypairs]]
-   (let []
-     {:db (assoc-in db [:wallet :keypairs] keypairs)})))
+(defn get-keypairs
+  [_]
+  {:fx [[:json-rpc/call
+         [{:method     "accounts_getKeypairs"
+           :params     []
+           :on-success [:wallet/get-keypairs-success]
+           :on-error   #(log/info "failed to get keypairs " %)}]]]})
+
+(rf/reg-event-fx :wallet/get-keypairs get-keypairs)
+
+(defn get-keypairs-success
+  [{:keys [db]} [keypairs]]
+  (let []
+    {:db (assoc-in db [:wallet :keypairs] keypairs)}))
+
+(rf/reg-event-fx :wallet/get-keypairs-success get-keypairs-success)
 
 (rf/reg-event-fx :wallet/bridge-select-token
  (fn [{:keys [db]} [{:keys [token stack-id]}]]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -198,9 +198,21 @@
  :wallet/derive-address-and-add-account
  (fn [_ [account-details]]
    (let [on-success (fn [derived-address-details]
+                      (println "dervied d" derived-address-details)
                       (rf/dispatch [:wallet/add-account account-details
                                     (first derived-address-details)]))]
      {:fx [[:dispatch [:wallet/create-derived-addresses account-details on-success]]]})))
+
+(rf/reg-event-fx
+  :wallet/finalize-new-keypair
+  (fn [_ [{:keys [sha3-pwd new-keypair] :as account-details}]]
+    (let [account-config    {}]
+     (println "wtff")
+     {:fx [[:json-rpc/call
+            [{:method     "accounts_addKeypair"
+              :params     [sha3-pwd new-keypair]
+              :on-success #(println "success new keypair: " %)
+              :on-error   #(log/info "failed to create keypair " %)}]]]})))
 
 (rf/reg-event-fx :wallet/bridge-select-token
  (fn [{:keys [db]} [{:keys [token stack-id]}]]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -207,7 +207,6 @@
  :wallet/finalize-new-keypair
  (fn [_ [{:keys [sha3-pwd new-keypair] :as account-details}]]
    (let [account-config {}]
-     (println "wtff")
      {:fx [[:json-rpc/call
             [{:method     "accounts_addKeypair"
               :params     [sha3-pwd new-keypair]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -204,9 +204,9 @@
      {:fx [[:dispatch [:wallet/create-derived-addresses account-details on-success]]]})))
 
 (rf/reg-event-fx
-  :wallet/finalize-new-keypair
-  (fn [_ [{:keys [sha3-pwd new-keypair] :as account-details}]]
-    (let [account-config    {}]
+ :wallet/finalize-new-keypair
+ (fn [_ [{:keys [sha3-pwd new-keypair] :as account-details}]]
+   (let [account-config {}]
      (println "wtff")
      {:fx [[:json-rpc/call
             [{:method     "accounts_addKeypair"

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -236,7 +236,7 @@
                  :accounts
                  (fn [accounts]
                    (map (fn [account]
-                          (set/rename-keys account {:color-id :customization-color}))
+                          (set/rename-keys account {:colorId :customization-color}))
                         accounts))))
        data))
 

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -224,8 +224,7 @@
 
 (defn get-keypairs-success
   [{:keys [db]} [keypairs]]
-  (let []
-    {:db (assoc-in db [:wallet :keypairs] keypairs)}))
+    {:db (assoc-in db [:wallet :keypairs] keypairs)})
 
 (rf/reg-event-fx :wallet/get-keypairs-success get-keypairs-success)
 

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -1,8 +1,5 @@
 (ns status-im.contexts.wallet.events
   (:require
-    [camel-snake-kebab.core :as csk]
-    [camel-snake-kebab.extras :as cske]
-    [clojure.set :as set]
     [clojure.string :as string]
     [react-native.background-timer :as background-timer]
     [react-native.platform :as platform]
@@ -228,22 +225,9 @@
 
 (rf/reg-event-fx :wallet/get-keypairs get-keypairs)
 
-
-(defn rename-color-id-in-data
-  [data]
-  (map (fn [item]
-         (update item
-                 :accounts
-                 (fn [accounts]
-                   (map (fn [account]
-                          (set/rename-keys account {:colorId :customization-color}))
-                        accounts))))
-       data))
-
 (defn get-keypairs-success
   [{:keys [db]} [keypairs]]
-  (let [renamed-data (rename-color-id-in-data keypairs)]
-    {:db (assoc-in db [:wallet :keypairs] (cske/transform-keys csk/->kebab-case-keyword renamed-data))}))
+  {:db (assoc-in db [:wallet :keypairs] (data-store/parse-keypairs keypairs))})
 
 (rf/reg-event-fx :wallet/get-keypairs-success get-keypairs-success)
 

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -55,17 +55,6 @@
         effects     (events/clear-new-keypair {:db db})]
     (is (match? (:db effects) expected-db))))
 
-(deftest get-keypairs-success
-  (let [db          {}
-        keypairs    [{:public-key "public_key1"
-                      :accounts   [{:colorId :blue}]}
-                     {:public-key "public_key2"
-                      :accounts   [{:colorId :red}]}]
-        expected-db {:wallet {:keypairs keypairs}}
-        effects     (events/get-keypairs-success {:db db} keypairs)
-        result-db   (:db effects)]
-    (is (match? result-db expected-db))))
-
 (deftest store-collectibles
   (testing "(displayable-collectible?) helper function"
     (let [expected-results [[true

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -58,9 +58,9 @@
 (deftest get-keypairs-success
   (let [db          {}
         keypairs    [{:public-key "public_key1"
-                      :accounts [{:color-id :blue}]}
+                      :accounts   [{:color-id :blue}]}
                      {:public-key "public_key2"
-                      :accounts [{:color-id :red}]}]
+                      :accounts   [{:color-id :red}]}]
         expected-db {:wallet {:keypairs keypairs}}
         effects     (events/get-keypairs-success {:db db} keypairs)
         result-db   (:db effects)]

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -59,8 +59,7 @@
   (let [db          {}
         keypairs    [{:public-key "public_key1"}
                      {:public-key "public_key2"}]
-        expected-db {:wallet {:ui       {:create-account {:new-keypair "test-keypair"}}
-                              :keypairs keypairs}}
+        expected-db {:wallet {:keypairs keypairs}}
         effects     (events/get-keypairs-success {:db db} keypairs)
         result-db   (:db effects)]
     (is (match? result-db expected-db))))

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -55,28 +55,6 @@
         effects     (events/clear-new-keypair {:db db})]
     (is (match? (:db effects) expected-db))))
 
-(deftest add-keypair-and-create-account
-  (let [db          {}
-        sha3-pwd    "password"
-        new-keypair {:public-key "public_key" :private-key "private_key"}
-        expected-db {:wallet {:ui       {:create-account {:new-keypair "test-keypair"}}
-                              :keypairs [new-keypair]}}
-        effects     (events/add-keypair-and-create-account {:db db}
-                                                           [{:sha3-pwd    sha3-pwd
-                                                             :new-keypair new-keypair}])
-        result-db   (:db effects)]
-    (is (match? result-db expected-db))))
-
-(deftest get-keypairs
-  (let [db          {}
-        keypairs    [{:public-key "public_key1"}
-                     {:public-key "public_key2"}]
-        expected-db {:wallet {:ui       {:create-account {:new-keypair "test-keypair"}}
-                              :keypairs keypairs}}
-        effects     (events/get-keypairs {:db db})
-        result-db   (:db effects)]
-    (is (match? result-db expected-db))))
-
 (deftest get-keypairs-success
   (let [db          {}
         keypairs    [{:public-key "public_key1"}

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -57,8 +57,10 @@
 
 (deftest get-keypairs-success
   (let [db          {}
-        keypairs    [{:public-key "public_key1"}
-                     {:public-key "public_key2"}]
+        keypairs    [{:public-key "public_key1"
+                      :accounts [{:color-id :blue}]}
+                     {:public-key "public_key2"
+                      :accounts [{:color-id :red}]}]
         expected-db {:wallet {:keypairs keypairs}}
         effects     (events/get-keypairs-success {:db db} keypairs)
         result-db   (:db effects)]

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -55,6 +55,39 @@
         effects     (events/clear-new-keypair {:db db})]
     (is (match? (:db effects) expected-db))))
 
+(deftest finalize-new-keypair
+  (let [db          {}
+        sha3-pwd    "password"
+        new-keypair {:public-key "public_key" :private-key "private_key"}
+        expected-db {:wallet {:ui       {:create-account {:new-keypair "test-keypair"}}
+                              :keypairs [new-keypair]}}
+        effects     (events/finalize-new-keypair {:db db}
+                                                 [{:sha3-pwd sha3-pwd :new-keypair new-keypair}])
+        result-db   (:db effects)]
+    (is (match? result-db expected-db))))
+
+(deftest get-keypairs
+  (let [db          {}
+        keypairs    [{:public-key "public_key1" :private-key "private_key1"}
+                     {:public-key "public_key2" :private-key "private_key2"}]
+        expected-db {:wallet {:ui       {:create-account {:new-keypair "test-keypair"}}
+                              :keypairs keypairs}}
+        effects     (events/get-keypairs {:db db})
+        result-db   (:db effects)]
+    (is (match? result-db expected-db))))
+
+(deftest get-keypairs-success
+  (let [db          {}
+        keypairs    [{:public-key "public_key1" :private-key "private_key1"}
+                     {:public-key "public_key2" :private-key "private_key2"}]
+        expected-db {:wallet {:ui       {:create-account {:new-keypair "test-keypair"}}
+                              :keypairs keypairs}}
+        effects     (events/get-keypairs-success {:db db} keypairs)
+        result-db   (:db effects)]
+    (is (match? result-db expected-db))))
+
+
+
 
 (deftest store-collectibles
   (testing "(displayable-collectible?) helper function"

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -55,14 +55,15 @@
         effects     (events/clear-new-keypair {:db db})]
     (is (match? (:db effects) expected-db))))
 
-(deftest finalize-new-keypair
+(deftest add-keypair-and-create-account
   (let [db          {}
         sha3-pwd    "password"
         new-keypair {:public-key "public_key" :private-key "private_key"}
         expected-db {:wallet {:ui       {:create-account {:new-keypair "test-keypair"}}
                               :keypairs [new-keypair]}}
-        effects     (events/finalize-new-keypair {:db db}
-                                                 [{:sha3-pwd sha3-pwd :new-keypair new-keypair}])
+        effects     (events/add-keypair-and-create-account {:db db}
+                                                           [{:sha3-pwd    sha3-pwd
+                                                             :new-keypair new-keypair}])
         result-db   (:db effects)]
     (is (match? result-db expected-db))))
 

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -68,8 +68,8 @@
 
 (deftest get-keypairs
   (let [db          {}
-        keypairs    [{:public-key "public_key1" :private-key "private_key1"}
-                     {:public-key "public_key2" :private-key "private_key2"}]
+        keypairs    [{:public-key "public_key1"}
+                     {:public-key "public_key2"}]
         expected-db {:wallet {:ui       {:create-account {:new-keypair "test-keypair"}}
                               :keypairs keypairs}}
         effects     (events/get-keypairs {:db db})
@@ -78,16 +78,13 @@
 
 (deftest get-keypairs-success
   (let [db          {}
-        keypairs    [{:public-key "public_key1" :private-key "private_key1"}
-                     {:public-key "public_key2" :private-key "private_key2"}]
+        keypairs    [{:public-key "public_key1"}
+                     {:public-key "public_key2"}]
         expected-db {:wallet {:ui       {:create-account {:new-keypair "test-keypair"}}
                               :keypairs keypairs}}
         effects     (events/get-keypairs-success {:db db} keypairs)
         result-db   (:db effects)]
     (is (match? result-db expected-db))))
-
-
-
 
 (deftest store-collectibles
   (testing "(displayable-collectible?) helper function"

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -58,9 +58,9 @@
 (deftest get-keypairs-success
   (let [db          {}
         keypairs    [{:public-key "public_key1"
-                      :accounts   [{:color-id :blue}]}
+                      :accounts   [{:colorId :blue}]}
                      {:public-key "public_key2"
-                      :accounts   [{:color-id :red}]}]
+                      :accounts   [{:colorId :red}]}]
         expected-db {:wallet {:keypairs keypairs}}
         effects     (events/get-keypairs-success {:db db} keypairs)
         result-db   (:db effects)]

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -10,7 +10,7 @@
 
 (defonce ^:private feature-flags-config
   (reagent/atom
-   {::wallet.edit-default-keypair (enabled-in-env? :FLAG_EDIT_DEFAULT_KEYPAIR_ENABLED)
+   {::wallet.edit-default-keypair true
     ::wallet.bridge-token         (enabled-in-env? :FLAG_BRIDGE_TOKEN_ENABLED)
     ::wallet.remove-account       (enabled-in-env? :FLAG_REMOVE_ACCOUNT_ENABLED)
     ::wallet.network-filter       (enabled-in-env? :FLAG_NETWORK_FILTER_ENABLED)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -94,6 +94,11 @@
  :-> :watch-address-activity-state)
 
 (rf/reg-sub
+ :wallet/keypairs
+ :<- [:wallet]
+ :-> :keypairs)
+
+(rf/reg-sub
  :wallet/accounts
  :<- [:wallet]
  :<- [:wallet/network-details]

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -498,6 +498,9 @@
              (assoc :network-preferences-names #{}))]
         (rf/sub [sub-name])))))
 
+(def keypairs
+  [{:key-uid "abc"}])
+
 (h/deftest-sub :wallet/keypairs
   [sub-name]
   (testing "returns all keypairs"

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -497,3 +497,12 @@
              (get "0x3")
              (assoc :network-preferences-names #{}))]
         (rf/sub [sub-name])))))
+
+(h/deftest-sub :wallet/keypairs
+  [sub-name]
+  (testing "returns all keypairs"
+    (swap! rf-db/app-db
+      #(assoc-in % [:wallet :keypairs] keypairs))
+    (is
+     (= keypairs
+        (rf/sub [sub-name])))))


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/18813

This PR implements the following:
- Finalizing the keypair creation
- Creating a new wallet account for the newly created keypair
- Removes mock data from keypairs list screen and replaces with real data

[Designs](https://www.figma.com/file/HKncH4wnDwZDAhc4AryK8Y/Wallet-for-Mobile?type=design&node-id=2070-596894&mode=design&t=W2rcdEsedZi3WNys-4)

Selecting an already created keypair to create a new wallet account will be implemented in another issue https://github.com/status-im/status-mobile/issues/18993

Demo:

https://github.com/status-im/status-mobile/assets/29354102/907873da-a1e3-4150-bf11-735121098dc4

