### PR TITLE
Prevent profiles list from disappearing after onboarding and logging out

### DIFF
--- a/src/status_im/contexts/profile/profiles/view.cljs
+++ b/src/status_im/contexts/profile/profiles/view.cljs
@@ -140,6 +140,9 @@
                     (reset! push-animation-fn-atom #(push-animation translate-x))
                     (reset! pop-animation-fn-atom #(pop-animation translate-x))
                     (fn []
+                      (when-let [pop-animation-fn @pop-animation-fn-atom]
+                        (when (not= translate-x 0)
+                          (pop-animation-fn)))
                       (reset! push-animation-fn-atom nil)
                       (reset! pop-animation-fn-atom nil))))
     [reanimated/view


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19094 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to fix the issues related to the profiles list not appearing when choosing a user profile at login.
  * This PR modifies the unmount hook of the profiles view to reset the `translate-x` offset to `0` after unmounting.
    * This seems necessary because the profiles view seems to display other views / modals inside of itself, which causes the profile list to be moved / animated offscreen. 
    * This offset value is supposed to be reset after the onboarding screens have finished or when the user navigates back to the profiles list.
    * This PR attempts to ensure that the offset value will always be reset whenever the profiles view or onboarding screens are finished.

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- account recovery
- new account
- existing account sync
- onboarding

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile
- Press the profiles list button (if viewing the login screen)
- Press the "+" button
- Press the "Create new profile" button
- Create a new profile or recover a profile
- Once passed the welcome screen, logout from the app
- While viewing the login screen, press the profiles list button

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before

https://github.com/status-im/status-mobile/assets/2845768/8b3c59f6-3165-4112-9fbd-ebe12123f550

#### After

https://github.com/status-im/status-mobile/assets/2845768/ec68bcfe-38de-45e3-a660-d3ff43c147ff

status: ready
