### PR TITLE
fix: handle limit event

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -120,7 +120,6 @@
 
 (def ^:const min-password-length 6)
 (def ^:const max-group-chat-participants 20)
-(def ^:const max-group-chat-contacts (dec max-group-chat-participants))
 (def ^:const default-number-of-messages 20)
 (def ^:const default-number-of-pin-messages 3)
 

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -120,6 +120,7 @@
 
 (def ^:const min-password-length 6)
 (def ^:const max-group-chat-participants 20)
+(def ^:const max-group-chat-contacts (dec max-group-chat-participants))
 (def ^:const default-number-of-messages 20)
 (def ^:const default-number-of-pin-messages 3)
 

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -49,6 +49,8 @@
                                (rf/dispatch [:open-modal :new-contact]))}
       (i18n/label :t/add-a-contact)]]))
 
+(def ^:private max-group-chat-contacts (dec constants/max-group-chat-participants))
+
 (defn contact-item-render
   [_]
   (fn [{:keys [public-key] :as item}]
@@ -59,7 +61,7 @@
                                       user-selected?
                                       (re-frame/dispatch [:deselect-contact public-key])
                                       (do
-                                        (when (= constants/max-group-chat-contacts
+                                        (when (= max-group-chat-contacts
                                                  selected-contacts-count)
                                           (rf/dispatch
                                            [:toasts/upsert
@@ -67,7 +69,7 @@
                                              :type :negative
                                              :text (i18n/label :t/new-group-limit
                                                                {:max-contacts
-                                                                constants/max-group-chat-contacts})}]))
+                                                                max-group-chat-contacts})}]))
                                         (re-frame/dispatch [:select-contact public-key]))))]
       [contact-list-item/contact-list-item
        {:on-press                on-toggle
@@ -81,7 +83,7 @@
   [{:keys [scroll-enabled? on-scroll close theme]}]
   (let [contacts                          (rf/sub [:contacts/sorted-and-grouped-by-first-letter])
         selected-contacts-count           (rf/sub [:selected-contacts-count])
-        has-reached-max-contact           (> selected-contacts-count constants/max-group-chat-contacts)
+        has-reached-max-contact           (> selected-contacts-count max-group-chat-contacts)
         selected-contacts                 (rf/sub [:group/selected-contacts])
         one-contact-selected?             (= selected-contacts-count 1)
         contacts-selected?                (pos? selected-contacts-count)
@@ -111,7 +113,7 @@
                                      (colors/theme-colors colors/neutral-40 colors/neutral-50 theme))}}
           (i18n/label :t/selected-count-from-max
                       {:selected selected-contacts-count
-                       :max      constants/max-group-chat-contacts})])]]
+                       :max      max-group-chat-contacts})])]]
      (if (empty? contacts)
        [no-contacts-view {:theme theme}]
        [gesture/section-list

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -57,8 +57,7 @@
     (let [user-selected?          (rf/sub [:is-contact-selected? public-key])
           selected-contacts-count (rf/sub [:selected-contacts-count])
           on-toggle               (fn []
-                                    (if
-                                      user-selected?
+                                    (if user-selected?
                                       (re-frame/dispatch [:deselect-contact public-key])
                                       (do
                                         (when (= max-group-chat-contacts

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -56,16 +56,15 @@
   (let [selected-contacts-count (rf/sub [:selected-contacts-count])]
     (if user-selected?
       (re-frame/dispatch [:deselect-contact public-key])
-      (do
-        (when (= contacts-selection-limit
-                 selected-contacts-count)
-          (rf/dispatch
-           [:toasts/upsert
-            {:id   :remove-nickname
-             :type :negative
-             :text (i18n/label :t/new-group-limit
-                               {:max-contacts
-                                contacts-selection-limit})}]))
+      (if (= contacts-selection-limit
+             selected-contacts-count)
+        (rf/dispatch
+         [:toasts/upsert
+          {:id   :remove-nickname
+           :type :negative
+           :text (i18n/label :t/new-group-limit
+                             {:max-contacts
+                              contacts-selection-limit})}])
         (re-frame/dispatch [:select-contact public-key])))))
 
 (defn contact-item-render

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -49,7 +49,7 @@
                                (rf/dispatch [:open-modal :new-contact]))}
       (i18n/label :t/add-a-contact)]]))
 
-(def ^:private max-group-chat-contacts (dec constants/max-group-chat-participants))
+(def ^:private contacts-selection-limit (dec constants/max-group-chat-participants))
 
 (defn contact-item-render
   [_]
@@ -60,7 +60,7 @@
                                     (if user-selected?
                                       (re-frame/dispatch [:deselect-contact public-key])
                                       (do
-                                        (when (= max-group-chat-contacts
+                                        (when (= contacts-selection-limit
                                                  selected-contacts-count)
                                           (rf/dispatch
                                            [:toasts/upsert
@@ -68,7 +68,7 @@
                                              :type :negative
                                              :text (i18n/label :t/new-group-limit
                                                                {:max-contacts
-                                                                max-group-chat-contacts})}]))
+                                                                contacts-selection-limit})}]))
                                         (re-frame/dispatch [:select-contact public-key]))))]
       [contact-list-item/contact-list-item
        {:on-press                on-toggle
@@ -82,7 +82,7 @@
   [{:keys [scroll-enabled? on-scroll close theme]}]
   (let [contacts                          (rf/sub [:contacts/sorted-and-grouped-by-first-letter])
         selected-contacts-count           (rf/sub [:selected-contacts-count])
-        has-reached-max-contact           (> selected-contacts-count max-group-chat-contacts)
+        has-reached-max-contact           (> selected-contacts-count contacts-selection-limit)
         selected-contacts                 (rf/sub [:group/selected-contacts])
         one-contact-selected?             (= selected-contacts-count 1)
         contacts-selected?                (pos? selected-contacts-count)
@@ -112,7 +112,7 @@
                                      (colors/theme-colors colors/neutral-40 colors/neutral-50 theme))}}
           (i18n/label :t/selected-count-from-max
                       {:selected selected-contacts-count
-                       :max      max-group-chat-contacts})])]]
+                       :max      contacts-selection-limit})])]]
      (if (empty? contacts)
        [no-contacts-view {:theme theme}]
        [gesture/section-list

--- a/translations/en.json
+++ b/translations/en.json
@@ -1037,6 +1037,7 @@
     "new-contract": "New Contract",
     "new-group": "New group",
     "new-group-chat": "New group chat",
+    "new-group-limit": "You can only add {{max-contacts}} contacts to the group chat",
     "new-network": "New network",
     "new-pin-description": "Enter new 6-digit passcode",
     "new-puk-description": "Enter new 12-digit PUK",


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/18980

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
Handles the limit event when creating a new group chat
- Adds toast for when the limit is surpassed
- Adds new translation for group chat limit

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- 1-1 chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Go to chat tab
- Click the + button in the top right to start a new chat
- Add more than the limit of 19 contacts to raise the event

status: ready 


![max group contact reached ](https://github.com/status-im/status-mobile/assets/45393944/05d73f17-cff0-4ac0-b83d-04b902f26417)
[^Changed contact limit to 3 for demo purposes]
