### PR TITLE
Add the Contract Tests to the mobile CI/CD pipeline

### DIFF
--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -10,7 +10,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 15, unit: 'MINUTES')
+    timeout(time: 20, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -62,6 +62,14 @@ pipeline {
         }
       }
     }
+    stage('Contract Tests') {
+      steps {
+        sh """#!/bin/bash
+          set -eo pipefail
+          make test-contract 2>&1 | tee -a ${LOG_FILE}
+        """
+      }
+    }
     stage('Integration Tests') {
       steps {
         sh """#!/bin/bash


### PR DESCRIPTION
Fixes #18782

### Summary
This quick PR modifies the JenkinsFile adding Contract Tests to Ci/CD pipeline


### Steps to test
Check Jenkins output here or at https://ci.infra.status.im/job/status-mobile/

### Notes
Tried to run it in parallel with Unit Tests but it was not working

status: ready!