### PR TITLE
fix Blink of shell screen occurs when the Scan sync button is tapped

### DIFF
--- a/src/status_im/contexts/syncing/setup_syncing/view.cljs
+++ b/src/status_im/contexts/syncing/setup_syncing/view.cljs
@@ -130,5 +130,5 @@
          [quo/divider-label {:tight? false} (i18n/label :t/have-a-sync-code?)]
          [quo/action-drawer
           [[{:icon     :i/scan
-             :on-press #(rf/dispatch [:navigate-to :scan-sync-code-page])
+             :on-press #(rf/dispatch [:open-modal :scan-sync-code-page])
              :label    (i18n/label :t/scan-or-enter-sync-code)}]]]]]])))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19096
fixes https://github.com/status-im/status-mobile/issues/19103


### Testing
Please let me know if any of the flow in settings screen is not working as expected

status: ready