### PR TITLE
fix: revert removal of key in profile settings view

### DIFF
--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -70,7 +70,8 @@
        :on-scroll                       #(scroll-handler % scroll-y)
        :bounces                         false}]
      [quo/floating-shell-button
-      {:jump-to
+      {:key :shell
+       :jump-to
        {:on-press            (fn []
                                (rf/dispatch [:navigate-back])
                                (debounce/throttle-and-dispatch [:shell/navigate-to-jump-to] 500))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

* This PR attempts to fix the displaying of the profile settings screen.
  * This PR adds a `key` prop to a component, which is needed atm.
  * Ideally, we would fix the `quo/overlay` component to use `into` to avoid needing `:key` props for children.
    * Here's a previous discussion about this for context: https://github.com/status-im/status-mobile/pull/18674#discussion_r1473539054

[comment]: # (Summarise the problem and how the pull request solves it)

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Opening Profile Settings 

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile
- Login as a user
- Press the profile settings button

### Before and after screenshots comparison

#### Before

https://github.com/status-im/status-mobile/assets/2845768/7727960f-218b-4a60-9a5a-dfe274a6f80e

#### After

https://github.com/status-im/status-mobile/assets/2845768/8d9c18df-daa8-4ce7-9127-fa89edcc3fd8

status: ready
