### PR TITLE
Add action to remove contact inside contact action menu

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -1224,6 +1224,7 @@
     "remove": "Remove",
     "remove-from-chat": "Remove from chat",
     "remove-from-contacts": "Remove from contacts",
+    "remove-contact": "Remove contact",
     "remove-from-contacts-text": "By removing a user from your contact list you do not hide your wallet address from them",
     "remove-network": "Remove network",
     "remove-token": "Remove token",


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19148 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to integrate the "Remove contact" action inside a contact's action menu.

### Testing notes
* The remove contact action will only be available once a user and a contact become mutual contacts.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- New contact profile action menu

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open the Status mobile and desktop app
- Enable the profile `new-contact-ui` feature flag on mobile
- Send a contact request from mobile user to desktop user
- Accept contact request via the desktop app
- View the contact profile of the desktop user on the mobile app
- Press the action button to open the contact action menu
- Press the "Remove action" button

### Before and after screenshots comparison

#### Before
<img width="438" alt="Screenshot 2024-03-11 at 12 07 36" src="https://github.com/status-im/status-mobile/assets/2845768/ecb342a6-2d7a-4ae9-a757-a0b452b9f49c">


#### After

https://github.com/status-im/status-mobile/assets/2845768/a594eb54-71ab-4345-835c-83bd8636e795


status: ready <!-- Can be ready or wip -->
