### PR TITLE
Fix drawer message according to desings

### DIFF
--- a/src/status_im/common/bottom_sheet/view.cljs
+++ b/src/status_im/common/bottom_sheet/view.cljs
@@ -70,12 +70,14 @@
         handle-sheet-height               (rn/use-callback (fn [e]
                                                              (when (= sheet-height 0)
                                                                (set-sheet-height
-                                                                (get-layout-height e)))))
+                                                                (get-layout-height e))))
+                                                           [sheet-height])
         [item-height set-item-height]     (rn/use-state 0)
         handle-item-height                (rn/use-callback (fn [e]
                                                              (when (= item-height 0)
                                                                (set-item-height
-                                                                (get-layout-height e)))))
+                                                                (get-layout-height e))))
+                                                           [item-height])
         {window-height :height}           (rn/get-window)
         bg-opacity                        (reanimated/use-shared-value 0)
         translate-y                       (reanimated/use-shared-value window-height)

--- a/src/status_im/contexts/chat/messenger/messages/content/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/style.cljs
@@ -33,5 +33,5 @@
                          1)})
 
 (def drawer-message-container
-  {:padding-horizontal 4
-   :padding-vertical   8})
+  {:padding-top    4
+   :padding-bottom 8})

--- a/src/status_im/contexts/chat/messenger/messages/content/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/style.cljs
@@ -31,3 +31,7 @@
    :opacity            (if (and outgoing (= outgoing-status :sending))
                          0.5
                          1)})
+
+(def drawer-message-container
+  {:padding-horizontal 4
+   :padding-vertical   8})

--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -77,11 +77,11 @@
 
 (defn system-message-contact-request
   [{:keys [chat-id timestamp-str from]} type]
-  (let [[primary-name _]     (rf/sub [:contacts/contact-two-names-by-identity chat-id])
-        contact              (rf/sub [:contacts/contact-by-address chat-id])
-        photo-path           (when (seq (:images contact)) (rf/sub [:chats/photo-path chat-id]))
-        customization-color  (rf/sub [:profile/customization-color])
-        {:keys [public-key]} (rf/sub [:profile/profile])]
+  (let [[primary-name _]    (rf/sub [:contacts/contact-two-names-by-identity chat-id])
+        contact             (rf/sub [:contacts/contact-by-address chat-id])
+        photo-path          (when (seq (:images contact)) (rf/sub [:chats/photo-path chat-id]))
+        customization-color (rf/sub [:profile/customization-color])
+        public-key          (rf/sub [:multiaccount/public-key])]
     [quo/system-message
      {:type                type
       :timestamp           timestamp-str
@@ -278,14 +278,14 @@
        (fn []
          [rn/view
           {:pointer-events :none
-           :padding-top    4}
+           :style          style/drawer-message-container}
           [user-message-content
-           {:message-data    message-data
-            :context         context
-            :keyboard-shown? keyboard-shown?
-            :show-reactions? true
-            :show-user-info? true
-            :preview?        true}]]))}]))
+           {:message-data                 message-data
+            :context                      context
+            :keyboard-shown?              keyboard-shown?
+            :show-user-info?              true
+            :in-reaction-and-action-menu? true
+            :preview?                     true}]]))}]))
 
 (defn system-message?
   [content-type]

--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -81,7 +81,7 @@
         contact             (rf/sub [:contacts/contact-by-address chat-id])
         photo-path          (when (seq (:images contact)) (rf/sub [:chats/photo-path chat-id]))
         customization-color (rf/sub [:profile/customization-color])
-        public-key          (rf/sub [:multiaccount/public-key])]
+        public-key          (rf/sub [:profile/public-key])]
     [quo/system-message
      {:type                type
       :timestamp           timestamp-str

--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -283,9 +283,9 @@
            {:message-data                 message-data
             :context                      context
             :keyboard-shown?              keyboard-shown?
-            :show-user-info?              true
             :in-reaction-and-action-menu? true
-            :preview?                     true}]]))}]))
+            :show-user-info?              false
+            :show-reactions?              true}]]))}]))
 
 (defn system-message?
   [content-type]

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -82,8 +82,16 @@
             :override-ring?  override-ring?
             :font-file       font-file}))}))))
 
+;; DEPRECATED
+;; use `:profile/public-key` instead
 (re-frame/reg-sub
  :multiaccount/public-key
+ :<- [:profile/profile]
+ (fn [{:keys [public-key]}]
+   public-key))
+
+(re-frame/reg-sub
+ :profile/public-key
  :<- [:profile/profile]
  (fn [{:keys [public-key]}]
    public-key))

--- a/src/status_im/subs/profile_test.cljs
+++ b/src/status_im/subs/profile_test.cljs
@@ -112,3 +112,9 @@
   (testing "returns the symbol of the user's selected currency"
     (swap! rf-db/app-db #(assoc % :profile/profile sample-profile))
     (is (match? "$" (rf/sub [sub-name])))))
+
+(h/deftest-sub :profile/public-key
+  [sub-name]
+  (testing "returns the user's public key"
+    (swap! rf-db/app-db #(assoc % :profile/profile sample-profile))
+    (is (match? (:public-key sample-profile) (rf/sub [sub-name])))))


### PR DESCRIPTION
fixes #19053
fixes #19164

### Summary

Fix issues with the message component when shown above the bottom sheet after long-press, based on the [design feedback](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=8065:58901&mode=design#645028150)

- fixed bottom-sheet not showing the selected-item
- fix spacings
- remove identicon
- remove emojis from message


### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Open chat
- Long press on a message

### Before and after screenshots comparison

<div style="display: flex; flex-direction: row">
<img src="https://github.com/status-im/status-mobile/assets/21865759/8442572c-d9ef-4d17-b63f-b1c1e46cc021" width=200 />
<img src="https://github.com/status-im/status-mobile/assets/21865759/26df20a7-5804-41ae-adbb-d5a7f0bdf153" width=200 />
</div>
status: ready <!-- Can be ready or wip -->
