### PR TITLE
fix multiple set view-id events dispatched

### DIFF
--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -21,6 +21,7 @@
     [status-im.contexts.profile.push-notifications.events :as notifications]
     [status-im.contexts.shell.jump-to.state :as shell.state]
     [status-im.contexts.shell.jump-to.utils :as shell.utils]
+    [status-im.navigation.core :as navigation]
     status-im.contexts.wallet.signals
     status-im.events
     status-im.navigation.core
@@ -44,7 +45,7 @@
 
 (defn init
   []
-
+  (navigation/init)
   (native-module/init #(re-frame/dispatch [:signals/signal-received %]))
   (when platform/android?
     (native-module/set-soft-input-mode adjust-resize))

--- a/src/status_im/navigation/core.cljs
+++ b/src/status_im/navigation/core.cljs
@@ -11,86 +11,88 @@
     [status-im.navigation.view :as views]
     [utils.re-frame :as rf]))
 
-(navigation/set-lazy-component-registrator
- (fn [screen-key]
-   (let [screen (views/screen screen-key)]
-     (navigation/register-component screen-key
-                                    (fn [] (gesture/gesture-handler-root-hoc screen))
-                                    (fn [] screen)))))
+(defn init
+  []
+  (navigation/set-lazy-component-registrator
+   (fn [screen-key]
+     (let [screen (views/screen screen-key)]
+       (navigation/register-component screen-key
+                                      (fn [] (gesture/gesture-handler-root-hoc screen))
+                                      (fn [] screen)))))
 
-;; APP LAUNCHED
-(navigation/reg-app-launched-listener
- (fn []
-   (navigation/set-default-options options/default-options)
-   (reset! state/curr-modal false)
-   (reset! state/dissmissing false)
-   (re-frame/dispatch [:bottom-sheet-hidden])
-   (if (= @state/root-id :multiaccounts-stack)
-     (re-frame/dispatch-sync [:set-multiaccount-root])
-     (when @state/root-id
-       (reset! theme/device-theme (rn/get-color-scheme))
-       (re-frame/dispatch [:init-root @state/root-id])
-       (re-frame/dispatch [:chat/check-last-chat])))
-   (rn/hide-splash-screen)))
-
-(navigation/reg-component-did-appear-listener
- (fn [view-id]
-   (when (get views/screens view-id)
-     ;;NOTE when back from the background on Android, this event happens for all screens, but we
-     ;;need only for active one
-     (when (and @state/curr-modal (= @state/curr-modal view-id))
-       (effects/set-view-id view-id))
-     (when-not @state/curr-modal
-       (effects/set-view-id view-id)
-       (reset! state/pushed-screen-id view-id)))))
-
-;;;; Modal
-
-(navigation/reg-button-pressed-listener
- (fn [id]
-   (if (= "dismiss-modal" id)
-     (do
-       (when-let [event (get-in views/screens [(last @state/modals) :on-dissmiss])]
-         (rf/dispatch event))
-       (effects/dismiss-modal))
-     (when-let [handler (get-in views/screens [(keyword id) :right-handler])]
-       (handler)))))
-
-(navigation/reg-modal-dismissed-listener
- (fn []
-   (if (> (count @state/modals) 1)
-     (let [new-modals (butlast @state/modals)]
-       (reset! state/modals (vec new-modals))
-       (effects/set-view-id (last new-modals)))
-     (do
-       (reset! state/modals [])
-       (reset! state/curr-modal false)
-       (effects/set-view-id @state/pushed-screen-id)))
-
-   (let [component @state/dissmissing]
+  ;; APP LAUNCHED
+  (navigation/reg-app-launched-listener
+   (fn []
+     (navigation/set-default-options options/default-options)
+     (reset! state/curr-modal false)
      (reset! state/dissmissing false)
-     (when (keyword? component)
-       (effects/open-modal component)))))
+     (re-frame/dispatch [:bottom-sheet-hidden])
+     (if (= @state/root-id :multiaccounts-stack)
+       (re-frame/dispatch-sync [:set-multiaccount-root])
+       (when @state/root-id
+         (reset! theme/device-theme (rn/get-color-scheme))
+         (re-frame/dispatch [:init-root @state/root-id])
+         (re-frame/dispatch [:chat/check-last-chat])))
+     (rn/hide-splash-screen)))
 
-;;;; Toast
+  (navigation/reg-component-did-appear-listener
+   (fn [view-id]
+     (when (get views/screens view-id)
+       ;;NOTE when back from the background on Android, this event happens for all screens, but we
+       ;;need only for active one
+       (when (and @state/curr-modal (= @state/curr-modal view-id))
+         (effects/set-view-id view-id))
+       (when-not @state/curr-modal
+         (effects/set-view-id view-id)
+         (reset! state/pushed-screen-id view-id)))))
 
-(navigation/register-component
- "toasts"
- ; `:flex 0` is the same as `flex: 0 0 auto` in CSS.
- ; We need this to override the HOC default layout which is
- ; flex 1. If we don't override this property, this HOC
- ; will catch all touches/gestures while the toast is shown,
- ; preventing the user doing any action in the app
- #(gesture/gesture-handler-root-hoc views/toasts
-                                    #js {:flex 0})
- (fn [] views/toasts))
+  ;;;; Modal
 
-;;;; Bottom sheet
+  (navigation/reg-button-pressed-listener
+   (fn [id]
+     (if (= "dismiss-modal" id)
+       (do
+         (when-let [event (get-in views/screens [(last @state/modals) :on-dissmiss])]
+           (rf/dispatch event))
+         (effects/dismiss-modal))
+       (when-let [handler (get-in views/screens [(keyword id) :right-handler])]
+         (handler)))))
 
-(navigation/register-component
- "bottom-sheet"
- (fn [] (gesture/gesture-handler-root-hoc views/bottom-sheet))
- (fn [] views/bottom-sheet))
+  (navigation/reg-modal-dismissed-listener
+   (fn []
+     (if (> (count @state/modals) 1)
+       (let [new-modals (butlast @state/modals)]
+         (reset! state/modals (vec new-modals))
+         (effects/set-view-id (last new-modals)))
+       (do
+         (reset! state/modals [])
+         (reset! state/curr-modal false)
+         (effects/set-view-id @state/pushed-screen-id)))
+
+     (let [component @state/dissmissing]
+       (reset! state/dissmissing false)
+       (when (keyword? component)
+         (effects/open-modal component)))))
+
+  ;;;; Toast
+
+  (navigation/register-component
+   "toasts"
+   ; `:flex 0` is the same as `flex: 0 0 auto` in CSS.
+   ; We need this to override the HOC default layout which is
+   ; flex 1. If we don't override this property, this HOC
+   ; will catch all touches/gestures while the toast is shown,
+   ; preventing the user doing any action in the app
+   #(gesture/gesture-handler-root-hoc views/toasts
+                                      #js {:flex 0})
+   (fn [] views/toasts))
+
+  ;;;; Bottom sheet
+
+  (navigation/register-component
+   "bottom-sheet"
+   (fn [] (gesture/gesture-handler-root-hoc views/bottom-sheet))
+   (fn [] views/bottom-sheet)))
 
 ;; LEGACY (should be removed in status 2.0)
 

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -129,12 +129,11 @@
 
 (defn open-modal
   [component]
-  (let [{:keys [options name]} (get views/screens component)
-        sheet?                 (:sheet? options)]
+  (let [{:keys [options]} (get views/screens component)
+        sheet?            (:sheet? options)]
     (if @state/dissmissing
       (reset! state/dissmissing component)
       (do
-        (set-view-id name) ; TODO https://github.com/status-im/status-mobile/issues/18811
         (reset! state/curr-modal true)
         (swap! state/modals conj component)
         (navigation/show-modal


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/18811

related to: https://discord.com/channels/1103692771585433630/1103692773363810317/1212833784869683300 (@flexsurfer)
> after navigating to screen there are set-view-id :shell-stack events twice

Every time app reloaded, `reg-modal-dismissed-listener` was being called and was behaving strange and firing set-view-id event multiple times (same times the app refreshed). Issue was in debug only.

@ibrkhalil Thank you for [reporting](https://github.com/status-im/status-mobile/pull/18785#discussion_r1487418159) wrong view-id for settings screen. Most probably this was caused by this same bug, where we are getting set-view-id being called multiple times and leading to wrong value. I checked Android and its working now. If you have access to IOS, please let me know if its right for you too. Thank you

### Testing
No manual testing is required for the PR. 

status: ready


