### PR TITLE
fix status and nav bar color

### DIFF
--- a/src/status_im/common/alert_banner/events.cljs
+++ b/src/status_im/common/alert_banner/events.cljs
@@ -7,7 +7,7 @@
         db                    (assoc-in db [:alert-banners (:type banner)] banner)]
     (cond-> {:db db}
       (zero? current-banners-count)
-      (assoc :show-alert-banner nil))))
+      (assoc :show-alert-banner (:view-id db)))))
 
 (defn remove-alert-banner
   [{:keys [db]} [banner-type]]
@@ -15,12 +15,12 @@
         new-count (count (get db :alert-banners))]
     (cond-> {:db db}
       (zero? new-count)
-      (assoc :hide-alert-banner nil))))
+      (assoc :hide-alert-banner (:view-id db)))))
 
 (defn remove-all-alert-banners
   [{:keys [db]}]
   {:db                (dissoc db :alert-banners)
-   :hide-alert-banner nil})
+   :hide-alert-banner (:view-id db)})
 
 (re-frame/reg-event-fx :alert-banners/add add-alert-banner)
 (re-frame/reg-event-fx :alert-banners/remove remove-alert-banner)

--- a/src/status_im/common/toasts/events.cljs
+++ b/src/status_im/common/toasts/events.cljs
@@ -19,7 +19,7 @@
                      (update :toasts dissoc :hide-toasts-timer-set))}
 
       (and (not update?) (= (count ordered) 1))
-      (assoc :show-toasts [])
+      (assoc :show-toasts (:view-id db))
 
       (not (:id opts))
       (update-in [:db :toasts :next-toast-number] inc))))
@@ -28,8 +28,9 @@
   {:events [:toasts/hide-with-check]}
   [{:keys [db]}]
   (when (get-in db [:toasts :hide-toasts-timer-set])
-    {:db          (update db :toasts dissoc :hide-toasts-timer-set)
-     :hide-toasts nil}))
+    {:db                         (update db :toasts dissoc :hide-toasts-timer-set)
+     :hide-toasts                nil
+     :reload-status-nav-color-fx (:view-id db)}))
 
 (rf/defn close
   {:events [:toasts/close]}

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -78,7 +78,7 @@
 
                   :else
                   [[:profile.settings/switch-theme-fx
-                    [(or (get-in db [:profile/profile :appearance])
+                    [(or (:appearance settings)
                          constants/theme-type-dark)
                      :shell-stack
                      false]]

--- a/src/status_im/contexts/profile/settings/effects.cljs
+++ b/src/status_im/contexts/profile/settings/effects.cljs
@@ -1,12 +1,11 @@
 (ns status-im.contexts.profile.settings.effects
   (:require [native-module.core :as native-module]
-            [quo.foundations.colors :as colors]
             [re-frame.core :as re-frame]
             [react-native.platform :as platform]
             [status-im.common.theme.core :as theme]
             [status-im.constants :as constants]
-            [status-im.contexts.shell.jump-to.utils :as shell.utils]
-            [status-im.setup.hot-reload :as hot-reload]))
+            [status-im.setup.hot-reload :as hot-reload]
+            [utils.re-frame :as rf]))
 
 (re-frame/reg-fx
  :profile.settings/blank-preview-flag-changed
@@ -22,19 +21,14 @@
 (re-frame/reg-fx
  :profile.settings/switch-theme-fx
  (fn [[theme-type view-id reload-ui?]]
-   (let [[theme status-bar-theme nav-bar-color]
-         ;; Status bar theme represents status bar icons colors, so opposite to app theme
-         (if (or (= theme-type constants/theme-type-dark)
-                 (and (= theme-type constants/theme-type-system)
-                      (theme/device-theme-dark?)))
-           [:dark :light colors/neutral-100]
-           [:light :dark colors/white])]
+   (let [theme (if (or (= theme-type constants/theme-type-dark)
+                       (and (= theme-type constants/theme-type-system)
+                            (theme/device-theme-dark?)))
+                 :dark
+                 :light)]
      (theme/set-theme theme)
-     (re-frame/dispatch [:change-shell-status-bar-style
-                         (if (shell.utils/home-stack-open?) status-bar-theme :light)])
+     (rf/dispatch [:reload-status-nav-color view-id])
      (when reload-ui?
        (re-frame/dispatch [:dismiss-all-overlays])
        (when js/goog.DEBUG
-         (hot-reload/reload))
-       (when-not (= view-id :shell-stack)
-         (re-frame/dispatch [:change-shell-nav-bar-color nav-bar-color]))))))
+         (hot-reload/reload))))))

--- a/src/status_im/contexts/shell/jump_to/animation.cljs
+++ b/src/status_im/contexts/shell/jump_to/animation.cljs
@@ -14,9 +14,7 @@
     (reanimated/set-shared-value (:home-stack-state @state/shared-values-atom) home-stack-state-value)
     (utils/change-selected-stack-id stack-id true home-stack-state-value)
     (js/setTimeout
-     (fn []
-       (utils/load-stack stack-id)
-       (utils/change-shell-status-bar-style))
+     #(utils/load-stack stack-id)
      (if animate? shell.constants/shell-animation-time 0))))
 
 (defn change-tab
@@ -41,7 +39,6 @@
     (reanimated/set-shared-value (:animate-home-stack-left @state/shared-values-atom) true)
     (reanimated/set-shared-value (:home-stack-state @state/shared-values-atom) home-stack-state-value)
     (utils/change-selected-stack-id stack-id true home-stack-state-value)
-    (utils/change-shell-status-bar-style)
     (when animate? (utils/update-view-id (or stack-id :shell)))))
 
 ;;;; Floating Screen

--- a/src/status_im/contexts/shell/jump_to/events.cljs
+++ b/src/status_im/contexts/shell/jump_to/events.cljs
@@ -108,16 +108,6 @@
      :dispatch [:set-view-id :shell]
      :effects.shell/navigate-to-jump-to nil}))
 
-(rf/defn change-shell-status-bar-style
-  {:events [:change-shell-status-bar-style]}
-  [_ style]
-  {:merge-options {:id "shell-stack" :options {:statusBar {:style style}}}})
-
-(rf/defn change-shell-nav-bar-color
-  {:events [:change-shell-nav-bar-color]}
-  [_ color]
-  {:merge-options {:id "shell-stack" :options {:navigationBar {:backgroundColor color}}}})
-
 (rf/defn shell-navigate-to
   {:events [:shell/navigate-to]}
   [{:keys [db now]} go-to-view-id screen-params animation hidden-screen?]

--- a/src/status_im/contexts/shell/jump_to/utils.cljs
+++ b/src/status_im/contexts/shell/jump_to/utils.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.shell.jump-to.utils
   (:require
-    [quo.theme :as quo.theme]
     [react-native.async-storage :as async-storage]
     [react-native.core :as rn]
     [react-native.platform :as platform]
@@ -136,12 +135,3 @@
 (defn update-view-id
   [view-id]
   (rf/dispatch [:set-view-id view-id]))
-
-;;; Misc
-(defn change-shell-status-bar-style
-  []
-  (rf/dispatch [:change-shell-status-bar-style
-                (if (or (= :dark (quo.theme/get-theme))
-                        (not (home-stack-open?)))
-                  :light
-                  :dark)]))

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -101,8 +101,9 @@
   (let [{:keys [sheets]} (:bottom-sheet db)
         rest-sheets      (butlast sheets)]
     (merge
-     {:db                (assoc db :bottom-sheet {:sheets rest-sheets :hide? false})
-      :hide-bottom-sheet nil}
+     {:db                         (assoc db :bottom-sheet {:sheets rest-sheets :hide? false})
+      :hide-bottom-sheet          nil
+      :reload-status-nav-color-fx (:view-id db)}
      (when (seq rest-sheets)
        {:dispatch [:show-next-bottom-sheet]}))))
 
@@ -134,7 +135,11 @@
 (rf/defn set-view-id
   {:events [:set-view-id]}
   [{:keys [db]} view-id]
-  (when-not (= view-id (:view-id db))
-    (let [view-id (if (= view-id :shell-stack) (shell.utils/calculate-view-id) view-id)]
-      {:db             (assoc db :view-id view-id)
-       :set-view-id-fx view-id})))
+  (let [view-id (if (= view-id :shell-stack) (shell.utils/calculate-view-id) view-id)]
+    {:db             (assoc db :view-id view-id)
+     :set-view-id-fx view-id}))
+
+(rf/defn reload-status-nav-color
+  {:events [:reload-status-nav-color]}
+  [{:keys [db]} view-id]
+  {:reload-status-nav-color-fx (or view-id (:view-id db))})

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -451,11 +451,7 @@
      :component settings-password/view}]
 
    [{:name    :shell
-     :options {:theme :dark}}
-    {:name :communities-stack}
-    {:name :chats-stack}
-    {:name :wallet-stack}
-    {:name :browser-stack}]
+     :options {:theme :dark}}]
 
    (when js/goog.DEBUG
      [{:name      :dev-component-preview

--- a/src/status_im/navigation/state.cljs
+++ b/src/status_im/navigation/state.cljs
@@ -4,6 +4,7 @@
 (defonce root-id (atom nil))
 (defonce modals (atom []))
 (defonce dissmissing (atom false))
+(defonce alert-banner-shown? (atom false))
 
 (defonce ^:private navigation-state (atom []))
 


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19072
fixes https://github.com/status-im/status-mobile/issues/19367
fixes https://github.com/status-im/status-mobile/issues/19366

### Summary & Testing Notes:

### What we are trying to fix
#### Android Navigation Bar
- For every light theme screen, the navigation bar should be light
- For every dark theme screen, the navigation bar should be dark
- For every light-themed bottom sheet, the navigation bar should be light
- For the home screen, the navigation bar should always be dark, due to the bottom tabs - check out bug video for reference https://github.com/status-im/status-mobile/issues/19072#issue-2163114567

#### For Status Bar
- For every light theme screen, the status bar should be dark
- For every dark theme screen, the status bar should be light
- When alert banners are visible, the status bar should be always light, no matter the screen
- Toasts should not break the status bar, as shown in https://github.com/status-im/status-mobile/issues/19072#issuecomment-1997484152


### Known Issues
- IOS - We are not able to change the iOS status bar theme color using the React native navigation library. So once theme is changed, app will still show old status color until relogin. In this PR we instead use the status bar api provided by react native itself. It works in the simulator, but not in iPhone 12. So it might or might not work on some/all devices. We can't fix this but please still let me know which is the case.
- Android - After login, the app theme should work as explained above. But as explained in https://github.com/status-im/status-mobile/pull/15596, the status bar theme that is provided at the time of logging in has high priority, and when we do operations like closing modal or going in the background, etc It reverts to that original status bar theme. Still, if you navigate to a different bottom tab or screen, it should fix itself. So PR partially fixes https://github.com/status-im/status-mobile/issues/19367

So basically, we can't fix the status bar color completely due to technical limitations. But PR should improve it and it should be better than develop. Please let me know if this is not the case.


status: ready