### PR TITLE
Fraschetti - Add wallet-get-address-details-contract-test

### DIFF
--- a/src/tests/contract_test/wallet_test.cljs
+++ b/src/tests/contract_test/wallet_test.cljs
@@ -87,3 +87,19 @@
                                "wallet_getWalletToken"
                                [default-address])]
         (assert-wallet-tokens response)))))
+
+(defn assert-address-details
+  [result]
+  (is (contains? result :address))
+  (is (contains? result :path))
+  (is (boolean? (:hasActivity result)))
+  (is (false? (:alreadyCreated result))))
+
+(deftest wallet-get-address-details-contract-test
+  (h/test-async :wallet/get-address-details
+    (fn []
+      (p/let [input       "test.eth"
+              chain-id    constants/ethereum-mainnet-chain-id
+              ens-address (contract-utils/call-rpc "ens_addressOf" chain-id input)
+              response    (contract-utils/call-rpc "wallet_getAddressDetails" chain-id ens-address)]
+        (assert-address-details response)))))


### PR DESCRIPTION
fixes #18349
Epic #18587

Summary
This pull request introduces comprehensive tests for the `wallet_getAddressDetails` endpoint, ensuring its robustness and reliability in our wallet functionality.

Steps to test
run `make test-contracts`

status: ready!