### PR TITLE
WIP: UI callbacks experiment

### DIFF
--- a/src/quo/components/buttons/button/view.cljs
+++ b/src/quo/components/buttons/button/view.cljs
@@ -35,6 +35,7 @@
            size                40
            customization-color (if (= type :primary) :blue nil)}}
    children]
+  (js/console.log "button - " children)
   (let [[pressed-state? set-pressed-state] (rn/use-state false)
         theme (quo.theme/use-theme)
         {:keys [icon-color background-color label-color border-color blur-type

--- a/src/quo/components/buttons/button/view.cljs
+++ b/src/quo/components/buttons/button/view.cljs
@@ -35,7 +35,7 @@
            size                40
            customization-color (if (= type :primary) :blue nil)}}
    children]
-  (js/console.log "button - " children)
+  (when (string? children) (js/console.log "button - " children))
   (let [[pressed-state? set-pressed-state] (rn/use-state false)
         theme (quo.theme/use-theme)
         {:keys [icon-color background-color label-color border-color blur-type

--- a/src/react_native/core.cljs
+++ b/src/react_native/core.cljs
@@ -181,6 +181,14 @@
     #(let [ret (handler)] (if (fn? ret) ret js/undefined))
     (get-js-deps deps))))
 
+(defn use-layout-effect
+  ([handler]
+   (use-layout-effect handler nil))
+  ([handler deps]
+   (react/useLayoutEffect
+    #(let [ret (handler)] (if (fn? ret) ret js/undefined))
+    (get-js-deps deps))))
+
 (defn use-mount
   [handler]
   (use-effect handler []))

--- a/src/react_native/utils.cljs
+++ b/src/react_native/utils.cljs
@@ -14,11 +14,11 @@
   [{:keys [on-press allow-multiple-presses? throttle-duration]} throttle-id]
   (if allow-multiple-presses?
     on-press
-    (fn []
+    (fn [event]
       (let [id @throttle-id]
         (when (and id (not (get @throttle id)))
           (swap! throttle assoc id true)
-          (on-press)
+          (on-press event)
           (js/setTimeout
            #(swap! throttle dissoc id)
            (or throttle-duration 500)))))))

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -54,22 +54,22 @@
         v))))
 
 (defn make-state-ref
-  [state-ratom label]
+  [state-ratom]
   (let [state-ref (atom nil)]
-    (js/console.log "init make-state-ref" label)
-    (let [reaction-sub (reagent.ratom/track!
-                        (fn [state-ratom]
-                          (js/console.log "reagent reaction" label)
-                          (let [state @state-ratom]
-                            (js/console.log
-                             (if (nil? @state-ref)
-                               "state-ref init"
-                               "state-ref update")
-                             label
-                             (clj->js state))
-                            (reset! state-ref state)
-                            state))
-                        state-ratom)]
+    (js/console.log "init make-state-ref")
+    (let [reaction-sub
+          (reagent.ratom/track!
+           (fn [state-ratom]
+             (js/console.log "reagent reaction")
+             (let [state @state-ratom]
+               (js/console.log
+                (if (nil? @state-ref)
+                  "state-ref init"
+                  "state-ref update")
+                (clj->js state))
+               (reset! state-ref state)
+               state))
+           state-ratom)]
       @reaction-sub
       {:sub reaction-sub
        :ref state-ref})))

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -130,9 +130,9 @@
                           :accessibility-label :send-contact-request
                           :customization-color customization-color
                           :on-press            on-message-submit}
-       :button-one-label (i18n/label :t/send-contact-request)
+       :button-one-label "Test Button One"
        :button-two-props {:accessibility-label :test-button
                           :customization-color :danger
                           :on-press            (bind on-press-test)}
-       :button-two-label "test"}]]))
+       :button-two-label "Test Button Two"}]]))
 

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -16,16 +16,6 @@
 (def contact-request-message-store
   (reagent.ratom/atom {}))
 
-(def button-count-store
-  (reagent.ratom/atom {}))
-
-(re-frame/reg-sub
- :button-count
- (fn []
-   [button-count-store])
- (fn [[store] [_ id]]
-   (get store id 0)))
-
 (re-frame/reg-sub
  :contact-request-message
  (fn []

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -38,7 +38,12 @@
   (memoize make-callback-sub))
 
 (defn use-bind [state-ratom]
-  (let [{:keys [factory]} (bind state-ratom)] 
+  (let [{:keys [factory sub]} (rn/use-memo (fn []
+                                         (make-callback-sub state-ratom))
+                                       [state-ratom])] 
+    (rn/use-unmount (fn []
+                      (js/console.log "unmount sub")
+                      (reagent.ratom/dispose! sub)))
     factory))
 
 (defonce contact-request-message-store

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -11,10 +11,10 @@
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
-(defn make-callback-sub
+(defn make-stateful-callbacks
   [state-ratom]
   (let [state-ref (atom nil)]
-    (js/console.log "init make-callback")
+    (js/console.log "init make-stateful-callbacks")
     (let [reaction-sub (reagent.ratom/track!
                         (fn [state-ratom]
                           (js/console.log "reagent reaction")
@@ -34,12 +34,9 @@
                    (fn [event]
                      (callback @state-ref event))))})))
 
-(def bind
-  (memoize make-callback-sub))
-
 (defn use-bind [state-ratom]
   (let [{:keys [factory sub]} (rn/use-memo (fn []
-                                         (make-callback-sub state-ratom))
+                                         (make-stateful-callbacks state-ratom))
                                        [state-ratom])] 
     (rn/use-unmount (fn []
                       (js/console.log "unmount sub")
@@ -82,7 +79,7 @@
                                                   (reset! message-sub %)
                                                   (set-message %)))
         callback-state-sub    (reagent.ratom/track combine-subs message-sub profile-sub)
-        act                   (use-bind callback-state-sub)
+        bind                  (use-bind callback-state-sub)
         on-message-submit     (rn/use-callback (fn []
                                                  (rf/dispatch [:hide-bottom-sheet])
                                                  (rf/dispatch [:contact.ui/send-contact-request
@@ -136,6 +133,6 @@
        :button-one-label (i18n/label :t/send-contact-request)
        :button-two-props {:accessibility-label :test-button
                           :customization-color :danger
-                          :on-press            (act on-press-test)}
+                          :on-press            (bind on-press-test)}
        :button-two-label "test"}]]))
 

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -148,11 +148,12 @@
         on-message-change     (rn/use-callback #(do
                                                   (rf/dispatch-sync [:ui/set-contact-request-message public-key %])
                                                   (set-message %)))
-        bind-sub              (use-bind-sub
-                               (combine-subs {:message message-sub
-                                              :public-key (reagent.ratom/cursor
-                                                           profile-sub
-                                                           [:public-key])}))
+        state-sub             (combine-subs {:message message-sub
+                                             :public-key (reagent.ratom/cursor
+                                                          profile-sub
+                                                          [:public-key])})
+        bind-sub              (use-bind-sub state-sub)
+        bind-sub-alt          (use-bind-sub state-sub)
         bind-state            (use-bind-state {:public-key public-key
                                                :message message})]
     (rn/use-unmount
@@ -197,7 +198,7 @@
        :button-one-props {:disabled?           (string/blank? message)
                           :accessibility-label :send-contact-request
                           :customization-color customization-color
-                          :on-press            (bind-state on-message-submit)}
+                          :on-press            (bind-sub-alt on-message-submit)}
        :button-one-label "Test Button One"
        :button-two-props {:accessibility-label :test-button
                           :customization-color :danger

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -11,58 +11,138 @@
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
-(defn make-stateful-callbacks
-  [state-ratom]
+;; ---
+
+(def contact-request-message-store
+  (reagent.ratom/atom {}))
+
+(def button-count-store
+  (reagent.ratom/atom {}))
+
+(re-frame/reg-sub
+ :button-count
+ (fn []
+   [button-count-store])
+ (fn [[store] [_ id]]
+   (get store id 0)))
+
+(re-frame/reg-sub
+ :contact-request-message
+ (fn []
+   [contact-request-message-store])
+ (fn [[store] [_ id]]
+   (get store id "")))
+
+(re-frame/reg-fx
+ :store/set-contact-request-message
+ (fn [[id message]]
+   (swap! contact-request-message-store assoc id message)))
+
+(re-frame/reg-event-fx
+ :ui/set-contact-request-message
+ (fn [_cofx [id message]]
+   {:fx [[:store/set-contact-request-message [id message]]]}))
+
+;; ---
+
+(defn make-state-ref
+  [state-ratom label]
   (let [state-ref (atom nil)]
-    (js/console.log "init make-stateful-callbacks")
+    (js/console.log "init make-state-ref" label)
     (let [reaction-sub (reagent.ratom/track!
                         (fn [state-ratom]
-                          (js/console.log "reagent reaction")
+                          (js/console.log "reagent reaction" label)
                           (let [state @state-ratom]
                             (js/console.log
                              (if (nil? @state-ref)
-                               "state init"
-                               "state update")
+                               "state-ref init"
+                               "state-ref update")
+                             label
                              (clj->js state))
-                            (reset! state-ref state)))
+                            (reset! state-ref state)
+                            state))
                         state-ratom)]
       @reaction-sub
       {:sub reaction-sub
-       :factory (memoize
-                 (fn [callback]
-                   (js/console.log "init callback")
-                   (fn [event]
-                     (callback @state-ref event))))})))
+       :ref state-ref})))
 
-(defn use-bind [state-ratom]
-  (let [{:keys [factory sub]} (rn/use-memo (fn []
-                                         (make-stateful-callbacks state-ratom))
-                                       [state-ratom])] 
+(defn make-state-handler-factory [state-ref]
+  (rn/use-callback
+   (memoize
+    (fn [callback]
+      (fn [event]
+        (callback @state-ref event))))
+   [state-ref]))
+
+(defn make-snapshot-handler-factory [state-ref]
+  (rn/use-callback
+   (let [snapshot @state-ref]
+     (fn [handler]
+       ((memoize
+         (fn [callback]
+           (fn [event]
+             (callback snapshot event))))
+        handler)))
+   [@state-ref]))
+
+(defn make-snapshot-state-handler-factory [state-ref]
+  (rn/use-callback
+   (let [snapshot @state-ref]
+     (fn [handler]
+       ((memoize
+         (fn [callback]
+           (fn [event]
+             (callback snapshot @state-ref event))))
+        handler)))
+   [@state-ref]))
+
+(defn use-bind-sub [state-sub]
+  (let [{:keys [ref sub]}
+        (rn/use-memo (fn []
+                       (make-state-ref state-sub "bind-sub"))
+                     [state-sub])]
     (rn/use-unmount (fn []
-                      (js/console.log "unmount sub")
+                      (js/console.log "unmount bind-sub")
                       (reagent.ratom/dispose! sub)))
-    factory))
+    (make-state-handler-factory ref)))
 
-(defonce contact-request-message-store
-  (reagent.ratom/atom {}))
+(defn use-bind-sub-snapshot [state-sub]
+  (let [{:keys [ref sub]}
+        (rn/use-memo (fn []
+                       (make-state-ref state-sub "bind-sub-snapshot"))
+                     [state-sub])]
+    (rn/use-unmount (fn []
+                      (js/console.log "unmount bind-sub-snapshot")
+                      (reagent.ratom/dispose! sub)))
+    (make-snapshot-state-handler-factory ref)))
 
-(defn access-message-store
-  ([k] (get-in @contact-request-message-store k ""))
-  ([k v] (swap! contact-request-message-store assoc-in k v)))
+(defn use-bind-state [state]
+  (let [state-ref (rn/use-ref-atom state)]
+    (reset! state-ref state)
+    (make-snapshot-handler-factory state-ref)))
 
-(defn get-message-sub [public-key]
-  (reagent.ratom/cursor access-message-store public-key))
+;; ---
 
-(defn on-press-test
-  [state event]
-  (js/console.log "on-press state" (clj->js state))
-  (js/console.log "on-press event" #js{:target (.-target event)})
-  (access-message-store (:public-key state) "")
-  (rf/dispatch [:hide-bottom-sheet]))
+(defn on-message-submit
+  ([state _event]
+   (js/console.log "on-press state" (clj->js state))
+   (let [{:keys [public-key message]} state]
+    ;;  (rf/dispatch [:hide-bottom-sheet])
+    ;;  (rf/dispatch [:contact.ui/send-contact-request
+    ;;                public-key message])
+     (rf/dispatch [:toasts/upsert
+                   {:id   :send-contact-request
+                    :type :positive
+                    :text message}]))))
 
-(defn combine-subs [message-sub profile-sub]
-  {:message @message-sub
-   :public-key @(reagent.ratom/cursor profile-sub [:public-key])})
+(defn combine-subs-helper [subs-map]
+  (reduce (fn [result [name sub]]
+            (assoc result name @sub))
+          {}
+          subs-map))
+
+(defn combine-subs [subs-map]
+  (reagent.ratom/track combine-subs-helper subs-map))
 
 (defn view
   []
@@ -73,23 +153,21 @@
         full-name             (profile.utils/displayed-name profile)
         profile-picture       (profile.utils/photo profile)
         input-ref             (rn/use-ref-atom nil)
-        message-sub           (get-message-sub public-key)
+        message-sub           (re-frame/subscribe [:contact-request-message public-key])
         [message set-message] (rn/use-state "")
         on-message-change     (rn/use-callback #(do
-                                                  (reset! message-sub %)
+                                                  (rf/dispatch-sync [:ui/set-contact-request-message public-key %])
                                                   (set-message %)))
-        callback-state-sub    (reagent.ratom/track combine-subs message-sub profile-sub)
-        bind                  (use-bind callback-state-sub)
-        on-message-submit     (rn/use-callback (fn []
-                                                 (rf/dispatch [:hide-bottom-sheet])
-                                                 (rf/dispatch [:contact.ui/send-contact-request
-                                                               public-key message])
-                                                 (rf/dispatch [:toasts/upsert
-                                                               {:id   :send-contact-request
-                                                                :type :positive
-                                                                :text (i18n/label
-                                                                       :t/contact-request-was-sent)}]))
-                                               [public-key message])]
+        bind-sub              (use-bind-sub
+                               (combine-subs {:message message-sub
+                                              :public-key (reagent.ratom/cursor
+                                                           profile-sub
+                                                           [:public-key])}))
+        bind-state            (use-bind-state {:public-key public-key
+                                               :message message})]
+    (rn/use-unmount
+     (fn []
+       (rf/dispatch [:ui/set-contact-request-message public-key ""])))
     (rn/use-mount
      (fn []
        (let [listener (.addListener rn/keyboard
@@ -129,10 +207,10 @@
        :button-one-props {:disabled?           (string/blank? message)
                           :accessibility-label :send-contact-request
                           :customization-color customization-color
-                          :on-press            on-message-submit}
+                          :on-press            (bind-state on-message-submit)}
        :button-one-label "Test Button One"
        :button-two-props {:accessibility-label :test-button
                           :customization-color :danger
-                          :on-press            (bind on-press-test)}
+                          :on-press            (bind-sub on-message-submit)}
        :button-two-label "Test Button Two"}]]))
 

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -76,12 +76,15 @@
 
 (defn make-state-handler-factory [state-ref]
   (let [storage (rn/use-memo #(atom {}) [state-ref])
-        factory (rn/use-callback
-                 (memo storage
-                       (fn [callback]
-                         (print "make state handler")
-                         (fn [event]
-                           (callback @state-ref event))))
+        factory (rn/use-memo
+                 (fn []
+                   (fn [handler]
+                     ((memo storage
+                            (fn [callback]
+                              (print "make state handler")
+                              (fn [event]
+                                (callback @state-ref event))))
+                      handler)))
                  [state-ref storage])]
     {:factory factory
      :storage storage}))

--- a/src/status_im/contexts/profile/contact/contact_request/view.cljs
+++ b/src/status_im/contexts/profile/contact/contact_request/view.cljs
@@ -92,12 +92,18 @@
 (defn make-snapshot-handler-factory [snapshot]
   (let [storage (rn/use-memo #(atom {}) [])
         capture (rn/use-memo #(atom snapshot) [])
+        _update (rn/use-layout-effect
+                 (fn []
+                   (swap! capture (fn [_] snapshot)))
+                 snapshot)
         factory (rn/use-memo
-                 (do (swap! capture (fn [_] snapshot))
-                     #(memo storage
+                 (fn []
+                   (fn [handler]
+                     ((memo storage
                             (fn [callback]
                               (fn [event]
-                                (callback @capture event)))))
+                                (callback @capture event))))
+                      handler)))
                  [storage capture])]
     {:factory factory
      :storage storage}))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

* This PR attempts to experiment with Reagent, Re-Frame, and React callbacks.
  * The core idea is to help alleviate the need for `use-callback` and dependency arrays.
  * This experiment tries to bind static callback functions with state using Reagent atoms and Clojure memoize.
    * Static functions are nice because they create a stable function reference that can be easily memoized.
    * Clojure memoize is convenient, but the way it's used here will likely create memory leaks, so this will need be refactored eventually, but the core idea should still work after the refactor.
* Note, this experiment is mainly attempting to show a potential path for defining callback functions with two parameters (`state` and `event`). 
  * The first parameter `state` is what is the callback function references for making decisions, for example it might want to read the state before dispatching. It also can read the state entirely without needing a dependency array to refresh the callback cache.
  * The second parameter `event` is what we'd typically receive from React as an event argument. This parameter can also be referenced if needed.
* ~~Also note that this code currently has a bug when hot-reloading the code. There seems to be some reagent subscriptions that aren't being cleaned up correctly, but I can debug that more soon.~~

### Demo

Here's the demo showing how the debug log statements print in a certain order.

https://github.com/status-im/status-mobile/assets/2845768/057a0a8e-e1ba-42d4-ac70-6bcf2a43afda

status: wip <!-- Can be ready or wip -->
