### PR TITLE
feat: add jump-to button in group-detail screen

### DIFF
--- a/src/status_im/contexts/chat/group_details/style.cljs
+++ b/src/status_im/contexts/chat/group_details/style.cljs
@@ -43,4 +43,3 @@
 (def floating-shell-button
   {:position :absolute
    :bottom   21})
-

--- a/src/status_im/contexts/chat/group_details/style.cljs
+++ b/src/status_im/contexts/chat/group_details/style.cljs
@@ -40,3 +40,7 @@
    :background-color   (colors/theme-colors colors/white colors/neutral-95-opa-70)
    :flex-direction     :row})
 
+(def floating-shell-button
+  {:position :absolute
+   :bottom   21})
+

--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -9,6 +9,7 @@
     [status-im.common.home.actions.view :as actions]
     [status-im.constants :as constants]
     [status-im.contexts.chat.group-details.style :as style]
+    [utils.debounce :as debounce]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -113,6 +114,7 @@
         members         (rf/sub [:contacts/group-members-sections chat-id])
         pinned-messages (rf/sub [:chats/pinned chat-id])
         current-pk      (rf/sub [:multiaccount/public-key])
+        profile-color   (rf/sub [:profile/customization-color])
         admin?          (get admins current-pk)]
     [:<>
      [quo/gradient-cover
@@ -126,8 +128,8 @@
                                                {:content (fn [] [actions/group-details-actions
                                                                  group])}])}]
        :icon-name  :i/arrow-left
+       :margin-top 30
        :on-press   #(rf/dispatch [:navigate-back])}]
-
      [quo/page-top
       {:title  chat-name
        :avatar {:customization-color color}}]
@@ -167,4 +169,15 @@
        :render-section-footer-fn       contacts-section-footer
        :render-data                    {:chat-id chat-id
                                         :admin?  admin?}
-       :render-fn                      contact-item-render}]]))
+       :render-fn                      contact-item-render}]
+     [quo/floating-shell-button
+      {:key     :shell
+       :jump-to {:on-press            (fn []
+                                        (rf/dispatch [:navigate-back])
+                                        (debounce/throttle-and-dispatch [:shell/navigate-to-jump-to]
+                                                                        500))
+                 :customization-color profile-color
+                 :label               (i18n/label :t/jump-to)}
+      }
+      style/floating-shell-button
+     ]]))

--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -9,7 +9,6 @@
     [status-im.common.home.actions.view :as actions]
     [status-im.constants :as constants]
     [status-im.contexts.chat.group-details.style :as style]
-    [utils.debounce :as debounce]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -171,12 +170,7 @@
        :render-fn                      contact-item-render}]
      [quo/floating-shell-button
       {:key     :shell
-       :jump-to {:on-press            (fn []
-                                        (rf/dispatch [:navigate-back])
-                                        (debounce/throttle-and-dispatch [:shell/navigate-to-jump-to]
-                                                                        500))
+       :jump-to {:on-press            #(rf/dispatch [:shell/navigate-to-jump-to])
                  :customization-color profile-color
-                 :label               (i18n/label :t/jump-to)}
-      }
-      style/floating-shell-button
-     ]]))
+                 :label               (i18n/label :t/jump-to)}}
+      style/floating-shell-button]]))

--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -169,8 +169,7 @@
                                         :admin?  admin?}
        :render-fn                      contact-item-render}]
      [quo/floating-shell-button
-      {:key     :shell
-       :jump-to {:on-press            #(rf/dispatch [:shell/navigate-to-jump-to])
+      {:jump-to {:on-press            #(rf/dispatch [:shell/navigate-to-jump-to])
                  :customization-color profile-color
                  :label               (i18n/label :t/jump-to)}}
       style/floating-shell-button]]))

--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -169,7 +169,10 @@
                                         :admin?  admin?}
        :render-fn                      contact-item-render}]
      [quo/floating-shell-button
-      {:jump-to {:on-press            #(rf/dispatch [:shell/navigate-to-jump-to])
+      {:jump-to {:on-press            (fn []
+                                        (rf/dispatch [:navigate-back])
+                                        (rf/dispatch [:shell/navigate-to-jump-to])
+                                      )
                  :customization-color profile-color
                  :label               (i18n/label :t/jump-to)}}
       style/floating-shell-button]]))

--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -128,7 +128,6 @@
                                                {:content (fn [] [actions/group-details-actions
                                                                  group])}])}]
        :icon-name  :i/arrow-left
-       :margin-top 30
        :on-press   #(rf/dispatch [:navigate-back])}]
      [quo/page-top
       {:title  chat-name

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -70,8 +70,7 @@
        :on-scroll                       #(scroll-handler % scroll-y)
        :bounces                         false}]
      [quo/floating-shell-button
-      {:key :shell
-       :jump-to
+      {:jump-to
        {:on-press            (fn []
                                (rf/dispatch [:navigate-back])
                                (debounce/throttle-and-dispatch [:shell/navigate-to-jump-to] 500))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

If you submit PR for issue with bounty then write here Fixes #NN where NN is issue number

*otherwise*

fixes #19122 

### Summary

This PR is to add the jump-to floating button in group detail screen.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Create a group chat
- Long press a group chat and click group details in the opening sheet.

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison
![Simulator Screenshot - iPhone 13 - 2024-03-07 at 09 04 20](https://github.com/status-im/status-mobile/assets/39961806/06d8951e-771d-440f-80c7-51413a2cb8a1)

status: ready <!-- Can be ready or wip -->
