### PR TITLE
fix: modal-view-ids to track multiple modals and fix suggested routes fetching when scanning address by QR

### DIFF
--- a/src/status_im/contexts/shell/jump_to/events.cljs
+++ b/src/status_im/contexts/shell/jump_to/events.cljs
@@ -177,10 +177,9 @@
                shell.constants/close-screen-with-slide-to-right-animation))}
        (when (and current-chat-id community-id)
          {:dispatch [:shell/add-switcher-card shell.constants/community-screen community-id]}))
-      (let [modal-view-ids (navigation.utils/remove-last-view-from-current-modal-stack (:modal-view-ids
-                                                                                        db))]
+      (let [modal-view-ids (navigation.utils/remove-current-modal-stack (:modal-view-ids db))]
         {:navigate-back nil
-         :db            (if modal-view-ids
+         :db            (if (seq modal-view-ids)
                           (assoc db :modal-view-ids modal-view-ids)
                           (dissoc db :modal-view-ids))}))))
 

--- a/src/status_im/contexts/shell/jump_to/events.cljs
+++ b/src/status_im/contexts/shell/jump_to/events.cljs
@@ -150,10 +150,12 @@
                           (not hidden-screen?)
                           (:current-chat-id db))
                      (conj [:chat/close]))})
-    {:db          (-> db
-                      (assoc :view-id go-to-view-id)
-                      (dissoc :modal-view-ids))
-     :navigate-to go-to-view-id}))
+    (let [modal-view-ids (navigation.utils/remove-current-modal-stack (:modal-view-ids db))]
+      {:navigate-to go-to-view-id
+       :db          (cond-> db
+                      true                       (assoc :view-id go-to-view-id)
+                      (seq modal-view-ids)       (assoc :modal-view-ids modal-view-ids)
+                      (not (seq modal-view-ids)) (dissoc :modal-view-ids))})))
 
 (rf/defn shell-navigate-back
   {:events [:shell/navigate-back]}

--- a/src/status_im/contexts/shell/jump_to/events.cljs
+++ b/src/status_im/contexts/shell/jump_to/events.cljs
@@ -177,7 +177,8 @@
                shell.constants/close-screen-with-slide-to-right-animation))}
        (when (and current-chat-id community-id)
          {:dispatch [:shell/add-switcher-card shell.constants/community-screen community-id]}))
-      (let [modal-view-ids (navigation.utils/remove-last-view-from-modals (:modal-view-ids db))]
+      (let [modal-view-ids (navigation.utils/remove-last-view-from-current-modal-stack (:modal-view-ids
+                                                                                        db))]
         {:navigate-back nil
          :db            (if modal-view-ids
                           (assoc db :modal-view-ids modal-view-ids)

--- a/src/status_im/contexts/shell/jump_to/events.cljs
+++ b/src/status_im/contexts/shell/jump_to/events.cljs
@@ -7,6 +7,7 @@
     status-im.contexts.shell.jump-to.effects
     [status-im.contexts.shell.jump-to.utils :as shell.utils]
     [status-im.navigation.state :as navigation.state]
+    [status-im.navigation.utils :as navigation.utils]
     [utils.re-frame :as rf]))
 
 ;;;; Events
@@ -176,8 +177,11 @@
                shell.constants/close-screen-with-slide-to-right-animation))}
        (when (and current-chat-id community-id)
          {:dispatch [:shell/add-switcher-card shell.constants/community-screen community-id]}))
-      {:navigate-back nil
-       :db            (dissoc db :modal-view-ids)})))
+      (let [modal-view-ids (navigation.utils/remove-last-view-from-modals (:modal-view-ids db))]
+        {:navigate-back nil
+         :db            (if modal-view-ids
+                          (assoc db :modal-view-ids modal-view-ids)
+                          (dissoc db :modal-view-ids))}))))
 
 (rf/defn floating-screen-opened
   {:events [:shell/floating-screen-opened]}

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -81,13 +81,15 @@
 
 (rf/defn init-root
   {:events [:init-root]}
-  [_ root-id]
-  {:set-root root-id})
+  [{:keys [db]} root-id]
+  {:set-root root-id
+   :db       (dissoc db :modal-view-ids)})
 
 (rf/defn set-stack-root
   {:events [:set-stack-root]}
-  [_ stack root]
-  {:set-stack-root-fx [stack root]})
+  [{:keys [db]} stack root]
+  {:set-stack-root-fx [stack root]
+   :db                (dissoc db :modal-view-ids)})
 
 (rf/defn change-tab
   {:events [:navigate-change-tab]}

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -28,14 +28,14 @@
 (rf/defn navigate-to-within-stack
   {:events [:navigate-to-within-stack]}
   [{:keys [db]} comp-id]
-  {:db (update db :modal-view-ids navigation.utils/add-view-to-modals (first comp-id))
+  {:db (update db :modal-view-ids navigation.utils/add-view-to-modal-stack (first comp-id))
    :fx [[:navigate-to-within-stack comp-id]]})
 
 (re-frame/reg-event-fx :open-modal
  (fn [{:keys [db]} [component screen-params]]
    {:db (-> db
             (assoc :view-id component)
-            (update :modal-view-ids navigation.utils/add-stack-to-modals component)
+            (update :modal-view-ids navigation.utils/add-stack-to-modal-stacks component)
             (all-screens-params component screen-params))
     :fx [[:dispatch [:hide-bottom-sheet]]
          [:open-modal-fx component]]}))
@@ -43,7 +43,7 @@
 (rf/defn dismiss-modal
   {:events [:dismiss-modal]}
   [{:keys [db]} comp-id]
-  {:db            (update db :modal-view-ids navigation.utils/remove-last-modal-stack)
+  {:db            (update db :modal-view-ids navigation.utils/remove-current-modal-stack)
    :dismiss-modal comp-id})
 
 (rf/defn navigate-back
@@ -54,13 +54,14 @@
 (rf/defn navigate-back-within-stack
   {:events [:navigate-back-within-stack]}
   [{:keys [db]} comp-id]
-  {:db (update db :modal-view-ids navigation.utils/remove-last-view-from-modals)
+  {:db (update db :modal-view-ids navigation.utils/remove-last-view-from-current-modal-stack)
    :fx [[:navigate-back-within-stack comp-id]]})
 
 (rf/defn navigate-back-to
   {:events [:navigate-back-to]}
   [{:keys [db]} comp-id]
-  (let [modal-view-ids (navigation.utils/remove-modal-views-until-comp-id (:modal-view-ids db) comp-id)]
+  (let [modal-view-ids (navigation.utils/remove-views-from-modal-stack-until-comp-id (:modal-view-ids db)
+                                                                                     comp-id)]
     (assoc {:navigate-back-to comp-id}
            :db
            (if modal-view-ids

--- a/src/status_im/navigation/utils.cljs
+++ b/src/status_im/navigation/utils.cljs
@@ -1,6 +1,6 @@
 (ns status-im.navigation.utils)
 
-(defn add-view-to-modals
+(defn add-view-to-modal-stack
   [modal-view-ids new-id]
   (if-let [current-stack (and (seq modal-view-ids) (last modal-view-ids))]
     (let [updated-stack (conj current-stack new-id)
@@ -8,7 +8,7 @@
       (conj without-last updated-stack))
     modal-view-ids))
 
-(defn remove-last-view-from-modals
+(defn remove-last-view-from-current-modal-stack
   [modal-view-ids]
   (if (empty? modal-view-ids)
     modal-view-ids
@@ -19,19 +19,19 @@
         without-last-stack
         (conj without-last-stack updated-last-stack)))))
 
-(defn add-stack-to-modals
+(defn add-stack-to-modal-stacks
   [modal-view-ids first-view-id]
   (if (seq modal-view-ids)
     (conj modal-view-ids [first-view-id])
     [[first-view-id]]))
 
-(defn remove-last-modal-stack
+(defn remove-current-modal-stack
   [modal-view-ids]
   (if (seq modal-view-ids)
     (vec (butlast modal-view-ids))
     []))
 
-(defn remove-modal-views-until-comp-id
+(defn remove-views-from-modal-stack-until-comp-id
   [modal-view-ids comp-id]
   (let [found-index (first (keep-indexed (fn [idx stack]
                                            (when (some #{comp-id} stack) idx))

--- a/src/status_im/navigation/utils.cljs
+++ b/src/status_im/navigation/utils.cljs
@@ -1,0 +1,44 @@
+(ns status-im.navigation.utils)
+
+(defn add-view-to-modals
+  [modal-view-ids new-id]
+  (if-let [current-stack (and (seq modal-view-ids) (last modal-view-ids))]
+    (let [updated-stack (conj current-stack new-id)
+          without-last  (butlast modal-view-ids)]
+      (conj without-last updated-stack))
+    modal-view-ids))
+
+(defn remove-last-view-from-modals
+  [modal-view-ids]
+  (if (empty? modal-view-ids)
+    modal-view-ids
+    (let [last-stack         (last modal-view-ids)
+          updated-last-stack (butlast last-stack)
+          without-last-stack (butlast modal-view-ids)]
+      (if (empty? updated-last-stack)
+        without-last-stack
+        (conj without-last-stack updated-last-stack)))))
+
+(defn add-stack-to-modals
+  [modal-view-ids first-view-id]
+  (if (seq modal-view-ids)
+    (conj modal-view-ids [first-view-id])
+    [[first-view-id]]))
+
+(defn remove-last-modal-stack
+  [modal-view-ids]
+  (if (seq modal-view-ids)
+    (vec (butlast modal-view-ids))
+    []))
+
+(defn remove-modal-views-until-comp-id
+  [modal-view-ids comp-id]
+  (let [found-index (first (keep-indexed (fn [idx stack]
+                                           (when (some #{comp-id} stack) idx))
+                                         modal-view-ids))]
+    (if found-index
+      (let [target-stack  (nth modal-view-ids found-index)
+            comp-id-index (.indexOf target-stack comp-id)
+            updated-stack (take (inc comp-id-index) target-stack)]
+        (assoc modal-view-ids found-index updated-stack))
+      modal-view-ids)))

--- a/src/status_im/navigation/utils.cljs
+++ b/src/status_im/navigation/utils.cljs
@@ -38,7 +38,7 @@
                                          modal-view-ids))]
     (if found-index
       (let [target-stack  (nth modal-view-ids found-index)
-            comp-id-index (.indexOf target-stack comp-id)
+            comp-id-index (.lastIndexOf target-stack comp-id)
             updated-stack (take (inc comp-id-index) target-stack)]
         (assoc modal-view-ids found-index updated-stack))
       modal-view-ids)))

--- a/src/status_im/navigation/utils.cljs
+++ b/src/status_im/navigation/utils.cljs
@@ -4,7 +4,7 @@
   [modal-view-ids new-id]
   (if-let [current-stack (and (seq modal-view-ids) (last modal-view-ids))]
     (let [updated-stack (conj current-stack new-id)
-          without-last  (butlast modal-view-ids)]
+          without-last  (vec (butlast modal-view-ids))]
       (conj without-last updated-stack))
     modal-view-ids))
 
@@ -13,8 +13,8 @@
   (if (empty? modal-view-ids)
     modal-view-ids
     (let [last-stack         (last modal-view-ids)
-          updated-last-stack (butlast last-stack)
-          without-last-stack (butlast modal-view-ids)]
+          updated-last-stack (vec (butlast last-stack))
+          without-last-stack (vec (butlast modal-view-ids))]
       (if (empty? updated-last-stack)
         without-last-stack
         (conj without-last-stack updated-last-stack)))))

--- a/src/status_im/navigation/utils_test.cljs
+++ b/src/status_im/navigation/utils_test.cljs
@@ -3,44 +3,65 @@
             [status-im.navigation.utils :as utils]))
 
 (deftest test-add-view-to-modal-stack
-  (testing "Add view ID to an existing modal stack"
+  (testing "Add view ID to an empty modal stack"
+    (is (= (utils/add-view-to-modal-stack [] 1)
+           [])))
+  (testing "Add view ID to a non-empty modal stack"
     (is (= (utils/add-view-to-modal-stack [[1 2]] 3)
            [[1 2 3]])))
-  (testing "Add view ID when there are no modal stacks"
-    (is (= (utils/add-view-to-modal-stack [] 1)
-           []))))
+  (testing "Add view ID when multiple modal stacks exist"
+    (is (= (utils/add-view-to-modal-stack [[1 2] [3 4]] 5)
+           [[1 2] [3 4 5]]))))
 
 (deftest test-remove-last-view-from-current-modal-stack
+  (testing "Remove last view ID from a single-element stack"
+    (is (= (utils/remove-last-view-from-current-modal-stack [[1]])
+           [])))
   (testing "Remove last view ID from the current modal stack"
     (is (= (utils/remove-last-view-from-current-modal-stack [[1 2 3] [4 5 6]])
            [[1 2 3] [4 5]])))
-  (testing "Handle removal when modal stacks are empty"
+  (testing "Handle empty modal stacks"
     (is (= (utils/remove-last-view-from-current-modal-stack [])
-           []))))
+           [])))
+  (testing "Ensure unchanged stack when nested stack is a single element"
+    (is (= (utils/remove-last-view-from-current-modal-stack [[1 2] [3]])
+           [[1 2]]))))
 
 (deftest test-add-stack-to-modal-stacks
+  (testing "Add a new stack to an empty list of modal stacks"
+    (is (= (utils/add-stack-to-modal-stacks [] 1)
+           [[1]])))
   (testing "Add a new stack to existing modal stacks"
     (is (= (utils/add-stack-to-modal-stacks [[1 2]] 3)
            [[1 2] [3]])))
-  (testing "Add a new stack when there are no modal stacks"
-    (is (= (utils/add-stack-to-modal-stacks [] 1)
-           [[1]]))))
+  (testing "Add a new stack when existing stacks are varied"
+    (is (= (utils/add-stack-to-modal-stacks [[1 2] [3 4]] 5)
+           [[1 2] [3 4] [5]]))))
 
 (deftest test-remove-current-modal-stack
-  (testing "Remove the current (last) modal stack"
-    (is (= (utils/remove-current-modal-stack [[1 2] [3 4]])
-           [[1 2]])))
-  (testing "Handle removal when there is only one modal stack"
+  (testing "Remove the only modal stack"
     (is (= (utils/remove-current-modal-stack [[1 2]])
            [])))
-  (testing "Handle removal when there are no modal stacks"
+  (testing "Remove the last modal stack from multiple"
+    (is (= (utils/remove-current-modal-stack [[1 2] [3 4] [5 6]])
+           [[1 2] [3 4]])))
+  (testing "Handle removal when modal stacks are empty"
     (is (= (utils/remove-current-modal-stack [])
-           []))))
+           [])))
+  (testing "Ensure unchanged when nested stacks have varied lengths"
+    (is (= (utils/remove-current-modal-stack [[1] [2 3] [4 5 6]])
+           [[1] [2 3]]))))
 
 (deftest test-remove-views-from-modal-stack-until-comp-id
-  (testing "Remove views from modal stack until comp-id is found"
-    (is (= (utils/remove-views-from-modal-stack-until-comp-id [[1 2 3] [4 5 6 7]] 5)
-           [[1 2 3] [4 5]])))
-  (testing "Do nothing if comp-id is not found"
-    (is (= (utils/remove-views-from-modal-stack-until-comp-id [[1 2 3] [4 5 6]] 8)
-           [[1 2 3] [4 5 6]]))))
+  (testing "Remove views until comp-id, including multiple occurrences"
+    (is (= (utils/remove-views-from-modal-stack-until-comp-id [[1 2 3] [4 5 5 6]] 5)
+           [[1 2 3] [4 5 5]])))
+  (testing "comp-id at the beginning of a stack"
+    (is (= (utils/remove-views-from-modal-stack-until-comp-id [[1 2] [3 4] [5 6 7]] 5)
+           [[1 2] [3 4] [5]])))
+  (testing "comp-id not found, no removal"
+    (is (= (utils/remove-views-from-modal-stack-until-comp-id [[1 2 3] [4 5 6]] 7)
+           [[1 2 3] [4 5 6]])))
+  (testing "comp-id is the last element in a stack"
+    (is (= (utils/remove-views-from-modal-stack-until-comp-id [[1 2 3] [4 5 6] [7 8 9]] 9)
+           [[1 2 3] [4 5 6] [7 8 9]]))))

--- a/src/status_im/navigation/utils_test.cljs
+++ b/src/status_im/navigation/utils_test.cljs
@@ -1,0 +1,46 @@
+(ns status-im.navigation.utils-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [status-im.navigation.utils :as utils]))
+
+(deftest test-add-view-to-modal-stack
+  (testing "Add view ID to an existing modal stack"
+    (is (= (utils/add-view-to-modal-stack [[1 2]] 3)
+           [[1 2 3]])))
+  (testing "Add view ID when there are no modal stacks"
+    (is (= (utils/add-view-to-modal-stack [] 1)
+           []))))
+
+(deftest test-remove-last-view-from-current-modal-stack
+  (testing "Remove last view ID from the current modal stack"
+    (is (= (utils/remove-last-view-from-current-modal-stack [[1 2 3] [4 5 6]])
+           [[1 2 3] [4 5]])))
+  (testing "Handle removal when modal stacks are empty"
+    (is (= (utils/remove-last-view-from-current-modal-stack [])
+           []))))
+
+(deftest test-add-stack-to-modal-stacks
+  (testing "Add a new stack to existing modal stacks"
+    (is (= (utils/add-stack-to-modal-stacks [[1 2]] 3)
+           [[1 2] [3]])))
+  (testing "Add a new stack when there are no modal stacks"
+    (is (= (utils/add-stack-to-modal-stacks [] 1)
+           [[1]]))))
+
+(deftest test-remove-current-modal-stack
+  (testing "Remove the current (last) modal stack"
+    (is (= (utils/remove-current-modal-stack [[1 2] [3 4]])
+           [[1 2]])))
+  (testing "Handle removal when there is only one modal stack"
+    (is (= (utils/remove-current-modal-stack [[1 2]])
+           [])))
+  (testing "Handle removal when there are no modal stacks"
+    (is (= (utils/remove-current-modal-stack [])
+           []))))
+
+(deftest test-remove-views-from-modal-stack-until-comp-id
+  (testing "Remove views from modal stack until comp-id is found"
+    (is (= (utils/remove-views-from-modal-stack-until-comp-id [[1 2 3] [4 5 6 7]] 5)
+           [[1 2 3] [4 5]])))
+  (testing "Do nothing if comp-id is not found"
+    (is (= (utils/remove-views-from-modal-stack-until-comp-id [[1 2 3] [4 5 6]] 8)
+           [[1 2 3] [4 5 6]]))))

--- a/src/status_im/subs/navigation.cljs
+++ b/src/status_im/subs/navigation.cljs
@@ -7,4 +7,7 @@
  :<- [:view-id]
  :<- [:modal-view-ids]
  (fn [[view-id modal-view-ids]]
-   (or (peek modal-view-ids) view-id)))
+   (or (some-> modal-view-ids
+               last
+               last)
+       view-id)))


### PR DESCRIPTION
fixes #18652 (hopefully for the last time)

### Summary

This PR adds support for multi level modals while tracking modal-view-ids and small refactor to address input due to removed usage of useEffect by https://github.com/status-im/status-mobile/commit/b7bffb3bd30653abab1e645e0db8d82c5b3e9bca // cc @smohamedjavid 

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in to your profile
- Navigate to the Wallet tab
- Tap on any account
- Tap on the Send button
- Scan any address
- Select any asset to send
- Enter any amount (below the limit) and be sure you have enough ETH for gas spending
- Verify routes are fetched

Additionally, a general smoke test would be appreciated due to that we are modifying general purpose parts of the codebase.

status: ready