### PR TITLE
fix: unresponsive add watched address screen when entering a multi-chain address

### DIFF
--- a/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_address_to_watch/view.cljs
@@ -6,6 +6,7 @@
     [react-native.core :as rn]
     [reagent.core :as reagent]
     [status-im.common.floating-button-page.view :as floating-button-page]
+    [status-im.constants :as constants]
     [status-im.contexts.wallet.add-address-to-watch.style :as style]
     [status-im.contexts.wallet.common.validation :as validation]
     [status-im.subs.wallet.add-account.address-to-watch]
@@ -21,6 +22,10 @@
     (not
      (or (validation/eth-address? user-input)
          (validation/ens-name? user-input))) (i18n/label :t/invalid-address)))
+
+(defn- extract-address
+  [scanned-text]
+  (re-find constants/regx-address-contains scanned-text))
 
 (defn- address-input
   [{:keys [input-value validation-msg validate clear-input]}]
@@ -138,7 +143,8 @@
                      :on-press            (fn []
                                             (rf/dispatch [:navigate-to
                                                           :screen/wallet.confirm-address-to-watch
-                                                          {:address validated-address}])
+                                                          {:address (extract-address
+                                                                     validated-address)}])
                                             (clear-input))
                      :container-style     {:z-index 2}}
                     (i18n/label :t/continue)]}


### PR DESCRIPTION
fixes #18950

### Summary

This PR aims to fix unresponsive add watched address screen when entering a multi-chain address. The approach I took is to extract the plain address from the multi-chain address so status-go endpoint doesn't return an error and the flow continues as expected. Either way address is watched for all the available chains.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

1. Open Status
2. Navigate to the Wallet tab
3. Tap on `+` to add new watch address
4. Enter a multichain address (Eg: `eth:opt:arb1:0x9bf27d0c9aba562dc33bc4b60c233a6609ce2987`)
5. Tap on `Confirm` to navigate to the next screen
6. Enter a name
7. Tap on `Add watched address`
8. Verify the screen is responsive and the watched address is created successfully

status: ready