### PR TITLE
fix: view-id not updating when navigating inside modals

### DIFF
--- a/src/status_im/navigation/core.cljs
+++ b/src/status_im/navigation/core.cljs
@@ -37,14 +37,14 @@
 
   (navigation/reg-component-did-appear-listener
    (fn [view-id]
-     (when (get views/screens view-id)
-       ;;NOTE when back from the background on Android, this event happens for all screens, but we
-       ;;need only for active one
-       (when (and @state/curr-modal (= @state/curr-modal view-id))
-         (effects/set-view-id view-id))
-       (when-not @state/curr-modal
+     (let [view-id-with-prefix (keyword (str "screen/" (name view-id)))
+           view                (or (get views/screens view-id)
+                                   (get views/screens view-id-with-prefix))
+           view-id             (:name view)]
+       (when view
          (effects/set-view-id view-id)
-         (reset! state/pushed-screen-id view-id)))))
+         (when-not @state/curr-modal
+           (reset! state/pushed-screen-id view-id))))))
 
   ;;;; Modal
 

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -33,7 +33,9 @@
 (rf/defn navigate-to-within-stack
   {:events [:navigate-to-within-stack]}
   [{:keys [db]} comp-id]
-  {:db (update db :modal-view-ids add-view-to-modals (first comp-id))
+  {:db (-> db
+           (update :modal-view-ids add-view-to-modals (first comp-id))
+           (assoc :view-id (first comp-id)))
    :fx [[:navigate-to-within-stack comp-id]]})
 
 (re-frame/reg-event-fx :open-modal


### PR DESCRIPTION
fixes #19126 

### Summary

This PR aims to fix :view-id not updating properly when navigating within modals. The way to test this PR is by using re-frisk, navigating within modals (an example is the wallet send flow), and check if `:view-id` key is updating properly when navigating within modals, opening modals and dismissing modals.

No manual QA is needed in this case.

#### Platforms

- Android
- iOS

status: ready