### PR TITLE
Feature: Ignore / Dismiss contact requests from contact profile

### DIFF
--- a/src/status_im/contexts/profile/contact/contact_review/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_review/view.cljs
@@ -28,8 +28,17 @@
                                                          :text (i18n/label
                                                                 :t/contact-request-was-accepted)}]))
                                         [contact-request-id])
-        on-contact-ignore              (rn/use-callback (fn []
-                                                          (rf/dispatch [:hide-bottom-sheet])))]
+        on-contact-ignore              (rn/use-callback
+                                        (fn []
+                                          (rf/dispatch [:hide-bottom-sheet])
+                                          (rf/dispatch [:activity-center.contact-requests/decline
+                                                        contact-request-id])
+                                          (rf/dispatch [:toasts/upsert
+                                                        {:id   :ignore-contact-request
+                                                         :type :positive
+                                                         :text (i18n/label
+                                                                :t/contact-request-was-ignored)}]))
+                                        [contact-request-id])]
     [:<>
      [quo/drawer-top
       {:type                :context-tag

--- a/src/status_im/contexts/profile/contact/header/view.cljs
+++ b/src/status_im/contexts/profile/contact/header/view.cljs
@@ -55,7 +55,8 @@
 
      (cond
        (or (not contact-request-state)
-           (= contact-request-state constants/contact-request-state-none))
+           (= contact-request-state constants/contact-request-state-none)
+           (= contact-request-state constants/contact-request-state-dismissed))
        [quo/button
         {:container-style style/button-wrapper
          :on-press        on-contact-request

--- a/translations/en.json
+++ b/translations/en.json
@@ -1979,6 +1979,7 @@
     "contact-request-was-sent": "Contact request sent",
     "contact-request-sent-to": "Contact request sent to",
     "contact-request-was-accepted": "Contact request accepted",
+    "contact-request-was-ignored": "Contact request ignored",
     "contact-request-is-now-a-contact": "is now a contact",
     "contact-request-removed-you-as-contact": "removed you as a contact",
     "contact-request-removed-as-contact": "removed as a contact",


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19131 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to integrate the ignore / dismiss logic while reviewing a contact request.
  * The ignore button now transitions the `contact-request-state` to dismissed.
  * And a toast is displayed to acknowledge the request to ignore the contact request.

### Testing notes

One important thing to note about this PR is that it does not implement the Figma designs completely. For the moment, it was decided to not allow a contact request to be re-reviewed after dismissing, and instead the mobile app will display the default state to send a contact request. 
* Note, that sending a contact request while an existing contact-request is dismissed will result with a contact request being accepted automatically by both users and they'll become mutual contacts.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- New Contact Profile

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open the Status mobile and desktop app
- Enable the profile `new-contact-ui` feature flag on mobile
- Send a contact request from desktop user to mobile user
- Review contact request via the mobile app
- Ignore contact request via the mobile app

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before

https://github.com/status-im/status-mobile/assets/2845768/69692a9e-60b3-40ad-a279-274a490b9b05

#### After

https://github.com/status-im/status-mobile/assets/2845768/ccce869a-5622-4912-b1fa-1e6faff59c6d

status: ready <!-- Can be ready or wip -->
