### PR TITLE
fix duplicate mention

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/content/text/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/text/style.cljs
@@ -14,18 +14,18 @@
 
 (defn mention-tag-wrapper
   [first-child-mention]
-  {:flex-direction :row
-   :align-items    :center
-   :height         (if platform/ios? 22 21)
-   :border-radius  6
-   :transform      [{:translateY (if platform/ios? (if first-child-mention 4.5 3) 4.5)}]})
+  {:flex-direction     :row
+   :align-items        :center
+   :height             (if platform/ios? 22 21)
+   :background-color   colors/primary-50-opa-10
+   :padding-horizontal 3
+   :border-radius      6
+   :transform          [{:translateY (if platform/ios? (if first-child-mention 4.5 3) 4.5)}]})
 
 (def mention-tag-text
   {:color                 (colors/theme-colors colors/primary-50
                                                colors/primary-60)
    :selection-color       :transparent
-   :background-color      colors/primary-50-opa-10
-   :padding-horizontal    3
    :suppress-highlighting true})
 
 (defn code

--- a/src/status_im/contexts/chat/messenger/messages/content/text/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/text/view.cljs
@@ -57,16 +57,14 @@
       :mention
       (conj
        units
-       (let [resolved-mention (rf/sub [:messages/resolve-mention literal])]
-         [rn/pressable
-          {:on-press #(rf/dispatch [:chat.ui/show-profile literal])
-           :key      resolved-mention
-           :style    (style/mention-tag-wrapper first-child-mention)}
-          [quo/text
-           {:weight :medium
-            :style  style/mention-tag-text
-            :size   :paragraph-1}
-           resolved-mention]]))
+       [rn/pressable
+        {:on-press #(rf/dispatch [:chat.ui/show-profile literal])
+         :style    (style/mention-tag-wrapper first-child-mention)}
+        [quo/text
+         {:weight :medium
+          :style  style/mention-tag-text
+          :size   :paragraph-1}
+         (rf/sub [:messages/resolve-mention literal])]])
 
       :edited
       (conj units
@@ -108,6 +106,7 @@
                 (render-inline acc e chat-id style-override mention-first))
               [quo/text
                {:size  :paragraph-1
+                :key   (rand-int 1000000) ;; https://github.com/status-im/status-mobile/pull/19203
                 :style {:margin-bottom (if mention-first (if platform/ios? 4 0) 2)
                         :margin-top    (if mention-first (if platform/ios? -4 0) -1)
                         :color         (when (seq style-override) colors/white)


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19124

### Summary
For inline render components like `mention` we are nesting all views inside the text component. But parent text component has several limitations compared to the normal view component.
- If the internal text component is directly nested, then we are not able to apply styles like `border-radius`
- If we use a wrapper around that internal text component for styling, and if the internal text component rerenders due to content change then wrapper dimensions are not updated and cause [issue](https://github.com/status-im/status-mobile/issues/18432)
- If we force the rerender wrapper too using key as resolved-mention then it loses positioning and will rerender at the start of the parent text
- The only solution is force rendering of the parent itself.

### Testing Note
- Please also test https://github.com/status-im/status-mobile/issues/18432

status: ready
