### PR TITLE
Correctly display 'Community admins will review your request' in community overview screen

### DIFF
--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -179,7 +179,7 @@
         (i18n/label :t/join-open-community)]])))
 
 (defn- join-community
-  [{:keys [id joined permissions role-permissions? can-join?] :as community}]
+  [{:keys [id joined permissions can-request-access?] :as community}]
   (let [pending?        (rf/sub [:communities/my-pending-request-to-join id])
         access-type     (get-access-type (:access permissions))
         unknown-access? (= access-type :unknown-access)
@@ -187,7 +187,7 @@
     [:<>
      (when-not (or joined pending? invite-only? unknown-access?)
        [token-requirements community])
-     (when (not (or pending? role-permissions? can-join?))
+     (when (and can-request-access? (not joined))
        [quo/text
         {:size   :paragraph-2
          :weight :regular


### PR DESCRIPTION
fixes #18706 

Display the text 'Community admins will review your request' under the join community button only for communities with the 'Request to join required' option enabled, except in the joined state.

status: ready <!-- Can be ready or wip -->
