### PR TITLE
[#16953] Implement change asset action in wallet send flow

### DIFF
--- a/src/quo/components/drawers/drawer_top/view.cljs
+++ b/src/quo/components/drawers/drawer_top/view.cljs
@@ -198,8 +198,9 @@
            on-button-press
            on-button-long-press
            button-disabled? account-avatar-emoji account-avatar-type customization-color icon-avatar
-           profile-picture keycard? networks label full-name]}]
-  [rn/view {:style style/container}
+           profile-picture keycard? networks label full-name
+           container-style]}]
+  [rn/view {:style (merge style/container container-style)}
    (when (left-image-supported-types type)
      [rn/view {:style style/left-container}
       [left-image

--- a/src/quo/components/list_items/token_network/schema.cljs
+++ b/src/quo/components/list_items/token_network/schema.cljs
@@ -11,5 +11,5 @@
      [:networks [:* [:map [:source :schema.common/image-source]]]]
      [:on-press {:optional true} [:maybe fn?]]
      [:customization-color {:optional true} [:maybe :schema.common/customization-color]]
-     [:state {:optional true} [:enum :default :active :selected]]]]
+     [:state {:optional true} [:maybe [:enum :default :active :selected]]]]]
    :any])

--- a/src/quo/components/tags/network_tags/view.cljs
+++ b/src/quo/components/tags/network_tags/view.cljs
@@ -16,7 +16,8 @@
    [preview-list/view
     {:type   :network
      :number (count networks)
-     :size   :size-16} networks]
+     :size   :size-16}
+    networks]
    [text/text
     {:weight :medium
      :size   :paragraph-2

--- a/src/quo/components/wallet/token_input/view.cljs
+++ b/src/quo/components/wallet/token_input/view.cljs
@@ -75,7 +75,7 @@
    [token-name-text theme text]])
 
 (defn input-section
-  [{:keys [on-change-text value value-atom on-selection-change]}]
+  [{:keys [on-change-text value value-atom on-selection-change on-token-press]}]
   (let [input-ref               (atom nil)
         set-ref                 #(reset! input-ref %)
         focus-input             #(when-let [ref ^js @input-ref]
@@ -95,13 +95,14 @@
     (fn [{:keys [theme token customization-color show-keyboard? crypto? currency value error?
                  selection]
           :or   {show-keyboard? true}}]
-      [rn/pressable
-       {:on-press focus-input
-        :style    {:flex 1}}
-       [token/view
-        {:token token
-         :size  :size-32}]
-       [rn/view {:style style/text-input-container}
+      [rn/view {:style {:flex 1}}
+       [rn/pressable {:on-press on-token-press}
+        [token/view
+         {:token token
+          :size  :size-32}]]
+       [rn/pressable
+        {:style    style/text-input-container
+         :on-press focus-input}
         [rn/text-input
          (cond-> {:style                    (style/text-input theme error?)
                   :placeholder-text-color   (style/placeholder-text theme)

--- a/src/status_im/contexts/wallet/common/asset_list/view.cljs
+++ b/src/status_im/contexts/wallet/common/asset_list/view.cljs
@@ -1,12 +1,17 @@
 (ns status-im.contexts.wallet.common.asset-list.view
   (:require
     [quo.core :as quo]
-    [react-native.core :as rn]
+    [react-native.gesture :as gesture]
     [status-im.contexts.wallet.common.utils :as utils]
     [utils.re-frame :as rf]))
 
 (defn- asset-component
-  [{:keys [total-balance] :as token} _ _ {:keys [currency currency-symbol on-token-press]}]
+  [{token-symbol  :symbol
+    token-name    :name
+    total-balance :total-balance
+    :as           token}
+   _ _
+   {:keys [currency currency-symbol on-token-press preselected-token-symbol]}]
   (let [fiat-value       (utils/calculate-token-fiat-value
                           {:currency currency
                            :balance  total-balance
@@ -14,25 +19,29 @@
         crypto-formatted (utils/get-standard-crypto-format token total-balance)
         fiat-formatted   (utils/get-standard-fiat-format crypto-formatted currency-symbol fiat-value)]
     [quo/token-network
-     {:token       (:symbol token)
-      :label       (:name token)
-      :token-value (str crypto-formatted " " (:symbol token))
+     {:token       token-symbol
+      :label       token-name
+      :token-value (str crypto-formatted " " token-symbol)
       :fiat-value  fiat-formatted
       :networks    (seq (:networks token))
-      :on-press    #(on-token-press token)}]))
+      :on-press    #(on-token-press token)
+      :state       (when (= preselected-token-symbol token-symbol)
+                     :selected)}]))
 
 (defn view
-  [{:keys [search-text on-token-press]}]
+  [{:keys [content-container-style search-text on-token-press preselected-token-symbol]
+    :or   {content-container-style {:padding-horizontal 8}}}]
   (let [filtered-tokens (rf/sub [:wallet/current-viewing-account-tokens-filtered search-text])
         currency        (rf/sub [:profile/currency])
         currency-symbol (rf/sub [:profile/currency-symbol])]
-    [rn/flat-list
+    [gesture/flat-list
      {:data                         filtered-tokens
-      :render-data                  {:currency        currency
-                                     :currency-symbol currency-symbol
-                                     :on-token-press  on-token-press}
+      :render-data                  {:currency                 currency
+                                     :currency-symbol          currency-symbol
+                                     :on-token-press           on-token-press
+                                     :preselected-token-symbol preselected-token-symbol}
       :style                        {:flex 1}
-      :content-container-style      {:padding-horizontal 8}
+      :content-container-style      content-container-style
       :keyboard-should-persist-taps :handled
       :key-fn                       :symbol
       :on-scroll-to-index-failed    identity

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -96,7 +96,8 @@
  :wallet/edit-token-to-send
  (fn [{:keys [db]} [token]]
    {:db (assoc-in db [:wallet :ui :send :token] token)
-    :fx [[:dispatch [:hide-bottom-sheet]]]}))
+    :fx [[:dispatch [:hide-bottom-sheet]]
+         [:dispatch [:wallet/clean-suggested-routes]]]}))
 
 (rf/reg-event-fx :wallet/clean-selected-token
  (fn [{:keys [db]}]

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -79,7 +79,8 @@
  (fn [{:keys [db]} [selected-networks]]
    {:db (assoc-in db [:wallet :ui :send :selected-networks] selected-networks)}))
 
-(rf/reg-event-fx :wallet/send-select-token
+(rf/reg-event-fx
+ :wallet/send-select-token
  (fn [{:keys [db]} [{:keys [token stack-id start-flow?]}]]
    {:db (-> db
             (update-in [:wallet :ui :send] dissoc :collectible)
@@ -90,6 +91,12 @@
            {:current-screen stack-id
             :start-flow?    start-flow?
             :flow-id        :wallet-flow}]]]}))
+
+(rf/reg-event-fx
+ :wallet/edit-token-to-send
+ (fn [{:keys [db]} [token]]
+   {:db (assoc-in db [:wallet :ui :send :token] token)
+    :fx [[:dispatch [:hide-bottom-sheet]]]}))
 
 (rf/reg-event-fx :wallet/clean-selected-token
  (fn [{:keys [db]}]

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -122,18 +122,19 @@
      :subtitle        amount}]])
 
 (defn select-asset-bottom-sheet
-  []
+  [clear-input!]
   (let [{preselected-token-symbol :symbol} (rf/sub [:wallet/wallet-send-token])]
     [:<> ;; Need to be a `:<>` to keep `asset-list` scrollable.
      [quo/drawer-top
-      {:title           "Select asset"
+      {:title           (i18n/label :t/select-asset)
        :container-style {:padding-bottom 8}}]
      [asset-list/view
       {:content-container-style  {:padding-horizontal 8
                                   :padding-bottom     8}
        :preselected-token-symbol preselected-token-symbol
        :on-token-press           (fn [token]
-                                   (rf/dispatch-sync [:wallet/edit-token-to-send token]))}]]))
+                                   (rf/dispatch [:wallet/edit-token-to-send token])
+                                   (clear-input!))}]]))
 
 (defn- f-view-internal
   ;; crypto-decimals, limit-crypto and initial-crypto-currency? args are needed
@@ -150,6 +151,7 @@
   (let [_ (rn/dismiss-keyboard!)
         bottom                (safe-area/get-bottom)
         input-value           (reagent/atom "")
+        clear-input!          #(reset! input-value "")
         input-error           (reagent/atom false)
         crypto-currency?      (reagent/atom initial-crypto-currency?)
         input-selection       (reagent/atom {:start 0 :end 0})
@@ -261,7 +263,9 @@
                                                                         currency-symbol
                                                                         fee-in-fiat))
             show-select-asset-sheet   #(rf/dispatch
-                                        [:show-bottom-sheet {:content select-asset-bottom-sheet}])]
+                                        [:show-bottom-sheet
+                                         {:content (fn []
+                                                     [select-asset-bottom-sheet clear-input!])}])]
         (rn/use-mount
          (fn []
            (let [dismiss-keyboard-fn   #(when (= % "active") (rn/dismiss-keyboard!))

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -44,6 +44,7 @@
                                                {:collectible %
                                                 :amount      1
                                                 :stack-id    :screen/wallet.select-asset}])))}]))
+
 (defn- tab-view
   [search-text selected-tab on-change-text]
   (let [unfiltered-collectibles (rf/sub [:wallet/current-viewing-account-collectibles])
@@ -62,7 +63,6 @@
                           {:search-text    search-text
                            :on-token-press on-token-press}]
        :tab/collectibles [collectibles-grid search-text])]))
-
 
 (defn- f-view-internal
   []

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -222,18 +222,18 @@
  :<- [:wallet/current-viewing-account]
  :<- [:wallet/network-details]
  (fn [[account networks] [_ query]]
-   (let [tokens          (map (fn [token]
-                                (assoc token
-                                       :networks      (utils/network-list token networks)
-                                       :total-balance (utils/calculate-total-token-balance token)))
-                              (:tokens account))
-         sorted-tokens   (sort-by :name compare tokens)
-         filtered-tokens (filter #(or (string/starts-with? (string/lower-case (:name %))
-                                                           (string/lower-case query))
-                                      (string/starts-with? (string/lower-case (:symbol %))
-                                                           (string/lower-case query)))
-                                 sorted-tokens)]
-     filtered-tokens)))
+   (let [tokens        (map (fn [token]
+                              (assoc token
+                                :networks           (utils/network-list token networks)
+                                :total-balance      (utils/calculate-total-token-balance token)))
+                            (:tokens account))
+         sorted-tokens (sort-by :name compare tokens)]
+     (if query
+       (let [query-string (string/lower-case query)]
+         (filter #(or (string/starts-with? (string/lower-case (:name %)) query-string)
+                      (string/starts-with? (string/lower-case (:symbol %)) query-string))
+                 sorted-tokens))
+       sorted-tokens))))
 
 (rf/reg-sub
  :wallet/token-by-symbol

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -224,8 +224,8 @@
  (fn [[account networks] [_ query]]
    (let [tokens        (map (fn [token]
                               (assoc token
-                                :networks           (utils/network-list token networks)
-                                :total-balance      (utils/calculate-total-token-balance token)))
+                                     :networks      (utils/network-list token networks)
+                                     :total-balance (utils/calculate-total-token-balance token)))
                             (:tokens account))
          sorted-tokens (sort-by :name compare tokens)]
      (if query


### PR DESCRIPTION
fixes #16953 


### Summary

This PR implements the change asset action.

Designs:

https://www.figma.com/file/HKncH4wnDwZDAhc4AryK8Y/Wallet-for-Mobile?type=design&node-id=2388-507409&mode=design&t=ONXSrT9icTPxa7La-4
![image](https://github.com/status-im/status-mobile/assets/90291778/55725aa5-67d3-4f7e-be08-5736484743bb)


Implementation:

[Screencast from 2024-03-25 11-47-29.webm](https://github.com/status-im/status-mobile/assets/90291778/dde16a66-1bd8-4130-92a1-3e41539bbd3d)

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->


#### Platforms

- Android
- iOS

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Navigate to wallet tab
- Select an account containing assets -> send -> pick destination -> select an asset

Now the user is able to press on the asset logo and a modal will open to change the asset.

status: ready
