### PR TITLE
Remove 'Community admins will review your request' text from community overview screen

### DIFF
--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -178,7 +178,7 @@
          :container-style     {:margin-horizontal 12 :margin-top 12 :margin-bottom 12}
          :disabled?           (not can-request-access?)
          :icon-left           (if can-request-access? :i/unlocked :i/locked)}
-        (i18n/label :t/join-open-community)]])))
+        (i18n/label :t/request-to-join)]])))
 
 (defn- join-community
   [{:keys [id joined permissions] :as community}]

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -181,20 +181,13 @@
         (i18n/label :t/join-open-community)]])))
 
 (defn- join-community
-  [{:keys [id joined permissions can-request-access?] :as community}]
+  [{:keys [id joined permissions] :as community}]
   (let [pending?        (rf/sub [:communities/my-pending-request-to-join id])
         access-type     (get-access-type (:access permissions))
         unknown-access? (= access-type :unknown-access)
         invite-only?    (= access-type :invite-only)]
-    [:<>
-     (when-not (or joined pending? invite-only? unknown-access?)
-       [token-requirements community])
-     (when (and can-request-access? (not joined))
-       [quo/text
-        {:size   :paragraph-2
-         :weight :regular
-         :style  style/review-notice}
-        (i18n/label :t/community-admins-will-review-your-request)])]))
+    (when-not (or joined pending? invite-only? unknown-access?)
+      [token-requirements community])))
 
 (defn- status-tag
   [community-id joined]

--- a/test/appium/tests/critical/test_deep_and_universal_links.py
+++ b/test/appium/tests/critical/test_deep_and_universal_links.py
@@ -128,8 +128,7 @@ class TestDeepLinksOneDevice(MultipleSharedDeviceTestCase):
         community_url = "https://status.app/c/Ow==#zQ3shbmfT3hvh4mKa1v6uAjjyztQEroh8Mfn6Ckegjd7LT3XK"
         self.home.open_link_from_google_search_app(community_url, app_package)
         self.sign_in.sign_in()
-        if not self.home.element_by_translation_id(
-                "community-admins-will-review-your-request").is_element_displayed(10):
+        if not self.community_view.join_button.is_element_displayed(10):
             self.errors.append("Closed community was not requested to join by the url %s" % community_url)
 
         # ToDo: enable when https://github.com/status-im/status-mobile/issues/18074 is fixed

--- a/translations/en.json
+++ b/translations/en.json
@@ -235,7 +235,6 @@
     "membership-title": "Membership requirement",
     "create-channel-title": "New channel",
     "edit-channel-title": "Edit channel",
-    "community-admins-will-review-your-request": "Community admins will review your request",
     "community-thumbnail-image": "Thumbnail image",
     "community-emoji-thumbnail-title": "Thumbnail",
     "community-thumbnail-upload": "Upload",


### PR DESCRIPTION
fixes #19354 
fixes #19355

- Remove 'Community admins will review your request' text from community overview screen
- Use "Request to join" instead of "Join community" button for all communities

status: ready <!-- Can be ready or wip -->
