### PR TITLE
fix: polish new chat

### DIFF
--- a/src/quo/components/list_items/user.cljs
+++ b/src/quo/components/list_items/user.cljs
@@ -6,8 +6,7 @@
     [quo.components.messages.author.view :as author]
     [quo.components.selectors.selectors.view :as selectors]
     [quo.foundations.colors :as colors]
-    [react-native.core :as rn]
-    [utils.re-frame :as rf]))
+    [react-native.core :as rn]))
 
 (def container-style
   {:margin-horizontal  8
@@ -19,26 +18,25 @@
    :align-items        :center})
 
 (defn action-icon
-  [{:keys [type on-press on-check disabled? checked?]} theme]
-  (let [customization-color (rf/sub [:profile/customization-color])]
-    [rn/touchable-opacity
-     {:on-press on-press}
-     (case type
-       :options
-       [icons/icon :i/options
-        {:size  20
-         :color (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)}]
-       :checkbox
-       [selectors/view
-        {:type                :checkbox
-         :checked?            checked?
-         :customization-color customization-color
-         :accessibility-label :user-list-toggle-check
-         :disabled?           disabled?
-         :on-change           (when on-check on-check)}]
-       :close
-       [text/text "not implemented"]
-       [rn/view])]))
+  [{:keys [type on-press on-check disabled? checked?]} customization-color theme]
+  [rn/touchable-opacity
+   {:on-press on-press}
+   (case type
+     :options
+     [icons/icon :i/options
+      {:size  20
+       :color (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)}]
+     :checkbox
+     [selectors/view
+      {:type                :checkbox
+       :checked?            checked?
+       :customization-color customization-color
+       :accessibility-label :user-list-toggle-check
+       :disabled?           disabled?
+       :on-change           (when on-check on-check)}]
+     :close
+     [text/text "not implemented"]
+     [rn/view])])
 
 (defn user
   [{:keys [short-chat-key primary-name secondary-name photo-path online? contact? verified?
@@ -71,4 +69,4 @@
          :style {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}}
         short-chat-key])]
     (when accessory
-      [action-icon accessory theme])]])
+      [action-icon accessory customization-color theme])]])

--- a/src/quo/components/list_items/user.cljs
+++ b/src/quo/components/list_items/user.cljs
@@ -22,7 +22,7 @@
   [{:keys [type on-press on-check disabled? checked?]} theme]
   (let [customization-color (rf/sub [:profile/customization-color])]
     [rn/touchable-opacity
-     {:on-press (when on-press on-press)}
+     {:on-press on-press}
      (case type
        :options
        [icons/icon :i/options

--- a/src/quo/components/list_items/user.cljs
+++ b/src/quo/components/list_items/user.cljs
@@ -6,7 +6,8 @@
     [quo.components.messages.author.view :as author]
     [quo.components.selectors.selectors.view :as selectors]
     [quo.foundations.colors :as colors]
-    [react-native.core :as rn]))
+    [react-native.core :as rn]
+    [utils.re-frame :as rf]))
 
 (def container-style
   {:margin-horizontal  8
@@ -19,23 +20,25 @@
 
 (defn action-icon
   [{:keys [type on-press on-check disabled? checked?]} theme]
-  [rn/touchable-opacity
-   {:on-press (when on-press on-press)}
-   (case type
-     :options
-     [icons/icon :i/options
-      {:size  20
-       :color (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)}]
-     :checkbox
-     [selectors/view
-      {:type                :checkbox
-       :checked?            checked?
-       :accessibility-label :user-list-toggle-check
-       :disabled?           disabled?
-       :on-change           (when on-check on-check)}]
-     :close
-     [text/text "not implemented"]
-     [rn/view])])
+  (let [customization-color (rf/sub [:profile/customization-color])]
+    [rn/touchable-opacity
+     {:on-press (when on-press on-press)}
+     (case type
+       :options
+       [icons/icon :i/options
+        {:size  20
+         :color (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)}]
+       :checkbox
+       [selectors/view
+        {:type                :checkbox
+         :checked?            checked?
+         :customization-color customization-color
+         :accessibility-label :user-list-toggle-check
+         :disabled?           disabled?
+         :on-change           (when on-check on-check)}]
+       :close
+       [text/text "not implemented"]
+       [rn/view])]))
 
 (defn user
   [{:keys [short-chat-key primary-name secondary-name photo-path online? contact? verified?

--- a/src/react_native/gesture.cljs
+++ b/src/react_native/gesture.cljs
@@ -98,8 +98,8 @@
 (defn- find-sticky-indices
   [data]
   (->> data
-       (map-indexed (fn [index item] (if (:header? item) index nil)))
-       (filter (complement nil?))
+       (map-indexed (fn [index item] (when (:header? item) index)))
+       (remove nil?)
        (vec)))
 
 (defn- is-last-item-in-section

--- a/src/react_native/gesture.cljs
+++ b/src/react_native/gesture.cljs
@@ -115,14 +115,14 @@
   (let [data (flatten-sections sections)]
     [flat-list
      (merge props
-            {:data data
-             :render-fn
-             (fn [p1 p2 p3 p4]
-               [:<>
-                (if (:header? p1)
-                  [render-section-header-fn p1 p2 p3 p4]
-                  [render-fn p1 p2 p3 p4])
-                (when (and render-section-footer-fn (is-last-item-in-section data p2))
-                  [render-section-footer-fn p1 p2 p3 p4])])
+            {:data                  data
+             :render-fn             (fn [p1 p2 p3 p4]
+                                      [:<>
+                                       (if (:header? p1)
+                                         [render-section-header-fn p1 p2 p3 p4]
+                                         [render-fn p1 p2 p3 p4])
+                                       (when (and render-section-footer-fn
+                                                  (is-last-item-in-section data p2))
+                                         [render-section-footer-fn p1 p2 p3 p4])])
              :sticky-header-indices (when sticky-section-headers-enabled
                                       (find-sticky-indices data))})]))

--- a/src/react_native/gesture.cljs
+++ b/src/react_native/gesture.cljs
@@ -102,8 +102,14 @@
        (filter (complement nil?))
        (vec)))
 
+(defn- is-last-item-in-section
+  [data index]
+  (let [next-item (nth data (inc index) nil)]
+    (or (nil? next-item) (:header? next-item))))
+
 (defn section-list
-  [{:keys [sections sticky-section-headers-enabled render-section-header-fn render-fn]
+  [{:keys [sections sticky-section-headers-enabled render-section-header-fn render-section-footer-fn
+           render-fn]
     :or   {sticky-section-headers-enabled true}
     :as   props}]
   (let [data (flatten-sections sections)]
@@ -112,8 +118,11 @@
             {:data data
              :render-fn
              (fn [p1 p2 p3 p4]
-               (if (:header? p1)
-                 [render-section-header-fn p1 p2 p3 p4]
-                 [render-fn p1 p2 p3 p4]))
+               [:<>
+                (if (:header? p1)
+                  [render-section-header-fn p1 p2 p3 p4]
+                  [render-fn p1 p2 p3 p4])
+                (when (and render-section-footer-fn (is-last-item-in-section data p2))
+                  [render-section-footer-fn p1 p2 p3 p4])])
              :sticky-header-indices (when sticky-section-headers-enabled
                                       (find-sticky-indices data))})]))

--- a/src/react_native/gesture.cljs
+++ b/src/react_native/gesture.cljs
@@ -95,7 +95,7 @@
             (into [{:title title :header? true}] data))
    sections))
 
-(defn find-sticky-indices
+(defn- find-sticky-indices
   [data]
   (->> data
        (map-indexed (fn [index item] (if (:header? item) index nil)))

--- a/src/react_native/gesture.cljs
+++ b/src/react_native/gesture.cljs
@@ -95,13 +95,25 @@
             (into [{:title title :header? true}] data))
    sections))
 
+(defn find-sticky-indices
+  [data]
+  (->> data
+       (map-indexed (fn [index item] (if (:header? item) index nil)))
+       (filter (complement nil?))
+       (vec)))
+
 (defn section-list
-  [{:keys [sections render-section-header-fn render-fn] :as props}]
+  [{:keys [sections sticky-section-headers-enabled render-section-header-fn render-fn]
+    :or   {sticky-section-headers-enabled true}
+    :as   props}]
   (let [data (flatten-sections sections)]
     [flat-list
      (merge props
-            {:data      data
-             :render-fn (fn [p1 p2 p3 p4]
-                          (if (:header? p1)
-                            [render-section-header-fn p1 p2 p3 p4]
-                            [render-fn p1 p2 p3 p4]))})]))
+            {:data data
+             :render-fn
+             (fn [p1 p2 p3 p4]
+               (if (:header? p1)
+                 [render-section-header-fn p1 p2 p3 p4]
+                 [render-fn p1 p2 p3 p4]))
+             :sticky-header-indices (when sticky-section-headers-enabled
+                                      (find-sticky-indices data))})]))

--- a/src/status_im/common/contact_list/style.cljs
+++ b/src/status_im/common/contact_list/style.cljs
@@ -1,5 +1,7 @@
-(ns status-im.common.contact-list.style)
+(ns status-im.common.contact-list.style
+  (:require [quo.foundations.colors :as colors]))
 
 (defn contacts-section-header
-  [first-item?]
-  {:padding-top (if first-item? 0 8)})
+  [first-item? theme]
+  {:background-color (colors/theme-colors colors/white colors/neutral-95 theme)
+   :padding-top      (if first-item? 0 8)})

--- a/src/status_im/common/contact_list/style.cljs
+++ b/src/status_im/common/contact_list/style.cljs
@@ -1,7 +1,9 @@
 (ns status-im.common.contact-list.style
   (:require [quo.foundations.colors :as colors]))
 
+(def contacts-section-footer
+  {:height 8})
+
 (defn contacts-section-header
-  [first-item? theme]
-  {:background-color (colors/theme-colors colors/white colors/neutral-95 theme)
-   :padding-top      (if first-item? 0 8)})
+  [theme]
+  {:background-color (colors/theme-colors colors/white colors/neutral-95 theme)})

--- a/src/status_im/common/contact_list/view.cljs
+++ b/src/status_im/common/contact_list/view.cljs
@@ -1,7 +1,7 @@
 (ns status-im.common.contact-list.view
   (:require
     [quo.core :as quo]
-    [quo.theme :as quo.theme]
+    [quo.theme]
     [react-native.core :as rn]
     [status-im.common.contact-list.style :as style]))
 

--- a/src/status_im/common/contact_list/view.cljs
+++ b/src/status_im/common/contact_list/view.cljs
@@ -1,10 +1,12 @@
 (ns status-im.common.contact-list.view
   (:require
     [quo.core :as quo]
+    [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [status-im.common.contact-list.style :as style]))
 
 (defn contacts-section-header
   [{:keys [title index]}]
-  [rn/view (style/contacts-section-header (= index 0))
-   [quo/divider-label title]])
+  (let [theme (quo.theme/use-theme-value)]
+    [rn/view (style/contacts-section-header (= index 0) theme)
+     [quo/divider-label title]]))

--- a/src/status_im/common/contact_list/view.cljs
+++ b/src/status_im/common/contact_list/view.cljs
@@ -5,8 +5,12 @@
     [react-native.core :as rn]
     [status-im.common.contact-list.style :as style]))
 
+(defn contacts-section-footer
+  []
+  [rn/view style/contacts-section-footer])
+
 (defn contacts-section-header
-  [{:keys [title index]}]
+  [{:keys [title]}]
   (let [theme (quo.theme/use-theme-value)]
-    [rn/view (style/contacts-section-header (= index 0) theme)
+    [rn/view (style/contacts-section-header theme)
      [quo/divider-label title]]))

--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -62,6 +62,7 @@
        :sticky-section-headers-enabled false
        :sections                       (rf/sub [:contacts/grouped-by-first-letter])
        :render-section-header-fn       contact-list/contacts-section-header
+       :render-section-footer-fn       contact-list/contacts-section-footer
        :content-container-style        {:padding-bottom 20}
        :render-data                    {:group group}
        :render-fn                      add-member-contact-item-render}]

--- a/src/status_im/contexts/chat/home/new_chat/styles.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/styles.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.chat.home.new-chat.styles
   (:require
+    [quo.foundations.colors :as colors]
     [react-native.safe-area :as safe-area]))
 
 (def contact-selection-heading
@@ -9,11 +10,16 @@
    :margin-top      24
    :margin-bottom   16})
 
-(def chat-button
-  {:position :absolute
-   :bottom   (+ 12 (safe-area/get-bottom))
-   :left     20
-   :right    20})
+(defn chat-button-container
+  [theme]
+  {:position           :absolute
+   :bottom             0
+   :padding-bottom     (+ 12 (safe-area/get-bottom))
+   :background-color   (colors/theme-colors colors/white-opa-70 colors/neutral-95-opa-70 theme)
+   :padding-top        12
+   :padding-horizontal 20
+   :left               0
+   :right              0})
 
 (defn no-contacts
   []

--- a/src/status_im/contexts/chat/home/new_chat/styles.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/styles.cljs
@@ -14,7 +14,7 @@
   [theme]
   {:position           :absolute
    :bottom             0
-   :padding-bottom     (+ 12 (safe-area/get-bottom))
+   :padding-bottom     33
    :background-color   (colors/theme-colors colors/white-opa-70 colors/neutral-95-opa-70 theme)
    :padding-top        12
    :padding-horizontal 20

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -128,14 +128,13 @@
      (if (empty? contacts)
        [no-contacts-view {:theme theme}]
        [gesture/section-list
-        {:key-fn                         :title
-         :sticky-section-headers-enabled true
-         :sections                       (rf/sub [:contacts/filtered-active-sections])
-         :render-section-header-fn       contact-list/contacts-section-header
-         :content-container-style        {:padding-bottom 70}
-         :render-fn                      render-fn
-         :scroll-enabled                 @scroll-enabled?
-         :on-scroll                      on-scroll}])
+        {:key-fn                   :title
+         :sections                 (rf/sub [:contacts/filtered-active-sections])
+         :render-section-header-fn contact-list/contacts-section-header
+         :content-container-style  {:padding-bottom 70}
+         :render-fn                render-fn
+         :scroll-enabled           @scroll-enabled?
+         :on-scroll                on-scroll}])
      (when contacts-selected?
        [quo/button
         {:type                :primary

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -91,6 +91,7 @@
         contacts                          (rf/sub [:contacts/sorted-and-grouped-by-first-letter])
         selected-contacts-count           (rf/sub [:selected-contacts-count])
         selected-contacts                 (rf/sub [:group/selected-contacts])
+        customization-color               (rf/sub [:profile/customization-color])
         one-contact-selected?             (= selected-contacts-count 1)
         [has-error? set-has-error]        (rn/use-state false)
         render-fn                         (rn/use-callback (fn [item]
@@ -137,11 +138,12 @@
          :render-fn                render-fn
          :scroll-enabled           @scroll-enabled?
          :on-scroll                on-scroll}])
-     [rn/view
-      {:style (style/chat-button-container theme)}
-      (when contacts-selected?
+     (when contacts-selected?
+       [rn/view
+        {:style (style/chat-button-container theme)}
         [quo/button
          {:type                :primary
+          :customization-color customization-color
           :accessibility-label :next-button
           :on-press            (fn []
                                  (if one-contact-selected?
@@ -149,4 +151,4 @@
                                    (rf/dispatch [:navigate-to :new-group])))}
          (if one-contact-selected?
            (i18n/label :t/chat-with {:selected-user primary-name})
-           (i18n/label :t/setup-group-chat))])]]))
+           (i18n/label :t/setup-group-chat))]])]))

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -85,9 +85,10 @@
                                 :on-check on-toggle}}
      item]))
 
-(defn- view-internal
-  [{:keys [scroll-enabled? on-scroll close theme]}]
-  (let [contacts                          (rf/sub [:contacts/sorted-and-grouped-by-first-letter])
+(defn view
+  [{:keys [scroll-enabled? on-scroll close]}]
+  (let [theme                             (quo.theme/use-theme-value)
+        contacts                          (rf/sub [:contacts/sorted-and-grouped-by-first-letter])
         selected-contacts-count           (rf/sub [:selected-contacts-count])
         selected-contacts                 (rf/sub [:group/selected-contacts])
         one-contact-selected?             (= selected-contacts-count 1)
@@ -148,5 +149,3 @@
          (if one-contact-selected?
            (i18n/label :t/chat-with {:selected-user primary-name})
            (i18n/label :t/setup-group-chat))])]]))
-
-(def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -132,6 +132,7 @@
         {:key-fn                   :title
          :sections                 (rf/sub [:contacts/filtered-active-sections])
          :render-section-header-fn contact-list/contacts-section-header
+         :render-section-footer-fn contact-list/contacts-section-footer
          :content-container-style  {:padding-bottom 70}
          :render-fn                render-fn
          :scroll-enabled           @scroll-enabled?

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -2,7 +2,7 @@
   (:require
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
-    [quo.theme :as quo.theme]
+    [quo.theme]
     [re-frame.core :as re-frame]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -135,17 +135,18 @@
          :render-fn                render-fn
          :scroll-enabled           @scroll-enabled?
          :on-scroll                on-scroll}])
-     (when contacts-selected?
-       [quo/button
-        {:type                :primary
-         :accessibility-label :next-button
-         :container-style     style/chat-button
-         :on-press            (fn []
-                                (if one-contact-selected?
-                                  (rf/dispatch [:chat.ui/start-chat public-key])
-                                  (rf/dispatch [:navigate-to :new-group])))}
-        (if one-contact-selected?
-          (i18n/label :t/chat-with {:selected-user primary-name})
-          (i18n/label :t/setup-group-chat))])]))
+     [rn/view
+      {:style (style/chat-button-container theme)}
+      (when contacts-selected?
+        [quo/button
+         {:type                :primary
+          :accessibility-label :next-button
+          :on-press            (fn []
+                                 (if one-contact-selected?
+                                   (rf/dispatch [:chat.ui/start-chat public-key])
+                                   (rf/dispatch [:navigate-to :new-group])))}
+         (if one-contact-selected?
+           (i18n/label :t/chat-with {:selected-user primary-name})
+           (i18n/label :t/setup-group-chat))])]]))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -111,7 +111,9 @@
         {:weight :semi-bold
          :size   :heading-1
          :style  {:color (colors/theme-colors colors/neutral-100 colors/white theme)}}
-        (i18n/label :t/new-chat)]
+        (if (or (not contacts-selected?) one-contact-selected?)
+          (i18n/label :t/new-chat)
+          (i18n/label :t/new-group-chat))]
        (when (seq contacts)
          [quo/text
           {:size   :paragraph-2
@@ -127,7 +129,7 @@
        [no-contacts-view {:theme theme}]
        [gesture/section-list
         {:key-fn                         :title
-         :sticky-section-headers-enabled false
+         :sticky-section-headers-enabled true
          :sections                       (rf/sub [:contacts/filtered-active-sections])
          :render-section-header-fn       contact-list/contacts-section-header
          :content-container-style        {:padding-bottom 70}

--- a/src/status_im/contexts/chat/home/view.cljs
+++ b/src/status_im/contexts/chat/home/view.cljs
@@ -127,48 +127,42 @@
     :title       (i18n/label :t/invite-friends-to-status)
     :description (i18n/label :t/share-invite-link)}})
 
-(defn- f-view-internal
-  [{:keys [theme]}]
-  (let [scroll-ref     (atom nil)
-        set-scroll-ref #(reset! scroll-ref %)]
-    (fn []
-      (let [{:keys [universal-profile-url]} (rf/sub [:profile/profile])
-            customization-color             (rf/sub [:profile/customization-color])
-            pending-contact-requests        (rf/sub [:activity-center/pending-contact-requests])
-            selected-tab                    (or (rf/sub [:messages-home/selected-tab]) :tab/recent)
-            scroll-shared-value             (reanimated/use-shared-value 0)]
-        [:<>
-         (if (= selected-tab :tab/contacts)
-           [contacts
-            {:pending-contact-requests pending-contact-requests
-             :set-scroll-ref           set-scroll-ref
-             :scroll-shared-value      scroll-shared-value
-             :theme                    theme}]
-           [chats
-            {:selected-tab        selected-tab
-             :set-scroll-ref      set-scroll-ref
-             :scroll-shared-value scroll-shared-value
-             :theme               theme}])
-         [:f> common.banner/animated-banner
-          {:content             (banner-data universal-profile-url)
-           :customization-color customization-color
-           :scroll-ref          scroll-ref
-           :tabs                [{:id                  :tab/recent
-                                  :label               (i18n/label :t/recent)
-                                  :accessibility-label :tab-recent}
-                                 {:id                  :tab/groups
-                                  :label               (i18n/label :t/groups)
-                                  :accessibility-label :tab-groups}
-                                 {:id                  :tab/contacts
-                                  :label               (i18n/label :t/contacts)
-                                  :accessibility-label :tab-contacts
-                                  :notification-dot?   (pos? (count pending-contact-requests))}]
-           :selected-tab        selected-tab
-           :on-tab-change       (fn [tab] (rf/dispatch [:messages-home/select-tab tab]))
-           :scroll-shared-value scroll-shared-value}]]))))
-
-(defn- internal-chats-home-view
-  [params]
-  [:f> f-view-internal params])
-
-(def view (quo.theme/with-theme internal-chats-home-view))
+(defn view
+  []
+  (let [theme                           (quo.theme/use-theme-value)
+        scroll-ref                      (rn/use-ref-atom nil)
+        set-scroll-ref                  (rn/use-callback #(reset! scroll-ref %))
+        {:keys [universal-profile-url]} (rf/sub [:profile/profile])
+        customization-color             (rf/sub [:profile/customization-color])
+        pending-contact-requests        (rf/sub [:activity-center/pending-contact-requests])
+        selected-tab                    (or (rf/sub [:messages-home/selected-tab]) :tab/recent)
+        scroll-shared-value             (reanimated/use-shared-value 0)]
+    [:<>
+     (if (= selected-tab :tab/contacts)
+       [contacts
+        {:pending-contact-requests pending-contact-requests
+         :set-scroll-ref           set-scroll-ref
+         :scroll-shared-value      scroll-shared-value
+         :theme                    theme}]
+       [chats
+        {:selected-tab        selected-tab
+         :set-scroll-ref      set-scroll-ref
+         :scroll-shared-value scroll-shared-value
+         :theme               theme}])
+     [common.banner/animated-banner
+      {:content             (banner-data universal-profile-url)
+       :customization-color customization-color
+       :scroll-ref          scroll-ref
+       :tabs                [{:id                  :tab/recent
+                              :label               (i18n/label :t/recent)
+                              :accessibility-label :tab-recent}
+                             {:id                  :tab/groups
+                              :label               (i18n/label :t/groups)
+                              :accessibility-label :tab-groups}
+                             {:id                  :tab/contacts
+                              :label               (i18n/label :t/contacts)
+                              :accessibility-label :tab-contacts
+                              :notification-dot?   (pos? (count pending-contact-requests))}]
+       :selected-tab        selected-tab
+       :on-tab-change       (fn [tab] (rf/dispatch [:messages-home/select-tab tab]))
+       :scroll-shared-value scroll-shared-value}]]))

--- a/src/status_im/contexts/chat/home/view.cljs
+++ b/src/status_im/contexts/chat/home/view.cljs
@@ -106,6 +106,7 @@
         :sections                          items
         :sticky-section-headers-enabled    false
         :render-section-header-fn          contact-list/contacts-section-header
+        :render-section-footer-fn          contact-list/contacts-section-footer
         :render-fn                         (fn [data]
                                              (contact-item-render data theme))
         :scroll-event-throttle             8


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/18981
Fixes https://github.com/status-im/status-mobile/issues/19202

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
Polishes the new chat UI/Sheet
- Adds appropriate text based on if it is a group chat or 1:1 chat
- Implements sticky header for `gesture/section-list` which is implemented using `gesture/flat-list (Flatlist)` from `react-native-gesture-handler`
- Adds opacity layer around button

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- 1-1 chats
- group chats

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Go to chat tab
- Click the + button in the top right to start a new chat

status: ready 

![Polish New Chat](https://github.com/status-im/status-mobile/assets/45393944/cdcf9e6a-59ff-4547-8a75-84d04f4beee0)



