### PR TITLE
chore: bump status-go version to v0.176.2

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.176.1",
-    "commit-sha1": "c5371bd3a550a9572eb1fbdec3a280af0ad15575",
-    "src-sha256": "0azngjf1r1jlavsjf5cvlb5a1j8h022sgsk72mm3aazvq3qk82pz"
+    "version": "v0.176.2",
+    "commit-sha1": "00f50a4112ef80cc29737f8edf34cdb1cf181709",
+    "src-sha256": "12z9qf0hhb2pc7ask6f86pah0wjp3kyxyv32rpfnkjl42maw0bw6"
 }


### PR DESCRIPTION
## Summary

In this PR we bump status-go version to v0.176.2

@pavloburykh : lets check e2e here

status: ready 
