### PR TITLE
[Fix] Chain down toast shown for chains unrelated to the current network

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -429,6 +429,12 @@
 (def ^:const mainnet-chain-ids
   #{ethereum-mainnet-chain-id arbitrum-mainnet-chain-id optimism-mainnet-chain-id})
 
+(def ^:const goerli-chain-ids
+  #{ethereum-goerli-chain-id arbitrum-goerli-chain-id optimism-goerli-chain-id})
+
+(def ^:const sepolia-chain-ids
+  #{ethereum-sepolia-chain-id arbitrum-sepolia-chain-id optimism-sepolia-chain-id})
+
 (def ^:const mainnet-short-name "eth")
 (def ^:const optimism-short-name "opt")
 (def ^:const arbitrum-short-name "arb1")

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -303,3 +303,15 @@
     label-props
     (assoc :label       :text
            :label-props label-props)))
+
+(defn get-default-chain-ids-by-mode
+  [{:keys [test-networks-enabled? is-goerli-enabled?]}]
+  (cond
+    (and test-networks-enabled? is-goerli-enabled?)
+    constants/goerli-chain-ids
+
+    test-networks-enabled?
+    constants/sepolia-chain-ids
+
+    :else
+    constants/mainnet-chain-ids))

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -3,7 +3,6 @@
     [clojure.string :as string]
     [react-native.background-timer :as background-timer]
     [react-native.platform :as platform]
-    [status-im.constants :as constants]
     [status-im.contexts.wallet.accounts.add-account.address-to-watch.events]
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.data-store :as data-store]
@@ -447,16 +446,15 @@
  (fn [{:keys [db]} [{:keys [message]}]]
    (let [chains                  (-> (transforms/json->clj message)
                                      (update-keys (comp utils.number/parse-int name)))
-         down-chains             (-> (select-keys chains
+         down-chain-ids          (-> (select-keys chains
                                                   (for [[k v] chains :when (= v "down")] k))
                                      keys)
          test-networks-enabled?  (get-in db [:profile/profile :test-networks-enabled?])
-         disabled-chain-id?      (fn [chain-id]
-                                   (let [mainnet-chain? (contains? constants/mainnet-chain-ids chain-id)]
-                                     (if test-networks-enabled?
-                                       mainnet-chain?
-                                       (not mainnet-chain?))))
-         chains-filtered-by-mode (remove disabled-chain-id? down-chains)
+         is-goerli-enabled?      (get-in db [:profile/profile :is-goerli-enabled?])
+         chain-ids-by-mode       (utils/get-default-chain-ids-by-mode
+                                  {:test-networks-enabled? test-networks-enabled?
+                                   :is-goerli-enabled?     is-goerli-enabled?})
+         chains-filtered-by-mode (remove #(not (contains? chain-ids-by-mode %)) down-chain-ids)
          chains-down?            (seq chains-filtered-by-mode)
          chain-names             (when chains-down?
                                    (->> (map #(-> (utils/id->network %)
@@ -465,9 +463,10 @@
                                              chains-filtered-by-mode)
                                         distinct
                                         (string/join ", ")))]
-     (when (seq down-chains)
-       (log/info "[wallet] Chain(s) down: " down-chains)
-       (log/info "[wallet] Test network enabled: " (boolean test-networks-enabled?)))
+     (when (seq down-chain-ids)
+       (log/info "[wallet] Chain(s) down: " down-chain-ids)
+       (log/info "[wallet] Test network enabled: " (boolean test-networks-enabled?))
+       (log/info "[wallet] Goerli network enabled: " (boolean is-goerli-enabled?)))
      {:db (assoc-in db [:wallet :statuses :blockchains] chains)
       :fx (when chains-down?
             [[:dispatch


### PR DESCRIPTION
fixes #19135

### Summary

This PR fixes chain down toast shown for chains unrelated to the current network.

### Review notes

The issue was caused by the Goerli Chain IDs but the user was on the Sepolia test network. When receiving the status signal from `status-go`, it contains all chains irrespective of the mode the user is in.
This PR adds an additional filter based on the test network to fix it.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Login to your profile
- Switch to the testnet mode (not enabling Goerli test networks)
- Check whether the toast is shown on login

#### NOTE: If Goerli is enabled, you will see some chains down as our provider is slowly removing support.

status: ready
