### PR TITLE
feat: show pinned messages bottom sheet in channel home

### DIFF
--- a/src/status_im/contexts/chat/messenger/menus/pinned_messages/view.cljs
+++ b/src/status_im/contexts/chat/messenger/menus/pinned_messages/view.cljs
@@ -33,7 +33,7 @@
      :description (i18n/label :t/no-pinned-messages-desc)}]])
 
 (defn f-pinned-messages
-  [{:keys [theme chat-id inside-chat?]}]
+  [{:keys [theme chat-id disable-message-long-press?]}]
   (let [pinned                 (rf/sub [:chats/pinned-sorted-list chat-id])
         render-data            (rf/sub [:chats/current-chat-message-list-view-context :in-pinned-view])
         current-chat           (rf/sub [:chats/chat-by-id chat-id])
@@ -60,7 +60,7 @@
      (if (pos? (count pinned))
        [rn/flat-list
         {:data        pinned
-         :render-data (assoc render-data :inside-chat? inside-chat?)
+         :render-data (assoc render-data :disable-message-long-press? disable-message-long-press?)
          :render-fn   message-render-fn
          :footer      [rn/view {:style style/list-footer}]
          :key-fn      list-key-fn

--- a/src/status_im/contexts/chat/messenger/menus/pinned_messages/view.cljs
+++ b/src/status_im/contexts/chat/messenger/menus/pinned_messages/view.cljs
@@ -33,7 +33,7 @@
      :description (i18n/label :t/no-pinned-messages-desc)}]])
 
 (defn f-pinned-messages
-  [{:keys [theme chat-id]}]
+  [{:keys [theme chat-id inside-chat?]}]
   (let [pinned                 (rf/sub [:chats/pinned-sorted-list chat-id])
         render-data            (rf/sub [:chats/current-chat-message-list-view-context :in-pinned-view])
         current-chat           (rf/sub [:chats/chat-by-id chat-id])
@@ -60,7 +60,7 @@
      (if (pos? (count pinned))
        [rn/flat-list
         {:data        pinned
-         :render-data render-data
+         :render-data (assoc render-data :inside-chat? inside-chat?)
          :render-fn   message-render-fn
          :footer      [rn/view {:style style/list-footer}]
          :key-fn      list-key-fn

--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -152,36 +152,36 @@
                  show-user-info? preview? theme]}]
       (let [{:keys [content-type quoted-message content
                     outgoing outgoing-status pinned-by
-                    message-id chat-id]} message-data
-            {:keys [inside-chat?]}       context
-            first-image                  (first (:album message-data))
-            outgoing-status              (if (= content-type
-                                                constants/content-type-album)
-                                           (:outgoing-status first-image)
-                                           outgoing-status)
-            outgoing                     (if (= content-type
-                                                constants/content-type-album)
-                                           (:outgoing first-image)
-                                           outgoing)
-            context                      (assoc context
-                                                :on-long-press
-                                                #(on-long-press message-data
-                                                                context
-                                                                keyboard-shown?))
-            response-to                  (:response-to content)
-            height                       (rf/sub [:dimensions/window-height])
+                    message-id chat-id]}          message-data
+            {:keys [disable-message-long-press?]} context
+            first-image                           (first (:album message-data))
+            outgoing-status                       (if (= content-type
+                                                         constants/content-type-album)
+                                                    (:outgoing-status first-image)
+                                                    outgoing-status)
+            outgoing                              (if (= content-type
+                                                         constants/content-type-album)
+                                                    (:outgoing first-image)
+                                                    outgoing)
+            context                               (assoc context
+                                                         :on-long-press
+                                                         #(on-long-press message-data
+                                                                         context
+                                                                         keyboard-shown?))
+            response-to                           (:response-to content)
+            height                                (rf/sub [:dimensions/window-height])
             {window-width :width
-             window-scale :scale}        (rn/get-window)
-            message-container-data       {:window-width           window-width
-                                          :padding-right          20
-                                          :padding-left           20
-                                          :avatar-container-width 32
-                                          :message-margin-left    8}
-            reactions                    (rf/sub [:chats/message-reactions message-id
-                                                  chat-id])
-            six-reactions?               (-> reactions
-                                             count
-                                             (= 6))]
+             window-scale :scale}                 (rn/get-window)
+            message-container-data                {:window-width           window-width
+                                                   :padding-right          20
+                                                   :padding-left           20
+                                                   :avatar-container-width 32
+                                                   :message-margin-left    8}
+            reactions                             (rf/sub [:chats/message-reactions message-id
+                                                           chat-id])
+            six-reactions?                        (-> reactions
+                                                      count
+                                                      (= 6))]
         [rn/touchable-highlight
          {:accessibility-label (if (and outgoing (= outgoing-status :sending))
                                  :message-sending
@@ -205,7 +205,7 @@
                                      (reset! show-delivery-state? true)
                                      (js/setTimeout #(reset! show-delivery-state? false)
                                                     delivery-state-showing-time-ms))))
-          :on-long-press       (when inside-chat?
+          :on-long-press       (when disable-message-long-press?
                                  #(on-long-press message-data context keyboard-shown?))}
          [:<>
           (when pinned-by

--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -205,7 +205,7 @@
                                      (reset! show-delivery-state? true)
                                      (js/setTimeout #(reset! show-delivery-state? false)
                                                     delivery-state-showing-time-ms))))
-          :on-long-press       (when disable-message-long-press?
+          :on-long-press       (when-not disable-message-long-press?
                                  #(on-long-press message-data context keyboard-shown?))}
          [:<>
           (when pinned-by

--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -153,6 +153,7 @@
       (let [{:keys [content-type quoted-message content
                     outgoing outgoing-status pinned-by
                     message-id chat-id]} message-data
+            {:keys [inside-chat?]}       context
             first-image                  (first (:album message-data))
             outgoing-status              (if (= content-type
                                                 constants/content-type-album)
@@ -204,7 +205,8 @@
                                      (reset! show-delivery-state? true)
                                      (js/setTimeout #(reset! show-delivery-state? false)
                                                     delivery-state-showing-time-ms))))
-          :on-long-press       #(on-long-press message-data context keyboard-shown?)}
+          :on-long-press       (when inside-chat?
+                                 #(on-long-press message-data context keyboard-shown?))}
          [:<>
           (when pinned-by
             [pin/pinned-by-view pinned-by])

--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -318,7 +318,7 @@
                                              :customization-color    customization-color}]
         :data                              messages
         :render-data                       {:theme           theme
-                                            :context         context
+                                            :context         (assoc context :inside-chat? true)
                                             :keyboard-shown? keyboard-shown
                                             :insets          insets}
         :render-fn                         render-fn

--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -318,7 +318,7 @@
                                              :customization-color    customization-color}]
         :data                              messages
         :render-data                       {:theme           theme
-                                            :context         (assoc context :inside-chat? true)
+                                            :context         context
                                             :keyboard-shown? keyboard-shown
                                             :insets          insets}
         :render-fn                         render-fn

--- a/src/status_im/contexts/chat/messenger/messages/pin/events.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/pin/events.cljs
@@ -132,5 +132,4 @@
    cofx
    {:content (fn [] [pinned-messages-menu/view
                      {:chat-id                     chat-id
-                      :disable-message-long-press? (not= :chat (get-in cofx [:db :view-id]))
-                     }])}))
+                      :disable-message-long-press? (not= :chat (get-in cofx [:db :view-id]))}])}))

--- a/src/status_im/contexts/chat/messenger/messages/pin/events.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/pin/events.cljs
@@ -127,5 +127,9 @@
 
 (rf/defn show-pins-bottom-sheet
   {:events [:pin-message/show-pins-bottom-sheet]}
-  [cofx chat-id]
-  (navigation/show-bottom-sheet cofx {:content (fn [] [pinned-messages-menu/view {:chat-id chat-id}])}))
+  [cofx chat-id & {:keys [inside-chat?] :or {inside-chat? true}}]
+  (println inside-chat?)
+  (navigation/show-bottom-sheet cofx
+                                {:content (fn [] [pinned-messages-menu/view
+                                                  {:chat-id      chat-id
+                                                   :inside-chat? inside-chat?}])}))

--- a/src/status_im/contexts/chat/messenger/messages/pin/events.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/pin/events.cljs
@@ -127,8 +127,10 @@
 
 (rf/defn show-pins-bottom-sheet
   {:events [:pin-message/show-pins-bottom-sheet]}
-  [cofx chat-id & {:keys [inside-chat?] :or {inside-chat? true}}]
-  (navigation/show-bottom-sheet cofx
-                                {:content (fn [] [pinned-messages-menu/view
-                                                  {:chat-id      chat-id
-                                                   :inside-chat? inside-chat?}])}))
+  [cofx chat-id]
+  (navigation/show-bottom-sheet
+   cofx
+   {:content (fn [] [pinned-messages-menu/view
+                     {:chat-id                     chat-id
+                      :disable-message-long-press? (not= :chat (get-in cofx [:db :view-id]))
+                     }])}))

--- a/src/status_im/contexts/chat/messenger/messages/pin/events.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/pin/events.cljs
@@ -128,7 +128,6 @@
 (rf/defn show-pins-bottom-sheet
   {:events [:pin-message/show-pins-bottom-sheet]}
   [cofx chat-id & {:keys [inside-chat?] :or {inside-chat? true}}]
-  (println inside-chat?)
   (navigation/show-bottom-sheet cofx
                                 {:content (fn [] [pinned-messages-menu/view
                                                   {:chat-id      chat-id

--- a/src/status_im/contexts/communities/actions/chat/view.cljs
+++ b/src/status_im/contexts/communities/actions/chat/view.cljs
@@ -85,7 +85,7 @@
    :on-press            (fn []
                           (rf/dispatch [:pin-message/load-pin-messages chat-id])
                           (rf/dispatch [:pin-message/show-pins-bottom-sheet
-                                        chat-id]))
+                                        chat-id {:inside-chat? false}]))
    :label               (i18n/label :t/pinned-messages)})
 
 

--- a/src/status_im/contexts/communities/actions/chat/view.cljs
+++ b/src/status_im/contexts/communities/actions/chat/view.cljs
@@ -84,8 +84,7 @@
    :accessibility-label :chat-pinned-messages
    :on-press            (fn []
                           (rf/dispatch [:pin-message/load-pin-messages chat-id])
-                          (rf/dispatch [:pin-message/show-pins-bottom-sheet
-                                        chat-id {:inside-chat? false}]))
+                          (rf/dispatch [:pin-message/show-pins-bottom-sheet chat-id]))
    :label               (i18n/label :t/pinned-messages)})
 
 

--- a/src/status_im/contexts/communities/actions/chat/view.cljs
+++ b/src/status_im/contexts/communities/actions/chat/view.cljs
@@ -78,11 +78,14 @@
    :sub-label           (i18n/label :t/only-mentions)})
 
 (defn- action-pinned-messages
-  []
+  [chat-id]
   {:icon                :i/pin
    :right-icon          :i/chevron-right
    :accessibility-label :chat-pinned-messages
-   :on-press            not-implemented/alert
+   :on-press            (fn []
+                          (rf/dispatch [:pin-message/load-pin-messages chat-id])
+                          (rf/dispatch [:pin-message/show-pins-bottom-sheet
+                                        chat-id]))
    :label               (i18n/label :t/pinned-messages)})
 
 
@@ -124,7 +127,7 @@
          (action-mark-as-read)
          (action-toggle-muted chat-id muted muted-till chat-type)
          (action-notification-settings)
-         (action-pinned-messages)
+         (action-pinned-messages chat-id)
          (action-invite-people)
          (action-qr-code chat-id)
          (action-share chat-id)]]]


### PR DESCRIPTION
fixes #19091 

### Summary

we want to show the pinned messages in a community home by long press of a channel.
This PR is to show this bottom sheet.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- community

### Before and after screenshots comparison

https://github.com/status-im/status-mobile/assets/39961806/c838e44b-5aa2-4e6c-abab-36e3f95ea3d6

status: ready <!-- Can be ready or wip -->
