### PR TITLE
Tweak UI for contact request notifications

### DIFF
--- a/src/quo/components/notifications/notification/style.cljs
+++ b/src/quo/components/notifications/notification/style.cljs
@@ -31,12 +31,12 @@
    :justify-content :center})
 
 (defn title
-  [override-theme]
-  {:color (colors/theme-colors colors/white colors/neutral-100 override-theme)})
+  [theme]
+  {:color (colors/theme-colors colors/white colors/neutral-100 theme)})
 
 (defn text
-  [override-theme]
-  {:color (colors/theme-colors colors/white colors/neutral-100 override-theme)})
+  [theme]
+  {:color (colors/theme-colors colors/white colors/neutral-100 theme)})
 
 (defn avatar-container
   [{:keys [multiline?]}]

--- a/src/quo/components/notifications/notification/style.cljs
+++ b/src/quo/components/notifications/notification/style.cljs
@@ -26,7 +26,9 @@
     :padding-vertical   8
     :padding-horizontal 12}))
 
-(def right-side-container {:flex 1})
+(def right-side-container
+  {:flex            1
+   :justify-content :center})
 
 (defn title
   [override-theme]
@@ -36,4 +38,7 @@
   [override-theme]
   {:color (colors/theme-colors colors/white colors/neutral-100 override-theme)})
 
-(def avatar-container {:margin-right 8 :margin-top 4})
+(defn avatar-container
+  [{:keys [multiline?]}]
+  {:margin-right 8
+   :margin-top   (if multiline? 4 0)})

--- a/src/quo/components/notifications/notification/style.cljs
+++ b/src/quo/components/notifications/notification/style.cljs
@@ -41,4 +41,5 @@
 (defn avatar-container
   [{:keys [multiline?]}]
   {:margin-right 8
+   :align-self   (when-not multiline? :center)
    :margin-top   (if multiline? 4 0)})

--- a/src/quo/components/notifications/notification/view.cljs
+++ b/src/quo/components/notifications/notification/view.cljs
@@ -25,11 +25,10 @@
    children])
 
 (defn title
-  ([text weight] (title text weight nil))
-  ([text weight theme]
+  ([{:keys [text weight theme multiline?]}]
    [text/text
     {:size                :paragraph-1
-     :weight              (or weight :semi-bold)
+     :weight              (or weight (if multiline? :semi-bold :medium))
      :style               (style/title theme)
      :accessibility-label :notification-title}
     text]))
@@ -63,19 +62,22 @@
 
 (defn notification
   [{title-text :title :keys [avatar user header title-weight text body container-style theme]}]
-  (let [context-theme (or theme (quo.theme/get-theme))
+  (let [theme         (or theme (quo.theme/get-theme))
+        body          (or body (when text [message text theme]))
         header        (or header
                           (when title-text
-                            [title title-text title-weight theme]))
+                            [title {:text title-text
+                                    :weight title-weight 
+                                    :theme theme
+                                    :multiline? (some? body)}]))
         header        (when header [header-container header])
-        body          (or body (when text [message text theme]))
         body          (when body [body-container body])
         user-avatar   (or avatar (when user (user-avatar/user-avatar user)))
         avatar        (when user-avatar
                         [avatar-container
                          {:multiline? (and header body)}
                          user-avatar])]
-    [quo.theme/provider {:theme context-theme}
+    [quo.theme/provider {:theme theme}
      [notification-container
       {:avatar          avatar
        :header          header

--- a/src/quo/components/notifications/notification/view.cljs
+++ b/src/quo/components/notifications/notification/view.cljs
@@ -62,7 +62,7 @@
      body]]])
 
 (defn notification
-  [{title-text :title :keys [user header title-weight text body container-style theme]}]
+  [{title-text :title :keys [avatar user header title-weight text body container-style theme]}]
   (let [context-theme (or theme (quo.theme/get-theme))
         header        (or header
                           (when title-text
@@ -70,7 +70,7 @@
         header        (when header [header-container header])
         body          (or body (when text [message text theme]))
         body          (when body [body-container body])
-        user-avatar   (when user (user-avatar/user-avatar user))
+        user-avatar   (or avatar (when user (user-avatar/user-avatar user)))
         avatar        (when user-avatar
                         [avatar-container
                          {:multiline? (and header body)}

--- a/src/quo/components/notifications/notification/view.cljs
+++ b/src/quo/components/notifications/notification/view.cljs
@@ -1,5 +1,6 @@
 (ns quo.components.notifications.notification.view
   (:require
+    [quo.components.avatars.user-avatar.view :as user-avatar]
     [quo.components.markdown.text :as text]
     [quo.components.notifications.notification.style :as style]
     [quo.theme]
@@ -61,7 +62,7 @@
      body]]])
 
 (defn notification
-  [{title-text :title :keys [avatar header title-weight text body container-style theme]}]
+  [{title-text :title :keys [user header title-weight text body container-style theme]}]
   (let [context-theme (or theme (quo.theme/get-theme))
         header        (or header
                           (when title-text
@@ -69,9 +70,11 @@
         header        (when header [header-container header])
         body          (or body (when text [message text theme]))
         body          (when body [body-container body])
-        avatar        (when avatar [avatar-container
+        user-avatar   (when user (user-avatar/user-avatar user))
+        avatar        (when user-avatar
+                        [avatar-container
                          {:multiline? (and header body)}
-                         avatar])]
+                         user-avatar])]
     [quo.theme/provider {:theme context-theme}
      [notification-container
       {:avatar          avatar

--- a/src/quo/components/notifications/notification/view.cljs
+++ b/src/quo/components/notifications/notification/view.cljs
@@ -16,10 +16,10 @@
   [into [rn/view {:accessibility-label :notification-body}] children])
 
 (defn avatar-container
-  [& children]
+  [{:keys [multiline?]} & children]
   [into
    [rn/view
-    {:style               style/avatar-container
+    {:style               (style/avatar-container {:multiline? multiline?})
      :accessibility-label :notification-avatar}]
    children])
 
@@ -69,7 +69,9 @@
         header        (when header [header-container header])
         body          (or body (when text [message text override-theme]))
         body          (when body [body-container body])
-        avatar        (when avatar [avatar-container avatar])]
+        avatar        (when avatar [avatar-container
+                         {:multiline? (and header body)}
+                         avatar])]
     [quo.theme/provider {:theme context-theme}
      [notification-container
       {:avatar          avatar

--- a/src/quo/components/notifications/notification/view.cljs
+++ b/src/quo/components/notifications/notification/view.cljs
@@ -37,6 +37,7 @@
   [text override-theme]
   [text/text
    {:size                :paragraph-2
+    :weight              :medium
     :style               (style/text override-theme)
     :accessibility-label :notification-content}
    text])

--- a/src/quo/components/notifications/notification/view.cljs
+++ b/src/quo/components/notifications/notification/view.cljs
@@ -25,25 +25,25 @@
 
 (defn title
   ([text weight] (title text weight nil))
-  ([text weight override-theme]
+  ([text weight theme]
    [text/text
     {:size                :paragraph-1
      :weight              (or weight :semi-bold)
-     :style               (style/title override-theme)
+     :style               (style/title theme)
      :accessibility-label :notification-title}
     text]))
 
 (defn message
-  [text override-theme]
+  [text theme]
   [text/text
    {:size                :paragraph-2
     :weight              :medium
-    :style               (style/text override-theme)
+    :style               (style/text theme)
     :accessibility-label :notification-content}
    text])
 
 (defn- notification-container
-  [{:keys [avatar header body container-style override-theme]}]
+  [{:keys [avatar header body container-style theme]}]
   [rn/view
    {:style (merge style/box-container container-style)}
    [blur/view
@@ -53,7 +53,7 @@
      :blur-type     :transparent
      :overlay-color :transparent}]
    [rn/view
-    {:style (style/content-container override-theme)}
+    {:style (style/content-container theme)}
     avatar
     [rn/view
      {:style style/right-side-container}
@@ -61,13 +61,13 @@
      body]]])
 
 (defn notification
-  [{title-text :title :keys [avatar header title-weight text body container-style override-theme]}]
-  (let [context-theme (or override-theme (quo.theme/get-theme))
+  [{title-text :title :keys [avatar header title-weight text body container-style theme]}]
+  (let [context-theme (or theme (quo.theme/get-theme))
         header        (or header
                           (when title-text
-                            [title title-text title-weight override-theme]))
+                            [title title-text title-weight theme]))
         header        (when header [header-container header])
-        body          (or body (when text [message text override-theme]))
+        body          (or body (when text [message text theme]))
         body          (when body [body-container body])
         avatar        (when avatar [avatar-container
                          {:multiline? (and header body)}
@@ -78,4 +78,4 @@
        :header          header
        :body            body
        :container-style container-style
-       :override-theme  override-theme}]]))
+       :theme           theme}]]))

--- a/src/quo/components/notifications/notification/view.cljs
+++ b/src/quo/components/notifications/notification/view.cljs
@@ -62,21 +62,22 @@
 
 (defn notification
   [{title-text :title :keys [avatar user header title-weight text body container-style theme]}]
-  (let [theme         (or theme (quo.theme/get-theme))
-        body          (or body (when text [message text theme]))
-        header        (or header
-                          (when title-text
-                            [title {:text title-text
-                                    :weight title-weight 
-                                    :theme theme
-                                    :multiline? (some? body)}]))
-        header        (when header [header-container header])
-        body          (when body [body-container body])
-        user-avatar   (or avatar (when user (user-avatar/user-avatar user)))
-        avatar        (when user-avatar
-                        [avatar-container
-                         {:multiline? (and header body)}
-                         user-avatar])]
+  (let [theme       (or theme (quo.theme/get-theme))
+        body        (or body (when text [message text theme]))
+        header      (or header
+                        (when title-text
+                          [title
+                           {:text       title-text
+                            :weight     title-weight
+                            :theme      theme
+                            :multiline? (some? body)}]))
+        header      (when header [header-container header])
+        body        (when body [body-container body])
+        user-avatar (or avatar (when user (user-avatar/user-avatar user)))
+        avatar      (when user-avatar
+                      [avatar-container
+                       {:multiline? (and header body)}
+                       user-avatar])]
     [quo.theme/provider {:theme theme}
      [notification-container
       {:avatar          avatar

--- a/src/quo/components/notifications/notification/view.cljs
+++ b/src/quo/components/notifications/notification/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [quo.components.markdown.text :as text]
     [quo.components.notifications.notification.style :as style]
+    [quo.theme]
     [react-native.blur :as blur]
     [react-native.core :as rn]))
 
@@ -60,16 +61,18 @@
 
 (defn notification
   [{title-text :title :keys [avatar header title-weight text body container-style override-theme]}]
-  (let [header (or header
-                   (when title-text
-                     [title title-text title-weight override-theme]))
-        header (when header [header-container header])
-        body   (or body (when text [message text override-theme]))
-        body   (when body [body-container body])
-        avatar (when avatar [avatar-container avatar])]
-    [notification-container
-     {:avatar          avatar
-      :header          header
-      :body            body
-      :container-style container-style
-      :override-theme  override-theme}]))
+  (let [context-theme (or override-theme (quo.theme/get-theme))
+        header        (or header
+                          (when title-text
+                            [title title-text title-weight override-theme]))
+        header        (when header [header-container header])
+        body          (or body (when text [message text override-theme]))
+        body          (when body [body-container body])
+        avatar        (when avatar [avatar-container avatar])]
+    [quo.theme/provider {:theme context-theme}
+     [notification-container
+      {:avatar          avatar
+       :header          header
+       :body            body
+       :container-style container-style
+       :override-theme  override-theme}]]))

--- a/src/status_im/contexts/preview/quo/notifications/notification.cljs
+++ b/src/status_im/contexts/preview/quo/notifications/notification.cljs
@@ -30,12 +30,11 @@
   []
   [notification-button
    "Notification: with title(header)"
-   {:avatar       [quo/user-avatar
-                   {:full-name           "A Y"
-                    :status-indicator?   true
-                    :online?             true
-                    :size                :small
-                    :customization-color :blue}]
+   {:user         {:full-name           "A Y"
+                   :status-indicator?   true
+                   :online?             true
+                   :size                :small
+                   :customization-color :blue}
     :title        "Alisher Yakupov accepted your contact request"
     :duration     4000
     :title-weight :medium
@@ -45,12 +44,11 @@
   []
   [notification-button
    "with title and body"
-   {:avatar   [quo/user-avatar
-               {:full-name           "A Y"
-                :status-indicator?   true
-                :online?             true
-                :size                :small
-                :customization-color :blue}]
+   {:user     {:full-name           "A Y"
+               :status-indicator?   true
+               :online?             true
+               :size                :small
+               :customization-color :blue}
     :title    "Default to semibold title"
     :text     "The quick brown fox jumped over the lazy dog and ate a potatoe."
     :duration 4000
@@ -60,12 +58,11 @@
   []
   [notification-button
    "with anything as header & body"
-   {:avatar   [quo/user-avatar
-               {:full-name           "A Y"
-                :status-indicator?   true
-                :online?             true
-                :size                :small
-                :customization-color :blue}]
+   {:user     {:full-name           "A Y"
+               :status-indicator?   true
+               :online?             true
+               :size                :small
+               :customization-color :blue}
     :header   [rn/view
                [quo/info-message
                 {:type :success

--- a/src/status_im/contexts/shell/activity_center/events.cljs
+++ b/src/status_im/contexts/shell/activity_center/events.cljs
@@ -2,7 +2,6 @@
   (:require
     [legacy.status-im.data-store.activities :as activities]
     [legacy.status-im.data-store.chats :as data-store.chats]
-    [quo.core :as quo]
     [re-frame.core :as re-frame]
     [status-im.common.json-rpc.events :as json-rpc]
     [status-im.common.toasts.events :as toasts]
@@ -545,7 +544,7 @@
                        (not dismissed))
                   (toasts/upsert cofx
                                  {:type            :notification
-                                  :avatar          [quo/user-avatar user-avatar]
+                                  :user            user-avatar
                                   :user-public-key author
                                   :title           (i18n/label :t/contact-request-sent-toast
                                                                {:name name})
@@ -557,7 +556,7 @@
                        (not dismissed))
                   (toasts/upsert cofx
                                  {:type            :notification
-                                  :avatar          [quo/user-avatar user-avatar]
+                                  :user            user-avatar
                                   ;; user public key who accepted the request
                                   :user-public-key chat-id
                                   :text            (i18n/label :t/contact-request-accepted-toast

--- a/src/status_im/contexts/shell/activity_center/events.cljs
+++ b/src/status_im/contexts/shell/activity_center/events.cljs
@@ -559,7 +559,7 @@
                                   :user            user-avatar
                                   ;; user public key who accepted the request
                                   :user-public-key chat-id
-                                  :text            (i18n/label :t/contact-request-accepted-toast
+                                  :title           (i18n/label :t/contact-request-accepted-toast
                                                                {:name (or name (:alias message))})})
                   :else
                   cofx)))

--- a/src/status_im/contexts/shell/activity_center/events.cljs
+++ b/src/status_im/contexts/shell/activity_center/events.cljs
@@ -2,7 +2,7 @@
   (:require
     [legacy.status-im.data-store.activities :as activities]
     [legacy.status-im.data-store.chats :as data-store.chats]
-    [quo.foundations.colors :as colors]
+    [quo.core :as quo]
     [re-frame.core :as re-frame]
     [status-im.common.json-rpc.events :as json-rpc]
     [status-im.common.toasts.events :as toasts]
@@ -544,9 +544,9 @@
                        (not accepted)
                        (not dismissed))
                   (toasts/upsert cofx
-                                 {:user            user-avatar
+                                 {:type            :notification
+                                  :avatar          [quo/user-avatar user-avatar]
                                   :user-public-key author
-                                  :icon-color      colors/primary-50-opa-40
                                   :title           (i18n/label :t/contact-request-sent-toast
                                                                {:name name})
                                   :text            (get-in message [:content :text])})
@@ -556,11 +556,11 @@
                        accepted
                        (not dismissed))
                   (toasts/upsert cofx
-                                 {:user            user-avatar
+                                 {:type            :notification
+                                  :avatar          [quo/user-avatar user-avatar]
                                   ;; user public key who accepted the request
                                   :user-public-key chat-id
-                                  :icon-color      colors/success-50-opa-40
-                                  :title           (i18n/label :t/contact-request-accepted-toast
+                                  :text            (i18n/label :t/contact-request-accepted-toast
                                                                {:name (or name (:alias message))})})
                   :else
                   cofx)))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19261 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to tweak the notifications UI for contact requests based on the design feedback in #19261 
  * The notifications that are affected:
    * Contact request notifications that appear when a user is notified that someone sent them a contact request.
    * Contact requests notifications that appear when a user is notified that their contact request was accepted.
  * Note that this PR refactors the Quo notification component, and uses the notification component for these specific contact request notifications.
* This PR may be able to `skip-manual-qa` because it mainly focuses on addressing design feedback. Though it does change the Quo notification component, but that component does not seem to be used anywhere else atm.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Contact request notifications

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile on two devices
- Login on each device with separate accounts
- Open the contact profiles between the two users
- Send a contact request from one user to the other
- Accept the contact request

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before

There are some screenshots present in #19261

#### After

<img width="448" alt="Screenshot 2024-03-20 at 09 12 14" src="https://github.com/status-im/status-mobile/assets/2845768/ca44939d-b1f0-4bac-9f48-b38a4a50f13f">

status: ready <!-- Can be ready or wip -->
