### PR TITLE
Add status tag for pending contact request to contact profile

### DIFF
--- a/src/status_im/contexts/profile/contact/header/style.cljs
+++ b/src/status_im/contexts/profile/contact/header/style.cljs
@@ -15,3 +15,12 @@
    {:background-color   (colors/theme-colors colors/white colors/neutral-95 theme)
     :padding-horizontal 20
     :margin-top         margin-top}))
+
+(def status-tag-wrapper
+  {:flex-direction :row
+   :padding-top    12
+   :padding-right  12})
+
+(def header-top-wrapper
+  {:flex-direction  :row
+   :justify-content :space-between})

--- a/src/status_im/contexts/profile/contact/header/view.cljs
+++ b/src/status_im/contexts/profile/contact/header/view.cljs
@@ -4,14 +4,16 @@
             [quo.theme]
             [react-native.core :as rn]
             [status-im.common.scalable-avatar.view :as avatar]
+            [status-im.constants :as constants]
             [status-im.contexts.profile.contact.header.style :as style]
             [status-im.contexts.profile.utils :as profile.utils]
+            [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
 (defn view
   [{:keys [scroll-y]}]
   (let [{:keys [public-key customization-color
-                emoji-hash bio]
+                emoji-hash bio contact-request-state]
          :as   profile}     (rf/sub [:contacts/current-contact])
         customization-color (or customization-color :blue)
         full-name           (profile.utils/displayed-name profile)
@@ -19,14 +21,21 @@
         online?             (rf/sub [:visibility-status-updates/online? public-key])
         theme               (quo.theme/use-theme-value)]
     [rn/view {:style style/header-container}
-     [rn/view {:style style/avatar-wrapper}
-      [avatar/view
-       {:scroll-y            scroll-y
-        :full-name           full-name
-        :online?             online?
-        :profile-picture     profile-picture
-        :border-color        (colors/theme-colors colors/white colors/neutral-95 theme)
-        :customization-color customization-color}]]
+     [rn/view {:style style/header-top-wrapper}
+      [rn/view {:style style/avatar-wrapper}
+       [avatar/view
+        {:scroll-y            scroll-y
+         :full-name           full-name
+         :online?             online?
+         :profile-picture     profile-picture
+         :border-color        (colors/theme-colors colors/white colors/neutral-95 theme)
+         :customization-color customization-color}]]
+      (when (= contact-request-state constants/contact-request-state-sent)
+        [rn/view {:style style/status-tag-wrapper}
+         [quo/status-tag
+          {:label  (i18n/label :t/contact-profile-request-pending)
+           :status {:type :pending}
+           :size   :large}]])]
      [quo/page-top
       {:title            full-name
        :description      :text

--- a/translations/en.json
+++ b/translations/en.json
@@ -2116,6 +2116,7 @@
     "selected-count-from-max": "{{selected}}/{{max}}",
     "online": "Online",
     "contact-request-chat-pending": "Your contact request is pending",
+    "contact-profile-request-pending": "Contact request pending",
     "contact-request-chat-add": "Add {{name}} as contact to send a message",
     "join-request": "Join request",
     "join-one-user": "Join {{user}}",


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19035 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR attempts to add a status-tag for representing a pending contact request on the contact profile. Note, that this PR does not hide the "Send contact request" button. This separation of functionality is to avoid some conflicts with this PR #19039, which will be responsible for hiding the "Send contact request" button after sending a contact request.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- New Contact Profiles

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open the Status mobile and desktop app
- Ensure the profile `new-contact-ui` feature flag is disabled on mobile
- Send a contact request from mobile user to desktop user
- Enable the profile `new-contact-ui` feature flag on mobile
- View the Status desktop profile as a contact from the mobile app

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before

https://github.com/status-im/status-mobile/assets/2845768/72029c4d-392d-4810-ab4c-96f8e5c3f199

#### After

https://github.com/status-im/status-mobile/assets/2845768/f2cc64aa-3883-40d0-b051-64835a4f2675

status: ready
