### PR TITLE
Show toast after sending contact request

### DIFF
--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -20,7 +20,12 @@
         on-message-submit     (rn/use-callback (fn []
                                                  (rf/dispatch [:hide-bottom-sheet])
                                                  (rf/dispatch [:contact.ui/send-contact-request
-                                                               public-key message]))
+                                                               public-key message])
+                                                 (rf/dispatch [:toasts/upsert
+                                                               {:id   :send-contact-request
+                                                                :type :positive
+                                                                :text (i18n/label
+                                                                       :t/contact-request-was-sent)}]))
                                                [public-key message])]
     [:<>
      [quo/drawer-top

--- a/translations/en.json
+++ b/translations/en.json
@@ -1975,6 +1975,7 @@
     "send-contact-request-message": "To start a chat you need to become contacts",
     "contact-request": "Contact request",
     "send-contact-request": "Send contact request",
+    "contact-request-was-sent": "Contact request sent",
     "contact-request-sent-to": "Contact request sent to",
     "contact-request-was-accepted": "Contact request accepted",
     "contact-request-is-now-a-contact": "is now a contact",


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19138 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR attempts to display a toast notification after confirming to send a contact request.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- New contact profiles

### Steps to test
- Open the Status mobile and desktop app
- Enable the profile `new-contact-ui` feature flag on mobile
- Send a contact request from mobile user to desktop user

### Before and after screenshots comparison

#### Before


https://github.com/status-im/status-mobile/assets/2845768/c0d54c88-daf1-4fa1-94cf-2a836b5582ec



#### After


https://github.com/status-im/status-mobile/assets/2845768/49342c0f-5493-42a3-91b5-4c9f86cf61f0



status: ready 
