### PR TITLE
fix the mention highlighted area is only updated after reopening the chat

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/content/text/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/text/style.cljs
@@ -14,18 +14,18 @@
 
 (defn mention-tag-wrapper
   [first-child-mention]
-  {:flex-direction     :row
-   :align-items        :center
-   :height             (if platform/ios? 22 21)
-   :background-color   colors/primary-50-opa-10
-   :padding-horizontal 3
-   :border-radius      6
-   :transform          [{:translateY (if platform/ios? (if first-child-mention 4.5 3) 4.5)}]})
+  {:flex-direction :row
+   :align-items    :center
+   :height         (if platform/ios? 22 21)
+   :border-radius  6
+   :transform      [{:translateY (if platform/ios? (if first-child-mention 4.5 3) 4.5)}]})
 
 (def mention-tag-text
   {:color                 (colors/theme-colors colors/primary-50
                                                colors/primary-60)
    :selection-color       :transparent
+   :background-color      colors/primary-50-opa-10
+   :padding-horizontal    3
    :suppress-highlighting true})
 
 (defn code

--- a/src/status_im/contexts/chat/messenger/messages/content/text/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/text/view.cljs
@@ -56,14 +56,16 @@
       :mention
       (conj
        units
-       [rn/pressable
-        {:on-press #(rf/dispatch [:chat.ui/show-profile literal])
-         :style    (style/mention-tag-wrapper first-child-mention)}
-        [quo/text
-         {:weight :medium
-          :style  style/mention-tag-text
-          :size   :paragraph-1}
-         (rf/sub [:messages/resolve-mention literal])]])
+       (let [resolved-mention (rf/sub [:messages/resolve-mention literal])]
+         [rn/pressable
+          {:on-press #(rf/dispatch [:chat.ui/show-profile literal])
+           :key      resolved-mention
+           :style    (style/mention-tag-wrapper first-child-mention)}
+          [quo/text
+           {:weight :medium
+            :style  style/mention-tag-text
+            :size   :paragraph-1}
+           resolved-mention]]))
 
       :edited
       (conj units


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/18432

status: ready