### PR TITLE
[#19117] fix: setting over scroll shows gap

### DIFF
--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -68,7 +68,8 @@
        :footer                          [footer insets logout-press]
        :scroll-event-throttle           16
        :on-scroll                       #(scroll-handler % scroll-y)
-       :bounces                         false}]
+       :bounces                         false
+       :over-scroll-mode                :never}]
      [quo/floating-shell-button
       {:key :shell
        :jump-to


### PR DESCRIPTION
fixes #19117

### Summary

Remove gap when user do over scroll

#### Platforms

- Android

### Before and after screenshots comparison

#### Before 
[Screen_recording_20240321_154031.webm](https://github.com/status-im/status-mobile/assets/71308738/016ee043-8b5f-4a1e-96f5-6b207ad3537d)

#### After 
[Screen_recording_20240321_153613.webm](https://github.com/status-im/status-mobile/assets/71308738/f555cc54-fd81-4490-8cba-9bf697a4614f)

status: ready
