### PR TITLE
updated community rules to display the actual rules

### DIFF
--- a/src/status_im/contexts/communities/actions/community_options/view.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/view.cljs
@@ -181,8 +181,9 @@
 (defn get-context-drawers
   [{:keys [id]}]
   (let [{:keys [token-permissions admin joined
-                muted banList muted-till color intro-message]} (rf/sub [:communities/community id])
-        request-id                               (rf/sub [:communities/my-pending-request-to-join id])]
+                muted banList muted-till color
+                intro-message]} (rf/sub [:communities/community id])
+        request-id              (rf/sub [:communities/my-pending-request-to-join id])]
     (cond
       admin      (owner-options id token-permissions muted muted-till intro-message)
       joined     (joined-options id token-permissions muted muted-till color intro-message)

--- a/src/status_im/contexts/communities/actions/community_rules_list/style.cljs
+++ b/src/status_im/contexts/communities/actions/community_rules_list/style.cljs
@@ -3,8 +3,7 @@
 (def community-rule
   {:flex-direction :row
    :flex           1
-   :align-items    :flex-start
-   :margin-top     16})
+   :align-items    :flex-start})
 
 (def community-rule-index
   {:margin-left 4})

--- a/src/status_im/contexts/communities/actions/generic_menu/style.cljs
+++ b/src/status_im/contexts/communities/actions/generic_menu/style.cljs
@@ -3,8 +3,7 @@
 (def container
   {:flex          1
    :margin-left   20
-   :margin-right  20
-   :margin-bottom 20})
+   :margin-right  20})
 
 (def inner-container
   {:display         :flex
@@ -14,4 +13,4 @@
 
 (def community-tag
   {:margin-right :auto
-   :margin-top   8})
+   :margin-top   4})

--- a/src/status_im/contexts/communities/actions/generic_menu/style.cljs
+++ b/src/status_im/contexts/communities/actions/generic_menu/style.cljs
@@ -1,9 +1,9 @@
 (ns status-im.contexts.communities.actions.generic-menu.style)
 
 (def container
-  {:flex          1
-   :margin-left   20
-   :margin-right  20})
+  {:flex         1
+   :margin-left  20
+   :margin-right 20})
 
 (def inner-container
   {:display         :flex

--- a/src/status_im/contexts/communities/actions/generic_menu/style.cljs
+++ b/src/status_im/contexts/communities/actions/generic_menu/style.cljs
@@ -1,9 +1,16 @@
 (ns status-im.contexts.communities.actions.generic-menu.style)
 
-(def container
+(defn container
+  [max-height]
   {:flex         1
+   :max-height   max-height
    :margin-left  20
    :margin-right 20})
+
+(defn scroll-view-style
+  [max-height]
+  {:margin-bottom 12
+   :max-height    max-height})
 
 (def inner-container
   {:display         :flex

--- a/src/status_im/contexts/communities/actions/generic_menu/view.cljs
+++ b/src/status_im/contexts/communities/actions/generic_menu/view.cljs
@@ -4,38 +4,46 @@
     [quo.core :as quo]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
+    [react-native.safe-area :as safe-area]
     [status-im.contexts.communities.actions.generic-menu.style :as style]
     [utils.re-frame :as rf]))
 
 (defn view
   [{:keys [id title]} children]
-  (let [{:keys [name images]}                       (rf/sub [:communities/community id])
-        [scroll-view-height set-scroll-view-height] (rn/use-state 0)
-        {window-height :height}                     (rn/get-window)
-        max-bottom-sheet-height                     (- window-height 44)
-        ;; This is the default height of the bottom sheet with zero nested views
-        empty-bottom-sheet-height                   62
-        total-bottom-sheet-height                   (+ scroll-view-height empty-bottom-sheet-height)]
-    [gesture/scroll-view
-     {:on-layout                       (fn [event]
-                                         (set-scroll-view-height (oops/oget
-                                                                  event
-                                                                  "nativeEvent.layout.height")))
-      :scroll-enabled                  (>= total-bottom-sheet-height max-bottom-sheet-height)
-      :scroll-event-throttle           16
-      :shows-vertical-scroll-indicator false}
-     [rn/view {:style style/container}
-      [rn/view {:style {:padding-bottom 12}}
-       [rn/view {:style style/inner-container}
-        [quo/text
-         {:accessibility-label :communities-join-community
-          :weight              :semi-bold
-          :size                :heading-2}
-         title]]
-       [rn/view {:style style/community-tag}
-        [quo/context-tag
-         {:type           :community
-          :size           24
-          :community-logo (:thumbnail images)
-          :community-name name}]]]
-      children]]))
+  (let [{:keys [name images]}                   (rf/sub [:communities/community id])
+        [content-height set-content-height]     (rn/use-state 0)
+        [sheet-header-height set-header-height] (rn/use-state 0)
+        insets                                  (safe-area/get-insets)
+        {window-height :height}                 (rn/get-window)
+        sheet-max-height                        (- window-height (:top insets))
+        max-height                              (- sheet-max-height sheet-header-height)]
+    [rn/view {:style (style/container max-height)}
+     [rn/view
+      {:style     {:padding-bottom 12}
+       :on-layout (fn [event]
+                    (set-header-height (oops/oget
+                                        event
+                                        "nativeEvent.layout.height")))}
+      [rn/view {:style style/inner-container}
+       [quo/text
+        {:accessibility-label :communities-join-community
+         :weight              :semi-bold
+         :size                :heading-2}
+        title]]
+      [rn/view {:style style/community-tag}
+       [quo/context-tag
+        {:type           :community
+         :size           24
+         :community-logo (:thumbnail images)
+         :community-name name}]]]
+     [gesture/scroll-view
+      {:scroll-enabled                  (> content-height max-height)
+       :scroll-event-throttle           16
+       :style                           (style/scroll-view-style max-height)
+       :shows-vertical-scroll-indicator false}
+      [rn/view
+       {:on-layout (fn [event]
+                     (set-content-height (oops/oget
+                                          event
+                                          "nativeEvent.layout.height")))}
+       children]]]))

--- a/src/status_im/contexts/communities/actions/generic_menu/view.cljs
+++ b/src/status_im/contexts/communities/actions/generic_menu/view.cljs
@@ -1,24 +1,34 @@
 (ns status-im.contexts.communities.actions.generic-menu.view
   (:require
-    [quo.core :as quo]
-    [react-native.core :as rn]
-    [status-im.contexts.communities.actions.generic-menu.style :as style]
-    [utils.re-frame :as rf]))
+   [oops.core :as oops]
+   [quo.core :as quo]
+   [react-native.core :as rn]
+   [status-im.contexts.communities.actions.generic-menu.style :as style]
+   [utils.re-frame :as rf]))
 
 (defn view
   [{:keys [id title]} children]
-  (let [{:keys [name images]} (rf/sub [:communities/community id])]
+  (let [{:keys [name images]} (rf/sub [:communities/community id])
+        [content-scroll-y set-content-scroll-y]    (rn/use-state 0)
+        {window-height :height} (rn/get-window)
+        max-bottom-sheet-height (- window-height 44)]
     [rn/view {:style style/container}
-     [rn/view {:style style/inner-container}
-      [quo/text
-       {:accessibility-label :communities-join-community
-        :weight              :semi-bold
-        :size                :heading-2}
-       title]]
-     [rn/view {:style style/community-tag}
-      [quo/context-tag
-       {:type           :community
-        :size           24
-        :community-logo (:thumbnail images)
-        :community-name name}]]
-     children]))
+     [rn/view {:style {:padding-bottom 12}}
+      [rn/view {:style style/inner-container}
+       [quo/text
+        {:accessibility-label :communities-join-community
+         :weight              :semi-bold
+         :size                :heading-2}
+        title]]
+      [rn/view {:style style/community-tag}
+       [quo/context-tag
+        {:type           :community
+         :size           24
+         :community-logo (:thumbnail images)
+         :community-name name}]]]
+     [rn/scroll-view {:on-layout (fn [event]
+                                   (set-content-scroll-y (oops/oget event "nativeEvent.layout.height")))
+                      (js/console.log (str "content-scroll-y " content-scroll-y))
+                      (js/console.log (str "max-bottom-sheet-height " max-bottom-sheet-height))
+                      :scroll-enabled (when (> content-scroll-y max-bottom-sheet-height) true)}
+      children]]))

--- a/src/status_im/contexts/communities/actions/generic_menu/view.cljs
+++ b/src/status_im/contexts/communities/actions/generic_menu/view.cljs
@@ -1,17 +1,17 @@
 (ns status-im.contexts.communities.actions.generic-menu.view
   (:require
-   [oops.core :as oops]
-   [quo.core :as quo]
-   [react-native.core :as rn]
-   [status-im.contexts.communities.actions.generic-menu.style :as style]
-   [utils.re-frame :as rf]))
+    [oops.core :as oops]
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [status-im.contexts.communities.actions.generic-menu.style :as style]
+    [utils.re-frame :as rf]))
 
 (defn view
   [{:keys [id title]} children]
-  (let [{:keys [name images]} (rf/sub [:communities/community id])
-        [content-scroll-y set-content-scroll-y]    (rn/use-state 0)
-        {window-height :height} (rn/get-window)
-        max-bottom-sheet-height (- window-height 44)]
+  (let [{:keys [name images]}                   (rf/sub [:communities/community id])
+        [content-scroll-y set-content-scroll-y] (rn/use-state 0)
+        {window-height :height}                 (rn/get-window)
+        max-bottom-sheet-height                 (- window-height 44)]
     [rn/view {:style style/container}
      [rn/view {:style {:padding-bottom 12}}
       [rn/view {:style style/inner-container}
@@ -26,9 +26,10 @@
          :size           24
          :community-logo (:thumbnail images)
          :community-name name}]]]
-     [rn/scroll-view {:on-layout (fn [event]
-                                   (set-content-scroll-y (oops/oget event "nativeEvent.layout.height")))
-                      (js/console.log (str "content-scroll-y " content-scroll-y))
-                      (js/console.log (str "max-bottom-sheet-height " max-bottom-sheet-height))
-                      :scroll-enabled (when (> content-scroll-y max-bottom-sheet-height) true)}
+     [rn/scroll-view
+      {:on-layout                       (fn [event]
+                                          (set-content-scroll-y (oops/oget event
+                                                                           "nativeEvent.layout.height")))
+       :scroll-enabled                  (when (> content-scroll-y max-bottom-sheet-height) true)
+       :shows-vertical-scroll-indicator false}
       children]]))

--- a/src/status_im/contexts/communities/actions/generic_menu/view.cljs
+++ b/src/status_im/contexts/communities/actions/generic_menu/view.cljs
@@ -3,33 +3,39 @@
     [oops.core :as oops]
     [quo.core :as quo]
     [react-native.core :as rn]
+    [react-native.gesture :as gesture]
     [status-im.contexts.communities.actions.generic-menu.style :as style]
     [utils.re-frame :as rf]))
 
 (defn view
   [{:keys [id title]} children]
-  (let [{:keys [name images]}                   (rf/sub [:communities/community id])
-        [content-scroll-y set-content-scroll-y] (rn/use-state 0)
-        {window-height :height}                 (rn/get-window)
-        max-bottom-sheet-height                 (- window-height 44)]
-    [rn/view {:style style/container}
-     [rn/view {:style {:padding-bottom 12}}
-      [rn/view {:style style/inner-container}
-       [quo/text
-        {:accessibility-label :communities-join-community
-         :weight              :semi-bold
-         :size                :heading-2}
-        title]]
-      [rn/view {:style style/community-tag}
-       [quo/context-tag
-        {:type           :community
-         :size           24
-         :community-logo (:thumbnail images)
-         :community-name name}]]]
-     [rn/scroll-view
-      {:on-layout                       (fn [event]
-                                          (set-content-scroll-y (oops/oget event
-                                                                           "nativeEvent.layout.height")))
-       :scroll-enabled                  (when (> content-scroll-y max-bottom-sheet-height) true)
-       :shows-vertical-scroll-indicator false}
+  (let [{:keys [name images]}                       (rf/sub [:communities/community id])
+        [scroll-view-height set-scroll-view-height] (rn/use-state 0)
+        {window-height :height}                     (rn/get-window)
+        max-bottom-sheet-height                     (- window-height 44)
+        ;; This is the default height of the bottom sheet with zero nested views
+        empty-bottom-sheet-height                   62
+        total-bottom-sheet-height                   (+ scroll-view-height empty-bottom-sheet-height)]
+    [gesture/scroll-view
+     {:on-layout                       (fn [event]
+                                         (set-scroll-view-height (oops/oget
+                                                                  event
+                                                                  "nativeEvent.layout.height")))
+      :scroll-enabled                  (>= total-bottom-sheet-height max-bottom-sheet-height)
+      :scroll-event-throttle           16
+      :shows-vertical-scroll-indicator false}
+     [rn/view {:style style/container}
+      [rn/view {:style {:padding-bottom 12}}
+       [rn/view {:style style/inner-container}
+        [quo/text
+         {:accessibility-label :communities-join-community
+          :weight              :semi-bold
+          :size                :heading-2}
+         title]]
+       [rn/view {:style style/community-tag}
+        [quo/context-tag
+         {:type           :community
+          :size           24
+          :community-logo (:thumbnail images)
+          :community-name name}]]]
       children]]))

--- a/src/status_im/contexts/communities/actions/see_rules/view.cljs
+++ b/src/status_im/contexts/communities/actions/see_rules/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [quo.core :as quo]
     [react-native.core :as rn]
+    [status-im.contexts.communities.actions.community-rules-list.view :as community-rules]
     [status-im.contexts.communities.actions.generic-menu.view :as generic-menu]
     [utils.i18n :as i18n]))
 
@@ -10,9 +11,11 @@
   [generic-menu/view
    {:id    id
     :title (i18n/label :t/community-rules)}
-   [rn/view {:style {:padding-vertical 8}}
-    [quo/text
-     {:accessibility-label :communities-rules
-      :weight              :regular
-      :size                :paragraph-2}
-     intro-message]]])
+   [rn/view {:style {:padding-top 8}}
+    (if (empty? intro-message)
+      [community-rules/view community-rules/standard-rules]
+      [quo/text
+       {:accessibility-label :communities-rules
+        :weight              :regular
+        :size                :paragraph-2}
+       intro-message])]])

--- a/src/status_im/contexts/communities/actions/see_rules/view.cljs
+++ b/src/status_im/contexts/communities/actions/see_rules/view.cljs
@@ -1,13 +1,18 @@
 (ns status-im.contexts.communities.actions.see-rules.view
   (:require
-    [status-im.contexts.communities.actions.community-rules-list.view :as community-rules]
+    [quo.core :as quo]
+    [react-native.core :as rn]
     [status-im.contexts.communities.actions.generic-menu.view :as generic-menu]
     [utils.i18n :as i18n]))
 
 (defn view
-  [id]
+  [id intro-message]
   [generic-menu/view
    {:id    id
     :title (i18n/label :t/community-rules)}
-
-   [community-rules/view community-rules/standard-rules]])
+   [rn/view {:style {:padding-vertical 8}}
+    [quo/text
+     {:accessibility-label :communities-rules
+      :weight              :regular
+      :size                :paragraph-2}
+     intro-message]]])


### PR DESCRIPTION
fixes [#18978](https://github.com/status-im/status-mobile/issues/18978)

### Summary

This allows the user to view the actual community rules set when the community was created

This pr. would appreciate a design review

<img src="https://github.com/status-im/status-mobile/assets/28704507/f2beffab-a0ab-4a3b-ba7a-fec3f55de143"  width="325">

<img src="https://github.com/status-im/status-mobile/assets/28704507/32cae706-f5ac-45d4-8690-48a1f1589a58"  width="325">


