### PR TITLE
JC-Fraschetti/[Wallet] Add fixtures to recovered accounts and refactor wallet_getDerivedAddresses test

### DIFF
--- a/src/test_helpers/integration.cljs
+++ b/src/test_helpers/integration.cljs
@@ -1,22 +1,22 @@
 (ns test-helpers.integration
   (:require
-   [cljs.test :refer [is] :as test]
-   legacy.status-im.events
-   [legacy.status-im.multiaccounts.logout.core :as logout]
-   legacy.status-im.subs.root
-   [native-module.core :as native-module]
-   [promesa.core :as p]
-   [re-frame.core :as rf]
-   [re-frame.interop :as rf.interop]
-   status-im.events
-   status-im.navigation.core
-   status-im.subs.root
-   [taoensso.timbre :as log]
-   [tests.integration-test.constants :as constants]
-   [tests.test-utils :as test-utils]
-   [utils.collection :as collection]
-   [utils.security.core :as security]
-   [utils.transforms :as transforms]))
+    [cljs.test :refer [is] :as test]
+    legacy.status-im.events
+    [legacy.status-im.multiaccounts.logout.core :as logout]
+    legacy.status-im.subs.root
+    [native-module.core :as native-module]
+    [promesa.core :as p]
+    [re-frame.core :as rf]
+    [re-frame.interop :as rf.interop]
+    status-im.events
+    status-im.navigation.core
+    status-im.subs.root
+    [taoensso.timbre :as log]
+    [tests.integration-test.constants :as constants]
+    [tests.test-utils :as test-utils]
+    [utils.collection :as collection]
+    [utils.security.core :as security]
+    [utils.transforms :as transforms]))
 
 (defn validate-mnemonic
   [mnemonic]
@@ -220,47 +220,47 @@
   "
   ([test-name f]
    (test-async
-    test-name
-    {:fail-fast? true
-     :timeout-ms default-integration-test-timeout-ms}
-    f))
+     test-name
+     {:fail-fast? true
+      :timeout-ms default-integration-test-timeout-ms}
+     f))
   ([test-name {:keys [fail-fast? timeout-ms]} f]
    (test/async
-    done
-    (let [restore-fn (rf/make-restore-fn)]
-      (log-headline test-name)
-      (-> (p/do (f done))
-          (p/timeout timeout-ms)
-          (p/catch (fn [error]
-                     (is (nil? error))
-                     (when fail-fast?
-                       (js/process.exit 1))))
-          (p/finally (fn []
-                       (restore-fn)
-                       (done))))))))
+     done
+     (let [restore-fn (rf/make-restore-fn)]
+       (log-headline test-name)
+       (-> (p/do (f done))
+           (p/timeout timeout-ms)
+           (p/catch (fn [error]
+                      (is (nil? error))
+                      (when fail-fast?
+                        (js/process.exit 1))))
+           (p/finally (fn []
+                        (restore-fn)
+                        (done))))))))
 
 (defn test-app-initialization
   []
   (test-async ::initialize-app
-              (fn []
-                (p/do
-                  (test-utils/init!)
-                  (rf/dispatch [:app-started])
+    (fn []
+      (p/do
+        (test-utils/init!)
+        (rf/dispatch [:app-started])
         ;; Use initialize-view because it has the longest avg. time and is
         ;; dispatched by initialize-multiaccounts (last non-view event).
-                  (wait-for [:profile/get-profiles-overview-success
-                             :font/init-font-file-for-initials-avatar])
-                  (assert-app-initialized)))))
+        (wait-for [:profile/get-profiles-overview-success
+                   :font/init-font-file-for-initials-avatar])
+        (assert-app-initialized)))))
 
 (defn test-account-creation
   []
   (test-async ::create-account
-              (fn []
-                (p/do
-                  (setup-app)
-                  (setup-account)
-                  (logout)
-                  (wait-for [::logout/logout-method])))))
+    (fn []
+      (p/do
+        (setup-app)
+        (setup-account)
+        (logout)
+        (wait-for [::logout/logout-method])))))
 
 ;;;; Fixtures
 
@@ -275,19 +275,19 @@
    {:before (if (= :recovered-account type)
               (fn []
                 (test/async done
-                            (p/do (setup-app)
-                                  (setup-recovered-account)
-                                  (done))))
+                  (p/do (setup-app)
+                        (setup-recovered-account)
+                        (done))))
               (fn []
                 (test/async done
-                            (p/do (setup-app)
-                                  (setup-account)
-                                  (done)))))
+                  (p/do (setup-app)
+                        (setup-account)
+                        (done)))))
     :after  (fn []
               (test/async done
-                          (p/do (logout)
-                                (wait-for [::logout/logout-method])
-                                (done))))})
+                (p/do (logout)
+                      (wait-for [::logout/logout-method])
+                      (done))))})
   ([] (fixture-session [:new-account])))
 
 (defn fixture-silence-reframe

--- a/src/test_helpers/integration.cljs
+++ b/src/test_helpers/integration.cljs
@@ -149,18 +149,17 @@
   (test-utils/init!)
   (if (app-initialized)
     (p/resolved ::app-initialized)
-    (do
-      (rf/dispatch [:app-started])
-      (wait-for [:profile/get-profiles-overview-success]))))
+    (p/do!
+     (rf/dispatch [:app-started])
+     (wait-for [:profile/get-profiles-overview-success]))))
 
 (defn setup-account
   []
   (if (messenger-started)
     (p/resolved ::messenger-started)
-    (do
-      (create-multiaccount!)
-      (-> (wait-for [:profile.login/messenger-started])
-          (.then #(assert-messenger-started))))))
+    (p/do!
+     (create-multiaccount!)
+     (p/then (wait-for [:profile.login/messenger-started]) #(assert-messenger-started)))))
 
 (defn- recover-and-login
   [seed-phrase]
@@ -184,18 +183,15 @@
     (rf/dispatch [:profile/profile-selected key-uid])
     (recover-and-login mnemonic)))
 
-
 (defn setup-recovered-account
   []
   (if (messenger-started)
     (p/resolved ::messenger-started)
-    (do
-      (recover-multiaccount!)
-      (-> (wait-for [:profile.login/messenger-started])
-          (.then #(assert-messenger-started)))
-      (enable-testnet!)
-      (-> (wait-for [:wallet/store-wallet-token])
-          (.then #(assert-wallet-loaded))))))
+    (p/do!
+     (recover-multiaccount!)
+     (p/then (wait-for [:profile.login/messenger-started]) #(assert-messenger-started))
+     (enable-testnet!)
+     (p/then (wait-for [:wallet/store-wallet-token]) #(assert-wallet-loaded)))))
 
 (defn test-async
   "Runs `f` inside `cljs.test/async` macro in a restorable re-frame checkpoint.
@@ -310,4 +306,3 @@
              (set! rf.interop/debug-enabled? false))
    :after  (fn []
              (set! rf.interop/debug-enabled? true))})
-

--- a/src/test_helpers/integration.cljs
+++ b/src/test_helpers/integration.cljs
@@ -66,7 +66,7 @@
   []
   @(rf/subscribe [:messenger/started?]))
 
-(defn wallet-loaded
+(defn wallet-loaded?
   []
   (not @(rf/subscribe [:wallet/tokens-loading?])))
 
@@ -76,7 +76,7 @@
 
 (defn assert-wallet-loaded
   []
-  (is (wallet-loaded)))
+  (is (wallet-loaded?)))
 
 (defn assert-community-created
   []

--- a/src/test_helpers/integration.cljs
+++ b/src/test_helpers/integration.cljs
@@ -1,22 +1,22 @@
 (ns test-helpers.integration
   (:require
-    [cljs.test :refer [is] :as test]
-    legacy.status-im.events
-    [legacy.status-im.multiaccounts.logout.core :as logout]
-    legacy.status-im.subs.root
-    [native-module.core :as native-module]
-    [promesa.core :as p]
-    [re-frame.core :as rf]
-    [re-frame.interop :as rf.interop]
-    status-im.events
-    status-im.navigation.core
-    status-im.subs.root
-    [taoensso.timbre :as log]
-    [tests.integration-test.constants :as constants]
-    [tests.test-utils :as test-utils]
-    [utils.collection :as collection]
-    [utils.security.core :as security]
-    [utils.transforms :as transforms]))
+   [cljs.test :refer [is] :as test]
+   legacy.status-im.events
+   [legacy.status-im.multiaccounts.logout.core :as logout]
+   legacy.status-im.subs.root
+   [native-module.core :as native-module]
+   [promesa.core :as p]
+   [re-frame.core :as rf]
+   [re-frame.interop :as rf.interop]
+   status-im.events
+   status-im.navigation.core
+   status-im.subs.root
+   [taoensso.timbre :as log]
+   [tests.integration-test.constants :as constants]
+   [tests.test-utils :as test-utils]
+   [utils.collection :as collection]
+   [utils.security.core :as security]
+   [utils.transforms :as transforms]))
 
 (defn validate-mnemonic
   [mnemonic]
@@ -66,9 +66,17 @@
   []
   @(rf/subscribe [:messenger/started?]))
 
+(defn wallet-loaded
+  []
+  (not @(rf/subscribe [:wallet/tokens-loading?])))
+
 (defn assert-messenger-started
   []
   (is (messenger-started)))
+
+(defn assert-wallet-loaded
+  []
+  (is (wallet-loaded)))
 
 (defn assert-community-created
   []
@@ -154,6 +162,41 @@
       (-> (wait-for [:profile.login/messenger-started])
           (.then #(assert-messenger-started))))))
 
+(defn- recover-and-login
+  [seed-phrase]
+  (rf/dispatch [:profile.recover/recover-and-login
+                {:display-name (:name constants/recovery-account)
+                 :seed-phrase  seed-phrase
+                 :password     constants/password
+                 :color        "blue"}]))
+
+(defn- enable-testnet!
+  []
+  (rf/dispatch [:profile.settings/profile-update :test-networks-enabled? true {}])
+  (rf/dispatch [:wallet/initialize]))
+
+(defn- recover-multiaccount!
+  []
+  (p/let [masked-seed-phrase (security/mask-data (:seed-phrase constants/recovery-account))
+          [mnemonic key-uid] (validate-mnemonic masked-seed-phrase)]
+    (rf/dispatch [:onboarding/seed-phrase-validated (security/mask-data mnemonic) key-uid])
+    (rf/dispatch [:pop-to-root :profiles])
+    (rf/dispatch [:profile/profile-selected key-uid])
+    (recover-and-login mnemonic)))
+
+
+(defn setup-recovered-account
+  []
+  (if (messenger-started)
+    (p/resolved ::messenger-started)
+    (do
+      (recover-multiaccount!)
+      (-> (wait-for [:profile.login/messenger-started])
+          (.then #(assert-messenger-started)))
+      (enable-testnet!)
+      (-> (wait-for [:wallet/store-wallet-token])
+          (.then #(assert-wallet-loaded))))))
+
 (defn test-async
   "Runs `f` inside `cljs.test/async` macro in a restorable re-frame checkpoint.
 
@@ -177,47 +220,47 @@
   "
   ([test-name f]
    (test-async
-     test-name
-     {:fail-fast? true
-      :timeout-ms default-integration-test-timeout-ms}
-     f))
+    test-name
+    {:fail-fast? true
+     :timeout-ms default-integration-test-timeout-ms}
+    f))
   ([test-name {:keys [fail-fast? timeout-ms]} f]
    (test/async
-     done
-     (let [restore-fn (rf/make-restore-fn)]
-       (log-headline test-name)
-       (-> (p/do (f done))
-           (p/timeout timeout-ms)
-           (p/catch (fn [error]
-                      (is (nil? error))
-                      (when fail-fast?
-                        (js/process.exit 1))))
-           (p/finally (fn []
-                        (restore-fn)
-                        (done))))))))
+    done
+    (let [restore-fn (rf/make-restore-fn)]
+      (log-headline test-name)
+      (-> (p/do (f done))
+          (p/timeout timeout-ms)
+          (p/catch (fn [error]
+                     (is (nil? error))
+                     (when fail-fast?
+                       (js/process.exit 1))))
+          (p/finally (fn []
+                       (restore-fn)
+                       (done))))))))
 
 (defn test-app-initialization
   []
   (test-async ::initialize-app
-    (fn []
-      (p/do
-        (test-utils/init!)
-        (rf/dispatch [:app-started])
+              (fn []
+                (p/do
+                  (test-utils/init!)
+                  (rf/dispatch [:app-started])
         ;; Use initialize-view because it has the longest avg. time and is
         ;; dispatched by initialize-multiaccounts (last non-view event).
-        (wait-for [:profile/get-profiles-overview-success
-                   :font/init-font-file-for-initials-avatar])
-        (assert-app-initialized)))))
+                  (wait-for [:profile/get-profiles-overview-success
+                             :font/init-font-file-for-initials-avatar])
+                  (assert-app-initialized)))))
 
 (defn test-account-creation
   []
   (test-async ::create-account
-    (fn []
-      (p/do
-        (setup-app)
-        (setup-account)
-        (logout)
-        (wait-for [::logout/logout-method])))))
+              (fn []
+                (p/do
+                  (setup-app)
+                  (setup-account)
+                  (logout)
+                  (wait-for [::logout/logout-method])))))
 
 ;;;; Fixtures
 
@@ -228,17 +271,24 @@
   Usage:
 
       (use-fixtures :each (h/fixture-logged))"
-  []
-  {:before (fn []
-             (test/async done
-               (p/do (setup-app)
-                     (setup-account)
-                     (done))))
-   :after  (fn []
-             (test/async done
-               (p/do (logout)
-                     (wait-for [::logout/logout-method])
-                     (done))))})
+  ([type]
+   {:before (if (= :recovered-account type)
+              (fn []
+                (test/async done
+                            (p/do (setup-app)
+                                  (setup-recovered-account)
+                                  (done))))
+              (fn []
+                (test/async done
+                            (p/do (setup-app)
+                                  (setup-account)
+                                  (done)))))
+    :after  (fn []
+              (test/async done
+                          (p/do (logout)
+                                (wait-for [::logout/logout-method])
+                                (done))))})
+  ([] (fixture-session [:new-account])))
 
 (defn fixture-silence-reframe
   "Fixture to disable most re-frame messages.
@@ -261,24 +311,3 @@
    :after  (fn []
              (set! rf.interop/debug-enabled? true))})
 
-(defn recover-and-login
-  [seed-phrase]
-  (rf/dispatch [:profile.recover/recover-and-login
-                {:display-name (:name constants/recovery-account)
-                 :seed-phrase  seed-phrase
-                 :password     constants/password
-                 :color        "blue"}]))
-
-(defn enable-testnet!
-  []
-  (rf/dispatch [:profile.settings/profile-update :test-networks-enabled? true {}])
-  (rf/dispatch [:wallet/initialize]))
-
-(defn recover-multiaccount!
-  []
-  (p/let [masked-seed-phrase (security/mask-data (:seed-phrase constants/recovery-account))
-          [mnemonic key-uid] (validate-mnemonic masked-seed-phrase)]
-    (rf/dispatch [:onboarding/seed-phrase-validated (security/mask-data mnemonic) key-uid])
-    (rf/dispatch [:pop-to-root :profiles])
-    (rf/dispatch [:profile/profile-selected key-uid])
-    (recover-and-login mnemonic)))

--- a/src/tests/contract_test/wallet_recovered_account_test.cljs
+++ b/src/tests/contract_test/wallet_recovered_account_test.cljs
@@ -1,0 +1,42 @@
+(ns tests.contract-test.wallet-recovered-account-test
+  (:require
+   [cljs.test :refer [deftest is use-fixtures]]
+   legacy.status-im.events
+   legacy.status-im.subs.root
+   [native-module.core :as native-module]
+   [promesa.core :as p]
+   status-im.events
+   status-im.navigation.core
+   status-im.subs.root
+   [test-helpers.integration :as h]
+   [tests.contract-test.utils :as contract-utils]
+   [tests.integration-test.constants :as integration-constants]))
+
+(use-fixtures :each (h/fixture-session :recovered-account))
+
+(defn get-main-account
+  [accounts] 
+  (:address (first accounts)))
+
+(def derived-address "0x542bf2d18e83ba176c151c949c53eee896fa5a3e")
+
+(defn assert-derived-account
+  [response]
+  (let [{:keys [address public-key]} (first response)]
+    (is (= derived-address address))
+    (is (= (:public-key integration-constants/recovery-account) public-key))
+    (is (= "m/43'/60'/1581'/0'/0" (:path (first response))))))
+
+(deftest wallet-get-derived-addressess-contract-test
+  (h/test-async :wallet/create-derived-addresses
+                (fn []
+                  (p/let [sha3-pwd        (native-module/sha3 integration-constants/password)
+                          derivation-path ["m/43'/60'/1581'/0'/0"]
+                          accounts        (contract-utils/call-rpc "accounts_getAccounts")
+                          main-account    (get-main-account accounts)
+                          response        (contract-utils/call-rpc
+                                           "wallet_getDerivedAddresses"
+                                           sha3-pwd
+                                           main-account
+                                           derivation-path)]
+                    (assert-derived-account response)))))

--- a/src/tests/contract_test/wallet_recovered_account_test.cljs
+++ b/src/tests/contract_test/wallet_recovered_account_test.cljs
@@ -1,21 +1,21 @@
 (ns tests.contract-test.wallet-recovered-account-test
   (:require
-   [cljs.test :refer [deftest is use-fixtures]]
-   legacy.status-im.events
-   legacy.status-im.subs.root
-   [native-module.core :as native-module]
-   [promesa.core :as p]
-   status-im.events
-   status-im.navigation.core
-   status-im.subs.root
-   [test-helpers.integration :as h]
-   [tests.contract-test.utils :as contract-utils]
-   [tests.integration-test.constants :as integration-constants]))
+    [cljs.test :refer [deftest is use-fixtures]]
+    legacy.status-im.events
+    legacy.status-im.subs.root
+    [native-module.core :as native-module]
+    [promesa.core :as p]
+    status-im.events
+    status-im.navigation.core
+    status-im.subs.root
+    [test-helpers.integration :as h]
+    [tests.contract-test.utils :as contract-utils]
+    [tests.integration-test.constants :as integration-constants]))
 
 (use-fixtures :each (h/fixture-session :recovered-account))
 
 (defn get-main-account
-  [accounts] 
+  [accounts]
   (:address (first accounts)))
 
 (def derived-address "0x542bf2d18e83ba176c151c949c53eee896fa5a3e")
@@ -29,14 +29,14 @@
 
 (deftest wallet-get-derived-addressess-contract-test
   (h/test-async :wallet/create-derived-addresses
-                (fn []
-                  (p/let [sha3-pwd        (native-module/sha3 integration-constants/password)
-                          derivation-path ["m/43'/60'/1581'/0'/0"]
-                          accounts        (contract-utils/call-rpc "accounts_getAccounts")
-                          main-account    (get-main-account accounts)
-                          response        (contract-utils/call-rpc
-                                           "wallet_getDerivedAddresses"
-                                           sha3-pwd
-                                           main-account
-                                           derivation-path)]
-                    (assert-derived-account response)))))
+    (fn []
+      (p/let [sha3-pwd        (native-module/sha3 integration-constants/password)
+              derivation-path ["m/43'/60'/1581'/0'/0"]
+              accounts        (contract-utils/call-rpc "accounts_getAccounts")
+              main-account    (get-main-account accounts)
+              response        (contract-utils/call-rpc
+                               "wallet_getDerivedAddresses"
+                               sha3-pwd
+                               main-account
+                               derivation-path)]
+        (assert-derived-account response)))))

--- a/src/tests/contract_test/wallet_recovered_account_test.cljs
+++ b/src/tests/contract_test/wallet_recovered_account_test.cljs
@@ -18,20 +18,18 @@
   [accounts]
   (:address (first accounts)))
 
-(def derived-address "0x542bf2d18e83ba176c151c949c53eee896fa5a3e")
-
 (defn assert-derived-account
   [response]
   (let [{:keys [address public-key]} (first response)]
-    (is (= derived-address address))
+    (is (= integration-constants/derived-address address))
     (is (= (:public-key integration-constants/recovery-account) public-key))
-    (is (= "m/43'/60'/1581'/0'/0" (:path (first response))))))
+    (is (= integration-constants/derivation-path (:path (first response))))))
 
 (deftest wallet-get-derived-addressess-contract-test
   (h/test-async :wallet/create-derived-addresses
     (fn []
       (p/let [sha3-pwd        (native-module/sha3 integration-constants/password)
-              derivation-path ["m/43'/60'/1581'/0'/0"]
+              derivation-path [integration-constants/derivation-path]
               accounts        (contract-utils/call-rpc "accounts_getAccounts")
               main-account    (get-main-account accounts)
               response        (contract-utils/call-rpc

--- a/src/tests/contract_test/wallet_test.cljs
+++ b/src/tests/contract_test/wallet_test.cljs
@@ -3,7 +3,6 @@
     [cljs.test :refer [deftest is use-fixtures]]
     legacy.status-im.events
     legacy.status-im.subs.root
-    [native-module.core :as native-module]
     [promesa.core :as p]
     [status-im.common.emoji-picker.utils :as emoji-picker.utils]
     [status-im.constants :as constants]
@@ -12,8 +11,7 @@
     status-im.navigation.core
     status-im.subs.root
     [test-helpers.integration :as h]
-    [tests.contract-test.utils :as contract-utils]
-    [tests.integration-test.constants :as integration-constants]))
+    [tests.contract-test.utils :as contract-utils]))
 
 (use-fixtures :each (h/fixture-session))
 
@@ -67,31 +65,3 @@
     (fn []
       (p/let [response (contract-utils/call-rpc "wallet_getEthereumChains")]
         (assert-ethereum-chains response)))))
-
-(defn get-main-account
-  [accounts]
-  (:address (first accounts)))
-
-(def test-password integration-constants/password)
-
-(defn assert-derived-account
-  [response]
-  (is (= (:address response) (:address response)))
-  (is (= (:public-key response) (:public-key response)))
-  (is (= "m/43'/60'/1581'/0'/0" (:path (first response)))))
-
-(deftest wallet-get-derived-addressess-contract-test
-  (h/test-async :wallet/create-derived-addresses
-    (fn []
-      (p/let [_ (h/enable-testnet!)
-              _ (h/recover-multiaccount!)
-              sha3-pwd        (native-module/sha3 test-password)
-              derivation-path ["m/43'/60'/1581'/0'/0"]
-              accounts        (contract-utils/call-rpc "accounts_getAccounts")
-              main-account    (get-main-account accounts)
-              response        (contract-utils/call-rpc
-                               "wallet_getDerivedAddresses"
-                               sha3-pwd
-                               main-account
-                               derivation-path)]
-        (assert-derived-account response)))))

--- a/src/tests/integration_test/constants.cljs
+++ b/src/tests/integration_test/constants.cljs
@@ -7,7 +7,8 @@
 (def account-name "account-abc")
 
 (def recovery-account
-  {:name         "wallet-abc"
-   :seed-phrase  "destroy end torch puzzle develop note wise island disease chaos kind bus"
-   :key-uid      "0x6827f3d1e21ae723a24e0dcbac1853b5ed4d651c821a2326492ce8f2367ec905"
-   :public-key   "0x04937b2d8ed320f89a437e3c854213ec56b34c0c5a5a6105fd6f0850574d10af6988f128b4e2b7b7171f4599deda75584c7c75f7cdf0846f8d485a7f593a5f31f6"})
+  {:name "wallet-abc"
+   :seed-phrase "destroy end torch puzzle develop note wise island disease chaos kind bus"
+   :key-uid "0x6827f3d1e21ae723a24e0dcbac1853b5ed4d651c821a2326492ce8f2367ec905"
+   :public-key
+   "0x04937b2d8ed320f89a437e3c854213ec56b34c0c5a5a6105fd6f0850574d10af6988f128b4e2b7b7171f4599deda75584c7c75f7cdf0846f8d485a7f593a5f31f6"})

--- a/src/tests/integration_test/constants.cljs
+++ b/src/tests/integration_test/constants.cljs
@@ -6,6 +6,10 @@
 
 (def account-name "account-abc")
 
+(def derivation-path "m/43'/60'/1581'/0'/0")
+
+(def derived-address "0x542bf2d18e83ba176c151c949c53eee896fa5a3e")
+
 (def recovery-account
   {:name "wallet-abc"
    :seed-phrase "destroy end torch puzzle develop note wise island disease chaos kind bus"

--- a/src/tests/integration_test/constants.cljs
+++ b/src/tests/integration_test/constants.cljs
@@ -10,5 +10,4 @@
   {:name         "wallet-abc"
    :seed-phrase  "destroy end torch puzzle develop note wise island disease chaos kind bus"
    :key-uid      "0x6827f3d1e21ae723a24e0dcbac1853b5ed4d651c821a2326492ce8f2367ec905"
-   :public-key   "0x48b8b9e2a8f71e1beae729d83bcd385ffc6af0d5"
-   :main-account "0x48b8b9e2a8f71e1beae729d83bcd385ffc6af0d5"})
+   :public-key   "0x04937b2d8ed320f89a437e3c854213ec56b34c0c5a5a6105fd6f0850574d10af6988f128b4e2b7b7171f4599deda75584c7c75f7cdf0846f8d485a7f593a5f31f6"})


### PR DESCRIPTION
Follow up:  #18343
Contribute:  #18587

### Summary

- Separate New Account from Recovered Account tests
- Add fixtures for Recovered Account
- Refactor  `wallet_getDerivedAddresses` endpoint test

### Motivation

In our current testing setup, we utilize `(use-fixtures :each h/fixture-session) ` to initialize the application and a new account for each test within the namespace. While this approach ensures a clean state for most tests, it introduces limitations for scenarios that require a stable, consistent account state across runs. Specifically, this affects our ability to reliably test account recovery features.

### Proposed Solution

To address this issue, we propose separating the tests into two distinct namespaces:

New Account Tests: These tests will continue to rely on the current namespace and setup (`tests.contract-test.wallet-test`) where a new account is generated for each test run, suitable for validating functionalities that depend on account creation.

Account Recovery Tests: These tests will live at `tests.contract-test.wallet-recovered-account-test` and bypass the `(use-fixtures :each (h/fixture-session :recovered-account))` setup in favor of using a fixed account. This change will ensure a stable testing environment for verifying account recovery processes, e.g. accuracy of derived addresses post-recovery.

### Steps to test

status: ready!
