### PR TITLE
[Chore] Remove POKT Sepolia and Goerli RPC URL

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "chore/remove-goerli-pokt-URL",
-    "commit-sha1": "bda33d7666a2d29fdece1b40aef6c350dfbb73b5",
-    "src-sha256": "1s437m5j1q2fs2s2aqzqz4j2czddj71blvcq42sj02zhb0xkvjsn"
+    "commit-sha1": "3a06c0e7bc28f540a4ed89b42886b9e3b76b5229",
+    "src-sha256": "1jzc136bybmcy6j4brwq231wq202z747hy7j8i4lrq4zsg2a336d"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "chore/remove-goerli-pokt-URL",
-    "commit-sha1": "3a06c0e7bc28f540a4ed89b42886b9e3b76b5229",
+    "version": "v0.176.4",
+    "commit-sha1": "9e1d65bcd9042c7e9861e799ce5ea86c2a006669",
     "src-sha256": "1jzc136bybmcy6j4brwq231wq202z747hy7j8i4lrq4zsg2a336d"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.176.2",
-    "commit-sha1": "00f50a4112ef80cc29737f8edf34cdb1cf181709",
-    "src-sha256": "12z9qf0hhb2pc7ask6f86pah0wjp3kyxyv32rpfnkjl42maw0bw6"
+    "version": "chore/remove-goerli-pokt-URL",
+    "commit-sha1": "bda33d7666a2d29fdece1b40aef6c350dfbb73b5",
+    "src-sha256": "1s437m5j1q2fs2s2aqzqz4j2czddj71blvcq42sj02zhb0xkvjsn"
 }


### PR DESCRIPTION
### Summary

This PR removes the POKT (Grove) URL for Sepolia and Goerli as POKT dropped support. 
Now, we will use Infura RPC for Sepolia and Goerli as default.

`status-go` PR: https://github.com/status-im/status-go/pull/4830

### Testing notes

A quick test on the wallet with the Sepolia and Goerli test network is appreciated.

### Platforms

- Android
- iOS

status: ready
