### PR TITLE
Refactor image server uri helpers

### DIFF
--- a/src/legacy/status_im/ui/components/chat_icon/screen.cljs
+++ b/src/legacy/status_im/ui/components/chat_icon/screen.cljs
@@ -12,7 +12,8 @@
     [re-frame.core :as re-frame.core]
     [react-native.core :as rn]
     [status-im.contexts.profile.utils :as profile.utils]
-    [utils.ens.core :as utils.ens]))
+    [utils.ens.core :as utils.ens]
+    [utils.image-server :as image-server]))
 
 ;;TODO REWORK THIS NAMESPACE
 
@@ -156,9 +157,11 @@
                                                      (styles/default-chat-icon-text size)
                                                      (styles/emoji-chat-icon-text size))}
                           override-styles)
-        photo-path (if (:fn photo-path)
+        img-config (:config photo-path)
+        photo-path (if img-config
                      ;; temp support new media server avatar for old component
-                     {:uri ((:fn photo-path)
+                     {:uri (image-server/get-image-uri
+                            img-config
                             {:size             size
                              :full-name        name
                              :font-size        (get-in styles [:default-chat-icon-text :font-size])

--- a/src/quo/components/avatars/user_avatar/view.cljs
+++ b/src/quo/components/avatars/user_avatar/view.cljs
@@ -8,6 +8,7 @@
     [react-native.core :as rn]
     [react-native.fast-image :as fast-image]
     [schema.core :as schema]
+    [utils.image-server :as image-server]
     utils.string))
 
 (defn initials-avatar
@@ -38,23 +39,23 @@
            online?           true
            ring?             true}
     :as   props}]
-  (let [theme              (quo.theme/use-theme)
-        full-name          (or full-name "Your Name")
+  (let [theme           (quo.theme/use-theme)
+        picture-config  (:config profile-picture)
+        full-name       (or full-name "Your Name")
         ;; image generated with `profile-picture-fn` is round cropped
         ;; no need to add border-radius for them
-        outer-styles       (style/outer size (not (:fn profile-picture)))
+        outer-styles    (style/outer size (not picture-config))
         ;; Once image is loaded, fast image re-renders view with the help of reagent atom,
         ;; But dynamic updates don't work when user-avatar is used inside hole-view
         ;; https://github.com/status-im/status-mobile/issues/15553
-        image-view         (if static? no-flicker-image/image fast-image/fast-image)
-        font-size          (get-in style/sizes [size :font-size])
-        amount-initials    (if (#{:xs :xxs :xxxs} size) 1 2)
-        sizes              (get style/sizes size)
-        indicator-color    (get (style/indicator-color theme) (if online? :online :offline))
-        profile-picture-fn (:fn profile-picture)]
+        image-view      (if static? no-flicker-image/image fast-image/fast-image)
+        font-size       (get-in style/sizes [size :font-size])
+        amount-initials (if (#{:xs :xxs :xxxs} size) 1 2)
+        sizes           (get style/sizes size)
+        indicator-color (get (style/indicator-color theme) (if online? :online :offline))]
 
     [rn/view {:style outer-styles :accessibility-label :user-avatar}
-     (if (and full-name (not (or profile-picture-fn profile-picture)))
+     (if (and full-name (not (or picture-config profile-picture)))
        ;; this is for things that's not user-avatar but are currently using user-avatar to render
        ;; the initials e.g. community avatar
        [initials-avatar props]
@@ -62,8 +63,9 @@
         {:accessibility-label :profile-picture
          :style outer-styles
          :source
-         (cond profile-picture-fn
-               {:uri (profile-picture-fn
+         (cond picture-config
+               {:uri (image-server/get-image-uri
+                      picture-config
                       {:length                   amount-initials
                        :full-name                full-name
                        :font-size                (:font-size (text/text-style {:size
@@ -76,7 +78,7 @@
                        :indicator-center-to-edge (when status-indicator?
                                                    (:status-indicator-center-to-edge sizes))
                        :indicator-color          indicator-color
-                       :override-theme           theme
+                       :theme                    theme
                        :color                    (:color style/initials-avatar-text)
                        :size                     (:width outer-styles)
                        :ring?                    ring?

--- a/src/schema/quo.cljs
+++ b/src/schema/quo.cljs
@@ -3,7 +3,7 @@
     [quo.foundations.colors :as colors]
     [schema.registry :as registry]))
 
-(def ^:private ?customization-color (into [:enum] colors/account-colors))
+(def ^:private ?customization-color (into [:enum :primary] colors/account-colors))
 
 (def ^:private ?profile-picture-options
   [:map

--- a/src/schema/quo.cljs
+++ b/src/schema/quo.cljs
@@ -3,7 +3,9 @@
     [quo.foundations.colors :as colors]
     [schema.registry :as registry]))
 
-(def ^:private ?profile-picture-fn-params
+(def ^:private ?customization-color (into [:enum] colors/account-colors))
+
+(def ^:private ?profile-picture-options
   [:map
    [:length :int]
    [:full-name :string]
@@ -11,22 +13,67 @@
    [:indicator-size {:optional true} [:maybe :int]]
    [:indicator-color {:optional true} [:maybe :string]]
    [:indicator-center-to-edge {:optional true} [:maybe :int]]
-   [:override-theme :schema.common/theme]
-   [:background-color :string]
+   [:theme :schema.common/theme]
    [:color :string]
    [:size :int]
    [:ring? :boolean]
    [:ring-width :int]])
 
+(def ^:private ?account-image-uri-options
+  [:map
+   [:port :int]
+   [:ratio :double]
+   [:key-uid :string]
+   [:image-name :string]
+   [:theme :schema.common/theme]
+   [:override-ring? [:maybe :boolean]]])
+
+(def ^:private ?initials-image-uri-options
+  [:map
+   [:port :int]
+   [:ratio :double]
+   [:uppercase-ratio :double]
+   [:font-file :string]
+   [:theme :schema.common/theme]
+   [:customization-color ?customization-color]
+   [:key-uid {:optional true} [:maybe :string]]
+   [:public-key {:optional true} [:maybe :string]]
+   [:override-ring? {:optional true} [:maybe :boolean]]])
+
+(def ^:private ?contact-image-uri-options
+  [:map
+   [:port :int]
+   [:clock :int]
+   [:ratio :double]
+   [:image-name :string]
+   [:public-key :string]
+   [:theme :schema.common/theme]
+   [:override-ring? [:maybe :boolean]]])
+
+(def ^:private ?image-uri-config
+  [:multi {:dispatch :type}
+   [:account
+    [:map
+     [:type [:= :account]]
+     [:options ?account-image-uri-options]]]
+   [:contact
+    [:map
+     [:type [:= :contact]]
+     [:options ?contact-image-uri-options]]]
+   [:initials
+    [:map
+     [:type [:= :initials]]
+     [:options ?initials-image-uri-options]]]])
+
 (def ^:private ?profile-picture-source
   [:or
    :schema.common/image-source
    [:map
-    [:fn [:=> [:cat ?profile-picture-fn-params] :string]]]])
-
-(def ^:private ?customization-color (into [:enum] colors/account-colors))
+    [:config ?image-uri-config]]])
 
 (defn register-schemas
   []
+  (registry/register ::customization-color ?customization-color)
+  (registry/register ::image-uri-config ?image-uri-config)
   (registry/register ::profile-picture-source ?profile-picture-source)
-  (registry/register ::customization-color ?customization-color))
+  (registry/register ::profile-picture-options ?profile-picture-options))

--- a/src/status_im/subs/contact.cljs
+++ b/src/status_im/subs/contact.cljs
@@ -11,8 +11,7 @@
     [status-im.subs.chat.utils :as chat.utils]
     [utils.address :as address]
     [utils.collection]
-    [utils.i18n :as i18n]
-    [utils.image-server :as image-server]))
+    [utils.i18n :as i18n]))
 
 (defn query-chat-contacts
   [{:keys [contacts]} all-contacts query-fn]
@@ -45,37 +44,40 @@
         (reduce (fn [acc image]
                   (let [image-name (:type image)
                         clock      (:clock image)
-                        uri        (image-server/get-contact-image-uri-fn
-                                    {:port port
-                                     :ratio pixel-ratio/ratio
-                                     :public-key
-                                     public-key
-                                     :image-name
-                                     image-name
-                                     ; We pass the clock so that we reload the
-                                     ; image if the image is updated
-                                     :clock
-                                     clock
-                                     :theme
-                                     theme
-                                     :override-ring?
-                                     (when ens-name false)})]
-                    (assoc-in acc [(keyword image-name) :fn] uri)))
+                        options    {:port port
+                                    :ratio pixel-ratio/ratio
+                                    :public-key
+                                    public-key
+                                    :image-name
+                                    image-name
+                                    ; We pass the clock so that we reload the
+                                    ; image if the image is updated
+                                    :clock
+                                    clock
+                                    :theme
+                                    theme
+                                    :override-ring?
+                                    (when ens-name false)}]
+                    (assoc-in acc
+                     [(keyword image-name) :config]
+                     {:type    :contact
+                      :options options})))
                 images
                 (vals images))
 
         images (if (seq images)
                  images
                  {:thumbnail
-                  {:fn (image-server/get-initials-avatar-uri-fn
-                        {:port                port
-                         :ratio               pixel-ratio/ratio
-                         :public-key          public-key
-                         :override-ring?      (when ens-name false)
-                         :uppercase-ratio     (:uppercase-ratio constants/initials-avatar-font-conf)
-                         :customization-color customization-color
-                         :theme               theme
-                         :font-file           font-file})}})]
+                  {:config {:type    :initials
+                            :options {:port                port
+                                      :ratio               pixel-ratio/ratio
+                                      :public-key          public-key
+                                      :override-ring?      (when ens-name false)
+                                      :uppercase-ratio     (:uppercase-ratio
+                                                            constants/initials-avatar-font-conf)
+                                      :customization-color customization-color
+                                      :theme               theme
+                                      :font-file           font-file}}}})]
 
     (assoc contact :images images)))
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #18967 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to refactor the way profile image URIs are built at runtime.
  * Instead of passing around functions that enclose over a map, we pass around maps with a `type` keyword. This keyword is meant to describe what kind of URI builder function should be used to build the image URI.
  * Malli schemas are used to validate the shape of the arguments and help ensure the right builder function is being called based on the `type` keyword.

### Testing notes

Since this refactors an important piece of logic for rendering profile images, there should likely be a regression test of the whole app, or at least the main parts of the app that display profile images. For example:
* contacts list
* contact profile
* chats
* etc

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Anywhere profile images appear 

status: ready
