### PR TITLE
implement the community channel details as per designs

### DIFF
--- a/src/legacy/status_im/ui/components/colors.cljs
+++ b/src/legacy/status_im/ui/components/colors.cljs
@@ -22,13 +22,15 @@
   {:positive-01    "rgba(68,208,88,1)"     ; Primary Positive, text, icons color
    :positive-02    "rgba(78,188,96,0.1)"   ; Secondary Positive, Supporting color for success
    ; illustrations
-   :positive-03    "rgba(78,188,96,1)"     ; Lighter Positive, Supporting color for success illustrations
+   :positive-03    "rgba(78,188,96,1)"     ; Lighter Positive, Supporting color for success
+                                           ; illustrations
    :negative-01    "rgba(255,45,85,1)"     ; Primary Negative, text, icons color
    :negative-02    "rgba(255,45,85,0.1))"  ; Secondary Negative, Supporting color for errors
    ; illustrations
    :warning-01     "rgba(255, 202, 15, 1)"
    :warning-02     "rgba(255, 202, 15, 0.1)"
-   :interactive-01 "rgba(67,96,223,1)"     ; Accent color, buttons, own message, actions,active state
+   :interactive-01 "rgba(67,96,223,1)"     ; Accent color, buttons, own message, actions,active
+                                           ; state
    :interactive-02 "rgba(236,239,252,1)"   ; Light Accent, buttons background, actions background,
    ; messages
    :interactive-03 "rgba(255,255,255,0.1)" ; Background for interactive above accent
@@ -130,12 +132,14 @@
 (def mentioned-background (:mentioned-background old-colors-mapping-light))
 (def mentioned-border (:mentioned-border old-colors-mapping-light))
 
-(def red-light "#ffe5ea")                                   ;; error tooltip TODO (andrey) should be white, but shadow needed
+(def red-light "#ffe5ea")                                   ;; error tooltip TODO (andrey) should be white, but shadow
+                                   ;; needed
 
 ;; BLACK
 (def black (:text-01 light-theme))                                  ;; Used as the default text color
 (def black-persist (:ui-background dark-theme))                           ;; this doesn't with theme
-(def black-transparent (:ui-02 light-theme))                   ;; Used as background color for rounded button on dark background and as background
+(def black-transparent (:ui-02 light-theme))                   ;; Used as background color for rounded button on dark background and as
+                   ;; background
 ;; color for containers like "Backup recovery phrase"
 (def black-transparent-20 (:backdrop light-theme))                ; accounts divider
 (def black-transparent-40 (:backdrop light-theme))
@@ -145,7 +149,8 @@
 (def black-transparent-86 (:ui-03 light-theme))
 
 ;; DARK GREY
-(def gray (:text-02 light-theme))                                    ;; Dark grey, used as a background for a light foreground and as
+(def gray (:text-02 light-theme))                                    ;; Dark grey, used as a background for a light foreground and
+                                    ;; as
 ;; section header and secondary text color
 (def gray-transparent-10 (alpha gray 0.1))
 (def gray-transparent-40 (alpha gray 0.4))
@@ -153,7 +158,8 @@
 (def gray-lighter (:ui-01 light-theme))                    ;; Light Grey, used as a background or shadow
 
 ;; ACCENT BLUE
-(def blue (:interactive-01 light-theme))                                    ;; Accent blue, used as main wallet color, and ios home add button
+(def blue (:interactive-01 light-theme))                                    ;; Accent blue, used as main wallet color, and ios home add
+                                    ;; button
 (def blue-persist (:interactive-01 light-theme))
 ;; LIGHT BLUE
 (def blue-light (:interactive-02 light-theme))                        ;; Light Blue
@@ -237,6 +243,6 @@
     (reset! theme-type type)))
 
 ;; Colors related to Visibility Status
-(def color-online "#7CDA00")
+(def color-online "#23ADA0")
 (def color-dnd "#FA6565")
 (def color-inactive "#939BA1")

--- a/src/status_im/contexts/communities/actions/chat/view.cljs
+++ b/src/status_im/contexts/communities/actions/chat/view.cljs
@@ -30,11 +30,11 @@
   (hide-sheet-and-dispatch [:chat.ui/mute chat-id false 0]))
 
 (defn- action-view-members-and-details
-  []
+  [chat-id]
   {:icon                :i/members
    :accessibility-label :chat-view-members-and-details
    :label               (i18n/label :t/view-channel-members-and-details)
-   :on-press            not-implemented/alert})
+   :on-press            #(hide-sheet-and-dispatch [:navigate-to :channel-chat-profile chat-id])})
 
 (defn- action-token-requirements
   []
@@ -122,7 +122,7 @@
 
       (and (not inside-chat?) (not locked?))
       [quo/action-drawer
-       [[(action-view-members-and-details)
+       [[(action-view-members-and-details chat-id)
          (action-mark-as-read)
          (action-toggle-muted chat-id muted muted-till chat-type)
          (action-notification-settings)
@@ -133,7 +133,7 @@
 
       (and inside-chat? (not locked?))
       [quo/action-drawer
-       [[(action-view-members-and-details)
+       [[(action-view-members-and-details chat-id)
          (action-token-requirements)
          (action-mark-as-read)
          (action-toggle-muted chat-id muted muted-till chat-type)

--- a/src/status_im/contexts/communities/channel_details/style.cljs
+++ b/src/status_im/contexts/communities/channel_details/style.cljs
@@ -1,0 +1,1 @@
+(ns status-im.contexts.communities.channel-details.style)

--- a/src/status_im/contexts/communities/channel_details/view.cljs
+++ b/src/status_im/contexts/communities/channel_details/view.cljs
@@ -1,0 +1,184 @@
+(ns status-im.contexts.communities.channel-details.view
+  (:require
+    [quo.core :as quo]
+    [quo.foundations.colors :as colors]
+    [react-native.core :as rn]
+    [reagent.core :as reagent]
+    [status-im.common.contact-list-item.view :as contact-list-item]
+    [status-im.common.contact-list.view :as contact-list]
+    [status-im.common.home.actions.view :as actions]
+    [status-im.constants :as constants]
+    [status-im.contexts.chat.group-details.style :as style]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
+
+(defn group-chat-member-toggle
+  [member? selected? public-key]
+  (if-not member?
+    (if selected?
+      (rf/dispatch [:select-participant public-key true])
+      (rf/dispatch [:deselect-participant public-key true]))
+    (if selected?
+      (rf/dispatch [:undo-deselect-member public-key true])
+      (rf/dispatch [:deselect-member public-key true]))))
+
+(defn add-member-contact-item-render
+  [{:keys [public-key] :as item} _ _ {:keys [group]}]
+  (let [current-pk         (rf/sub [:multiaccount/public-key])
+        {:keys [contacts]} group
+        member?            (contains? contacts public-key)
+        checked?           (reagent/atom member?)]
+    (fn []
+      (let [on-toggle #(group-chat-member-toggle member? (swap! checked? not) public-key)]
+        [contact-list-item/contact-list-item
+         (when (not= current-pk public-key)
+           {:on-press                on-toggle
+            :allow-multiple-presses? true
+            :accessory               {:type     :checkbox
+                                      :checked? @checked?
+                                      :on-check on-toggle}})
+         item]))))
+
+(defn add-manage-members
+  []
+  (let [selected-participants      (rf/sub [:group-chat/selected-participants])
+        deselected-members         (rf/sub [:group-chat/deselected-members])
+        chat-id                    (rf/sub [:get-screen-params :group-chat-profile])
+        {:keys [admins] :as group} (rf/sub [:chats/chat-by-id chat-id])
+        admin?                     (get admins (rf/sub [:multiaccount/public-key]))]
+    [rn/view {:flex 1 :margin-top 20}
+     [rn/touchable-opacity
+      {:on-press            #(rf/dispatch [:navigate-back])
+       :accessibility-label :close-manage-members
+       :style               (style/close-icon)}
+      [quo/icon :i/close {:color (colors/theme-colors colors/neutral-100 colors/white)}]]
+     [quo/text
+      {:size   :heading-1
+       :weight :semi-bold
+       :style  {:margin-left 20}}
+      (i18n/label (if admin? :t/manage-members :t/add-members))]
+     [rn/section-list
+      {:key-fn                         :title
+       :sticky-section-headers-enabled false
+       :sections                       (rf/sub [:contacts/grouped-by-first-letter])
+       :render-section-header-fn       contact-list/contacts-section-header
+       :content-container-style        {:padding-bottom 20}
+       :render-data                    {:group group}
+       :render-fn                      add-member-contact-item-render}]
+     [rn/view {:style (style/bottom-container 30)}
+      [quo/button
+       {:container-style     {:flex 1}
+        :type                :primary
+        :accessibility-label :save
+        :on-press            (fn []
+                               (rf/dispatch [:navigate-back])
+                               (js/setTimeout (fn []
+                                                (rf/dispatch
+                                                 [:group-chats.ui/remove-members-pressed chat-id]))
+                                              500)
+                               (rf/dispatch [:group-chats.ui/add-members-pressed chat-id]))
+        :disabled?           (and (zero? (count selected-participants))
+                                  (zero? (count deselected-members)))}
+       (i18n/label :t/save)]]]))
+
+(defn contact-item-render
+  [{:keys [public-key] :as item} _ _ extra-data]
+  (let [current-pk           (rf/sub [:multiaccount/public-key])
+        show-profile-actions #(rf/dispatch [:show-bottom-sheet
+                                            {:content (fn [] [actions/contact-actions item
+                                                              extra-data])}])]
+    [contact-list-item/contact-list-item
+     (when (not= public-key current-pk)
+       {:on-press                #(rf/dispatch [:chat.ui/show-profile public-key])
+        :allow-multiple-presses? true
+        :on-long-press           show-profile-actions
+        :accessory               {:type     :options
+                                  :on-press show-profile-actions}})
+     item]))
+
+(defn contacts-section-header
+  [{:keys [title]}]
+  [quo/divider-label {:tight? true} title])
+
+(defn contacts-section-footer
+  [_]
+  [rn/view {:style {:height 8}}])
+
+(defn actions
+  [chat-id cover-bg-color]
+  (let [latest-pin-text                      (rf/sub [:chats/last-pinned-message-text chat-id])
+        pins-count                           (rf/sub [:chats/pin-messages-count chat-id])
+        {:keys [muted muted-till chat-type]} (rf/sub [:chats/chat-by-id chat-id])
+        community-channel?                   (= constants/community-chat-type chat-type)
+        muted?                               (and muted (some? muted-till))
+        mute-chat-label                      (if community-channel? :t/mute-channel :t/mute-chat)
+        unmute-chat-label                    (if community-channel?
+                                               :t/unmute-channel
+                                               :t/unmute-chat)]
+    [quo/channel-actions
+     {:container-style {:margin-vertical 20 :padding-horizontal 20}
+      :actions         [{:accessibility-label :action-button-pinned
+                         :big?                true
+                         :label               (or latest-pin-text
+                                                  (i18n/label :t/no-pinned-messages))
+                         :color               cover-bg-color
+                         :icon                :i/pin
+                         :counter-value       pins-count
+                         :on-press            (fn []
+                                                (rf/dispatch [:pin-message/show-pins-bottom-sheet
+                                                              chat-id]))}
+                        {:accessibility-label :action-button-mute
+                         :label               (i18n/label (if muted
+                                                            unmute-chat-label
+                                                            mute-chat-label))
+                         :color               cover-bg-color
+                         :icon                (if muted? :i/activity-center :i/muted)
+                         :on-press            (fn []
+                                                (if muted?
+                                                  (actions/unmute-chat-action chat-id)
+                                                  (actions/mute-chat-action chat-id
+                                                                            chat-type
+                                                                            muted?)))}]}]))
+
+
+(defn channel-details
+  []
+  (let [chat-id         (rf/sub [:get-screen-params :channel-chat-profile])
+        {:keys [admins chat-id community-id chat-name emoji color]
+         :as   channel} (rf/sub [:chats/chat-by-id chat-id])
+        display-name    (str (when emoji (str emoji " ")) "# " chat-name)
+        members         (rf/sub [:contacts/group-members-sections chat-id])
+        current-pk      (rf/sub [:multiaccount/public-key])
+        admin?          (get admins current-pk)
+        sorted-members  (rf/sub [:communities/sorted-community-members
+                                 community-id])]
+    (println sorted-members)
+    [:<>
+     [quo/gradient-cover
+      {:height              286
+       :customization-color color}]
+     [quo/page-nav
+      {:type       :no-title
+       :background :photo
+       :right-side [{:icon-name :i/options
+                     :on-press  #(rf/dispatch [:show-bottom-sheet
+                                               {:content (fn [] [actions/group-details-actions
+                                                                 channel])}])}]
+       :icon-name  :i/arrow-left
+       :on-press   #(rf/dispatch [:navigate-back])}]
+
+     [quo/page-top
+      {:title  display-name
+       :avatar {:customization-color color}}]
+
+     [actions chat-id color]
+
+     [rn/section-list
+      {:key-fn                         :title
+       :sticky-section-headers-enabled false
+       :sections                       members
+       :render-section-header-fn       contacts-section-header
+       :render-section-footer-fn       contacts-section-footer
+       :render-data                    {:chat-id chat-id
+                                        :admin?  admin?}
+       :render-fn                      contact-item-render}]]))

--- a/src/status_im/contexts/communities/channel_details/view.cljs
+++ b/src/status_im/contexts/communities/channel_details/view.cljs
@@ -122,7 +122,7 @@
                          :big?                true
                          :label               (or latest-pin-text
                                                   (i18n/label :t/no-pinned-messages))
-                         :color               cover-bg-color
+                         :customization-color cover-bg-color
                          :icon                :i/pin
                          :counter-value       pins-count
                          :on-press            (fn []
@@ -132,7 +132,7 @@
                          :label               (i18n/label (if muted
                                                             unmute-chat-label
                                                             mute-chat-label))
-                         :color               cover-bg-color
+                         :customization-color cover-bg-color
                          :icon                (if muted? :i/activity-center :i/muted)
                          :on-press            (fn []
                                                 (if muted?
@@ -145,7 +145,7 @@
 (defn channel-details
   []
   (let [chat-id         (rf/sub [:get-screen-params :channel-chat-profile])
-        {:keys [admins chat-id community-id chat-name emoji color]
+        {:keys [admins chat-id community-id chat-name emoji color description]
          :as   channel} (rf/sub [:chats/chat-by-id chat-id])
         display-name    (str (when emoji (str emoji " ")) "# " chat-name)
         current-pk      (rf/sub [:multiaccount/public-key])
@@ -153,22 +153,21 @@
         contacts        (rf/sub [:communities/current-channel-contacts community-id
                                  (string/replace chat-id community-id "")])]
     [:<>
-     [quo/gradient-cover
-      {:height              286
-       :customization-color color}]
      [quo/page-nav
       {:type       :no-title
        :background :photo
        :right-side [{:icon-name :i/options
                      :on-press  #(rf/dispatch [:show-bottom-sheet
-                                               {:content (fn [] [actions/group-details-actions
+                                               {:content (fn [] [actions/chat-actions
                                                                  channel])}])}]
        :icon-name  :i/arrow-left
        :on-press   #(rf/dispatch [:navigate-back])}]
 
      [quo/page-top
-      {:title  display-name
-       :avatar {:customization-color color}}]
+      {:title            display-name
+       :description      :text
+       :description-text description
+       :avatar           {:customization-color color}}]
 
      [actions chat-id color]
 

--- a/src/status_im/contexts/communities/channel_details/view.cljs
+++ b/src/status_im/contexts/communities/channel_details/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.communities.channel-details.view
   (:require
+    [clojure.string :as string]
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
     [react-native.core :as rn]
@@ -147,12 +148,10 @@
         {:keys [admins chat-id community-id chat-name emoji color]
          :as   channel} (rf/sub [:chats/chat-by-id chat-id])
         display-name    (str (when emoji (str emoji " ")) "# " chat-name)
-        members         (rf/sub [:contacts/group-members-sections chat-id])
         current-pk      (rf/sub [:multiaccount/public-key])
         admin?          (get admins current-pk)
-        sorted-members  (rf/sub [:communities/sorted-community-members
-                                 community-id])]
-    (println sorted-members)
+        contacts        (rf/sub [:communities/current-channel-contacts community-id
+                                 (string/replace chat-id community-id "")])]
     [:<>
      [quo/gradient-cover
       {:height              286
@@ -176,9 +175,10 @@
      [rn/section-list
       {:key-fn                         :title
        :sticky-section-headers-enabled false
-       :sections                       members
+       :sections                       contacts
        :render-section-header-fn       contacts-section-header
        :render-section-footer-fn       contacts-section-footer
        :render-data                    {:chat-id chat-id
                                         :admin?  admin?}
-       :render-fn                      contact-item-render}]]))
+       :render-fn                      contact-item-render}]
+    ]))

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -18,6 +18,7 @@
     [status-im.contexts.communities.actions.airdrop-addresses.view :as airdrop-addresses]
     [status-im.contexts.communities.actions.request-to-join.view :as join-menu]
     [status-im.contexts.communities.actions.share-community-channel.view :as share-community-channel]
+    [status-im.contexts.communities.channel-details.view :as channel-details]
     [status-im.contexts.communities.discover.view :as communities.discover]
     [status-im.contexts.communities.overview.view :as communities.overview]
     [status-im.contexts.onboarding.create-password.view :as create-password]
@@ -129,6 +130,10 @@
     {:name      :share-community-channel
      :options   options/transparent-screen-options
      :component share-community-channel/view}
+
+    {:name      :channel-chat-profile
+     :options   {:insets {:top? true}}
+     :component channel-details/channel-details}
 
     ;; Note: the sheet screen is used when selecting addresses to share when
     ;; joining a community. The non-sheet screen is used when editing shared


### PR DESCRIPTION
fixes #19092

### Summary

Implement the community channel detail screen as design
https://www.figma.com/file/h9wo4GipgZURbqqr1vShFN/Communities-for-Mobile?type=design&node-id=6501-482960&mode=design&t=P90YEyz4VvydXUob-4

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Community channel chat
- Community home

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Go to a community
- In the channel list, long press a channel and then click "View channel members and details"

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison
![Simulator Screenshot - iPhone 13 - 2024-03-22 at 07 14 29](https://github.com/status-im/status-mobile/assets/39961806/1a17ee6d-54ea-4bff-807a-0eaebf524a99)

Uploading Simulator Screen Recording - iPhone 13 - 2024-03-22 at 07.15.21.mp4…


status: ready <!-- Can be ready or wip -->
