### PR TITLE
add empty check for keychain credentials server

### DIFF
--- a/src/react_native/keychain.cljs
+++ b/src/react_native/keychain.cljs
@@ -62,23 +62,26 @@
   ([server username password]
    (save-credentials server username password identity))
   ([server username password callback]
-   (-> (.setInternetCredentials ^js react-native-keychain
-                                (string/lower-case server)
-                                username
-                                password
-                                keychain-secure-hardware
-                                keychain-restricted-availability)
-       (.then callback))))
+   (when-not (empty? server)
+     (-> (.setInternetCredentials ^js react-native-keychain
+                                  (string/lower-case server)
+                                  username
+                                  password
+                                  keychain-secure-hardware
+                                  keychain-restricted-availability)
+         (.then callback)))))
 
 (defn get-credentials
   "Gets the credentials for a specified server from the Keychain"
   ([server]
    (get-credentials server identity))
   ([server callback]
-   (-> (.getInternetCredentials ^js react-native-keychain (string/lower-case server))
-       (.then callback))))
+   (when-not (empty? server)
+     (-> (.getInternetCredentials ^js react-native-keychain (string/lower-case server))
+         (.then callback)))))
 
 (defn reset-credentials
   [server]
-  (-> (.resetInternetCredentials ^js react-native-keychain (string/lower-case server))
-      (.then #(when-not % (log/error (str "Error while clearing saved password."))))))
+  (when-not (empty? server)
+    (-> (.resetInternetCredentials ^js react-native-keychain (string/lower-case server))
+        (.then #(when-not % (log/error (str "Error while clearing saved password.")))))))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19239

### Summary

https://github.com/status-im/status-mobile/blob/614b03d7015f9d8814d66ad64c6a46a7b845b82c/src/status_im/common/keychain/events.cljs#L64-L66

We have empty check for save-auth-method, but `get-credentials`, `reset-credentials` etc. are missing this empty check. So if for some reason key-uid is nil, it will cause crash.

### Testing notes
Please test all account types
- Simple login
- Biometric login
- Account restored from local pairing `(this one is most suspicious, maybe also check in develop if this one is causing the bug)`

Note: I am not able to reproduce this issue, but most likely cause mentioned in Summary is culprit. As these are only effects with string/lower-case in logout method.

status: ready