### PR TITLE
[#18736] add address to watch using an ENS

### DIFF
--- a/src/status_im/contexts/wallet/accounts/add_account/address_to_watch/events.cljs
+++ b/src/status_im/contexts/wallet/accounts/add_account/address_to_watch/events.cljs
@@ -1,8 +1,8 @@
 (ns status-im.contexts.wallet.accounts.add-account.address-to-watch.events
   (:require [clojure.string :as string]
             [status-im.constants :as constants]
-            [utils.re-frame :as rf]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [utils.re-frame :as rf]))
 
 (rf/reg-event-fx
  :wallet/ens-not-found

--- a/src/status_im/contexts/wallet/accounts/add_account/address_to_watch/events.cljs
+++ b/src/status_im/contexts/wallet/accounts/add_account/address_to_watch/events.cljs
@@ -1,0 +1,54 @@
+(ns status-im.contexts.wallet.accounts.add-account.address-to-watch.events
+  (:require [clojure.string :as string]
+            [status-im.constants :as constants]
+            [utils.re-frame :as rf]
+            [taoensso.timbre :as log]))
+
+(rf/reg-event-fx
+ :wallet/ens-not-found
+ (fn [{:keys [db]} _]
+   {:db (-> db
+            (assoc-in [:wallet :ui :add-address-to-watch :activity-state] :invalid-ens)
+            (assoc-in [:wallet :ui :add-address-to-watch :validated-address] nil))}))
+
+(rf/reg-event-fx
+ :wallet/store-address-activity
+ (fn [{:keys [db]} [address {:keys [hasActivity]}]]
+   (let [registered-addresses        (-> db :wallet :accounts keys set)
+         address-already-registered? (registered-addresses address)]
+     (if address-already-registered?
+       {:db (-> db
+                (assoc-in [:wallet :ui :add-address-to-watch :activity-state]
+                          :address-already-registered)
+                (assoc-in [:wallet :ui :add-address-to-watch :validated-address] nil))}
+       (let [state (if hasActivity :has-activity :no-activity)]
+         {:db (-> db
+                  (assoc-in [:wallet :ui :add-address-to-watch :activity-state] state)
+                  (assoc-in [:wallet :ui :add-address-to-watch :validated-address] address))})))))
+
+(rf/reg-event-fx
+ :wallet/clear-address-activity
+ (fn [{:keys [db]}]
+   {:db (update-in db [:wallet :ui] dissoc :add-address-to-watch)}))
+
+(rf/reg-event-fx
+ :wallet/get-address-details
+ (fn [{:keys [db]} [address-or-ens]]
+   (let [request-params [constants/ethereum-mainnet-chain-id address-or-ens]
+         ens?           (string/includes? address-or-ens ".")]
+     {:db (-> db
+              (assoc-in [:wallet :ui :add-address-to-watch :activity-state] :scanning)
+              (assoc-in [:wallet :ui :add-address-to-watch :validated-address] nil))
+      :fx [(if ens?
+             [:json-rpc/call
+              [{:method     "ens_addressOf"
+                :params     request-params
+                :on-success [:wallet/get-address-details]
+                :on-error   [:wallet/ens-not-found]}]]
+             [:json-rpc/call
+              [{:method     "wallet_getAddressDetails"
+                :params     request-params
+                :on-success [:wallet/store-address-activity address-or-ens]
+                :on-error   #(log/info "failed to get address details"
+                                       {:error %
+                                        :event :wallet/get-address-details})}]])]})))

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -8,6 +8,7 @@
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.contexts.wallet.add-address-to-watch.style :as style]
     [status-im.contexts.wallet.common.validation :as validation]
+    [status-im.subs.wallet.add-account.address-to-watch]
     [utils.debounce :as debounce]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -76,22 +76,23 @@
                                        :icon                :i/done
                                        :type                :success
                                        :message             :t/this-address-has-activity}
-                        :no-activity {:accessibility-label :account-has-no-activity
-                                      :icon                :i/info
-                                      :type                :warning
-                                      :message             :t/this-address-has-no-activity}
-                        :invalid-ens {:accessibility-label :error-message
-                                      :icon                :i/info
-                                      :type                :error
-                                      :message             :t/invalid-address}
+                        :no-activity  {:accessibility-label :account-has-no-activity
+                                       :icon                :i/info
+                                       :type                :warning
+                                       :message             :t/this-address-has-no-activity}
+                        :invalid-ens  {:accessibility-label :error-message
+                                       :icon                :i/info
+                                       :type                :error
+                                       :message             :t/invalid-address}
                         {:accessibility-label :searching-for-activity
                          :icon                :i/pending-state
                          :type                :default
                          :message             :t/searching-for-activity})]
     (when activity-state
-      [quo/info-message (assoc props
-                          :style style/info-message
-                          :size :default)
+      [quo/info-message
+       (assoc props
+              :style style/info-message
+              :size  :default)
        (i18n/label message)])))
 
 (defn view

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -11,19 +11,16 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn validate-message
-  [addresses]
-  (fn [s]
-    (cond
-      (or (= s nil) (= s ""))             nil
-      (contains? addresses s)             (i18n/label :t/address-already-in-use)
-      (not (or (validation/eth-address? s)
-               (validation/ens-name? s))) (i18n/label :t/invalid-address)
-      :else                               nil)))
+(defn- validate-address
+  [known-addresses s]
+  (cond
+    (or (nil? s) (= s ""))              nil
+    (contains? known-addresses s)       (i18n/label :t/address-already-in-use)
+    (not (or (validation/eth-address? s)
+             (validation/ens-name? s))) (i18n/label :t/invalid-address)))
 
 (defn- address-input
-  [{:keys [input-value validation-msg validate
-           clear-input]}]
+  [{:keys [input-value validation-msg validate clear-input]}]
   (let [scanned-address (rf/sub [:wallet/scanned-address])
         empty-input?    (and (string/blank? @input-value)
                              (string/blank? scanned-address))
@@ -33,9 +30,9 @@
                           (reagent/flush)
                           (if (and (not-empty new-text) (nil? (validate new-text)))
                             (rf/dispatch [:wallet/get-address-details new-text])
-                            (rf/dispatch [:wallet/clear-address-activity-check]))
+                            (rf/dispatch [:wallet/clear-address-activity]))
                           (when (and scanned-address (not= scanned-address new-text))
-                            (rf/dispatch [:wallet/clear-address-activity-check])
+                            (rf/dispatch [:wallet/clear-address-activity])
                             (rf/dispatch [:wallet/clean-scanned-address])))
         paste-on-input  #(clipboard/get-string
                           (fn [clipboard-text]
@@ -72,84 +69,87 @@
       :i/scan]]))
 
 (defn activity-indicator
-  []
-  (let [activity-state (rf/sub [:wallet/watch-address-activity-state])
-        {:keys [accessibility-label icon type message]}
-        (case activity-state
-          :has-activity {:accessibility-label :account-has-activity
-                         :icon                :i/done
-                         :type                :success
-                         :message             :t/this-address-has-activity}
-          :no-activity  {:accessibility-label :account-has-no-activity
-                         :icon                :i/info
-                         :type                :warning
-                         :message             :t/this-address-has-no-activity}
-          {:accessibility-label :searching-for-activity
-           :icon                :i/pending-state
-           :type                :default
-           :message             :t/searching-for-activity})]
+  [activity-state]
+  (let [{:keys [message]
+         :as   props} (case activity-state
+                        :has-activity {:accessibility-label :account-has-activity
+                                       :icon                :i/done
+                                       :type                :success
+                                       :message             :t/this-address-has-activity}
+                        :no-activity {:accessibility-label :account-has-no-activity
+                                      :icon                :i/info
+                                      :type                :warning
+                                      :message             :t/this-address-has-no-activity}
+                        :invalid-ens {:accessibility-label :error-message
+                                      :icon                :i/info
+                                      :type                :error
+                                      :message             :t/invalid-address}
+                        {:accessibility-label :searching-for-activity
+                         :icon                :i/pending-state
+                         :type                :default
+                         :message             :t/searching-for-activity})]
     (when activity-state
-      [quo/info-message
-       {:accessibility-label accessibility-label
-        :size                :default
-        :icon                icon
-        :type                type
-        :style               style/info-message}
+      [quo/info-message (assoc props
+                          :style style/info-message
+                          :size :default)
        (i18n/label message)])))
 
 (defn view
   []
   (let [addresses           (rf/sub [:wallet/addresses])
         input-value         (reagent/atom nil)
-        validate            (validate-message (set addresses))
-        validation-msg      (reagent/atom (validate
-                                           @input-value))
+        validate            #(validate-address (set addresses) %)
+        validation-msg      (reagent/atom nil)
         clear-input         (fn []
                               (reset! input-value nil)
                               (reset! validation-msg nil)
-                              (rf/dispatch [:wallet/clear-address-activity-check])
+                              (rf/dispatch [:wallet/clear-address-activity])
                               (rf/dispatch [:wallet/clean-scanned-address]))
         customization-color (rf/sub [:profile/customization-color])]
     (rf/dispatch [:wallet/clean-scanned-address])
-    (rf/dispatch [:wallet/clear-address-activity-check])
+    (rf/dispatch [:wallet/clear-address-activity])
     (fn []
-      [rn/view
-       {:style {:flex 1}}
-       [floating-button-page/view
-        {:header [quo/page-nav
-                  {:type      :no-title
-                   :icon-name :i/close
-                   :on-press  (fn []
-                                (rf/dispatch [:wallet/clean-scanned-address])
-                                (rf/dispatch [:wallet/clear-address-activity-check])
-                                (rf/dispatch [:navigate-back]))}]
-         :footer [quo/button
-                  {:customization-color customization-color
-                   :disabled?           (or (string/blank? @input-value)
-                                            (some? (validate @input-value)))
-                   :on-press            (fn []
-                                          (rf/dispatch [:navigate-to
-                                                        :confirm-address-to-watch
-                                                        {:address @input-value}])
-                                          (clear-input))
-                   :container-style     {:z-index 2}}
-                  (i18n/label :t/continue)]}
-        [quo/page-top
-         {:container-style  style/header-container
-          :title            (i18n/label :t/add-address)
-          :description      :text
-          :description-text (i18n/label :t/enter-eth)}]
-        [:f> address-input
-         {:input-value    input-value
-          :validate       validate
-          :validation-msg validation-msg
-          :clear-input    clear-input}]
-        (when @validation-msg
-          [quo/info-message
-           {:accessibility-label :error-message
-            :size                :default
-            :icon                :i/info
-            :type                :error
-            :style               style/info-message}
-           @validation-msg])
-        [activity-indicator]]])))
+      (let [activity-state    (rf/sub [:wallet/watch-address-activity-state])
+            validated-address (rf/sub [:wallet/watch-address-validated-address])]
+        [rn/view {:style {:flex 1}}
+         [floating-button-page/view
+          {:header [quo/page-nav
+                    {:type      :no-title
+                     :icon-name :i/close
+                     :on-press  (fn []
+                                  (rf/dispatch [:wallet/clean-scanned-address])
+                                  (rf/dispatch [:wallet/clear-address-activity])
+                                  (rf/dispatch [:navigate-back]))}]
+           :footer [quo/button
+                    {:customization-color customization-color
+                     :disabled?           (or (string/blank? @input-value)
+                                              (some? (validate @input-value))
+                                              (= activity-state :invalid-ens)
+                                              (= activity-state :scanning)
+                                              (not validated-address))
+                     :on-press            (fn []
+                                            (rf/dispatch [:navigate-to
+                                                          :confirm-address-to-watch
+                                                          {:address validated-address}])
+                                            (clear-input))
+                     :container-style     {:z-index 2}}
+                    (i18n/label :t/continue)]}
+          [quo/page-top
+           {:container-style  style/header-container
+            :title            (i18n/label :t/add-address)
+            :description      :text
+            :description-text (i18n/label :t/enter-eth)}]
+          [:f> address-input
+           {:input-value    input-value
+            :validate       validate
+            :validation-msg validation-msg
+            :clear-input    clear-input}]
+          (when @validation-msg
+            [quo/info-message
+             {:accessibility-label :error-message
+              :size                :default
+              :icon                :i/info
+              :type                :error
+              :style               style/info-message}
+             @validation-msg])
+          [activity-indicator activity-state]]]))))

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -13,12 +13,13 @@
     [utils.re-frame :as rf]))
 
 (defn- validate-address
-  [known-addresses s]
+  [known-addresses user-input]
   (cond
-    (or (nil? s) (= s ""))              nil
-    (contains? known-addresses s)       (i18n/label :t/address-already-in-use)
-    (not (or (validation/eth-address? s)
-             (validation/ens-name? s))) (i18n/label :t/invalid-address)))
+    (or (nil? user-input) (= user-input "")) nil
+    (contains? known-addresses user-input)   (i18n/label :t/address-already-in-use)
+    (not
+     (or (validation/eth-address? user-input)
+         (validation/ens-name? user-input))) (i18n/label :t/invalid-address)))
 
 (defn- address-input
   [{:keys [input-value validation-msg validate clear-input]}]

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -8,6 +8,7 @@
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.contexts.wallet.add-address-to-watch.style :as style]
     [status-im.contexts.wallet.common.validation :as validation]
+    [utils.debounce :as debounce]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -29,7 +30,8 @@
                           (reset! input-value new-text)
                           (reagent/flush)
                           (if (and (not-empty new-text) (nil? (validate new-text)))
-                            (rf/dispatch [:wallet/get-address-details new-text])
+                            (debounce/debounce-and-dispatch [:wallet/get-address-details new-text]
+                                                            500)
                             (rf/dispatch [:wallet/clear-address-activity]))
                           (when (and scanned-address (not= scanned-address new-text))
                             (rf/dispatch [:wallet/clear-address-activity])
@@ -41,8 +43,7 @@
                      (when-not (string/blank? scanned-address)
                        (on-change-text scanned-address)))
                    [scanned-address])
-    [rn/view
-     {:style style/input-container}
+    [rn/view {:style style/input-container}
      [quo/input
       {:accessibility-label :add-address-to-watch
        :placeholder         (i18n/label :t/address-placeholder)

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -76,14 +76,18 @@
                                        :icon                :i/done
                                        :type                :success
                                        :message             :t/this-address-has-activity}
-                        :no-activity  {:accessibility-label :account-has-no-activity
-                                       :icon                :i/info
-                                       :type                :warning
-                                       :message             :t/this-address-has-no-activity}
-                        :invalid-ens  {:accessibility-label :error-message
-                                       :icon                :i/info
-                                       :type                :error
-                                       :message             :t/invalid-address}
+                        :no-activity {:accessibility-label :account-has-no-activity
+                                      :icon                :i/info
+                                      :type                :warning
+                                      :message             :t/this-address-has-no-activity}
+                        :invalid-ens {:accessibility-label :error-message
+                                      :icon                :i/info
+                                      :type                :error
+                                      :message             :t/invalid-address}
+                        :address-already-registered {:accessibility-label :error-message
+                                                     :icon                :i/info
+                                                     :type                :error
+                                                     :message             :t/address-already-in-use}
                         {:accessibility-label :searching-for-activity
                          :icon                :i/pending-state
                          :type                :default
@@ -145,12 +149,12 @@
             :validate       validate
             :validation-msg validation-msg
             :clear-input    clear-input}]
-          (when @validation-msg
+          (if @validation-msg
             [quo/info-message
              {:accessibility-label :error-message
               :size                :default
               :icon                :i/info
               :type                :error
               :style               style/info-message}
-             @validation-msg])
-          [activity-indicator activity-state]]]))))
+             @validation-msg]
+            [activity-indicator activity-state])]]))))

--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -72,18 +72,18 @@
   [activity-state]
   (let [{:keys [message]
          :as   props} (case activity-state
-                        :has-activity {:accessibility-label :account-has-activity
-                                       :icon                :i/done
-                                       :type                :success
-                                       :message             :t/this-address-has-activity}
-                        :no-activity {:accessibility-label :account-has-no-activity
-                                      :icon                :i/info
-                                      :type                :warning
-                                      :message             :t/this-address-has-no-activity}
-                        :invalid-ens {:accessibility-label :error-message
-                                      :icon                :i/info
-                                      :type                :error
-                                      :message             :t/invalid-address}
+                        :has-activity               {:accessibility-label :account-has-activity
+                                                     :icon                :i/done
+                                                     :type                :success
+                                                     :message             :t/this-address-has-activity}
+                        :no-activity                {:accessibility-label :account-has-no-activity
+                                                     :icon :i/info
+                                                     :type :warning
+                                                     :message :t/this-address-has-no-activity}
+                        :invalid-ens                {:accessibility-label :error-message
+                                                     :icon                :i/info
+                                                     :type                :error
+                                                     :message             :t/invalid-address}
                         :address-already-registered {:accessibility-label :error-message
                                                      :icon                :i/info
                                                      :type                :error

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -195,9 +195,7 @@
             [{:method     "accounts_addAccount"
               :params     [(when (= type :generated) sha3-pwd) account-config]
               :on-success [:wallet/add-account-success lowercase-address]
-              :on-error   #(log/info "failed to create account " %
-                                     "params:"
-                                     [(when (= type :generated) sha3-pwd) account-config])}]]]})))
+              :on-error   #(log/info "failed to create account " %)}]]]})))
 
 (rf/reg-event-fx
  :wallet/derive-address-and-add-account
@@ -362,7 +360,6 @@
  (fn [{:keys [db]}]
    {:db (assoc db :wallet/valid-ens-or-address? false)}))
 
-;;
 (rf/reg-event-fx
  :wallet/ens-not-found
  (fn [{:keys [db]} _]
@@ -370,7 +367,6 @@
             (assoc-in [:wallet :ui :add-address-to-watch :activity-state] :invalid-ens)
             (assoc-in [:wallet :ui :add-address-to-watch :validated-address] nil))}))
 
-;;
 (rf/reg-event-fx
  :wallet/store-valid-address-activity
  (fn [{:keys [db]} [address {:keys [hasActivity]}]]
@@ -386,7 +382,6 @@
                   (assoc-in [:wallet :ui :add-address-to-watch :activity-state] state)
                   (assoc-in [:wallet :ui :add-address-to-watch :validated-address] address))})))))
 
-;;
 (rf/reg-event-fx
  :wallet/clear-address-activity
  (fn [{:keys [db]}]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -10,7 +10,6 @@
     [status-im.contexts.wallet.item-types :as item-types]
     [taoensso.timbre :as log]
     [utils.collection]
-    [utils.ethereum.chain :as chain]
     [utils.ethereum.eip.eip55 :as eip55]
     [utils.i18n :as i18n]
     [utils.number]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -378,7 +378,8 @@
          already-registered?  (registered-addresses address)]
      (if already-registered?
        {:db (-> db
-                (assoc-in [:wallet :ui :add-address-to-watch :activity-state] :address-already-registered)
+                (assoc-in [:wallet :ui :add-address-to-watch :activity-state]
+                          :address-already-registered)
                 (assoc-in [:wallet :ui :add-address-to-watch :validated-address] nil))}
        (let [state (if hasActivity :has-activity :no-activity)]
          {:db (-> db

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -368,14 +368,13 @@
             (assoc-in [:wallet :ui :add-address-to-watch :validated-address] nil))}))
 
 (rf/reg-event-fx
- :wallet/store-valid-address-activity
+ :wallet/store-address-activity
  (fn [{:keys [db]} [address {:keys [hasActivity]}]]
-   (let [registered-addresses (-> db :wallet :accounts keys set)
-         already-registered?  (registered-addresses address)]
-     (if already-registered?
+   (let [registered-addresses        (-> db :wallet :accounts keys set)
+         address-already-registered? (registered-addresses address)]
+     (if address-already-registered?
        {:db (-> db
-                (assoc-in [:wallet :ui :add-address-to-watch :activity-state]
-                          :address-already-registered)
+                (assoc-in [:wallet :ui :add-address-to-watch :activity-state] :address-already-registered)
                 (assoc-in [:wallet :ui :add-address-to-watch :validated-address] nil))}
        (let [state (if hasActivity :has-activity :no-activity)]
          {:db (-> db
@@ -390,7 +389,7 @@
 (rf/reg-event-fx
  :wallet/get-address-details
  (fn [{:keys [db]} [address-or-ens]]
-   (let [request-params [(chain/chain-id db) address-or-ens]
+   (let [request-params [constants/ethereum-mainnet-chain-id address-or-ens]
          ens?           (string/includes? address-or-ens ".")]
      {:db (-> db
               (assoc-in [:wallet :ui :add-address-to-watch :activity-state] :scanning)
@@ -404,7 +403,7 @@
              [:json-rpc/call
               [{:method     "wallet_getAddressDetails"
                 :params     request-params
-                :on-success [:wallet/store-valid-address-activity address-or-ens]
+                :on-success [:wallet/store-address-activity address-or-ens]
                 :on-error   #(log/info "failed to get address details"
                                        {:error %
                                         :event :wallet/get-address-details})}]])]})))

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -374,10 +374,16 @@
 (rf/reg-event-fx
  :wallet/store-valid-address-activity
  (fn [{:keys [db]} [address {:keys [hasActivity]}]]
-   (let [state (if hasActivity :has-activity :no-activity)]
-     {:db (-> db
-              (assoc-in [:wallet :ui :add-address-to-watch :activity-state] state)
-              (assoc-in [:wallet :ui :add-address-to-watch :validated-address] address))})))
+   (let [registered-addresses (-> db :wallet :accounts keys set)
+         already-registered?  (registered-addresses address)]
+     (if already-registered?
+       {:db (-> db
+                (assoc-in [:wallet :ui :add-address-to-watch :activity-state] :address-already-registered)
+                (assoc-in [:wallet :ui :add-address-to-watch :validated-address] nil))}
+       (let [state (if hasActivity :has-activity :no-activity)]
+         {:db (-> db
+                  (assoc-in [:wallet :ui :add-address-to-watch :activity-state] state)
+                  (assoc-in [:wallet :ui :add-address-to-watch :validated-address] address))})))))
 
 ;;
 (rf/reg-event-fx

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -394,16 +394,18 @@
               (assoc-in [:wallet :ui :add-address-to-watch :activity-state] :scanning)
               (assoc-in [:wallet :ui :add-address-to-watch :validated-address] nil))
       :fx [(if ens?
-             [:json-rpc/call [{:method     "ens_addressOf"
-                               :params     request-params
-                               :on-success [:wallet/get-address-details]
-                               :on-error   [:wallet/ens-not-found]}]]
-             [:json-rpc/call [{:method     "wallet_getAddressDetails"
-                               :params     request-params
-                               :on-success [:wallet/store-valid-address-activity address-or-ens]
-                               :on-error   #(log/info "failed to get address details"
-                                                      {:error %
-                                                       :event :wallet/get-address-details})}]])]})))
+             [:json-rpc/call
+              [{:method     "ens_addressOf"
+                :params     request-params
+                :on-success [:wallet/get-address-details]
+                :on-error   [:wallet/ens-not-found]}]]
+             [:json-rpc/call
+              [{:method     "wallet_getAddressDetails"
+                :params     request-params
+                :on-success [:wallet/store-valid-address-activity address-or-ens]
+                :on-error   #(log/info "failed to get address details"
+                                       {:error %
+                                        :event :wallet/get-address-details})}]])]})))
 
 (rf/reg-event-fx
  :wallet/navigate-to-chain-explorer-from-bottom-sheet

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -115,16 +115,15 @@
 
 (defn- local-suggestions-list
   []
-  (fn []
-    (let [local-suggestion (rf/sub [:wallet/local-suggestions])]
-      [rn/view {:style {:flex 1}}
-       [rn/flat-list
-        {:data                         local-suggestion
-         :content-container-style      {:flex-grow 1}
-         :key-fn                       :id
-         :on-scroll-to-index-failed    identity
-         :keyboard-should-persist-taps :handled
-         :render-fn                    suggestion-component}]])))
+  (let [local-suggestion (rf/sub [:wallet/local-suggestions])]
+    [rn/view {:style {:flex 1}}
+     [rn/flat-list
+      {:data                         local-suggestion
+       :content-container-style      {:flex-grow 1}
+       :key-fn                       :id
+       :on-scroll-to-index-failed    identity
+       :keyboard-should-persist-taps :handled
+       :render-fn                    suggestion-component}]]))
 
 (defn- f-view
   []

--- a/src/status_im/subs/wallet/add_account/address_to_watch.cljs
+++ b/src/status_im/subs/wallet/add_account/address_to_watch.cljs
@@ -1,0 +1,17 @@
+(ns status-im.subs.wallet.add-account.address-to-watch
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-sub
+ :wallet/add-address-to-watch
+ :<- [:wallet/ui]
+ :-> :add-address-to-watch)
+
+(rf/reg-sub
+ :wallet/watch-address-activity-state
+ :<- [:wallet/add-address-to-watch]
+ :-> :activity-state)
+
+(rf/reg-sub
+ :wallet/watch-address-validated-address
+ :<- [:wallet/add-address-to-watch]
+ :-> :validated-address)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -2,6 +2,7 @@
   (:require [clojure.string :as string]
             [re-frame.core :as rf]
             [status-im.contexts.wallet.common.utils :as utils]
+            [status-im.subs.wallet.add-account.address-to-watch]
             [utils.number]))
 
 (defn- filter-networks
@@ -92,21 +93,6 @@
  :wallet/wallet-bridge-to-chain-id
  :<- [:wallet/wallet-send]
  :-> :bridge-to-chain-id)
-
-(rf/reg-sub
- :wallet/add-address-to-watch
- :<- [:wallet/ui]
- :-> :add-address-to-watch)
-
-(rf/reg-sub
- :wallet/watch-address-activity-state
- :<- [:wallet/add-address-to-watch]
- :-> :activity-state)
-
-(rf/reg-sub
- :wallet/watch-address-validated-address
- :<- [:wallet/add-address-to-watch]
- :-> :validated-address)
 
 (rf/reg-sub
  :wallet/keypairs

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -94,9 +94,19 @@
  :-> :bridge-to-chain-id)
 
 (rf/reg-sub
- :wallet/watch-address-activity-state
+ :wallet/add-address-to-watch
  :<- [:wallet/ui]
- :-> :watch-address-activity-state)
+ :-> :add-address-to-watch)
+
+(rf/reg-sub
+ :wallet/watch-address-activity-state
+ :<- [:wallet/add-address-to-watch]
+ :-> :activity-state)
+
+(rf/reg-sub
+ :wallet/watch-address-validated-address
+ :<- [:wallet/add-address-to-watch]
+ :-> :validated-address)
 
 (rf/reg-sub
  :wallet/keypairs

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -296,12 +296,16 @@
     (is (nil? (rf/sub [sub-name]))))
 
   (testing "watch address activity state with no-activity value"
-    (swap! rf-db/app-db #(assoc-in % [:wallet :ui :watch-address-activity-state] :no-activity))
+    (swap! rf-db/app-db #(assoc-in % [:wallet :ui :add-address-to-watch :activity-state] :no-activity))
     (is (match? :no-activity (rf/sub [sub-name]))))
 
   (testing "watch address activity state with has-activity value"
-    (swap! rf-db/app-db #(assoc-in % [:wallet :ui :watch-address-activity-state] :has-activity))
-    (is (match? :has-activity (rf/sub [sub-name])))))
+    (swap! rf-db/app-db #(assoc-in % [:wallet :ui :add-address-to-watch :activity-state] :has-activity))
+    (is (match? :has-activity (rf/sub [sub-name]))))
+
+  (testing "watch address activity state with invalid-ens value"
+    (swap! rf-db/app-db #(assoc-in % [:wallet :ui :add-address-to-watch :activity-state] :invalid-ens))
+    (is (match? :invalid-ens (rf/sub [sub-name])))))
 
 (h/deftest-sub :wallet/accounts-without-current-viewing-account
   [sub-name]


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #18736

### Summary

This PR adds the ability to register an address to watch using  an ENS, also some some small bugs.
Check the following example, `sonnyf.eth` exists and `sonnyff.eth` doesn't exist,.

Before: 

[Screencast from 2024-02-28 12-48-32.webm](https://github.com/status-im/status-mobile/assets/90291778/35145a0d-3c5b-4c53-8db1-94776d0797fe)

Now:

[Screencast from 2024-02-28 12-56-16.webm](https://github.com/status-im/status-mobile/assets/90291778/00557e49-7614-4cb8-a365-a2b999229341) 

[Screencast from 2024-02-28 13-11-37.webm](https://github.com/status-im/status-mobile/assets/90291778/c915a611-1c31-483a-9c2b-60973dcc37aa)


#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to wallet tab
- Register a new watch account using an ENS (now is possible)
- Try to register the same ENS, the UI shouldn't allow it.

status: ready
