### PR TITLE
[Feature] Show "Testnet mode enabled" banner if testnet enabled

### DIFF
--- a/src/status_im/contexts/onboarding/welcome/view.cljs
+++ b/src/status_im/contexts/onboarding/welcome/view.cljs
@@ -57,6 +57,7 @@
       [quo/button
        {:on-press            (fn []
                                (rf/dispatch [:init-root :shell-stack])
+                               (rf/dispatch [:profile/show-testnet-mode-banner-if-enabled])
                                (rf/dispatch [:universal-links/process-stored-event]))
         :type                :primary
         :accessibility-label :welcome-button

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -10,6 +10,7 @@
     [status-im.contexts.profile.rpc :as profile.rpc]
     [taoensso.timbre :as log]
     [utils.ethereum.chain :as chain]
+    [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
 
@@ -82,7 +83,8 @@
                          constants/theme-type-dark)
                      :shell-stack
                      false]]
-                   [:set-root :shell-stack]]))})))
+                   [:set-root :shell-stack]
+                   [:dispatch [:profile/show-testnet-mode-banner-if-enabled]]]))})))
 
 ;; login phase 2: we want to load and show chats faster, so we split login into 2 phases
 (rf/reg-event-fx :profile.login/get-chats-callback
@@ -234,3 +236,12 @@
  :profile/on-password-input-changed
  (fn [{:keys [db]} [{:keys [password error]}]]
    {:db (update db :profile/login assoc :password password :error error)}))
+
+(rf/reg-event-fx
+ :profile/show-testnet-mode-banner-if-enabled
+ (fn [{:keys [db]}]
+   (when (get-in db [:profile/profile :test-networks-enabled?])
+     {:fx [[:dispatch
+            [:alert-banners/add
+             {:type :alert
+              :text (i18n/label :t/testnet-mode-enabled)}]]]})))

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -314,6 +314,7 @@ class BaseView(object):
         # share contact screen
         self.show_qr_button = Button(self.driver, accessibility_id="show-qr-button")
         self.link_to_profile_button = Button(self.driver, accessibility_id="share-qr-code-info-text")
+        self.sharing_text_native = Text(self.driver, xpath="//*[@resource-id='android:id/content_preview_text']")
 
         # checkboxes and toggles
         self.checkbox_button = CheckBox(self.driver, accessibility_id="checkbox-off")

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -331,6 +331,7 @@ class HomeView(BaseView):
         self.mark_all_read_activity_button = Button(self.driver, translation_id="mark-all-notifications-as-read")
 
         # Share tab
+        self.link_to_profile_button = Button(self.driver, accessibility_id="link-to-profile")
         self.link_to_profile_text = Text(self.driver, accessibility_id="share-qr-code-info-text")
         self.close_share_tab_button = Button(self.driver, accessibility_id="close-shell-share-tab")
 
@@ -562,9 +563,10 @@ class HomeView(BaseView):
 
     def get_link_to_profile(self):
         self.show_qr_code_button.click()
-        self.link_to_profile_text.wait_for_visibility_of_element()
-        self.link_to_profile_text.click()
-        return self.driver.get_clipboard_text()
+        self.link_to_profile_button.click()
+        link_to_profile = self.sharing_text_native.text
+        self.click_system_back_button()
+        return link_to_profile
 
     def get_public_key(self):
         self.driver.info("Getting public key via Share tab")

--- a/translations/en.json
+++ b/translations/en.json
@@ -2566,5 +2566,6 @@
     "key-name-error-length": "Key name too long",
     "key-name-error-emoji": "Emojis are not allowed",
     "key-name-error-special-char": "Special characters are not allowed",
-    "display": "Display"
+    "display": "Display",
+    "testnet-mode-enabled": "Testnet mode enabled"
 }


### PR DESCRIPTION
fixes #19357

### Summary

This PR adds the "Testnet mode enabled" banner if the User has enabled the testnet.

<img width="220" src="https://github.com/status-im/status-mobile/assets/19339952/bd301fc6-f481-4219-b7b1-ea8b98c89d6e" />

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Log into a profile
- Navigate to `Profile > Advanced`
- Enable `Testnet mode` toggle
- Verify the "Testnet mode enabled" is shown after login


#### ⚠️ NOTE:

Since this commit, https://github.com/status-im/status-mobile/commit/1d44472aa660cc1d22cc1374da9e215770578a3d is merged. This enables Test Networks in Dev, E2E and PR Builds by default and disables in Release/Nightly Builds.

This enables in create account or restore account flow. If you upgrade the app from the old build with an existing profile, it will use the last saved (test networks enabled) state of that profile.

status: ready
