### PR TITLE
fix: remove biometric button in the login screen when disabled biomet…

### DIFF
--- a/src/status_im/contexts/profile/profiles/view.cljs
+++ b/src/status_im/contexts/profile/profiles/view.cljs
@@ -170,20 +170,18 @@
 (defn password-input
   []
   (let [auth-method         (rf/sub [:auth-method])
-        on-press-biometrics (rn/use-callback
-                             (fn []
-                               (when (= auth-method constants/auth-method-biometric)
-                                 (rf/dispatch [:biometric/authenticate
-                                               {:on-success #(rf/dispatch
-                                                              [:profile.login/biometric-success])
-                                                :on-fail    #(rf/dispatch
-                                                              [:profile.login/biometric-auth-fail
-                                                               %])}])))
-                             [auth-method])]
+        on-press-biometrics (fn []
+                              (rf/dispatch [:biometric/authenticate
+                                            {:on-success #(rf/dispatch
+                                                           [:profile.login/biometric-success])
+                                             :on-fail    #(rf/dispatch
+                                                           [:profile.login/biometric-auth-fail
+                                                            %])}]))
+       ]
     [standard-authentication/password-input
      {:shell?              true
       :blur?               true
-      :on-press-biometrics on-press-biometrics}]))
+      :on-press-biometrics (when (= auth-method constants/auth-method-biometric) on-press-biometrics)}]))
 
 (defn login-section
   [{:keys [show-profiles]}]


### PR DESCRIPTION
fixes #19078 

### Summary

This PR is to hide the biometrics login icon in login screen when it's disabled

### Testing notes
Check login screen after disable biometrics in device

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- login
<!-- (PRs will only be accepted if squashed into single commit.) -->
![Uploading Simulator Screenshot - iPhone 13 - 2024-03-05 at 08.54.22.png…]()
status: ready <!-- Can be ready or wip -->
