### PR TITLE
qualify onboarding screens keys

### DIFF
--- a/src/legacy/status_im/keycard/login.cljs
+++ b/src/legacy/status_im/keycard/login.cljs
@@ -18,7 +18,7 @@
   [{:keys [db] :as cofx}]
   (rf/merge cofx
             {:db db}
-            (navigation/pop-to-root :profiles)))
+            (navigation/pop-to-root :screen/profile.profiles)))
 
 (rf/defn login-pin-more-icon-pressed
   {:events [:keycard.login.pin.ui/more-icon-pressed]}

--- a/src/legacy/status_im/keycard/recovery.cljs
+++ b/src/legacy/status_im/keycard/recovery.cljs
@@ -74,7 +74,8 @@
                  (assoc :recovered-account? true))
              :keycard/check-nfc-enabled nil}
             (bottom-sheet/hide-bottom-sheet-old)
-            (navigation/navigate-to-within-stack [:keycard-recovery-intro :new-to-status])))
+            (navigation/navigate-to-within-stack [:keycard-recovery-intro
+                                                  :screen/onboarding.new-to-status])))
 
 (rf/defn access-key-pressed
   {:events [:multiaccounts.recover.ui/recover-multiaccount-button-pressed]}
@@ -127,7 +128,7 @@
                          :multiaccount-whisper-public-key)}
             (navigation/navigate-to (if platform/android?
                                       :notifications-settings
-                                      :welcome)
+                                      :screen/onboarding.welcome)
                                     nil)))
 
 (rf/defn intro-wizard

--- a/src/status_im/common/pairing/events.cljs
+++ b/src/status_im/common/pairing/events.cljs
@@ -32,10 +32,10 @@
         multiaccount-data               (when received-account?
                                           (merge account {:password password}))
         navigate-to-syncing-devices?    (and (or connection-success? connection-error?) receiver?)
-        user-in-syncing-devices-screen? (or (= (:view-id db) :syncing-progress)
-                                            (= (:view-id db) :profiles)
-                                            (= (:view-id db) :syncing-progress-intro))
-        user-in-sign-in-intro-screen?   (= (:view-id db) :sign-in-intro)]
+        user-in-syncing-devices-screen? (or (= (:view-id db) :screen/onboarding.syncing-progress)
+                                            (= (:view-id db) :screen/profile.profiles)
+                                            (= (:view-id db) :screen/onboarding.syncing-progress-intro))
+        user-in-sign-in-intro-screen?   (= (:view-id db) :screen/onboarding.sign-in-intro)]
     (merge {:db (cond-> db
                   connection-success?
                   (assoc-in [:syncing :pairing-status] :connected)
@@ -51,8 +51,9 @@
            (cond
              (and navigate-to-syncing-devices? (not user-in-syncing-devices-screen?))
              {:dispatch (if user-in-sign-in-intro-screen?
-                          [:navigate-to-within-stack [:syncing-progress-intro :sign-in-intro]]
-                          [:navigate-to :syncing-progress])}
+                          [:navigate-to-within-stack
+                           [:screen/onboarding.syncing-progress-intro :screen/onboarding.sign-in-intro]]
+                          [:navigate-to :screen/onboarding.syncing-progress])}
 
              (and completed-pairing? sender?)
              {:dispatch [:syncing/clear-states]}

--- a/src/status_im/contexts/onboarding/common/background/view.cljs
+++ b/src/status_im/contexts/onboarding/common/background/view.cljs
@@ -69,9 +69,9 @@
 
     (rn/use-effect
      (fn []
-       (reanimated/set-shared-value @paused? (not= view-id :intro))
+       (reanimated/set-shared-value @paused? (not= view-id :screen/onboarding.intro))
        (fn []
-         (when (= view-id :generating-keys)
+         (when (= view-id :screen/onboarding.generating-keys)
            (carousel.animation/cleanup-animation progress paused?))))
      [view-id])
 

--- a/src/status_im/contexts/onboarding/enable_biometrics/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_biometrics/view.cljs
@@ -28,7 +28,7 @@
         bio-type-label           (biometric/get-label-by-type supported-biometric-type)
         profile-color            (or (:color (rf/sub [:onboarding/profile]))
                                      (rf/sub [:profile/customization-color]))
-        syncing-results?         (= :syncing-results @state/root-id)]
+        syncing-results?         (= :screen/onboarding.syncing-results @state/root-id)]
     [rn/view {:style (style/buttons insets)}
      [quo/button
       {:size                40
@@ -43,7 +43,8 @@
        :type                :grey
        :on-press            #(rf/dispatch (if syncing-results?
                                             [:navigate-to-within-stack
-                                             [:enable-notifications :enable-biometrics]]
+                                             [:screen/onboarding.enable-notifications
+                                              :screen/onboarding.enable-biometrics]]
                                             [:onboarding/create-account-and-login]))
        :container-style     {:margin-top 12}}
       (i18n/label :t/maybe-later)]]))

--- a/src/status_im/contexts/onboarding/enable_notifications/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_notifications/view.cljs
@@ -36,7 +36,8 @@
                                  :on-denied   #(log/error "user denied push notification permissions")}])
                               (rf/dispatch [:push-notifications/switch true platform/ios?])
                               (rf/dispatch [:navigate-to-within-stack
-                                            [:welcome :enable-notifications]]))
+                                            [:screen/onboarding.welcome
+                                             :screen/onboarding.enable-notifications]]))
        :type                :primary
        :icon-left           :i/notifications
        :accessibility-label :enable-notifications-button
@@ -46,7 +47,8 @@
       {:on-press            (fn []
                               (shell.utils/change-selected-stack-id :communities-stack true nil)
                               (rf/dispatch [:navigate-to-within-stack
-                                            [:welcome :enable-notifications]]))
+                                            [:screen/onboarding.welcome
+                                             :screen/onboarding.enable-notifications]]))
        :accessibility-label :enable-notifications-later-button
        :type                :grey
        :background          :blur

--- a/src/status_im/contexts/onboarding/events.cljs
+++ b/src/status_im/contexts/onboarding/events.cljs
@@ -27,7 +27,8 @@
   {:events [:onboarding/profile-data-set]}
   [{:keys [db]} onboarding-data]
   {:db       (update db :onboarding/profile merge onboarding-data)
-   :dispatch [:navigate-to-within-stack [:create-profile-password :new-to-status]]})
+   :dispatch [:navigate-to-within-stack
+              [:screen/onboarding.create-profile-password :screen/onboarding.new-to-status]]})
 
 (rf/defn enable-biometrics
   {:events [:onboarding/enable-biometrics]}
@@ -42,7 +43,8 @@
   [{:keys [db]}]
   (let [key-uid (get-in db [:profile/profile :key-uid])]
     {:db       (dissoc db :onboarding/profile)
-     :dispatch [:navigate-to-within-stack [:enable-notifications :enable-biometrics]]}))
+     :dispatch [:navigate-to-within-stack
+                [:screen/onboarding.enable-notifications :screen/onboarding.enable-biometrics]]}))
 
 (rf/defn biometrics-done
   {:events [:onboarding/biometrics-done]}
@@ -64,7 +66,8 @@
   (let [{:keys [display-name seed-phrase password image-path color] :as profile}
         (:onboarding/profile db)]
     (rf/merge cofx
-              {:dispatch       [:navigate-to-within-stack [:generating-keys :new-to-status]]
+              {:dispatch       [:navigate-to-within-stack
+                                [:screen/onboarding.generating-keys :screen/onboarding.new-to-status]]
                :dispatch-later [{:ms       constants/onboarding-generating-keys-animation-duration-ms
                                  :dispatch [:onboarding/navigate-to-identifiers]}]
                :db             (-> db
@@ -82,7 +85,7 @@
     (merge
      {:db (assoc db :profile/profiles-overview multiaccounts)}
      (when-not (seq multiaccounts)
-       {:set-root :intro}))))
+       {:set-root :screen/onboarding.intro}))))
 
 (rf/defn password-set
   {:events [:onboarding/password-set]}
@@ -92,7 +95,8 @@
                    (assoc-in [:onboarding/profile :password] password)
                    (assoc-in [:onboarding/profile :auth-method] constants/auth-method-password))
      :dispatch (if supported-type
-                 [:navigate-to-within-stack [:enable-biometrics :new-to-status]]
+                 [:navigate-to-within-stack
+                  [:screen/onboarding.enable-biometrics :screen/onboarding.new-to-status]]
                  [:onboarding/create-account-and-login])}))
 
 (rf/defn navigate-to-enable-biometrics
@@ -100,8 +104,8 @@
   [{:keys [db]}]
   (let [supported-type (get-in db [:biometrics :supported-type])]
     {:dispatch (if supported-type
-                 [:open-modal :enable-biometrics]
-                 [:open-modal :enable-notifications])}))
+                 [:open-modal :screen/onboarding.enable-biometrics]
+                 [:open-modal :screen/onboarding.enable-notifications])}))
 
 (rf/defn seed-phrase-entered
   {:events [:onboarding/seed-phrase-entered]}
@@ -121,19 +125,21 @@
       :content             (i18n/label :t/multiaccount-exists-content)
       :confirm-button-text (i18n/label :t/unlock)
       :on-accept           (fn []
-                             (re-frame/dispatch [:pop-to-root :profiles])
+                             (re-frame/dispatch [:pop-to-root :screen/profile.profiles])
                              (re-frame/dispatch
                               [:profile/profile-selected key-uid]))
       :on-cancel           #(re-frame/dispatch [:pop-to-root :multiaccounts])}}
     {:db       (assoc-in db [:onboarding/profile :seed-phrase] seed-phrase)
-     :dispatch [:navigate-to-within-stack [:create-profile :new-to-status]]}))
+     :dispatch [:navigate-to-within-stack
+                [:screen/onboarding.create-profile :screen/onboarding.new-to-status]]}))
 
 (rf/defn navigate-to-create-profile
   {:events [:onboarding/navigate-to-create-profile]}
   [{:keys [db]}]
   ;; Restart the flow
   {:db       (dissoc db :onboarding/profile)
-   :dispatch [:navigate-to-within-stack [:create-profile :new-to-status]]})
+   :dispatch [:navigate-to-within-stack
+              [:screen/onboarding.create-profile :screen/onboarding.new-to-status]]})
 
 (rf/reg-event-fx :onboarding/set-auth-method
  (fn [{:keys [db]} [auth-method]]
@@ -167,6 +173,7 @@
   {:events [:onboarding/navigate-to-identifiers]}
   [{:keys [db]}]
   (if (:onboarding/generated-keys? db)
-    {:dispatch [:navigate-to-within-stack [:identifiers :new-to-status]]}
+    {:dispatch [:navigate-to-within-stack
+                [:screen/onboarding.identifiers :screen/onboarding.new-to-status]]}
     {:dispatch-later [{:ms       constants/onboarding-generating-keys-navigation-retry-ms
                        :dispatch [:onboarding/navigate-to-identifiers]}]}))

--- a/src/status_im/contexts/onboarding/identifiers/view.cljs
+++ b/src/status_im/contexts/onboarding/identifiers/view.cljs
@@ -63,7 +63,8 @@
          :type                :grey
          :background          :blur
          :on-press            #(rf/dispatch [:navigate-to-within-stack
-                                             [:enable-notifications :new-to-status]])
+                                             [:screen/onboarding.enable-notifications
+                                              :screen/onboarding.new-to-status]])
          :container-style     style/button}
         (i18n/label :t/continue)]]]]))
 

--- a/src/status_im/contexts/onboarding/intro/view.cljs
+++ b/src/status_im/contexts/onboarding/intro/view.cljs
@@ -19,9 +19,10 @@
                             (reset! scan-sync-code/dismiss-animations reset-top-animation-fn))
      :animations-duration constants/onboarding-modal-animation-duration
      :animations-delay    constants/onboarding-modal-animation-delay
-     :top-card            {:on-press            #(debounce/throttle-and-dispatch [:open-modal
-                                                                                  :sign-in-intro]
-                                                                                 2000)
+     :top-card            {:on-press            #(debounce/throttle-and-dispatch
+                                                  [:open-modal
+                                                   :screen/onboarding.sign-in-intro]
+                                                  2000)
                            :heading             (i18n/label :t/sign-in)
                            :animated-heading    (i18n/label :t/sign-in-by-syncing)
                            :accessibility-label :already-use-status-button}
@@ -29,7 +30,7 @@
                                                   (when-let [blur-show-fn @overlay/blur-show-fn-atom]
                                                     (blur-show-fn))
                                                   (debounce/throttle-and-dispatch
-                                                   [:open-modal :new-to-status]
+                                                   [:open-modal :screen/onboarding.new-to-status]
                                                    1000))
                            :heading             (i18n/label :t/new-to-status)
                            :accessibility-label :new-to-status-button}}

--- a/src/status_im/contexts/onboarding/new_to_status/view.cljs
+++ b/src/status_im/contexts/onboarding/new_to_status/view.cljs
@@ -45,7 +45,9 @@
         :title    (i18n/label :t/use-recovery-phrase)
         :subtitle (i18n/label :t/use-recovery-phrase-subtitle)
         :image    (resources/get-image :ethereum-address)
-        :on-press #(rf/dispatch [:navigate-to-within-stack [:enter-seed-phrase :new-to-status]])}]
+        :on-press #(rf/dispatch [:navigate-to-within-stack
+                                 [:screen/onboarding.enter-seed-phrase
+                                  :screen/onboarding.new-to-status]])}]
       [rn/view {:style style/space-between-suboptions}]
       [quo/small-option-card
        {:variant  :icon

--- a/src/status_im/contexts/onboarding/syncing/progress/view.cljs
+++ b/src/status_im/contexts/onboarding/syncing/progress/view.cljs
@@ -32,11 +32,14 @@
                            (rf/dispatch [:syncing/clear-states])
                            (cond
                              logged-in?     (rf/dispatch [:navigate-back])
-                             in-onboarding? (rf/dispatch [:navigate-back-to :sign-in-intro])
+                             in-onboarding? (rf/dispatch [:navigate-back-to
+                                                          :screen/onboarding.sign-in-intro])
                              :else          (do
                                               (rf/dispatch [:navigate-back])
-                                              (debounce/throttle-and-dispatch [:open-modal :sign-in]
-                                                                              1000))))
+                                              (debounce/throttle-and-dispatch
+                                               [:open-modal
+                                                :screen/onboarding.sign-in]
+                                               1000))))
     :accessibility-label :try-again-later-button
     :customization-color profile-color
     :container-style     style/try-again-button}

--- a/src/status_im/contexts/preview/quo/common.cljs
+++ b/src/status_im/contexts/preview/quo/common.cljs
@@ -9,7 +9,7 @@
   [{:keys [theme title]}]
   (let [logged-in?    (rf/sub [:multiaccount/logged-in?])
         has-profiles? (boolean (rf/sub [:profile/profiles-overview]))
-        root          (if has-profiles? :profiles :intro)
+        root          (if has-profiles? :screen/profile.profiles :screen/onboarding.intro)
         light?        (= theme :light)]
     [quo/page-nav
      {:type       :title

--- a/src/status_im/contexts/profile/events.cljs
+++ b/src/status_im/contexts/profile/events.cljs
@@ -45,14 +45,14 @@
                   (assoc :profile/profiles-overview profiles)
                   (update :profile/login #(select-profile % key-uid)))
               db)
-        :fx [[:set-root :profiles]
+        :fx [[:set-root :screen/profile.profiles]
              (when key-uid
                [:effects.biometric/check-if-available
                 {:key-uid    key-uid
                  :on-success (fn [auth-method]
                                (rf/dispatch [:profile.login/check-biometric-success key-uid
                                              auth-method]))}])]})
-     {:fx [[:set-root :intro]]})))
+     {:fx [[:set-root :screen/onboarding.intro]]})))
 
 (rf/reg-event-fx
  :profile/update-setting-from-backup

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -71,7 +71,7 @@
 
                 (cond
                   pairing-completed?
-                  [[:set-root :syncing-results]]
+                  [[:set-root :screen/onboarding.syncing-results]]
 
                   (get db :onboarding/new-account?)
                   [[:dispatch [:onboarding/finalize-setup]]]

--- a/src/status_im/contexts/profile/profiles/view.cljs
+++ b/src/status_im/contexts/profile/profiles/view.cljs
@@ -50,13 +50,13 @@
                              (when @push-animation-fn-atom
                                (@push-animation-fn-atom))
                              (debounce/throttle-and-dispatch
-                              [:open-modal :new-to-status]
+                              [:open-modal :screen/onboarding.new-to-status]
                               1000))
       :accessibility-label :create-new-profile}
      {:icon                :i/multi-profile
       :label               (i18n/label :t/add-existing-status-profile)
       :on-press            #(debounce/throttle-and-dispatch
-                             [:open-modal :sign-in]
+                             [:open-modal :screen/onboarding.sign-in]
                              1000)
       :accessibility-label :multi-profile}]]])
 

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -53,7 +53,8 @@
        {:background :blur
         :icon-name  :i/close
         :on-press   #(rf/dispatch [:navigate-back])
-        :right-side [{:icon-name :i/multi-profile :on-press #(rf/dispatch [:open-modal :sign-in])}
+        :right-side [{:icon-name :i/multi-profile
+                      :on-press  #(rf/dispatch [:open-modal :screen/onboarding.sign-in])}
                      {:icon-name :i/qr-code
                       :on-press  #(debounce/throttle-and-dispatch [:open-modal :share-shell] 1000)}
                      {:icon-name :i/share :on-press not-implemented/alert}]}]]

--- a/src/status_im/contexts/syncing/scan_sync_code/view.cljs
+++ b/src/status_im/contexts/syncing/scan_sync_code/view.cljs
@@ -301,8 +301,8 @@
                                          @camera-permission-granted?
                                          @preflight-check-passed?
                                          (some #{view-id}
-                                               [:sign-in-intro
-                                                :sign-in
+                                               [:screen/onboarding.sign-in-intro
+                                                :screen/onboarding.sign-in
                                                 :scan-sync-code-page])
                                          (boolean (not-empty @qr-view-finder)))
             camera-ready-to-scan?   (and (or (not animated?) @render-camera?)
@@ -326,7 +326,7 @@
         (when animated?
           (rn/use-effect
            (fn []
-             (when (= view-id :sign-in-intro)
+             (when (= view-id :screen/onboarding.sign-in-intro)
                (rn/hw-back-add-listener reset-animations-fn)
                #(rn/hw-back-remove-listener reset-animations-fn)))
            [view-id])

--- a/src/status_im/navigation/roots.cljs
+++ b/src/status_im/navigation/roots.cljs
@@ -10,17 +10,17 @@
 ;;    [:db :profile/profile :appearance] will be used (for mulitaccounts)
 ;; 3). Fallback theme - Dark
 (def themes
-  {:intro       constants/theme-type-dark
-   :profiles    constants/theme-type-dark
-   :shell-stack nil})
+  {:screen/onboarding.intro constants/theme-type-dark
+   :screen/profile.profiles constants/theme-type-dark
+   :shell-stack             nil})
 
 (defn roots-internal
   []
-  {:intro
+  {:screen/onboarding.intro
    {:root
-    {:stack {:id       :intro
-             :children [{:component {:name    :intro
-                                     :id      :intro
+    {:stack {:id       :screen/onboarding.intro
+             :children [{:component {:name    :screen/onboarding.intro
+                                     :id      :screen/onboarding.intro
                                      :options (options/dark-root-options)}}]}}}
    :shell-stack
    {:root
@@ -29,25 +29,25 @@
                                      :id      :shell-stack
                                      :options (options/root-options
                                                {:nav-bar-color colors/neutral-100})}}]}}}
-   :profiles
+   :screen/profile.profiles
    {:root
-    {:stack {:id       :profiles
-             :children [{:component {:name    :profiles
-                                     :id      :profiles
+    {:stack {:id       :screen/profile.profiles
+             :children [{:component {:name    :screen/profile.profiles
+                                     :id      :screen/profile.profiles
                                      :options (options/dark-root-options)}}]}}}
 
-   :enable-notifications
-   {:root {:stack {:children [{:component {:name    :enable-notifications
-                                           :id      :enable-notifications
+   :screen/onboarding.enable-notifications
+   {:root {:stack {:children [{:component {:name    :screen/onboarding.enable-notifications
+                                           :id      :screen/onboarding.enable-notifications
                                            :options (options/dark-root-options)}}]}}}
 
-   :welcome
-   {:root {:stack {:children [{:component {:name    :welcome
-                                           :id      :welcome
+   :screen/onboarding.welcome
+   {:root {:stack {:children [{:component {:name    :screen/onboarding.welcome
+                                           :id      :screen/onboarding.welcome
                                            :options (options/dark-root-options)}}]}}}
-   :syncing-results
-   {:root {:stack {:children [{:component {:name    :syncing-results
-                                           :id      :syncing-results
+   :screen/onboarding.syncing-results
+   {:root {:stack {:children [{:component {:name    :screen/onboarding.syncing-results
+                                           :id      :screen/onboarding.syncing-results
                                            :options (options/dark-root-options)}}]}}}})
 
 (defn old-roots

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -192,12 +192,12 @@
      :component settings-setup-syncing/view}
 
     ;; Onboarding
-    {:name      :intro
+    {:name      :screen/onboarding.intro
      :options   {:theme :dark}
      :on-focus  [:onboarding/overlay-dismiss]
      :component intro/view}
 
-    {:name      :profiles
+    {:name      :screen/profile.profiles
      :options   {:theme  :dark
                  :layout options/onboarding-layout}
      :on-focus  [:onboarding/overlay-dismiss]
@@ -227,7 +227,7 @@
      :options   options/transparent-screen-options
      :component share-contact/view}
 
-    {:name      :new-to-status
+    {:name      :screen/onboarding.new-to-status
      :options   {:theme                  :dark
                  :layout                 options/onboarding-transparent-layout
                  :animations             (merge
@@ -237,14 +237,14 @@
                  :modalPresentationStyle :overCurrentContext}
      :component new-to-status/new-to-status}
 
-    {:name      :create-profile
+    {:name      :screen/onboarding.create-profile
      :options   {:theme      :dark
                  :layout     options/onboarding-transparent-layout
                  :animations transitions/push-animations-for-transparent-background
                  :popGesture false}
      :component create-profile/create-profile}
 
-    {:name      :create-profile-password
+    {:name      :screen/onboarding.create-profile-password
      :options   {:theme      :dark
                  :insets     {:top false}
                  :layout     options/onboarding-transparent-layout
@@ -252,7 +252,7 @@
                  :popGesture false}
      :component create-password/create-password}
 
-    {:name      :enable-biometrics
+    {:name      :screen/onboarding.enable-biometrics
      :options   {:theme                  :dark
                  :layout                 options/onboarding-transparent-layout
                  :animations             (merge
@@ -264,7 +264,7 @@
                                           :popStackOnPress     false}}
      :component enable-biometrics/view}
 
-    {:name      :generating-keys
+    {:name      :screen/onboarding.generating-keys
      :options   {:theme              :dark
                  :layout             options/onboarding-transparent-layout
                  :animations         transitions/push-animations-for-transparent-background
@@ -273,14 +273,14 @@
                                       :popStackOnPress     false}}
      :component generating-keys/generating-keys}
 
-    {:name      :enter-seed-phrase
+    {:name      :screen/onboarding.enter-seed-phrase
      :options   {:theme      :dark
                  :layout     options/onboarding-transparent-layout
                  :animations transitions/push-animations-for-transparent-background
                  :popGesture false}
      :component enter-seed-phrase/enter-seed-phrase}
 
-    {:name      :enable-notifications
+    {:name      :screen/onboarding.enable-notifications
      :options   {:theme                  :dark
                  :layout                 options/onboarding-transparent-layout
                  :animations             (merge
@@ -289,7 +289,7 @@
                  :modalPresentationStyle :overCurrentContext}
      :component enable-notifications/view}
 
-    {:name      :identifiers
+    {:name      :screen/onboarding.identifiers
      :component identifiers/view
      :options   {:theme              :dark
                  :layout             options/onboarding-transparent-layout
@@ -302,7 +302,7 @@
      :options   options/dark-screen
      :component scan-sync-code-page/view}
 
-    {:name      :sign-in-intro
+    {:name      :screen/onboarding.sign-in-intro
      :options   {:layout                 options/onboarding-transparent-layout
                  :animations             (merge
                                           transitions/sign-in-modal-animations
@@ -310,30 +310,30 @@
                  :modalPresentationStyle :overCurrentContext}
      :component sign-in/animated-view}
 
-    {:name      :sign-in
+    {:name      :screen/onboarding.sign-in
      :options   {:theme                  :dark
                  :modalPresentationStyle :overCurrentContext
                  :layout                 options/onboarding-layout}
      :component sign-in/view}
 
-    {:name      :syncing-progress
+    {:name      :screen/onboarding.syncing-progress
      :options   {:theme      :dark
                  :layout     options/onboarding-layout
                  :popGesture false}
      :component syncing-devices/view}
 
-    {:name      :syncing-progress-intro
+    {:name      :screen/onboarding.syncing-progress-intro
      :options   {:theme      :dark
                  :layout     options/onboarding-transparent-layout
                  :animations transitions/push-animations-for-transparent-background
                  :popGesture false}
      :component syncing-devices/view-onboarding}
 
-    {:name      :syncing-results
+    {:name      :screen/onboarding.syncing-results
      :options   {:theme :dark}
      :component syncing-results/view}
 
-    {:name      :welcome
+    {:name      :screen/onboarding.welcome
      :options   {:theme      :dark
                  :layout     options/onboarding-transparent-layout
                  :animations transitions/push-animations-for-transparent-background}

--- a/src/status_im/subs/general.cljs
+++ b/src/status_im/subs/general.cljs
@@ -185,7 +185,7 @@
  :my-profile/recovery
  :<- [:my-profile/seed]
  (fn [seed]
-   (or seed {:step :intro})))
+   (or seed {:step :screen/onboarding.intro})))
 
 (re-frame/reg-sub
  :bottom-sheet-old

--- a/src/test_helpers/integration.cljs
+++ b/src/test_helpers/integration.cljs
@@ -179,7 +179,7 @@
   (p/let [masked-seed-phrase (security/mask-data (:seed-phrase constants/recovery-account))
           [mnemonic key-uid] (validate-mnemonic masked-seed-phrase)]
     (rf/dispatch [:onboarding/seed-phrase-validated (security/mask-data mnemonic) key-uid])
-    (rf/dispatch [:pop-to-root :profiles])
+    (rf/dispatch [:pop-to-root :screen/profile.profiles])
     (rf/dispatch [:profile/profile-selected key-uid])
     (recover-and-login mnemonic)))
 


### PR DESCRIPTION
This pr is a continuation of: https://github.com/status-im/status-mobile/pull/18778
qualifying the onboarding screens with `:screen/onboarding.<name>`

No functionality is changed. It only updates the screen keywords for onboarding related views.

To test: a quick smoke test of the onboarding flows (and perhaps syncing) is worth doing.

