### PR TITLE
Implement Contact Request flow in Contact Profile

### DIFF
--- a/src/quo/components/drawers/drawer_top/view.cljs
+++ b/src/quo/components/drawers/drawer_top/view.cljs
@@ -76,7 +76,8 @@
    (str description " · " (i18n/label :t/on-device))])
 
 (defn- context-tag-subtitle
-  [{:keys [context-tag-type community-logo community-name account-name emoji customization-color]}]
+  [{:keys [context-tag-type community-logo community-name account-name emoji customization-color
+           full-name profile-picture]}]
   (let [tag-type (or context-tag-type :account)]
     [rn/view
      {:accessibility-label :context-tag-wrapper
@@ -88,7 +89,9 @@
        :community-name      community-name
        :community-logo      community-logo
        :size                24
-       :customization-color customization-color}]]))
+       :customization-color customization-color
+       :profile-picture     profile-picture
+       :full-name           full-name}]]))
 
 (defn- description-subtitle
   [{:keys [theme blur? description]}]
@@ -100,7 +103,7 @@
 
 (defn- subtitle
   [{:keys [type theme blur? keycard? networks description community-name community-logo
-           context-tag-type account-name emoji customization-color]}]
+           context-tag-type account-name emoji customization-color full-name profile-picture]}]
   (cond
     (= :keypair type)
     [keypair-subtitle
@@ -128,7 +131,9 @@
       :community-name      community-name
       :account-name        account-name
       :emoji               emoji
-      :customization-color customization-color}]
+      :customization-color customization-color
+      :profile-picture     profile-picture
+      :full-name           full-name}]
 
     (and (not= :label type) description)
     [description-subtitle
@@ -187,7 +192,7 @@
            on-button-press
            on-button-long-press
            button-disabled? account-avatar-emoji account-avatar-type customization-color icon-avatar
-           profile-picture keycard? networks label]}]
+           profile-picture keycard? networks label full-name]}]
   [rn/view {:style style/container}
    (when (left-image-supported-types type)
      [rn/view {:style style/left-container}
@@ -218,7 +223,9 @@
       :context-tag-type    context-tag-type
       :customization-color customization-color
       :account-name        account-name
-      :emoji               emoji}]]
+      :emoji               emoji
+      :full-name           full-name
+      :profile-picture     profile-picture}]]
    [right-icon
     {:theme                theme
      :type                 type

--- a/src/status_im/contexts/profile/contact/contact_request/style.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/style.cljs
@@ -1,0 +1,10 @@
+(ns status-im.contexts.profile.contact.contact-request.style)
+
+(def message-prompt-wrapper
+  {:padding-top        4
+   :padding-bottom     8
+   :padding-horizontal 20})
+
+(def message-input-wrapper
+  {:padding-vertical   8
+   :padding-horizontal 20})

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -3,12 +3,19 @@
             [quo.core :as quo]
             [react-native.core :as rn]
             [status-im.contexts.profile.contact.contact-request.style :as style]
+            [status-im.contexts.profile.utils :as profile.utils]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
 (defn view
-  [{:keys [full-name profile-picture customization-color public-key]}]
-  (let [[message set-message] (rn/use-state "")
+  []
+  (let [{:keys [public-key customization-color]
+         :as   profile}       (rf/sub [:contacts/current-contact])
+        ;; TODO: remove :blue when #18733 merged.
+        customization-color   (or customization-color :blue)
+        full-name             (profile.utils/displayed-name profile)
+        profile-picture       (profile.utils/photo profile)
+        [message set-message] (rn/use-state "")
         on-message-change     (rn/use-callback #(set-message %))
         on-message-submit     (rn/use-callback (fn []
                                                  (rf/dispatch [:hide-bottom-sheet])

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -1,0 +1,39 @@
+(ns status-im.contexts.profile.contact.contact-request.view
+  (:require [clojure.string :as string]
+            [quo.core :as quo]
+            [react-native.core :as rn]
+            [status-im.contexts.profile.contact.contact-request.style :as style]
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]))
+
+(defn view
+  [{:keys [full-name profile-picture customization-color public-key]}]
+  (let [[message set-message] (rn/use-state "")
+        on-message-change     (rn/use-callback #(set-message %))
+        on-message-submit     (rn/use-callback (fn []
+                                                 (rf/dispatch [:hide-bottom-sheet])
+                                                 (rf/dispatch [:contact.ui/send-contact-request
+                                                               public-key message]))
+                                               [public-key message])]
+    [:<>
+     [quo/drawer-top
+      {:type                :context-tag
+       :context-tag-type    :default
+       :title               (i18n/label :t/send-contact-request)
+       :full-name           full-name
+       :profile-picture     profile-picture
+       :customization-color customization-color}]
+     [rn/text {:style style/message-prompt-wrapper}
+      (i18n/label :t/contact-request-message-prompt)]
+     [rn/view {:style style/message-input-wrapper}
+      [quo/input
+       {:type           :text
+        :multiline?     true
+        :char-limit     280
+        :label          (i18n/label :t/message)
+        :on-change-text on-message-change}]]
+     [quo/bottom-actions
+      {:actions          :one-action
+       :button-one-props {:disabled? (string/blank? message)
+                          :on-press  on-message-submit}
+       :button-one-label (i18n/label :t/send-contact-request)}]]))

--- a/src/status_im/contexts/profile/contact/header/style.cljs
+++ b/src/status_im/contexts/profile/contact/header/style.cljs
@@ -7,6 +7,11 @@
    :padding-left 20
    :align-items  :flex-start})
 
+(def button-wrapper
+  {:padding-top        8
+   :padding-bottom     16
+   :padding-horizontal 20})
+
 (defn header-container
   [border-radius theme margin-top]
   (reanimated/apply-animations-to-style

--- a/src/status_im/contexts/profile/contact/header/view.cljs
+++ b/src/status_im/contexts/profile/contact/header/view.cljs
@@ -3,6 +3,7 @@
             [quo.foundations.colors :as colors]
             [quo.theme]
             [react-native.core :as rn]
+            [status-im.common.not-implemented]
             [status-im.common.scalable-avatar.view :as avatar]
             [status-im.constants :as constants]
             [status-im.contexts.profile.contact.header.style :as style]
@@ -40,4 +41,9 @@
       {:title            full-name
        :description      :text
        :description-text bio
-       :emoji-dash       emoji-hash}]]))
+       :emoji-dash       emoji-hash}]
+     [rn/view {:style style/button-wrapper}
+      [quo/button
+       {:on-press status-im.common.not-implemented/alert
+        :icon-left :i/add-user}
+       (i18n/label :t/send-contact-request)]]]))

--- a/src/status_im/contexts/profile/contact/header/view.cljs
+++ b/src/status_im/contexts/profile/contact/header/view.cljs
@@ -45,8 +45,14 @@
        :description      :text
        :description-text bio
        :emoji-dash       emoji-hash}]
-     [rn/view {:style style/button-wrapper}
-      [quo/button
-       {:on-press  on-contact-request
-        :icon-left :i/add-user}
-       (i18n/label :t/send-contact-request)]]]))
+
+     (cond
+       (or (not contact-request-state)
+           (= contact-request-state constants/contact-request-state-none))
+       [rn/view {:style style/button-wrapper}
+        [quo/button
+         {:on-press  on-contact-request
+          :icon-left :i/add-user}
+         (i18n/label :t/send-contact-request)]]
+
+       :else nil)]))

--- a/src/status_im/contexts/profile/contact/header/view.cljs
+++ b/src/status_im/contexts/profile/contact/header/view.cljs
@@ -46,10 +46,6 @@
      [rn/view {:style style/button-wrapper}
       [quo/button
        {:on-press  #(rf/dispatch [:show-bottom-sheet
-                                  {:content (fn [] [contact-request/view
-                                                    {:customization-color customization-color
-                                                     :profile-picture     profile-picture
-                                                     :full-name           full-name
-                                                     :public-key          public-key}])}])
+                                  {:content (fn [] [contact-request/view])}])
         :icon-left :i/add-user}
        (i18n/label :t/send-contact-request)]]]))

--- a/src/status_im/contexts/profile/contact/header/view.cljs
+++ b/src/status_im/contexts/profile/contact/header/view.cljs
@@ -6,6 +6,7 @@
             [status-im.common.not-implemented]
             [status-im.common.scalable-avatar.view :as avatar]
             [status-im.constants :as constants]
+            [status-im.contexts.profile.contact.contact-request.view :as contact-request]
             [status-im.contexts.profile.contact.header.style :as style]
             [status-im.contexts.profile.utils :as profile.utils]
             [utils.i18n :as i18n]
@@ -44,6 +45,11 @@
        :emoji-dash       emoji-hash}]
      [rn/view {:style style/button-wrapper}
       [quo/button
-       {:on-press status-im.common.not-implemented/alert
+       {:on-press  #(rf/dispatch [:show-bottom-sheet
+                                  {:content (fn [] [contact-request/view
+                                                    {:customization-color customization-color
+                                                     :profile-picture     profile-picture
+                                                     :full-name           full-name
+                                                     :public-key          public-key}])}])
         :icon-left :i/add-user}
        (i18n/label :t/send-contact-request)]]]))

--- a/src/status_im/contexts/profile/contact/header/view.cljs
+++ b/src/status_im/contexts/profile/contact/header/view.cljs
@@ -21,7 +21,9 @@
         full-name           (profile.utils/displayed-name profile)
         profile-picture     (profile.utils/photo profile)
         online?             (rf/sub [:visibility-status-updates/online? public-key])
-        theme               (quo.theme/use-theme-value)]
+        theme               (quo.theme/use-theme-value)
+        on-contact-request  (rn/use-callback #(rf/dispatch [:show-bottom-sheet
+                                                            {:content (fn [] [contact-request/view])}]))]
     [rn/view {:style style/header-container}
      [rn/view {:style style/header-top-wrapper}
       [rn/view {:style style/avatar-wrapper}
@@ -45,7 +47,6 @@
        :emoji-dash       emoji-hash}]
      [rn/view {:style style/button-wrapper}
       [quo/button
-       {:on-press  #(rf/dispatch [:show-bottom-sheet
-                                  {:content (fn [] [contact-request/view])}])
+       {:on-press  on-contact-request
         :icon-left :i/add-user}
        (i18n/label :t/send-contact-request)]]]))

--- a/translations/en.json
+++ b/translations/en.json
@@ -1985,6 +1985,7 @@
     "contact-request-removed-you-as-contact": "removed you as a contact",
     "contact-request-removed-as-contact": "removed as a contact",
     "contact-requests": "Contact requests",
+    "contact-request-message-prompt": "Why should they accept your request?",
     "say-hi": "Say hi",
     "opened": "Opened",
     "accepted": "Accepted",

--- a/translations/en.json
+++ b/translations/en.json
@@ -1978,6 +1978,7 @@
     "new-ui": "New UI",
     "send-contact-request-message": "To start a chat you need to become contacts",
     "contact-request": "Contact request",
+    "send-contact-request": "Send contact request",
     "contact-request-sent-to": "Contact request sent to",
     "contact-request-was-accepted": "Contact request accepted",
     "contact-request-is-now-a-contact": "is now a contact",


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #18965 
aligns with #18998 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR attempts to implement the new designs for the Contact Request in Contact Profiles. This PR is dependent on the changes inside PR #18998, which means that contact requests will not support personalised messages until those changes are merged. This PR aligns with the changes inside #18998, but does directly rely on those commits in this branch.

### Testing notes

* ~~Note that while testing this PR the personalised messages will not be functioning properly until #18998 is merged.~~ All other functionality related to #18965 is intended to be functioning correctly.
  * PR #18998 is merged so personalised messages are now testable 🙌 
* Another note, this PR modifies the Quo `top-drawer` component, which may affect other UI elements like bottom sheets or drawers.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- New Contact Profile UI
- Top-Drawer components
- Top-Drawer components with Context-Tags

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile and Status desktop app
- Enable the `new-contact-ui` feature flag in the mobile app
- View a contact profile on mobile
- Press the contact request button
- Provide a contact request message and press the "send contact request" button

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before

<img width="446" alt="Screenshot 2024-02-29 at 09 28 58" src="https://github.com/status-im/status-mobile/assets/2845768/eda419a5-d1f7-43cf-ac05-35f7af2a8778">

#### After

https://github.com/status-im/status-mobile/assets/2845768/f88953fa-78bd-458c-8602-5666b4a59d22

status: ready
