### PR TITLE
Fix chat navigation buttons when scrolling to top

### DIFF
--- a/src/js/worklets/chat/messenger/messages.js
+++ b/src/js/worklets/chat/messenger/messages.js
@@ -1,4 +1,5 @@
-import { withTiming, runOnJS } from 'react-native-reanimated';
+import { useAnimatedReaction, withTiming, runOnJS } from 'react-native-reanimated';
+import { useState } from "react"
 
 export function messagesListOnScroll(distanceFromListTop, chatListScrollY, callback) {
   return function (event) {
@@ -11,4 +12,18 @@ export function messagesListOnScroll(distanceFromListTop, chatListScrollY, callb
     chatListScrollY.value = currentY;
     runOnJS(callback)(layoutHeight, newDistance);
   };
+}
+
+export function useMessagesScrolledToTop(distanceFromListTop, threshold) {
+    const [scrolledToTop, setScrolledToTop] = useState(false)
+
+    useAnimatedReaction(function () {
+	return distanceFromListTop.value <= threshold;
+    }, function (current, previous) {
+	if(current !== previous && current !== scrolledToTop) {
+	    runOnJS(setScrolledToTop)(current)
+	}
+    }, [scrolledToTop])
+
+    return scrolledToTop
 }

--- a/src/js/worklets/chat/messenger/messages.js
+++ b/src/js/worklets/chat/messenger/messages.js
@@ -14,16 +14,16 @@ export function messagesListOnScroll(distanceFromListTop, chatListScrollY, callb
   };
 }
 
-export function useMessagesScrolledToTop(distanceFromListTop, threshold) {
-    const [scrolledToTop, setScrolledToTop] = useState(false)
+export function useMessagesScrolledToThreshold(distanceFromListTop, threshold) {
+    const [scrolledToThreshold, setScrolledToThreshold] = useState(false)
 
     useAnimatedReaction(function () {
 	return distanceFromListTop.value <= threshold;
     }, function (current, previous) {
-	if(current !== previous && current !== scrolledToTop) {
-	    runOnJS(setScrolledToTop)(current)
+	if(current !== previous && current !== scrolledToThreshold) {
+	    runOnJS(setScrolledToThreshold)(current)
 	}
-    }, [scrolledToTop])
+    }, [scrolledToThreshold])
 
-    return scrolledToTop
+    return scrolledToThreshold
 }

--- a/src/js/worklets/chat/messenger/messages.js
+++ b/src/js/worklets/chat/messenger/messages.js
@@ -19,8 +19,8 @@ export function useMessagesScrolledToThreshold(distanceFromListTop, threshold) {
 
     useAnimatedReaction(function () {
 	return distanceFromListTop.value <= threshold;
-    }, function (current, previous) {
-	if(current !== previous && current !== scrolledToThreshold) {
+    }, function (current) {
+	if(current !== scrolledToThreshold) {
 	    runOnJS(setScrolledToThreshold)(current)
 	}
     }, [scrolledToThreshold])

--- a/src/js/worklets/chat/messenger/navigation.js
+++ b/src/js/worklets/chat/messenger/navigation.js
@@ -19,6 +19,13 @@ export function navigationHeaderPosition(distanceFromListTop, isAllLoaded, topBa
   });
 }
 
+export function navigationButtonsCompleteOpacity(isCalculationComplete) {
+    return useDerivedValue(function () {
+	'worklet'
+	return isCalculationComplete.value ? withTiming(1) : 0
+    })
+}
+
 export function interpolateNavigationViewOpacity(props) {
   return useDerivedValue(function () {
     'worklet';

--- a/src/status_im/contexts/chat/messenger/messages/navigation/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/navigation/style.cljs
@@ -32,6 +32,12 @@
    :height             top-bar-height
    :align-items        :center})
 
+(defn button-animation-container
+  [opacity-value]
+  (reanimated/apply-animations-to-style
+   {:opacity opacity-value}
+   {}))
+
 ;;;; Content
 
 (defn header-content-container

--- a/src/status_im/contexts/chat/messenger/messages/navigation/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/navigation/view.cljs
@@ -112,10 +112,10 @@
         top-insets                           (safe-area/get-top)
         top-bar-height                       messages.constants/top-bar-height
         navigation-view-height               (+ top-bar-height top-insets)
-        reached-top?                         (messages.worklets/use-messages-scrolled-to-top
+        reached-threshold?                   (messages.worklets/use-messages-scrolled-to-threshold
                                               distance-from-list-top
                                               top-bar-height)
-        button-background                    (if reached-top? :photo :blur)]
+        button-background                    (if reached-threshold? :photo :blur)]
     (rn/use-effect (fn [] (reanimated/set-shared-value all-loaded? all-loaded-sub))
                    [all-loaded-sub])
     [rn/view

--- a/src/status_im/contexts/chat/messenger/messages/navigation/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/navigation/view.cljs
@@ -112,6 +112,8 @@
         top-insets                           (safe-area/get-top)
         top-bar-height                       messages.constants/top-bar-height
         navigation-view-height               (+ top-bar-height top-insets)
+        navigation-buttons-opacity           (worklets/navigation-buttons-complete-opacity
+                                              chat-screen-layout-calculations-complete?)
         reached-threshold?                   (messages.worklets/use-messages-scrolled-to-threshold
                                               distance-from-list-top
                                               top-bar-height)
@@ -126,27 +128,29 @@
        :distance-from-list-top distance-from-list-top
        :all-loaded?            all-loaded?}]
      [rn/view {:style (style/header-container top-insets top-bar-height)}
-      [quo/button
-       {:icon-only?          true
-        :type                :grey
-        :background          button-background
-        :size                32
-        :accessibility-label :back-button
-        :on-press            #(rf/dispatch [:navigate-back])}
-       (if (= chat-type constants/community-chat-type) :i/arrow-left :i/close)]
+      [reanimated/view {:style (style/button-animation-container navigation-buttons-opacity)}
+       [quo/button
+        {:icon-only?          true
+         :type                :grey
+         :background          button-background
+         :size                32
+         :accessibility-label :back-button
+         :on-press            #(rf/dispatch [:navigate-back])}
+        (if (= chat-type constants/community-chat-type) :i/arrow-left :i/close)]]
       [:f> f-header-content-container
        {:chat                                      chat
         :distance-from-list-top                    distance-from-list-top
         :all-loaded?                               all-loaded?
         :chat-screen-layout-calculations-complete? chat-screen-layout-calculations-complete?}]
-      [quo/button
-       {:icon-only?          true
-        :type                :grey
-        :background          button-background
-        :size                32
-        :accessibility-label :options-button
-        :on-press            (fn []
-                               (rf/dispatch [:dismiss-keyboard])
-                               (rf/dispatch [:show-bottom-sheet
-                                             {:content (fn [] [actions/chat-actions chat true])}]))}
-       :i/options]]]))
+      [reanimated/view {:style (style/button-animation-container navigation-buttons-opacity)}
+       [quo/button
+        {:icon-only?          true
+         :type                :grey
+         :background          button-background
+         :size                32
+         :accessibility-label :options-button
+         :on-press            (fn []
+                                (rf/dispatch [:dismiss-keyboard])
+                                (rf/dispatch [:show-bottom-sheet
+                                              {:content (fn [] [actions/chat-actions chat true])}]))}
+        :i/options]]]]))

--- a/src/status_im/contexts/chat/messenger/messages/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/view.cljs
@@ -24,7 +24,7 @@
     [rn/keyboard-avoiding-view
      {:style                    style/keyboard-avoiding-container
       :keyboard-vertical-offset (- (:bottom insets))}
-     [:f> messages.navigation/f-view
+     [messages.navigation/view
       {:distance-from-list-top                    distance-from-list-top
        :chat-screen-layout-calculations-complete? chat-screen-layout-calculations-complete?}]
      [:f> list.view/f-messages-list-content

--- a/src/utils/worklets/chat/messenger/messages.cljs
+++ b/src/utils/worklets/chat/messenger/messages.cljs
@@ -6,8 +6,6 @@
   [distance-from-list-top chat-list-scroll-y callback]
   (.messagesListOnScroll ^js worklets distance-from-list-top chat-list-scroll-y callback))
 
-(defn use-messages-scrolled-to-top
-  "Returns true if `distance-from-list-top` (animated value) crossed the threshold.
-  e.g. reaching the very top would need a threshold of `0`"
+(defn use-messages-scrolled-to-threshold
   [distance-from-list-top threshold]
-  (.useMessagesScrolledToTop ^js worklets distance-from-list-top threshold))
+  (.useMessagesScrolledToThreshold ^js worklets distance-from-list-top threshold))

--- a/src/utils/worklets/chat/messenger/messages.cljs
+++ b/src/utils/worklets/chat/messenger/messages.cljs
@@ -5,3 +5,9 @@
 (defn messages-list-on-scroll
   [distance-from-list-top chat-list-scroll-y callback]
   (.messagesListOnScroll ^js worklets distance-from-list-top chat-list-scroll-y callback))
+
+(defn use-messages-scrolled-to-top
+  "Returns true if `distance-from-list-top` (animated value) crossed the threshold.
+  e.g. reaching the very top would need a threshold of `0`"
+  [distance-from-list-top threshold]
+  (.useMessagesScrolledToTop ^js worklets distance-from-list-top threshold))

--- a/src/utils/worklets/chat/messenger/messages.cljs
+++ b/src/utils/worklets/chat/messenger/messages.cljs
@@ -8,4 +8,6 @@
 
 (defn use-messages-scrolled-to-threshold
   [distance-from-list-top threshold]
-  (.useMessagesScrolledToThreshold ^js worklets distance-from-list-top threshold))
+  (.useMessagesScrolledToThreshold ^js worklets
+                                   distance-from-list-top
+                                   threshold))

--- a/src/utils/worklets/chat/messenger/navigation.cljs
+++ b/src/utils/worklets/chat/messenger/navigation.cljs
@@ -18,6 +18,10 @@
                              top-bar-height
                              start-position))
 
+(defn navigation-buttons-complete-opacity
+  [chat-screen-layout-calculations-complete?]
+  (.navigationButtonsCompleteOpacity ^js worklets chat-screen-layout-calculations-complete?))
+
 (defn interpolate-navigation-view-opacity
   [props]
   (.interpolateNavigationViewOpacity ^js worklets (clj->js props)))


### PR DESCRIPTION
fixes #19095 

### Summary
The navigation buttons (back/more) in the chat have the :photo background while the navbar is transparent (i.e scrolled to the top) and :blur when opaque (i.e. while scrolling through messages)


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Login
- Open chat
- Scroll to top
- Navigation buttons should change background from `:blur` to `:photo` as header becomes transparent

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

https://github.com/status-im/status-mobile/assets/21865759/146331fe-3ab9-47ef-a102-3b787967d147



status: ready <!-- Can be ready or wip -->
