### PR TITLE
Prevent a full nix derivation build for android when cljs code is updated and improve debug build speed

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -199,10 +199,6 @@ android {
         doNotStrip '*/mips/*.so'
         doNotStrip '*/mips64/*.so'
     }
-    dexOptions {
-        jumboMode true
-        javaMaxHeapSize "8g"
-    }
     splits {
         abi {
             reset()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,23 @@ subprojects {
                 defaultConfig {
                     targetSdkVersion rootProject.ext.targetSdkVersion
                 }
+
+                // Speed up Tests Stage
+                tasks.withType(Test).configureEach {
+                    // https://docs.gradle.org/current/userguide/performance.html#execute_tests_in_parallel
+                    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+                    // https://docs.gradle.org/current/userguide/performance.html#fork_tests_into_multiple_processes
+                    forkEvery = 100
+                    // https://docs.gradle.org/current/userguide/performance.html#disable_reports
+                    reports.html.required = false
+                    reports.junitXml.required = false
+                }
+                // Speed up Java Compile Stage
+                // https://docs.gradle.org/current/userguide/performance.html#run_the_compiler_as_a_separate_process
+                tasks.withType(JavaCompile).configureEach {
+                    options.fork = true
+                }
+
             }
         }
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -43,7 +43,7 @@ ANDROID_ABI_SPLIT=false
 # Some platforms are excluded though
 ANDROID_ABI_INCLUDE=armeabi-v7a;arm64-v8a;x86;x86_64
 
-org.gradle.jvmargs=-Xmx8704M
+org.gradle.jvmargs=-Xmx8704M -XX:+UseParallelGC
 
 versionCode=9999
 commitHash=unknown


### PR DESCRIPTION
fixes #19081

## Summary
This PR aims to improve android build step for debug variants by ensuring we do not rebuild the android derivation for any change made to `clojurescript` code. 

We also do the following things : 
-  enable `JVM` parallel garbage collector.
-  get rid of `dexOptions` which was deprecated in `gradle 8`.
-  add additional `parallel` flag to gradle to speed up builds.

## Review notes
- `make run-clojure`
- `make run-android`
- ctrl + C on android terminal and edit any `cljs` file
- `make run-android`  ( should build almost instantly )

## Testing notes
can skip QA since this is only developer experience related.

#### Platforms
- Android

status: ready
