### PR TITLE
fix: routes not being fetched when scanning an address

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -174,11 +174,11 @@
                                     (reagent/flush))))
         on-navigate-back      on-navigate-back
         fetch-routes          (fn [input-num-value current-limit-amount]
-                                (let [nav-current-screen-id (rf/sub [:view-id])]
+                                (let [view-id (rf/sub [:view-id])]
                                   ; this check is to prevent effect being triggered when screen is
                                   ; loaded but not being shown to the user (deep in the navigation
                                   ; stack) and avoid undesired behaviors
-                                  (when (= nav-current-screen-id current-screen-id)
+                                  (when (= view-id current-screen-id)
                                     (if-not (or (empty? @input-value)
                                                 (<= input-num-value 0)
                                                 (> input-num-value current-limit-amount))


### PR DESCRIPTION
fixes #18652 (hopefully for the last time)

### Summary

This PR fixes routes not fetching when scanning an address.

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in to your profile
- Navigate to the Wallet tab
- Tap on any account
- Tap on the Send button
- Scan any address 
- Select any asset to send
- Enter any amount (below the limit) and be sure you have enough ETH for gas spending
- Verify routes are fetched

status: ready