### PR TITLE
build: less node_modules recopy from nix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,13 +331,14 @@ shadow-server:##@ Start shadow-cljs in server mode for watching
 
 _test-clojure: export TARGET := clojure
 _test-clojure: export WATCH ?= false
+_test-clojure: status-go-library
 _test-clojure:
 ifeq ($(WATCH), true)
-	yarn install && \
+	yarn node-pre-gyp rebuild && \
 	yarn shadow-cljs compile mocks && \
 	nodemon --exec "yarn shadow-cljs compile test && node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO" -e cljs
 else
-	yarn install && \
+	yarn node-pre-gyp rebuild && \
 	yarn shadow-cljs compile mocks && \
 	yarn shadow-cljs compile test && \
 	node --require ./test-resources/override.js "$$SHADOW_OUTPUT_TO"
@@ -350,8 +351,9 @@ test: _test-clojure
 
 test-watch-for-repl: export SHADOW_OUTPUT_TO := target/test/test.js
 test-watch-for-repl: export SHADOW_NS_REGEXP := .*-test$$
+test-watch-for-repl: status-go-library
 test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connections
-	yarn install
+	yarn node-pre-gyp rebuild
 	rm -f target/test/test.js
 	yarn shadow-cljs compile mocks && \
 	concurrently --kill-others --prefix-colors 'auto' --names 'build,repl' \

--- a/nix/scripts/node_modules.sh
+++ b/nix/scripts/node_modules.sh
@@ -61,6 +61,8 @@ findFilesNewerThan() {
       -not -ipath "*/*android/build/*" -prune \
       -not -ipath "*/xcuserdata/*" -prune \
       -not -ipath "*/scripts/.packager.env" \
+      -not -path "*/node_modules/react-native/ReactCommon/react/renderer/components/rncore/*" \
+      -not -path "*/node_modules/react-native-config/ios/ReactNativeConfig/GeneratedDotEnv.m" \
       -print
 }
 

--- a/nix/scripts/node_modules.sh
+++ b/nix/scripts/node_modules.sh
@@ -53,6 +53,14 @@ copyNodeModules() {
 
 # Find files that were modified and should cause a re-copying of node modules.
 # Some files are generated/modified by build processes and should be ignored.
+#
+# react-native/ReactCommon/react/renderer/components/rncore/*
+# generated at runtime by react-native
+# related code https://github.com/facebook/react-native/blob/v0.72.5/packages/react-native/ReactCommon/React-rncore.podspec#L19
+#
+# react-native-config/ios/ReactNativeConfig/GeneratedDotEnv.m
+# generated at runtime by react-native-config
+# related code https://github.com/lugg/react-native-config/blob/v1.5.0/react-native-config.podspec#L52
 findFilesNewerThan() {
   local sentinel="${1}"
   local dir="${2}"


### PR DESCRIPTION
### Summary

rebuild clojure nix shell won't break running build after this PR

- these files in node_modules always got changed after `make run-ios` (maybe by rn?)
	- react-native/ReactCommon/react/renderer/components/rncore/ShadowNodes.cpp
	- react-native/ReactCommon/react/renderer/components/rncore/Props.h
	- react-native/ReactCommon/react/renderer/components/rncore/Props.cpp
	- react-native/ReactCommon/react/renderer/components/rncore/ComponentDescriptors.h
	- react-native/ReactCommon/react/renderer/components/rncore/ShadowNodes.h
	- react-native/ReactCommon/react/renderer/components/rncore/EventEmitters.h
	- react-native/ReactCommon/react/renderer/components/rncore/States.h
	- react-native/ReactCommon/react/renderer/components/rncore/EventEmitters.cpp
	- react-native/ReactCommon/react/renderer/components/rncore/States.cpp
	- react-native/ReactCommon/react/renderer/components/rncore/RCTComponentViewHelpers.h
	- react-native-config/ios/ReactNativeConfig/GeneratedDotEnv.m
	
  skip these file in `nix/scripts/node_modules`


- `yarn install` is used in tests to trigger `node-pre-gyp rebuild` for `modules/react-native-status/nodejs/bindings.js`
changed `yarn install` to `node-pre-gpy rebuild`

status: ready <!-- Can be ready or wip -->