### PR TITLE
fix: re-route a user's own profile link to their settings page

### DIFF
--- a/src/status_im/common/universal_links.cljs
+++ b/src/status_im/common/universal_links.cljs
@@ -75,7 +75,7 @@
     (and public-key (own-public-key? db public-key))
     (rf/merge cofx
               {:pop-to-root-fx :shell-stack}
-              (navigation/navigate-to :my-profile nil))
+              (navigation/navigate-to :settings nil))
 
     public-key
     {:dispatch [:chat.ui/show-profile public-key ens-name]}))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19328 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to route a user to their settings page when opening their own profile link.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Opening profile links

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

This issues provides a video on how to re-produce: #19328

- Open Status mobile
- Open share screen
- Copy profile link
- Send profile link in chat
- Open profile link in chat

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before

https://github.com/status-im/status-mobile/assets/2845768/e8f834e3-779d-4ab6-8a1f-9dc28ceb15b3

#### After

https://github.com/status-im/status-mobile/assets/2845768/60027c88-57de-48bf-bf62-6648ba6e477b

status: ready
