### PR TITLE
feat: add ability to tap to disable from networks in send & bridge flow

### DIFF
--- a/src/quo/components/wallet/network_link/helpers.cljs
+++ b/src/quo/components/wallet/network_link/helpers.cljs
@@ -1,0 +1,23 @@
+(ns quo.components.wallet.network-link.helpers)
+
+(def ^:private central-figure-width 63)
+
+(defn calculate-side-lines-path-1x
+  "Calculates the `d` attribute for the side lines based on the SVG width."
+  [width]
+  (let [side-offset (/ (- width central-figure-width) 2)]
+    {:left  (str "M0 57 L" side-offset " 57")
+     :right (str "M" (+ side-offset central-figure-width) " 1 L" width " 1")}))
+
+(defn calculate-transform
+  "Calculates the transform attribute for the central figure based on the SVG width."
+  [width]
+  (let [translate-x (/ (- width central-figure-width) 2)]
+    (str "translate(" translate-x " 0)")))
+
+(defn calculate-side-lines-path-2x
+  "Calculates the `d` attribute for the side lines based on the SVG width."
+  [width]
+  (let [side-offset (/ (- width central-figure-width) 2)]
+    {:left  (str "M0 113 L" side-offset " 113")
+     :right (str "M" (+ side-offset central-figure-width) " 1 L" width " 1")}))

--- a/src/quo/components/wallet/network_link/style.cljs
+++ b/src/quo/components/wallet/network_link/style.cljs
@@ -1,0 +1,34 @@
+(ns quo.components.wallet.network-link.style)
+
+(def left-circle-container
+  {:position :absolute
+   :left     -3})
+
+(def right-circle-container
+  {:position :absolute
+   :right    -3})
+
+(def bottom-left-circle-container
+  {:position :absolute
+   :bottom   -3
+   :left     -3})
+
+(def top-right-circle-container
+  {:position :absolute
+   :top      -3
+   :right    -3})
+
+(def link-linear-container
+  {:flex-direction :row
+   :align-items    :center
+   :height         10})
+
+(def link-1x-container
+  {:flex            1
+   :height          58
+   :justify-content :center})
+
+(def link-2x-container
+  {:flex            1
+   :height          114
+   :justify-content :center})

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -448,6 +448,8 @@
 (def ^:const optimism-short-name "opt")
 (def ^:const arbitrum-short-name "arb1")
 
+(def ^:const default-multichain-address-prefix "eth:opt:arb1:")
+
 (def ^:const mainnet-abbreviated-name "Eth.")
 (def ^:const optimism-abbreviated-name "Opt.")
 (def ^:const arbitrum-abbreviated-name "Arb1.")

--- a/src/status_im/contexts/preview/quo/wallet/network_link.cljs
+++ b/src/status_im/contexts/preview/quo/wallet/network_link.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.preview.quo.wallet.network-link
   (:require
     [quo.core :as quo]
+    [react-native.core :as rn]
     [reagent.core :as reagent]
     [status-im.contexts.preview.quo.preview :as preview]))
 
@@ -23,17 +24,21 @@
     :options networks}
    {:key     :destination
     :type    :select
-    :options networks}])
+    :options networks}
+   {:key  :width
+    :type :number}])
 
 (defn view
   []
   (let [state (reagent/atom {:shape       :linear
                              :source      :ethereum
-                             :destination :optimism})]
+                             :destination :optimism
+                             :width       63})]
     (fn []
       [preview/preview-container
        {:state                     state
         :descriptor                descriptor
         :component-container-style {:padding-top 40
                                     :align-items :center}}
-       [quo/network-link @state]])))
+       [rn/view {:style {:width (max (:width @state) 63)}}
+        [quo/network-link @state]]])))

--- a/src/status_im/contexts/wallet/bridge/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/input_amount/view.cljs
@@ -15,6 +15,7 @@
      :button-one-label  (i18n/label :t/confirm-bridge)
      :button-one-props  {:icon-left :i/bridge}
      :on-navigate-back  (fn []
+                          (rf/dispatch [:wallet/clean-disabled-from-networks])
                           (rf/dispatch [:navigate-back]))}]])
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/common/utils/networks.cljs
+++ b/src/status_im/contexts/wallet/common/utils/networks.cljs
@@ -1,0 +1,18 @@
+(ns status-im.contexts.wallet.common.utils.networks
+  (:require [clojure.string :as string]
+            [status-im.constants :as constants]
+            [status-im.contexts.wallet.common.utils :as utils]))
+
+(defn resolve-receiver-networks
+  [{:keys [prefix testnet-enabled? goerli-enabled?]}]
+  (let [prefix     (if (string/blank? prefix)
+                     constants/default-multichain-address-prefix
+                     prefix)
+        prefix-seq (string/split prefix #":")]
+    (->> prefix-seq
+         (remove string/blank?)
+         (mapv
+          #(utils/network->chain-id
+            {:network          %
+             :testnet-enabled? testnet-enabled?
+             :goerli-enabled?  goerli-enabled?})))))

--- a/src/status_im/contexts/wallet/common/utils/send_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils/send_test.cljs
@@ -20,3 +20,44 @@
             expected-eip1559-disabled-result (money/bignumber 0.000760406)]
         (is (money/equal-to (utils/calculate-gas-fee data-eip1559-disabled)
                             expected-eip1559-disabled-result))))))
+
+(deftest test-find-affordable-networks
+  (testing "All networks affordable and selected, none disabled"
+    (let [balances-per-chain {"1" {:balance "50.0" :chain-id "1"}
+                              "2" {:balance "40.0" :chain-id "2"}}
+          input-value        20
+          selected-networks  ["1" "2"]
+          disabled-chain-ids []
+          expected           ["1" "2"]]
+      (is (= (set (utils/find-affordable-networks {:balances-per-chain balances-per-chain
+                                                   :input-value        input-value
+                                                   :selected-networks  selected-networks
+                                                   :disabled-chain-ids disabled-chain-ids}))
+             (set expected)))))
+
+  (testing "No networks affordable"
+    (let [balances-per-chain {"1" {:balance "5.0" :chain-id "1"}
+                              "2" {:balance "1.0" :chain-id "2"}}
+          input-value        10
+          selected-networks  ["1" "2"]
+          disabled-chain-ids []
+          expected           []]
+      (is (= (set (utils/find-affordable-networks {:balances-per-chain balances-per-chain
+                                                   :input-value        input-value
+                                                   :selected-networks  selected-networks
+                                                   :disabled-chain-ids disabled-chain-ids}))
+             (set expected)))))
+
+  (testing "Selected networks subset, with some disabled"
+    (let [balances-per-chain {"1" {:balance "100.0" :chain-id "1"}
+                              "2" {:balance "50.0" :chain-id "2"}
+                              "3" {:balance "20.0" :chain-id "3"}}
+          input-value        15
+          selected-networks  ["1" "2" "3"]
+          disabled-chain-ids ["2"]
+          expected           ["1" "3"]]
+      (is (= (set (utils/find-affordable-networks {:balances-per-chain balances-per-chain
+                                                   :input-value        input-value
+                                                   :selected-networks  selected-networks
+                                                   :disabled-chain-ids disabled-chain-ids}))
+             (set expected))))))

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -5,60 +5,75 @@
     [status-im.contexts.wallet.send.input-amount.view :as input-amount]
     [test-helpers.component :as h]
     [utils.debounce :as debounce]
+    [utils.money :as money]
     [utils.re-frame :as rf]))
 
 (set! rf/dispatch #())
 (set! debounce/debounce-and-dispatch #())
 
 (def sub-mocks
-  {:profile/profile                              {:currency :usd}
-   :wallet/selected-network-details              [{:source           525
-                                                   :short-name       "eth"
-                                                   :network-name     :mainnet
-                                                   :chain-id         1
-                                                   :related-chain-id 5}]
-   :wallet/current-viewing-account               {:path "m/44'/60'/0'/0/1"
-                                                  :emoji "💎"
-                                                  :key-uid "0x2f5ea39"
-                                                  :address "0x1"
-                                                  :wallet false
-                                                  :name "Account One"
-                                                  :type :generated
-                                                  :watch-only? false
-                                                  :chat false
-                                                  :test-preferred-chain-ids #{5 420 421613}
-                                                  :color :purple
-                                                  :hidden false
-                                                  :prod-preferred-chain-ids #{1 10 42161}
-                                                  :network-preferences-names #{:mainnet :arbitrum
-                                                                               :optimism}
-                                                  :position 1
-                                                  :clock 1698945829328
-                                                  :created-at 1698928839000
-                                                  :operable "fully"
-                                                  :mixedcase-address "0x7bcDfc75c431"
-                                                  :public-key "0x04371e2d9d66b82f056bc128064"
-                                                  :removed false}
-   :wallet/wallet-send-token                     {:symbol                     :eth
-                                                  :total-balance              100
-                                                  :market-values-per-currency {:usd {:price 10}}}
-   :wallet/wallet-send-loading-suggested-routes? false
-   :wallet/wallet-send-route                     [{:from       {:chainid                1
-                                                                :native-currency-symbol "ETH"}
-                                                   :to         {:chain-id               1
-                                                                :native-currency-symbol "ETH"}
-                                                   :gas-amount "23487"
-                                                   :gas-fees   {:base-fee                 "32.325296406"
-                                                                :max-priority-fee-per-gas "0.011000001"
-                                                                :eip1559-enabled          true}}]
-   :wallet/wallet-send-suggested-routes          {:candidates []}
-   :wallet/wallet-send-selected-networks         []
-   :view-id                                      :screen/wallet.send-input-amount
-   :wallet/wallet-send-to-address                "0x04371e2d9d66b82f056bc128064"
-   :profile/currency-symbol                      "$"
-   :wallet/token-by-symbol                       {:symbol                     :eth
-                                                  :total-balance              100
-                                                  :market-values-per-currency {:usd {:price 10}}}})
+  {:profile/profile                                {:currency :usd}
+   :wallet/selected-network-details                [{:source           525
+                                                     :short-name       "eth"
+                                                     :network-name     :mainnet
+                                                     :chain-id         1
+                                                     :related-chain-id 5}]
+   :wallet/current-viewing-account                 {:path "m/44'/60'/0'/0/1"
+                                                    :emoji "💎"
+                                                    :key-uid "0x2f5ea39"
+                                                    :address "0x1"
+                                                    :wallet false
+                                                    :name "Account One"
+                                                    :type :generated
+                                                    :watch-only? false
+                                                    :chat false
+                                                    :test-preferred-chain-ids #{5 420 421613}
+                                                    :color :purple
+                                                    :hidden false
+                                                    :prod-preferred-chain-ids #{1 10 42161}
+                                                    :network-preferences-names #{:mainnet :arbitrum
+                                                                                 :optimism}
+                                                    :position 1
+                                                    :clock 1698945829328
+                                                    :created-at 1698928839000
+                                                    :operable "fully"
+                                                    :mixedcase-address "0x7bcDfc75c431"
+                                                    :public-key "0x04371e2d9d66b82f056bc128064"
+                                                    :removed false}
+   :wallet/wallet-send-token                       {:symbol   :eth
+                                                    :networks [{:source           879
+                                                                :short-name       "eth"
+                                                                :network-name     :mainnet
+                                                                :abbreviated-name "Eth."
+                                                                :chain-id         1
+                                                                :related-chain-id 1
+                                                                :layer            1}]}
+   :wallet/current-viewing-account-tokens-filtered {:balances-per-chain         {1 {:raw-balance
+                                                                                    (money/bignumber
+                                                                                     "2500")
+                                                                                    :has-error false}}
+                                                    :total-balance              100
+                                                    :market-values-per-currency {:usd {:price 10}}}
+   :wallet/wallet-send-loading-suggested-routes?   false
+   :wallet/wallet-send-route                       [{:from       {:chainid                1
+                                                                  :native-currency-symbol "ETH"}
+                                                     :to         {:chain-id               1
+                                                                  :native-currency-symbol "ETH"}
+                                                     :gas-amount "23487"
+                                                     :gas-fees   {:base-fee "32.325296406"
+                                                                  :max-priority-fee-per-gas "0.011000001"
+                                                                  :eip1559-enabled true}}]
+   :wallet/wallet-send-suggested-routes            {:candidates []}
+   :wallet/wallet-send-selected-networks           [1]
+   :view-id                                        :screen/wallet.send-input-amount
+   :wallet/wallet-send-to-address                  "0x04371e2d9d66b82f056bc128064"
+   :profile/currency-symbol                        "$"
+   :wallet/token-by-symbol                         {:symbol                     :eth
+                                                    :total-balance              100
+                                                    :market-values-per-currency {:usd {:price 10}}}
+   :wallet/wallet-send-disabled-from-chain-ids     []
+   :wallet/wallet-send-from-values-by-chain        {1 (money/bignumber "250")}
+   :wallet/wallet-send-to-values-by-chain          {1 (money/bignumber "250")}})
 
 (h/describe "Send > input amount screen"
   (h/setup-restorable-re-frame)

--- a/src/status_im/contexts/wallet/send/routes/style.cljs
+++ b/src/status_im/contexts/wallet/send/routes/style.cljs
@@ -12,20 +12,23 @@
   {:flex-direction  :row
    :justify-content :space-between})
 
-(def routes-inner-container
-  {:margin-top      8
+(defn routes-inner-container
+  [first-item?]
+  {:margin-top      (if first-item? 7.5 11)
    :flex-direction  :row
    :align-items     :center
    :justify-content :space-between})
 
-(defn section-label
-  [margin-left]
-  {:flex        0.5
-   :margin-left margin-left})
+(def section-label-right
+  {:width 135})
+
+(def section-label-left
+  {:width 136})
 
 (def network-link
-  {:right   6
-   :z-index 1})
+  {:margin-horizontal -1.5
+   :z-index           1
+   :flex              1})
 
 (def empty-container
   {:flex-grow       1
@@ -33,9 +36,8 @@
    :justify-content :center})
 
 (def add-network
-  {:margin-top 8
-   :align-self :flex-end
-   :right      12})
+  {:margin-top 11
+   :align-self :flex-end})
 
 (defn warning-container
   [color theme]

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -132,6 +132,7 @@
                          (rf/dispatch [:wallet/clean-selected-token])
                          (rf/dispatch [:wallet/clean-selected-collectible])
                          (rf/dispatch [:wallet/clean-send-address])
+                         (rf/dispatch [:wallet/clean-disabled-from-networks])
                          (rf/dispatch [:wallet/select-address-tab nil])
                          (rf/dispatch [:navigate-back]))
         on-change-tab  #(rf/dispatch [:wallet/select-address-tab %])

--- a/src/status_im/contexts/wallet/send/send_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/send_amount/view.cljs
@@ -10,6 +10,8 @@
   [input-amount/view
    {:current-screen-id :screen/wallet.send-input-amount
     :button-one-label  (i18n/label :t/confirm)
-    :on-navigate-back  #(rf/dispatch [:navigate-back])}])
+    :on-navigate-back  (fn []
+                         (rf/dispatch [:wallet/clean-disabled-from-networks])
+                         (rf/dispatch [:navigate-back]))}])
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/send/utils_test.cljs
+++ b/src/status_im/contexts/wallet/send/utils_test.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.wallet.send.utils-test
   (:require [cljs.test :refer [deftest is testing]]
-            [status-im.contexts.wallet.send.utils :as utils]))
+            [status-im.contexts.wallet.send.utils :as utils]
+            [utils.money :as money]))
 
 (deftest test-amount-in-hex
   (testing "Test amount-in-hex function"
@@ -27,3 +28,68 @@
               "0x11" {:status   :pending
                       :id       61
                       :chain-id :420}})))))
+
+(deftest test-network-amounts-by-chain
+  (testing "Correctly calculates network amounts for transaction with native token"
+    (let [route          [{:amount-in "0xde0b6b3a7640000"
+                           :to        {:chain-id "1"}}
+                          {:amount-in "0xde0b6b3a7640000"
+                           :to        {:chain-id "2"}}]
+          token-decimals 18
+          native-token?  true
+          to?            true
+          result         (utils/network-amounts-by-chain {:route          route
+                                                          :token-decimals token-decimals
+                                                          :native-token?  native-token?
+                                                          :to?            to?})
+          expected       {"1" (money/bignumber "1")
+                          "2" (money/bignumber "1")}]
+      (doseq [[chain-id exp-value] expected]
+        (is (money/equal-to (get result chain-id) exp-value)))))
+
+  (testing
+    "Correctly calculates network amounts for transaction with native token and multiple routes to same chain-id"
+    (let [route          [{:amount-in "0xde0b6b3a7640000"
+                           :to        {:chain-id "1"}}
+                          {:amount-in "0xde0b6b3a7640000"
+                           :to        {:chain-id "1"}}]
+          token-decimals 18
+          native-token?  true
+          to?            true
+          result         (utils/network-amounts-by-chain {:route          route
+                                                          :token-decimals token-decimals
+                                                          :native-token?  native-token?
+                                                          :to?            to?})
+          expected       {"1" (money/bignumber "2")}]
+      (doseq [[chain-id exp-value] expected]
+        (is (money/equal-to (get result chain-id) exp-value)))))
+
+  (testing "Correctly calculates network amounts for transaction with non-native token"
+    (let [route          [{:amount-out "0x1e8480"
+                           :from       {:chain-id "1"}}
+                          {:amount-out "0x1e8480"
+                           :from       {:chain-id "2"}}]
+          token-decimals 6
+          native-token?  false
+          to?            false
+          result         (utils/network-amounts-by-chain {:route          route
+                                                          :token-decimals token-decimals
+                                                          :native-token?  native-token?
+                                                          :to?            to?})
+          expected       {"1" (money/bignumber "2")
+                          "2" (money/bignumber "2")}]
+      (doseq [[chain-id exp-value] expected]
+        (is (money/equal-to (get result chain-id) exp-value))))))
+
+(deftest test-network-values-for-ui
+  (testing "Sanitizes values correctly for display"
+    (let [amounts  {"1" (money/bignumber "0")
+                    "2" (money/bignumber "2.5")
+                    "3" (money/bignumber "0.005")}
+          result   (utils/network-values-for-ui amounts)
+          expected {"1" "<0.01"
+                    "2" (money/bignumber "2.5")
+                    "3" (money/bignumber "0.005")}]
+      (doseq [[chain-id exp-value] expected]
+        (is #(or (= (get result chain-id) exp-value)
+                 (money/equal-to (get result chain-id) exp-value)))))))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -96,6 +96,21 @@
  :-> :token)
 
 (rf/reg-sub
+ :wallet/wallet-send-disabled-from-chain-ids
+ :<- [:wallet/wallet-send]
+ :-> :disabled-from-chain-ids)
+
+(rf/reg-sub
+ :wallet/wallet-send-from-values-by-chain
+ :<- [:wallet/wallet-send]
+ :-> :from-values-by-chain)
+
+(rf/reg-sub
+ :wallet/wallet-send-to-values-by-chain
+ :<- [:wallet/wallet-send]
+ :-> :to-values-by-chain)
+
+(rf/reg-sub
  :wallet/wallet-send-loading-suggested-routes?
  :<- [:wallet/wallet-send]
  :-> :loading-suggested-routes?)

--- a/src/utils/vector.cljs
+++ b/src/utils/vector.cljs
@@ -1,0 +1,7 @@
+(ns utils.vector)
+
+(defn insert-element-at
+  [data element index]
+  (let [before (take index data)
+        after  (drop index data)]
+    (vec (concat before [element] after))))

--- a/src/utils/vector_test.cljs
+++ b/src/utils/vector_test.cljs
@@ -1,0 +1,17 @@
+(ns utils.vector-test
+  (:require
+    [cljs.test :refer-macros [deftest is testing]]
+    [utils.vector :as vector]))
+
+(deftest test-insert-element-at
+  (testing "Inserting into an empty vector"
+    (is (= [42] (vector/insert-element-at [] 42 0))))
+
+  (testing "Inserting at the beginning of a vector"
+    (is (= [42 1 2 3] (vector/insert-element-at [1 2 3] 42 0))))
+
+  (testing "Inserting in the middle of a vector"
+    (is (= [1 42 2 3] (vector/insert-element-at [1 2 3] 42 1))))
+
+  (testing "Inserting at the end of a vector"
+    (is (= [1 2 3 42] (vector/insert-element-at [1 2 3] 42 3)))))


### PR DESCRIPTION
fixes #18655 
fixes #19440

### Summary

Well, this PR turned to be larger than I wanted to be, but I think it is worth it.

The main purpose of this PR is to adds the ability for the user to disable sender networks when tapping a network on the "From" column in the Send or Bridge flow.

For example, this enables a way for the user to select the "From" network when bridging. The steps would be:
- First, wait for the best route to load
- Then, disable the unwanted chain(s) and wait for the new route to be loaded

Alternatively, user can re-enable the network by tapping again on it.

#### Demo video of the main added feature:

https://github.com/status-im/status-mobile/assets/18485527/136e8056-9e48-4c69-8c31-d1f99a5705ec

#### Now, about what additionally included in this PR:
- Moved logic to calculate the total amount sent from / to for each chain, that was previously on transaction confirmation view to events namespace, so we can now subscribe to the data that is needed also when showing suggested routes. New related subs are `:wallet/wallet-send-from-values-by-chain` and `:wallet/wallet-send-to-values-by-chain`.
- Worked on a refactor of Network Link component, which was not resizable and was causing UI issues. This implied rebuilding SVG composition to have a static part in the middle, and stretchable parts at the side. 

| Before | After |
|----------|----------|
| <img src="https://github.com/status-im/status-mobile/assets/18485527/1807497f-dce7-41e9-a3bd-031f3ada4935" width="350">    | <img src="https://github.com/status-im/status-mobile/assets/18485527/e59b8999-1f4b-4883-8534-760530138777" width="350">   |

###### Stretchable Network Link Demo
https://github.com/status-im/status-mobile/assets/18485527/01a9357e-2eae-4c0e-897c-d5a8128315f1

- Added unit tests for utils functions.
- Fixed logic to show affordable networks when loading suggested routes.
- Included a fix for #19440
- Lots of UI polishing on suggested routes UI.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Login with an account with some funds
- Go to wallet
- Select the account
- Tap on Send
- Select a receiver address
- Select a token where you have balances on more than one chain
- Input an amount 
- Wait for routes to be loaded. If there is no issues with entered amount and owned balances, suggested routes will show.
- Tap a route network on the From column to disable it. If there is only one available chain for the token and amount, disable won't work.
- Wait for new route to be loaded without the disabled network.
- Additionally, tap the disabled network in the From column to re-enable it.

status: ready