### PR TITLE
Hide community channels when hide channels option is enabled

### DIFF
--- a/src/legacy/status_im/data_store/chats.cljs
+++ b/src/legacy/status_im/data_store/chats.cljs
@@ -70,20 +70,21 @@
 (defn <-rpc
   [chat]
   (-> chat
-      (set/rename-keys {:id                     :chat-id
-                        :communityId            :community-id
-                        :syncedFrom             :synced-from
-                        :syncedTo               :synced-to
-                        :membershipUpdateEvents :membership-update-events
-                        :deletedAtClockValue    :deleted-at-clock-value
-                        :chatType               :chat-type
-                        :unviewedMessagesCount  :unviewed-messages-count
-                        :unviewedMentionsCount  :unviewed-mentions-count
-                        :lastMessage            :last-message
-                        :lastClockValue         :last-clock-value
-                        :invitationAdmin        :invitation-admin
-                        :profile                :profile-public-key
-                        :muteTill               :muted-till})
+      (set/rename-keys {:id                      :chat-id
+                        :communityId             :community-id
+                        :syncedFrom              :synced-from
+                        :syncedTo                :synced-to
+                        :membershipUpdateEvents  :membership-update-events
+                        :deletedAtClockValue     :deleted-at-clock-value
+                        :chatType                :chat-type
+                        :unviewedMessagesCount   :unviewed-messages-count
+                        :unviewedMentionsCount   :unviewed-mentions-count
+                        :lastMessage             :last-message
+                        :lastClockValue          :last-clock-value
+                        :invitationAdmin         :invitation-admin
+                        :profile                 :profile-public-key
+                        :muteTill                :muted-till
+                        :hideIfPermissionsNotMet :hide-if-permissions-not-met?})
       rpc->type
       unmarshal-members
       (update :last-message #(when % (messages/<-rpc %)))
@@ -92,38 +93,40 @@
 
 (defn <-rpc-js
   [^js chat]
-  (-> {:name                    (.-name chat)
-       :description             (.-description chat)
-       :color                   (<-color (.-color chat))
-       :emoji                   (.-emoji chat)
-       :timestamp               (.-timestamp chat)
-       :alias                   (.-alias chat)
-       :muted                   (.-muted chat)
-       :joined                  (.-joined chat)
-       :muted-till              (.-muteTill chat)
-       :chat-id                 (.-id chat)
-       :community-id            (.-communityId chat)
-       :synced-from             (.-syncedFrom chat)
-       :synced-to               (.-syncedTo chat)
-       :deleted-at-clock-value  (.-deletedAtClockValue chat)
-       :chat-type               (.-chatType chat)
-       :unviewed-messages-count (.-unviewedMessagesCount chat)
-       :unviewed-mentions-count (.-unviewedMentionsCount chat)
-       :last-message            {:content            {:text        (.-text chat)
-                                                      :parsed-text (types/js->clj (.-parsedText chat))
-                                                      :response-to (.-responseTo chat)}
-                                 :content-type       (.-contentType chat)
-                                 :community-id       (.-contentCommunityId chat)
-                                 :outgoing           (boolean (.-outgoingStatus chat))
-                                 :album-images-count (.-albumImagesCount chat)
-                                 :from               (.-from chat)
-                                 :deleted?           (.-deleted chat)
-                                 :deleted-for-me?    (.-deletedForMe chat)}
-       :last-clock-value        (.-lastClockValue chat)
-       :profile-public-key      (.-profile chat)
-       :highlight               (.-highlight chat)
-       :active                  (.-active chat)
-       :members                 (types/js->clj (.-members chat))}
+  (-> {:name                        (.-name chat)
+       :description                 (.-description chat)
+       :color                       (<-color (.-color chat))
+       :emoji                       (.-emoji chat)
+       :timestamp                   (.-timestamp chat)
+       :alias                       (.-alias chat)
+       :muted                       (.-muted chat)
+       :joined                      (.-joined chat)
+       :muted-till                  (.-muteTill chat)
+       :chat-id                     (.-id chat)
+       :community-id                (.-communityId chat)
+       :synced-from                 (.-syncedFrom chat)
+       :synced-to                   (.-syncedTo chat)
+       :deleted-at-clock-value      (.-deletedAtClockValue chat)
+       :chat-type                   (.-chatType chat)
+       :unviewed-messages-count     (.-unviewedMessagesCount chat)
+       :unviewed-mentions-count     (.-unviewedMentionsCount chat)
+       :last-message                {:content            {:text        (.-text chat)
+                                                          :parsed-text (types/js->clj (.-parsedText
+                                                                                       chat))
+                                                          :response-to (.-responseTo chat)}
+                                     :content-type       (.-contentType chat)
+                                     :community-id       (.-contentCommunityId chat)
+                                     :outgoing           (boolean (.-outgoingStatus chat))
+                                     :album-images-count (.-albumImagesCount chat)
+                                     :from               (.-from chat)
+                                     :deleted?           (.-deleted chat)
+                                     :deleted-for-me?    (.-deletedForMe chat)}
+       :last-clock-value            (.-lastClockValue chat)
+       :profile-public-key          (.-profile chat)
+       :highlight                   (.-highlight chat)
+       :active                      (.-active chat)
+       :members                     (types/js->clj (.-members chat))
+       :hide-if-permissions-not-met (.-hideIfPermissionsNotMet chat)}
       rpc->type
       unmarshal-members))
 

--- a/src/legacy/status_im/data_store/communities.cljs
+++ b/src/legacy/status_im/data_store/communities.cljs
@@ -27,10 +27,11 @@
                (assoc acc
                       (name k)
                       (-> v
-                          (assoc :token-gated? (:tokenGated v)
-                                 :can-post?    (:canPost v)
-                                 :can-view?    (:canView v))
-                          (dissoc :canPost :tokenGated :canView)
+                          (assoc :token-gated?                 (:tokenGated v)
+                                 :can-post?                    (:canPost v)
+                                 :can-view?                    (:canView v)
+                                 :hide-if-permissions-not-met? (:hideIfPermissionsNotMet v))
+                          (dissoc :canPost :tokenGated :canView :hideIfPermissionsNotMet)
                           (update :members walk/stringify-keys))))
              {}
              chats))


### PR DESCRIPTION
fixes #19377 

### Summary

Hide channels when "hideIfPermissionsNotMet" flag is enabled and token-gating permissions are not fullfiled.

status: ready
