### PR TITLE
Partial handlers update (re-frame/reg-event-fx instead of rf/defn)

### DIFF
--- a/src/legacy/status_im/browser/core.cljs
+++ b/src/legacy/status_im/browser/core.cljs
@@ -15,6 +15,7 @@
     [native-module.core :as native-module]
     [re-frame.core :as re-frame]
     [react-native.platform :as platform]
+    [status-im.common.json-rpc.events :as json-rpc]
     [status-im.common.universal-links :as links]
     [status-im.constants :as constants]
     [status-im.contexts.chat.events :as chat.events]
@@ -654,12 +655,11 @@
                           stored-bookmarks)]
     {:db (assoc db :bookmarks/bookmarks bookmarks)}))
 
-(rf/defn initialize-browser
-  [_]
-  {:json-rpc/call
-   [{:method     "wakuext_getBrowsers"
-     :on-success #(re-frame/dispatch [::initialize-browsers %])}
-    {:method     "browsers_getBookmarks"
-     :on-success #(re-frame/dispatch [::initialize-bookmarks %])}
-    {:method     "permissions_getDappPermissions"
-     :on-success #(re-frame/dispatch [::initialize-dapp-permissions %])}]})
+(re-frame/reg-fx :browser/initialize-browser
+ (fn []
+   (json-rpc/call {:method     "wakuext_getBrowsers"
+                   :on-success [::initialize-browsers]})
+   (json-rpc/call {:method     "browsers_getBookmarks"
+                   :on-success [::initialize-bookmarks]})
+   (json-rpc/call {:method     "permissions_getDappPermissions"
+                   :on-success [::initialize-dapp-permissions]})))

--- a/src/legacy/status_im/communities/core.cljs
+++ b/src/legacy/status_im/communities/core.cljs
@@ -4,7 +4,6 @@
     [legacy.status-im.bottom-sheet.events :as bottom-sheet]
     legacy.status-im.communities.e2e
     [re-frame.core :as re-frame]
-    [status-im.contexts.shell.activity-center.events :as activity-center]
     [status-im.navigation.events :as navigation]
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]))
@@ -84,13 +83,12 @@
             (navigation/navigate-back)
             (handle-response response-js)))
 
-(rf/defn member-banned
-  {:events [::member-banned]}
-  [cofx response-js]
-  (rf/merge cofx
-            (bottom-sheet/hide-bottom-sheet-old)
-            (handle-response response-js)
-            (activity-center/notifications-fetch-unread-count)))
+(re-frame/reg-event-fx ::member-banned
+ (fn [{:keys [db]} [response-js]]
+   {:db (assoc db :bottom-sheet/show? false)
+    :fx [[:dismiss-bottom-sheet-overlay-old]
+         [:sanitize-messages-and-process-response response-js]
+         [:activity-center.notifications/fetch-unread-count]]}))
 
 (rf/defn member-ban
   {:events [::member-ban]}

--- a/src/legacy/status_im/contact/block.cljs
+++ b/src/legacy/status_im/contact/block.cljs
@@ -6,7 +6,6 @@
     [re-frame.core :as re-frame]
     [status-im.contexts.chat.contacts.events :as contacts-store]
     [status-im.contexts.chat.messenger.messages.list.events :as message-list]
-    [status-im.contexts.shell.activity-center.events :as activity-center]
     [status-im.navigation.events :as navigation]
     [utils.re-frame :as rf]))
 
@@ -45,16 +44,16 @@
     (apply
      rf/merge
      cofx
-     {:db                                                     (->
-                                                                db
-                                                                (update :chats dissoc public-key)
-                                                                (update :chats-home-list disj public-key)
-                                                                (assoc-in [:contacts/contacts public-key
-                                                                           :added?]
-                                                                          false))
-      :dispatch                                               [:shell/close-switcher-card public-key]
-      :effects/push-notifications-clear-message-notifications [public-key]}
-     (activity-center/notifications-fetch-unread-count)
+     {:db (->
+            db
+            (update :chats dissoc public-key)
+            (update :chats-home-list disj public-key)
+            (assoc-in [:contacts/contacts public-key
+                       :added?]
+                      false))
+      :fx [[:activity-center.notifications/fetch-unread-count]
+           [:effects/push-notifications-clear-message-notifications [public-key]]
+           [:dispatch [:shell/close-switcher-card public-key]]]}
      fxs)))
 
 (rf/defn block-contact

--- a/src/legacy/status_im/data_store/chats.cljs
+++ b/src/legacy/status_im/data_store/chats.cljs
@@ -3,9 +3,10 @@
     [clojure.set :as set]
     [legacy.status-im.data-store.messages :as messages]
     [legacy.status-im.utils.deprecated-types :as types]
+    [re-frame.core :as re-frame]
+    [status-im.common.json-rpc.events :as json-rpc]
     [status-im.constants :as constants]
-    [taoensso.timbre :as log]
-    [utils.re-frame :as rf]))
+    [taoensso.timbre :as log]))
 
 (defn rpc->type
   [{:keys [chat-type name] :as chat}]
@@ -117,10 +118,10 @@
       rpc->type
       unmarshal-members))
 
-(rf/defn fetch-chats-preview
-  [_ {:keys [on-success]}]
-  {:json-rpc/call [{:method      "wakuext_chatsPreview"
-                    :params      []
-                    :js-response true
-                    :on-success  #(on-success ^js %)
-                    :on-error    #(log/error "failed to fetch chats" 0 -1 %)}]})
+(re-frame/reg-fx :fetch-chats-preview
+ (fn [{:keys [on-success]}]
+   (json-rpc/call {:method      "wakuext_chatsPreview"
+                   :params      []
+                   :js-response true
+                   :on-success  #(on-success ^js %)
+                   :on-error    #(log/error "failed to fetch chats" 0 -1 %)})))

--- a/src/legacy/status_im/data_store/switcher_cards.cljs
+++ b/src/legacy/status_im/data_store/switcher_cards.cljs
@@ -2,6 +2,8 @@
   (:require
     [clojure.set :as set]
     [clojure.walk :as walk]
+    [re-frame.core :as re-frame]
+    [status-im.common.json-rpc.events :as json-rpc]
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]))
 
@@ -32,11 +34,11 @@
                     :on-success #()
                     :on-error   #()}]})
 
-(rf/defn fetch-switcher-cards-rpc
-  [_]
-  {:json-rpc/call [{:method     "wakuext_switcherCards"
-                    :params     []
-                    :on-success #(rf/dispatch
-                                  [:shell/switcher-cards-loaded
-                                   (:switcherCards ^js %)])
-                    :on-error   #(log/error "Failed to fetch switcher cards" %)}]})
+(re-frame/reg-fx :switcher-cards/fetch
+ (fn []
+   (json-rpc/call {:method     "wakuext_switcherCards"
+                   :params     []
+                   :on-success #(rf/dispatch
+                                 [:shell/switcher-cards-loaded
+                                  (:switcherCards ^js %)])
+                   :on-error   #(log/error "Failed to fetch switcher cards" %)})))

--- a/src/legacy/status_im/data_store/visibility_status_updates.cljs
+++ b/src/legacy/status_im/data_store/visibility_status_updates.cljs
@@ -2,8 +2,8 @@
   (:require
     [clojure.set :as set]
     [re-frame.core :as re-frame]
-    [taoensso.timbre :as log]
-    [utils.re-frame :as rf]))
+    [status-im.common.json-rpc.events :as json-rpc]
+    [taoensso.timbre :as log]))
 
 (defn <-rpc
   [visibility-status-update]
@@ -18,13 +18,13 @@
        {:current-user-status :current-user-visibility-status})
       (update :current-user-visibility-status <-rpc)))
 
-(rf/defn fetch-visibility-status-updates-rpc
-  [_]
-  {:json-rpc/call [{:method     "wakuext_statusUpdates"
-                    :params     []
-                    :on-success #(re-frame/dispatch
-                                  [:visibility-status-updates/visibility-status-updates-loaded
-                                   (:statusUpdates ^js %)])
-                    :on-error   #(log/error
-                                  "failed to fetch visibility-status-updates"
-                                  %)}]})
+(re-frame/reg-fx :visibility-status-updates/fetch
+ (fn []
+   (json-rpc/call {:method     "wakuext_statusUpdates"
+                   :params     []
+                   :on-success #(re-frame/dispatch
+                                 [:visibility-status-updates/visibility-status-updates-loaded
+                                  (:statusUpdates ^js %)])
+                   :on-error   #(log/error
+                                 "failed to fetch visibility-status-updates"
+                                 %)})))

--- a/src/legacy/status_im/ethereum/transactions/core.cljs
+++ b/src/legacy/status_im/ethereum/transactions/core.cljs
@@ -239,7 +239,7 @@
 
 (rf/defn tx-history-end-reached
   [{:keys [db] :as cofx} address]
-  (let [syncing-allowed? (utils.mobile-sync/syncing-allowed? cofx)]
+  (let [syncing-allowed? (utils.mobile-sync/syncing-allowed? db)]
     {:db (assoc-in db
           [:wallet-legacy :fetching address :all-fetched?]
           (if syncing-allowed?
@@ -327,7 +327,7 @@
       {:chain-tokens      (:wallet-legacy/all-tokens db)
        :addresses         [address]
        :before-block      min-known-block
-       :fetch-more?       (utils.mobile-sync/syncing-allowed? cofx)
+       :fetch-more?       (utils.mobile-sync/syncing-allowed? db)
        ;; Transfers are requested before and including `min-known-block` because there is no
        ;; guarantee that all transfers from that block are shown already. To make sure that we fetch
        ;; the whole `default-transfers-limit` of transfers the number of transfers already received

--- a/src/legacy/status_im/events.cljs
+++ b/src/legacy/status_im/events.cljs
@@ -8,11 +8,16 @@
     legacy.status-im.chat.models.loading
     legacy.status-im.contact.block
     legacy.status-im.currency.core
+    legacy.status-im.data-store.chats
+    legacy.status-im.data-store.switcher-cards
+    legacy.status-im.data-store.visibility-status-updates
     legacy.status-im.fleet.core
+    legacy.status-im.group-chats.core
     [legacy.status-im.keycard.core :as keycard]
     legacy.status-im.log-level.core
     legacy.status-im.mailserver.constants
     [legacy.status-im.mailserver.core :as mailserver]
+    legacy.status-im.mobile-sync-settings.core
     legacy.status-im.multiaccounts.login.core
     legacy.status-im.multiaccounts.logout.core
     [legacy.status-im.multiaccounts.model :as multiaccounts.model]

--- a/src/legacy/status_im/network/net_info.cljs
+++ b/src/legacy/status_im/network/net_info.cljs
@@ -1,7 +1,6 @@
 (ns legacy.status-im.network.net-info
   (:require
     ["@react-native-community/netinfo" :default net-info]
-    [legacy.status-im.mobile-sync-settings.core :as mobile-network]
     [native-module.core :as native-module]
     [re-frame.core :as re-frame]
     [taoensso.timbre :as log]
@@ -13,11 +12,11 @@
             {:db (assoc db :network-status (if is-connected? :online :offline))}))
 
 (rf/defn change-network-type
-  [{:keys [db] :as cofx} old-network-type network-type expensive?]
+  [{:keys [db] :as cofx} network-type expensive?]
   (rf/merge cofx
             {:db                       (assoc db :network/type network-type)
-             :network/notify-status-go [network-type expensive?]}
-            (mobile-network/on-network-status-change)))
+             :network/notify-status-go [network-type expensive?]
+             :dispatch                 [:mobile-network/on-network-status-change]}))
 
 (rf/defn handle-network-info-change
   {:events [::network-info-changed]}
@@ -37,7 +36,7 @@
               (when-not status-changed?
                 (change-network-status isConnected))
               (when-not type-changed?
-                (change-network-type old-network-type type (:is-connection-expensive details))))))
+                (change-network-type type (:is-connection-expensive details))))))
 
 (defn add-net-info-listener
   []

--- a/src/legacy/status_im/stickers/core.cljs
+++ b/src/legacy/status_im/stickers/core.cljs
@@ -2,6 +2,7 @@
   (:require
     [legacy.status-im.utils.utils :as utils]
     [re-frame.core :as re-frame]
+    [status-im.common.json-rpc.events :as json-rpc]
     [status-im.constants :as constants]
     [utils.ethereum.chain :as chain]
     [utils.re-frame :as rf]))
@@ -21,6 +22,21 @@
     :json-rpc/call [{:method     "stickers_install"
                      :params     [(chain/chain-id db) id]
                      :on-success #()}]}))
+
+(re-frame/reg-fx :stickers/load-packs
+ (fn [chain-id]
+   (json-rpc/call {:method     "stickers_market"
+                   :params     [chain-id]
+                   :on-success [:stickers/stickers-market-success]})
+   (json-rpc/call {:method     "stickers_installed"
+                   :params     []
+                   :on-success [:stickers/stickers-installed-success]})
+   (json-rpc/call {:method     "stickers_pending"
+                   :params     []
+                   :on-success [:stickers/stickers-pending-success]})
+   (json-rpc/call {:method     "stickers_recent"
+                   :params     []
+                   :on-success [:stickers/stickers-recent-success]})))
 
 (rf/defn load-packs
   {:events [:stickers/load-packs]}

--- a/src/legacy/status_im/subs/mailservers.cljs
+++ b/src/legacy/status_im/subs/mailservers.cljs
@@ -61,7 +61,7 @@
 (re-frame/reg-sub
  :mailserver/use-status-nodes?
  (fn [db _]
-   (boolean (mailserver/fetch-use-mailservers? {:db db}))))
+   (boolean (mailserver/fetch-use-mailservers? db))))
 
 (re-frame/reg-sub
  :mailserver.edit/validation-errors

--- a/src/legacy/status_im/ui/screens/default_sync_period_settings/view.cljs
+++ b/src/legacy/status_im/ui/screens/default_sync_period_settings/view.cljs
@@ -21,7 +21,7 @@
    {:active    (= value id)
     :accessory :radio
     :title     (get titles id)
-    :on-press  #(re-frame/dispatch [:profile.settings/update-value :default-sync-period id])}])
+    :on-press  #(re-frame/dispatch [:profile.settings/profile-update :default-sync-period id])}])
 
 (views/defview default-sync-period-settings
   []

--- a/src/legacy/status_im/ui/screens/notifications_settings/events.cljs
+++ b/src/legacy/status_im/ui/screens/notifications_settings/events.cljs
@@ -51,6 +51,6 @@
   [{:keys [db] :as cofx} enabled?]
   (rf/merge cofx
             (if enabled?
-              {:push-notifications-enable nil}
-              {:push-notifications-disable nil})
+              {:effects/push-notifications-enable nil}
+              {:effects/push-notifications-disable nil})
             (multiaccounts.update/multiaccount-update :notifications-enabled? enabled? {})))

--- a/src/legacy/status_im/ui/screens/notifications_settings/events.cljs
+++ b/src/legacy/status_im/ui/screens/notifications_settings/events.cljs
@@ -51,6 +51,6 @@
   [{:keys [db] :as cofx} enabled?]
   (rf/merge cofx
             (if enabled?
-              {:effects/push-notifications-enable nil}
-              {:effects/push-notifications-disable nil})
+              {:push-notifications-enable nil}
+              {:push-notifications-disable nil})
             (multiaccounts.update/multiaccount-update :notifications-enabled? enabled? {})))

--- a/src/legacy/status_im/ui/screens/privacy_and_security_settings/views.cljs
+++ b/src/legacy/status_im/ui/screens/privacy_and_security_settings/views.cljs
@@ -111,7 +111,7 @@
          :subtitle           (i18n/label :t/webview-camera-permission-requests-subtitle)
          :subtitle-max-lines 2
          :on-press           #(re-frame/dispatch
-                               [:profile.settings/update-value
+                               [:profile.settings/profile-update
                                 :webview-allow-permission-requests?
                                 ((complement boolean) webview-allow-permission-requests?)])}])
      [separator]
@@ -169,8 +169,7 @@
    {:active    (= value id)
     :accessory :radio
     :title     (get titles id)
-    :on-press  #(re-frame/dispatch [:profile.settings/update-value :profile-pictures-visibility
-                                    id])}])
+    :on-press  #(re-frame/dispatch [:profile.settings/profile-update :profile-pictures-visibility id])}])
 
 (views/defview profile-pic
   []

--- a/src/legacy/status_im/ui/screens/profile/user/edit_picture.cljs
+++ b/src/legacy/status_im/ui/screens/profile/user/edit_picture.cljs
@@ -51,4 +51,4 @@
          :icon                :main-icons/delete
          :theme               :accent
          :title               (i18n/label :t/profile-pic-remove)
-         :on-press            #(re-frame/dispatch [:profile.settings/delete-profile-picture nil])}])]))
+         :on-press            #(re-frame/dispatch [:profile.settings/delete-profile-picture])}])]))

--- a/src/legacy/status_im/utils/logging/core.cljs
+++ b/src/legacy/status_im/utils/logging/core.cljs
@@ -10,6 +10,7 @@
     [re-frame.core :as re-frame]
     [react-native.mail :as react-native-mail]
     [react-native.platform :as platform]
+    [status-im.common.json-rpc.events :as json-rpc]
     [status-im.common.log :as log]
     [status-im.config :as config]
     [utils.datetime :as datetime]
@@ -31,11 +32,10 @@
   [{:keys [db]} node-version]
   {:db (assoc db :web3-node-version node-version)})
 
-(rf/defn initialize-web3-client-version
-  {:events [:logging/initialize-web3-client-version]}
-  [_]
-  {:json-rpc/call [{:method     "web3_clientVersion"
-                    :on-success #(re-frame/dispatch [:logging/store-web3-client-version %])}]})
+(re-frame/reg-fx :logging/initialize-web3-client-version
+ (fn []
+   (json-rpc/call {:method     "web3_clientVersion"
+                   :on-success [:logging/store-web3-client-version]})))
 
 (defn extract-url-components
   [address]

--- a/src/legacy/status_im/utils/mobile_sync.cljs
+++ b/src/legacy/status_im/utils/mobile_sync.cljs
@@ -5,7 +5,7 @@
   (= network-type "cellular"))
 
 (defn syncing-allowed?
-  [{:keys [db]}]
+  [db]
   (let [network                              (:network/type db)
         {:keys [syncing-on-mobile-network?]} (:profile/profile db)]
     (or (= network "wifi")

--- a/src/status_im/common/log.cljs
+++ b/src/status_im/common/log.cljs
@@ -4,9 +4,7 @@
     [clojure.string :as string]
     [native-module.core :as native-module]
     [re-frame.core :as re-frame]
-    [status-im.config :as config]
     [taoensso.timbre :as log]
-    [utils.re-frame :as rf]
     [utils.transforms :as transforms]))
 
 (def logs-queue (atom #queue []))
@@ -52,9 +50,3 @@
  :logs/set-level
  (fn [level]
    (setup level)))
-
-(rf/defn set-log-level
-  [{:keys [db]} log-level]
-  (let [log-level (or log-level config/log-level)]
-    {:db             (assoc-in db [:profile/profile :log-level] log-level)
-     :logs/set-level log-level}))

--- a/src/status_im/common/signals/events.cljs
+++ b/src/status_im/common/signals/events.cljs
@@ -7,7 +7,6 @@
     [status-im.contexts.chat.messenger.messages.link-preview.events :as link-preview]
     [status-im.contexts.chat.messenger.messages.transport.events :as messages.transport]
     [status-im.contexts.communities.discover.events]
-    [status-im.contexts.profile.login.events :as profile.login]
     [status-im.contexts.profile.push-notifications.local.events :as local-notifications]
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]
@@ -37,7 +36,9 @@
         ^js event-js (.-event data)
         type         (.-type data)]
     (case type
-      "node.login"                 (profile.login/login-node-signal cofx (transforms/js->clj event-js))
+      "node.login"                 {:fx [[:dispatch
+                                          [:profile.login/login-node-signal
+                                           (transforms/js->clj event-js)]]]}
       "backup.performed"           {:db (assoc-in db
                                          [:profile/profile :last-backup]
                                          (.-lastBackup event-js))}

--- a/src/status_im/contexts/chat/home/add_new_contact/events.cljs
+++ b/src/status_im/contexts/chat/home/add_new_contact/events.cljs
@@ -186,9 +186,3 @@
   {:db (dissoc db :contacts/new-identity)})
 
 (re-frame/reg-event-fx :contacts/clear-new-identity clear-new-identity)
-
-(defn set-new-identity-reconnected
-  [{:keys [db]}]
-  (let [input (get-in db [:contacts/new-identity :input])]
-    (re-frame/dispatch [:contacts/set-new-identity {:input input}])))
-

--- a/src/status_im/contexts/profile/config.cljs
+++ b/src/status_im/contexts/profile/config.cljs
@@ -2,8 +2,8 @@
   (:require
     [clojure.string :as string]
     [native-module.core :as native-module]
+    [re-frame.core :as re-frame]
     [status-im.config :as config]
-    [utils.re-frame :as rf]
     [utils.transforms :as transforms]))
 
 (defn login
@@ -51,14 +51,14 @@
   (when path
     (string/replace-first path "file://" "")))
 
-(rf/defn get-node-config-callback
-  {:events [:profile.config/get-node-config-callback]}
-  [{:keys [db]} node-config-json]
-  (let [node-config (transforms/json->clj node-config-json)]
-    {:db (assoc-in db
-          [:profile/profile :wakuv2-config]
-          (get node-config :WakuV2Config))}))
+(re-frame/reg-event-fx :profile.config/get-node-config-callback
+ (fn [{:keys [db]} [node-config-json]]
+   (let [node-config (transforms/json->clj node-config-json)]
+     {:db (assoc-in db
+           [:profile/profile :wakuv2-config]
+           (get node-config :WakuV2Config))})))
 
-(rf/defn get-node-config
-  [_]
-  (native-module/get-node-config #(rf/dispatch [:profile.config/get-node-config-callback %])))
+(re-frame/reg-fx :profile.config/get-node-config
+ (fn []
+   (native-module/get-node-config
+    #(re-frame/dispatch [:profile.config/get-node-config-callback %]))))

--- a/src/status_im/contexts/profile/events.cljs
+++ b/src/status_im/contexts/profile/events.cljs
@@ -19,48 +19,49 @@
 (defn- reduce-profiles
   [profiles]
   (reduce
-    (fn [acc {:keys [key-uid] :as profile}]
-      (assoc acc key-uid (profile.rpc/rpc->profiles-overview profile)))
-    {}
-    profiles))
+   (fn [acc {:keys [key-uid] :as profile}]
+     (assoc acc key-uid (profile.rpc/rpc->profiles-overview profile)))
+   {}
+   profiles))
 
 (rf/reg-fx
-  :profile/get-profiles-overview
-  (fn [callback]
-    (native-module/open-accounts callback)))
+ :profile/get-profiles-overview
+ (fn [callback]
+   (native-module/open-accounts callback)))
 
 (rf/reg-event-fx
-  :profile/profile-selected
-  (fn [{:keys [db]} [key-uid]]
-    {:db (update db :profile/login #(select-profile % key-uid))}))
+ :profile/profile-selected
+ (fn [{:keys [db]} [key-uid]]
+   {:db (update db :profile/login #(select-profile % key-uid))}))
 
 (rf/reg-event-fx
-  :profile/get-profiles-overview-success
-  (fn [{:keys [db]} [profiles-overview]]
-    (if (seq profiles-overview)
-      (let [profiles (reduce-profiles profiles-overview)
-            {:keys [key-uid]} (first (sort-by :timestamp > (vals profiles)))]
-        {:db (if key-uid
-               (-> db
-                   (assoc :profile/profiles-overview profiles)
-                   (update :profile/login #(select-profile % key-uid)))
-               db)
-         :fx [[:set-root :profiles]
-              (when key-uid
-                [:effects.biometric/check-if-available
-                 {:key-uid    key-uid
-                  :on-success (fn [auth-method]
-                                (rf/dispatch [:profile.login/check-biometric-success key-uid auth-method]))}])]})
-      {:fx [[:set-root :intro]]})))
+ :profile/get-profiles-overview-success
+ (fn [{:keys [db]} [profiles-overview]]
+   (if (seq profiles-overview)
+     (let [profiles          (reduce-profiles profiles-overview)
+           {:keys [key-uid]} (first (sort-by :timestamp > (vals profiles)))]
+       {:db (if key-uid
+              (-> db
+                  (assoc :profile/profiles-overview profiles)
+                  (update :profile/login #(select-profile % key-uid)))
+              db)
+        :fx [[:set-root :profiles]
+             (when key-uid
+               [:effects.biometric/check-if-available
+                {:key-uid    key-uid
+                 :on-success (fn [auth-method]
+                               (rf/dispatch [:profile.login/check-biometric-success key-uid
+                                             auth-method]))}])]})
+     {:fx [[:set-root :intro]]})))
 
 (rf/reg-event-fx
-  :profile/update-setting-from-backup
-  (fn [{:keys [db]} [{:keys [backedUpSettings]}]]
-    (let [setting (update backedUpSettings :name keyword)
-          {:keys [name value]} (data-store.settings/rpc->setting-value setting)]
-      {:db (assoc-in db [:profile/profile name] value)})))
+ :profile/update-setting-from-backup
+ (fn [{:keys [db]} [{:keys [backedUpSettings]}]]
+   (let [setting              (update backedUpSettings :name keyword)
+         {:keys [name value]} (data-store.settings/rpc->setting-value setting)]
+     {:db (assoc-in db [:profile/profile name] value)})))
 
 (rf/reg-event-fx
-  :profile/update-profile-from-backup
-  (fn [_ [{{:keys [ensUsernameDetails]} :backedUpProfile}]]
-    {:fx [[:dispatch [:ens/update-usernames ensUsernameDetails]]]}))
+ :profile/update-profile-from-backup
+ (fn [_ [{{:keys [ensUsernameDetails]} :backedUpProfile}]]
+   {:fx [[:dispatch [:ens/update-usernames ensUsernameDetails]]]}))

--- a/src/status_im/contexts/profile/events.cljs
+++ b/src/status_im/contexts/profile/events.cljs
@@ -19,47 +19,48 @@
 (defn- reduce-profiles
   [profiles]
   (reduce
-   (fn [acc {:keys [key-uid] :as profile}]
-     (assoc acc key-uid (profile.rpc/rpc->profiles-overview profile)))
-   {}
-   profiles))
+    (fn [acc {:keys [key-uid] :as profile}]
+      (assoc acc key-uid (profile.rpc/rpc->profiles-overview profile)))
+    {}
+    profiles))
 
 (rf/reg-fx
- :profile/get-profiles-overview
- (fn [callback]
-   (native-module/open-accounts callback)))
+  :profile/get-profiles-overview
+  (fn [callback]
+    (native-module/open-accounts callback)))
 
 (rf/reg-event-fx
- :profile/profile-selected
- (fn [{:keys [db]} [key-uid]]
-   {:db (update db :profile/login #(select-profile % key-uid))}))
+  :profile/profile-selected
+  (fn [{:keys [db]} [key-uid]]
+    {:db (update db :profile/login #(select-profile % key-uid))}))
 
 (rf/reg-event-fx
- :profile/get-profiles-overview-success
- (fn [{:keys [db]} [profiles-overview]]
-   (if (seq profiles-overview)
-     (let [profiles          (reduce-profiles profiles-overview)
-           {:keys [key-uid]} (first (sort-by :timestamp > (vals profiles)))]
-       {:db (if key-uid
-              (-> db
-                  (assoc :profile/profiles-overview profiles)
-                  (update :profile/login #(select-profile % key-uid)))
-              db)
-        :fx [[:set-root :profiles]
-             (when key-uid
-               [:biometric/check-if-available
-                [key-uid
-                 #(rf/dispatch [:profile.login/check-biometric-success % key-uid])]])]})
-     {:fx [[:set-root :intro]]})))
+  :profile/get-profiles-overview-success
+  (fn [{:keys [db]} [profiles-overview]]
+    (if (seq profiles-overview)
+      (let [profiles (reduce-profiles profiles-overview)
+            {:keys [key-uid]} (first (sort-by :timestamp > (vals profiles)))]
+        {:db (if key-uid
+               (-> db
+                   (assoc :profile/profiles-overview profiles)
+                   (update :profile/login #(select-profile % key-uid)))
+               db)
+         :fx [[:set-root :profiles]
+              (when key-uid
+                [:effects.biometric/check-if-available
+                 {:key-uid    key-uid
+                  :on-success (fn [auth-method]
+                                (rf/dispatch [:profile.login/check-biometric-success key-uid auth-method]))}])]})
+      {:fx [[:set-root :intro]]})))
 
 (rf/reg-event-fx
- :profile/update-setting-from-backup
- (fn [{:keys [db]} [{:keys [backedUpSettings]}]]
-   (let [setting              (update backedUpSettings :name keyword)
-         {:keys [name value]} (data-store.settings/rpc->setting-value setting)]
-     {:db (assoc-in db [:profile/profile name] value)})))
+  :profile/update-setting-from-backup
+  (fn [{:keys [db]} [{:keys [backedUpSettings]}]]
+    (let [setting (update backedUpSettings :name keyword)
+          {:keys [name value]} (data-store.settings/rpc->setting-value setting)]
+      {:db (assoc-in db [:profile/profile name] value)})))
 
 (rf/reg-event-fx
- :profile/update-profile-from-backup
- (fn [_ [{{:keys [ensUsernameDetails]} :backedUpProfile}]]
-   {:fx [[:dispatch [:ens/update-usernames ensUsernameDetails]]]}))
+  :profile/update-profile-from-backup
+  (fn [_ [{{:keys [ensUsernameDetails]} :backedUpProfile}]]
+    {:fx [[:dispatch [:ens/update-usernames ensUsernameDetails]]]}))

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -1,210 +1,187 @@
 (ns status-im.contexts.profile.login.events
   (:require
-    [legacy.status-im.browser.core :as browser]
-    [legacy.status-im.data-store.chats :as data-store.chats]
     [legacy.status-im.data-store.settings :as data-store.settings]
-    [legacy.status-im.data-store.switcher-cards :as switcher-cards-store]
-    [legacy.status-im.data-store.visibility-status-updates :as visibility-status-updates-store]
-    [legacy.status-im.group-chats.core :as group-chats]
     [legacy.status-im.mailserver.core :as mailserver]
-    [legacy.status-im.mobile-sync-settings.core :as mobile-network]
-    [legacy.status-im.pairing.core :as pairing]
-    [legacy.status-im.stickers.core :as stickers]
     [native-module.core :as native-module]
-    [re-frame.core :as re-frame]
     [status-im.common.keychain.events :as keychain]
-    [status-im.common.log :as logging]
-    [status-im.common.universal-links :as universal-links]
     [status-im.config :as config]
-    [status-im.contexts.chat.contacts.events :as contacts]
-    [status-im.contexts.chat.messenger.messages.link-preview.events :as link-preview]
-    [status-im.contexts.profile.config :as profile.config]
+    [status-im.constants :as constants]
     status-im.contexts.profile.login.effects
-    [status-im.contexts.profile.push-notifications.events :as notifications]
     [status-im.contexts.profile.rpc :as profile.rpc]
-    [status-im.contexts.profile.settings.events :as profile.settings.events]
-    [status-im.contexts.shell.activity-center.events :as activity-center]
-    [status-im.navigation.events :as navigation]
     [taoensso.timbre :as log]
+    [utils.ethereum.chain :as chain]
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
 
-(rf/defn login
-  {:events [:profile.login/login]}
-  [{:keys [db]}]
-  (let [{:keys [key-uid password]} (:profile/login db)
-        login-sha3-password        (native-module/sha3 (security/safe-unmask-data password))]
-    {:db                    (-> db
-                                (assoc-in [:profile/login :processing] true)
-                                (assoc-in [:syncing :login-sha3-password] login-sha3-password))
-     :effects.profile/login [key-uid login-sha3-password]}))
+(rf/reg-event-fx :profile.login/login
+ (fn [{:keys [db]}]
+   (let [{:keys [key-uid password]} (:profile/login db)
+         login-sha3-password        (native-module/sha3 (security/safe-unmask-data password))]
+     {:db (-> db
+              (assoc-in [:profile/login :processing] true)
+              (assoc-in [:syncing :login-sha3-password] login-sha3-password))
+      :fx [[:effects.profile/login [key-uid login-sha3-password]]]})))
 
-(rf/defn biometrics-login
-  {:events [:profile.login/biometrics-login]}
-  [{:keys [db]}]
-  (let [{:keys [key-uid password]} (:profile/login db)]
-    {:db                    (assoc-in db [:profile/login :processing] true)
-     :effects.profile/login [key-uid (security/safe-unmask-data password)]}))
+(rf/reg-event-fx :profile.login/local-paired-user
+ (fn [{:keys [db]}]
+   (let [{:keys [key-uid password]} (get-in db [:syncing :profile])
+         login-sha3-password        (get-in db [:syncing :login-sha3-password])
+         password                   (if-not (nil? login-sha3-password) ;; already logged in
+                                      login-sha3-password
+                                      password)
+         masked-password            (security/mask-data password)]
+     {:db                    (-> db
+                                 (assoc-in [:onboarding/profile :password] masked-password)
+                                 (assoc-in [:onboarding/profile :syncing?] true))
+      :effects.profile/login [key-uid password]})))
 
-(rf/defn login-local-paired-user
-  {:events [:profile.login/local-paired-user]}
-  [{:keys [db]}]
-  (let [{:keys [key-uid password]} (get-in db [:syncing :profile])
-        login-sha3-password        (get-in db [:syncing :login-sha3-password])
-        password                   (if-not (nil? login-sha3-password) ;; already logged in
-                                     login-sha3-password
-                                     password)
-        masked-password            (security/mask-data password)]
-    {:db                    (-> db
-                                (assoc-in [:onboarding/profile :password] masked-password)
-                                (assoc-in [:onboarding/profile :syncing?] true))
-     :effects.profile/login [key-uid password]}))
+;; login phase 1: we want to load and show chats faster, so we split login into 2 phases
+(rf/reg-event-fx :profile.login/login-existing-profile
+ (fn [{:keys [db]} [settings account]]
+   (let [{:networks/keys [current-network networks]
+          :as            settings}
+         (data-store.settings/rpc->settings settings)
+         profile-overview (profile.rpc/rpc->profiles-overview account)
+         log-level (or (:log-level settings) config/log-level)
+         pairing-completed? (= (get-in db [:syncing :pairing-status]) :completed)]
+     {:db (cond-> (-> db
+                      (assoc :chats/loading?           true
+                             :networks/current-network current-network
+                             :networks/networks        (merge networks config/default-networks-by-id)
+                             :profile/profile          (merge profile-overview
+                                                              settings
+                                                              {:log-level log-level}))
+                      (assoc-in [:activity-center :loading?] true))
+            pairing-completed?
+            (dissoc :syncing))
+      :fx (into [[:dispatch [:universal-links/generate-profile-url]]
+                 [:dispatch [:community/fetch]]
+                 [:dispatch [:wallet/initialize]]
+                 [:push-notifications/load-preferences]
+                 [:fetch-chats-preview
+                  {:on-success (fn [result]
+                                 (rf/dispatch [:chats-list/load-success result])
+                                 (rf/dispatch [:communities/get-user-requests-to-join])
+                                 (rf/dispatch [:profile.login/get-chats-callback]))}]
+                 [:profile.config/get-node-config]
+                 [:logs/set-level log-level]
+                 [:activity-center.notifications/fetch-pending-contact-requests-fx]
+                 [:activity-center/update-seen-state]
+                 [:activity-center.notifications/fetch-unread-count]]
 
-(rf/defn redirect-to-root
-  [{:keys [db] :as cofx}]
-  (let [pairing-completed? (= (get-in db [:syncing :pairing-status]) :completed)]
-    (cond
-      pairing-completed?
-      {:db       (dissoc db :syncing)
-       :dispatch [:init-root :syncing-results]}
+                (cond
+                  pairing-completed?
+                  [[:set-root :syncing-results]]
 
-      (get db :onboarding/new-account?)
-      {:dispatch [:onboarding/finalize-setup]}
+                  (get db :onboarding/new-account?)
+                  [[:dispatch [:onboarding/finalize-setup]]]
 
-      :else
-      (rf/merge
-       cofx
-       (profile.settings.events/switch-theme nil :shell-stack)
-       (navigation/init-root :shell-stack)))))
+                  :else
+                  [[:profile.settings/switch-theme-fx
+                    [(or (get-in db [:profile/profile :appearance])
+                         constants/theme-type-dark)
+                     :shell-stack
+                     false]]
+                   [:set-root :shell-stack]]))})))
 
-;; login phase 1, we want to load and show chats faster so we split login into 2 phases
-(rf/defn login-existing-profile
-  [{:keys [db] :as cofx} settings account]
-  (let [{:networks/keys [current-network networks]
-         :as            settings}
-        (data-store.settings/rpc->settings settings)
-        profile-overview (profile.rpc/rpc->profiles-overview account)]
-    (rf/merge cofx
-              {:db (-> db
-                       (assoc :chats/loading?           true
-                              :networks/current-network current-network
-                              :networks/networks        (merge networks config/default-networks-by-id)
-                              :profile/profile          (merge profile-overview settings)))
-               :fx [[:dispatch [:universal-links/generate-profile-url]]
-                    [:dispatch [:community/fetch]]
-                    [:dispatch [:wallet/initialize]]]}
-              (notifications/load-preferences)
-              (data-store.chats/fetch-chats-preview
-               {:on-success
-                #(do (re-frame/dispatch [:chats-list/load-success %])
-                     (rf/dispatch [:communities/get-user-requests-to-join])
-                     (re-frame/dispatch [:profile.login/get-chats-callback]))})
-              (profile.config/get-node-config)
-              (logging/set-log-level (:log-level settings))
-              (activity-center/notifications-fetch-pending-contact-requests)
-              (activity-center/update-seen-state)
-              (activity-center/notifications-fetch-unread-count)
-              (redirect-to-root))))
+;; login phase 2: we want to load and show chats faster, so we split login into 2 phases
+(rf/reg-event-fx :profile.login/get-chats-callback
+ (fn [{:keys [db]}]
+   (let [{:networks/keys [current-network networks]} db
+         {:keys [notifications-enabled? key-uid
+                 preview-privacy?]}                  (:profile/profile db)
+         network-id                                  (str (get-in networks
+                                                                  [current-network :config :NetworkId]))]
+     {:db db
+      :fx [[:json-rpc/call
+            [{:method     "wakuext_startMessenger"
+              :on-success [:profile.login/messenger-started]
+              :on-error   #(log/error
+                            "failed to start messenger")}]]
+           [:check-eip1559-activation {:network-id network-id}]
+           [:effects.profile/enable-local-notifications]
+           [:contacts/initialize-contacts]
+           [:browser/initialize-browser]
+           [:dispatch [:mobile-network/on-network-status-change]]
+           [:group-chats/get-group-chat-invitations]
+           [:profile.settings/get-profile-picture key-uid]
+           [:profile.settings/blank-preview-flag-changed preview-privacy?]
+           [:chat.ui/request-link-preview-whitelist]
+           [:visibility-status-updates/fetch]
+           [:switcher-cards/fetch]
+           (when-not (:universal-links/handling db)
+             [:effects.chat/open-last-chat key-uid])
+           (when notifications-enabled?
+             [:effects/push-notifications-enable])]})))
 
-;; login phase 2, we want to load and show chats faster so we split login into 2 phases
-(rf/defn get-chats-callback
-  {:events [:profile.login/get-chats-callback]}
-  [{:keys [db] :as cofx}]
-  (let [{:networks/keys [current-network networks]} db
-        {:keys [notifications-enabled?]}            (:profile/profile db)
-        current-network-config                      (get networks current-network)
-        network-id                                  (str (get-in networks
-                                                                 [current-network :config :NetworkId]))]
-    (rf/merge
-     cofx
-     (cond-> {:json-rpc/call                              [{:method     "wakuext_startMessenger"
-                                                            :on-success #(re-frame/dispatch
-                                                                          [:messenger-started %])
-                                                            :on-error   #(log/error
-                                                                          "failed to start messenger")}]
-              :check-eip1559-activation                   {:network-id network-id}
-              :effects.profile/enable-local-notifications nil}
-       (not (:universal-links/handling db))
-       (assoc :effects.chat/open-last-chat (get-in db [:profile/profile :key-uid]))
-       notifications-enabled?
-       (assoc :effects/push-notifications-enable nil))
-     (contacts/initialize-contacts)
-     (browser/initialize-browser)
-     (mobile-network/on-network-status-change)
-     (group-chats/get-group-chat-invitations)
-     (profile.settings.events/get-profile-picture)
-     (profile.settings.events/change-preview-privacy)
-     (link-preview/request-link-preview-whitelist)
-     (visibility-status-updates-store/fetch-visibility-status-updates-rpc)
-     (switcher-cards-store/fetch-switcher-cards-rpc))))
+(rf/reg-event-fx :profile.login/messenger-started
+ (fn [{:keys [db]} [{:keys [mailservers]}]]
+   (let [chain-id     (chain/chain-id db)
+         new-account? (get db :onboarding/new-account?)]
+     {:db (-> db
+              (assoc :messenger/started? true)
+              (mailserver/add-mailservers mailservers))
+      :fx [[:json-rpc/call
+            [{:method     "admin_nodeInfo"
+              :on-success [:profile.login/node-info-fetched]
+              :on-error   #(log/error "node-info: failed error" %)}]]
+           [:pairing/get-our-installations]
+           [:stickers/load-packs chain-id]
+           (when-not new-account?
+             [:dispatch [:universal-links/process-stored-event]])]})))
 
-(rf/defn messenger-started
-  {:events [:messenger-started]}
-  [{:keys [db] :as cofx} {:keys [mailservers] :as response}]
-  (log/info "Messenger started")
-  (let [new-account? (get db :onboarding/new-account?)]
-    (rf/merge cofx
-              {:db            (-> db
-                                  (assoc :messenger/started? true)
-                                  (mailserver/add-mailservers mailservers))
-               :json-rpc/call [{:method     "admin_nodeInfo"
-                                :on-success #(re-frame/dispatch [:node-info-fetched %])
-                                :on-error   #(log/error "node-info: failed error" %)}]}
-              (pairing/init)
-              (stickers/load-packs)
-              (when-not new-account?
-                (universal-links/process-stored-event)))))
+(rf/reg-event-fx :profile.login/node-info-fetched
+ (fn [{:keys [db]} [node-info]]
+   {:db (assoc db :node-info node-info)}))
 
-(rf/defn set-node-info
-  {:events [:node-info-fetched]}
-  [{:keys [db]} node-info]
-  {:db (assoc db :node-info node-info)})
+(rf/reg-event-fx
+ :profile.login/login-node-signal
+ (fn [{{:onboarding/keys [recovered-account? new-account?] :as db} :db}
+      [{:keys [settings account ensUsernames error]}]]
+   (log/debug "[signals] node.login" "error" error)
+   (if error
+     {:db (update db :profile/login #(-> % (dissoc :processing) (assoc :error error)))}
+     {:db (dissoc db :profile/login)
+      :fx [[:logging/initialize-web3-client-version]
+           (when (and new-account? (not recovered-account?))
+             [:dispatch [:wallet-legacy/set-initial-blocks-range]])
+           [:dispatch [:ens/update-usernames ensUsernames]]
+           [:dispatch [:profile.login/login-existing-profile settings account]]]})))
 
-(rf/defn login-node-signal
-  [{{:onboarding/keys [recovered-account? new-account?] :as db} :db :as cofx}
-   {:keys [settings account ensUsernames error]}]
-  (log/debug "[signals] node.login" "error" error)
-  (if error
-    {:db (update db :profile/login #(-> % (dissoc :processing) (assoc :error error)))}
-    (rf/merge cofx
-              {:db         (dissoc db :profile/login)
-               :dispatch-n [[:logging/initialize-web3-client-version]
-                            (when (and new-account? (not recovered-account?))
-                              [:wallet-legacy/set-initial-blocks-range])
-                            [:ens/update-usernames ensUsernames]]}
-              (login-existing-profile settings account))))
+(rf/reg-event-fx
+ :profile.login/login-with-biometric-if-available
+ (fn [_ [key-uid]]
+   {:fx [[:effects.biometric/check-if-available {:key-uid    key-uid
+                                                 :on-success (fn [auth-method]
+                                                               (rf/dispatch
+                                                                 [:profile.login/check-biometric-success
+                                                                  key-uid auth-method]))}]]}))
 
-(rf/defn login-with-biometric-if-available
-  {:events [:profile.login/login-with-biometric-if-available]}
-  [_ key-uid]
-  {:effects.biometric/check-if-available {:key-uid    key-uid
-                                          :on-success (fn [auth-method]
-                                                        (rf/dispatch
-                                                         [:profile.login/check-biometric-success
-                                                          key-uid auth-method]))}})
-
-(rf/defn check-biometric-success
-  {:events [:profile.login/check-biometric-success]}
-  [{:keys [db]} key-uid auth-method]
-  (merge {:db (assoc db :auth-method auth-method)}
-         (when (= auth-method keychain/auth-method-biometric)
-           {:keychain/password-hash-migration
+(rf/reg-event-fx
+ :profile.login/check-biometric-success
+ (fn [{:keys [db]} [key-uid auth-method]]
+   {:db (assoc db :auth-method auth-method)
+    :fx [(when (= auth-method keychain/auth-method-biometric)
+           [:keychain/password-hash-migration
             {:key-uid  key-uid
              :callback (fn []
-                         (rf/dispatch [:biometric/authenticate
-                                       {:on-success #(rf/dispatch [:profile.login/biometric-success])
-                                        :on-fail    #(rf/dispatch
-                                                      [:profile.login/biometric-auth-fail %])}]))}})))
+                         (rf/dispatch
+                          [:biometric/authenticate
+                           {:on-success #(rf/dispatch
+                                          [:profile.login/biometric-success])
+                            :on-fail    #(rf/dispatch
+                                          [:profile.login/biometric-auth-fail %])}]))}])]}))
 
-(rf/defn get-user-password-success
-  {:events [:profile.login/get-user-password-success]}
-  [{:keys [db] :as cofx} password]
-  (when password
-    (rf/merge
-     cofx
-     {:db (assoc-in db [:profile/login :password] password)}
-     (navigation/init-root :progress)
-     (biometrics-login))))
+(rf/reg-event-fx
+ :profile.login/get-user-password-success
+ (fn [{:keys [db]} [password]]
+   (when password
+     (let [{:keys [key-uid password]} (:profile/login db)]
+       {:db (-> db
+                (assoc-in [:profile/login :password] password)
+                (assoc-in [:profile/login :processing] true))
+        :fx [[:set-root :progress]
+             [:effects.profile/login [key-uid (security/safe-unmask-data password)]]]}))))
 
 (rf/reg-event-fx
  :profile.login/biometric-success
@@ -223,35 +200,35 @@
                          :event :profile.login/biometric-auth-fail)))
    {:dispatch [:biometric/show-message (ex-cause error)]}))
 
-(rf/defn verify-database-password
-  {:events [:profile.login/verify-database-password]}
-  [_ entered-password cb]
-  (let [hashed-password (-> entered-password
-                            security/safe-unmask-data
-                            native-module/sha3)]
-    {:json-rpc/call [{:method     "accounts_verifyPassword"
-                      :params     [hashed-password]
-                      :on-success #(rf/dispatch [:profile.login/verified-database-password % cb])
-                      :on-error   #(log/error "accounts_verifyPassword error" %)}]}))
+(rf/reg-event-fx
+ :profile.login/verify-database-password
+ (fn [_ [entered-password cb]]
+   (let [hashed-password (-> entered-password
+                             security/safe-unmask-data
+                             native-module/sha3)]
+     {:json-rpc/call [{:method     "accounts_verifyPassword"
+                       :params     [hashed-password]
+                       :on-success #(rf/dispatch [:profile.login/verified-database-password % cb])
+                       :on-error   #(log/error "accounts_verifyPassword error" %)}]})))
 
-(rf/defn verify-database-password-success
-  {:events [:profile.login/verified-database-password]}
-  [{:keys [db]} valid? callback]
-  (if valid?
-    (do
-      (when (fn? callback)
-        (callback))
-      {:db (update db
-                   :profile/login
-                   dissoc
-                   :processing :error)})
-    {:db (update db
-                 :profile/login
-                 #(-> %
-                      (dissoc :processing)
-                      (assoc :error "Invalid password")))}))
+(rf/reg-event-fx
+ :profile.login/verified-database-password
+ (fn [{:keys [db]} [valid? callback]]
+   (if valid?
+     (do
+       (when (fn? callback)
+         (callback))
+       {:db (update db
+                    :profile/login
+                    dissoc
+                    :processing :error)})
+     {:db (update db
+                  :profile/login
+                  #(-> %
+                       (dissoc :processing)
+                       (assoc :error "Invalid password")))})))
 
-(re-frame/reg-event-fx
+(rf/reg-event-fx
  :profile/on-password-input-changed
  (fn [{:keys [db]} [{:keys [password error]}]]
    {:db (update db :profile/login assoc :password password :error error)}))

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -151,11 +151,12 @@
 (rf/reg-event-fx
  :profile.login/login-with-biometric-if-available
  (fn [_ [key-uid]]
-   {:fx [[:effects.biometric/check-if-available {:key-uid    key-uid
-                                                 :on-success (fn [auth-method]
-                                                               (rf/dispatch
-                                                                 [:profile.login/check-biometric-success
-                                                                  key-uid auth-method]))}]]}))
+   {:fx [[:effects.biometric/check-if-available
+          {:key-uid    key-uid
+           :on-success (fn [auth-method]
+                         (rf/dispatch
+                          [:profile.login/check-biometric-success
+                           key-uid auth-method]))}]]}))
 
 (rf/reg-event-fx
  :profile.login/check-biometric-success

--- a/src/status_im/contexts/profile/push_notifications/events.cljs
+++ b/src/status_im/contexts/profile/push_notifications/events.cljs
@@ -2,9 +2,11 @@
   (:require
     [cljs-bean.core :as bean]
     [native-module.push-notifications :as native-module.pn]
+    [re-frame.core :as re-frame]
     [react-native.async-storage :as async-storage]
     [react-native.platform :as platform]
     [react-native.push-notification-ios :as pn-ios]
+    [status-im.common.json-rpc.events :as json-rpc]
     [status-im.config :as config]
     status-im.contexts.profile.push-notifications.effects
     [taoensso.timbre :as log]
@@ -55,8 +57,8 @@
   [{:keys [db]} preferences]
   {:db (assoc db :push-notifications/preferences preferences)})
 
-(rf/defn load-preferences
-  [_]
-  {:json-rpc/call [{:method     "localnotifications_notificationPreferences"
-                    :params     []
-                    :on-success #(rf/dispatch [:push-notifications/preferences-loaded %])}]})
+(re-frame/reg-fx :push-notifications/load-preferences
+ (fn []
+   (json-rpc/call {:method     "localnotifications_notificationPreferences"
+                   :params     []
+                   :on-success [:push-notifications/preferences-loaded]})))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -8,13 +8,17 @@
     status-im.common.emoji-picker.events
     status-im.common.font.events
     [status-im.common.json-rpc.events]
+    status-im.common.log
     status-im.common.password-authentication.events
     status-im.common.signals.events
     status-im.common.theme.events
     [status-im.common.toasts.events]
+    status-im.common.universal-links
+    status-im.contexts.chat.contacts.events
     status-im.contexts.chat.events
     [status-im.contexts.chat.home.add-new-contact.events]
     status-im.contexts.chat.messenger.composer.events
+    status-im.contexts.chat.messenger.messages.link-preview.events
     status-im.contexts.chat.messenger.photo-selector.events
     status-im.contexts.communities.events
     status-im.contexts.communities.overview.events
@@ -29,6 +33,7 @@
     status-im.contexts.wallet.send.events
     status-im.contexts.wallet.signals
     [status-im.db :as db]
+    status-im.navigation.events
     [utils.re-frame :as rf]))
 
 (rf/defn start-app

--- a/src/test_helpers/integration.cljs
+++ b/src/test_helpers/integration.cljs
@@ -151,7 +151,7 @@
     (p/resolved ::messenger-started)
     (do
       (create-multiaccount!)
-      (-> (wait-for [:messenger-started])
+      (-> (wait-for [:profile.login/messenger-started])
           (.then #(assert-messenger-started))))))
 
 (defn test-async


### PR DESCRIPTION
This PR aims to update quite some namespace to match the new guidelines: https://github.com/status-im/status-mobile/blob/9fab422e0c9fa7c72bdc2dff8973785b768721ca/doc/new-guidelines.md#registering-event-handlers

The original intention was to update deprecated handlers defined with `rf/defn` only in `status-im.contexts.profile.settings.events` namespace because I was working with it in another pull request but one thing led to another, and at some point I ended up completely updating the following namespaces:

`status-im.contexts.profile.login.events`
`status-im.contexts.profile.settings.events`
`status-im.contexts.profile.events`
`status-im.contexts.chat.messenger.messages.link-preview.events`

### Review notes

All the changes are relevant to login process, user settings and user profiles.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- account recovery
- new account
- user profile updates

status: ready <!-- Can be ready or wip -->
