### PR TITLE
Disable button when request is in flight

### DIFF
--- a/src/legacy/status_im/data_store/communities.cljs
+++ b/src/legacy/status_im/data_store/communities.cljs
@@ -64,6 +64,7 @@
         :canJoin                     :can-join?
         :requestedToJoinAt           :requested-to-join-at
         :isMember                    :is-member?
+        :outroMessage                :outro-message
         :adminSettings               :admin-settings
         :tokenPermissions            :token-permissions
         :communityTokensMetadata     :tokens-metadata

--- a/src/status_im/contexts/communities/discover/events.cljs
+++ b/src/status_im/contexts/communities/discover/events.cljs
@@ -3,7 +3,7 @@
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]))
 
-(def commmunity-keys-renamed
+(def community-keys-renamed
   {:requestedAccessAt           :requested-access-at
    :fileSize                    :file-size
    :communityTokensMetadata     :community-tokens-metadata
@@ -35,7 +35,7 @@
   [k]
   (let [s                  (name k)
         starts-with-digit? (re-matches #"^\d.*" s)
-        existing-rename    (k commmunity-keys-renamed)]
+        existing-rename    (k community-keys-renamed)]
     (cond starts-with-digit? s
           existing-rename    existing-rename
           :else              (keyword s))))

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -32,21 +32,38 @@
 
 (re-frame/reg-sub
  :communities/community-chats
- :<- [:communities]
- (fn [communities [_ id]]
-   (get-in communities [id :chats])))
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:communities/community community-id])])
+ (fn [[{:keys [chats]}] _]
+   chats))
 
 (re-frame/reg-sub
  :communities/community-color
- :<- [:communities]
- (fn [communities [_ id]]
-   (get-in communities [id :color])))
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:communities/community community-id])])
+ (fn [[{:keys [color]}] _]
+   color))
+
+(re-frame/reg-sub
+ :communities/community-outro-message
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:communities/community community-id])])
+ (fn [[{:keys [outro-message]}] _]
+   outro-message))
+
+(re-frame/reg-sub
+ :communities/community-joined
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:communities/community community-id])])
+ (fn [[{:keys [joined]}] _]
+   joined))
 
 (re-frame/reg-sub
  :communities/community-members
- :<- [:communities]
- (fn [communities [_ id]]
-   (get-in communities [id :members])))
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:communities/community community-id])])
+ (fn [[{:keys [members]}] _]
+   members))
 
 (re-frame/reg-sub
  :communities/current-community-members
@@ -159,6 +176,13 @@
  :<- [:communities/my-pending-requests-to-join]
  (fn [requests [_ community-id]]
    (:id (get requests community-id))))
+
+(re-frame/reg-sub
+ :communities/has-pending-request-to-join?
+ (fn [[_ community-id]]
+   (re-frame/subscribe [:communities/my-pending-request-to-join community-id]))
+ (fn [request]
+   (boolean request)))
 
 (re-frame/reg-sub
  :communities/edited-community
@@ -328,6 +352,7 @@
  :<- [:communities/permissions-check]
  (fn [permissions [_ id]]
    (get permissions id)))
+
 
 (re-frame/reg-sub
  :communities/checking-permissions-all-by-id

--- a/src/status_im/subs/communities_test.cljs
+++ b/src/status_im/subs/communities_test.cljs
@@ -345,7 +345,7 @@
                                                        :members {"0x04" {"roles" [1]}}}}
                             :members                 {"0x04" {"roles" [1]}}
                             :can-request-access?     false
-                            :outroMessage            "bla"
+                            :outro-message           "bla"
                             :verified                false}]
     (swap! rf-db/app-db assoc-in [:communities community-id] community)
     (swap! rf-db/app-db assoc-in [:communities/permissions-check community-id] checks)
@@ -439,7 +439,7 @@
                   :token-images          {"ETH" token-image-eth}
                   :name                  "Community super name"
                   :can-request-access?   false
-                  :outroMessage          "bla"
+                  :outro-message         "bla"
                   :verified              false}]
       (swap! rf-db/app-db assoc-in [:communities community-id] community)
       (swap! rf-db/app-db assoc-in [:communities/permissions-check-all community-id] checks)
@@ -475,7 +475,7 @@
                   :token-images          {"ETH" token-image-eth}
                   :name                  "Community super name"
                   :can-request-access?   false
-                  :outroMessage          "bla"
+                  :outro-message         "bla"
                   :verified              false}]
       (swap! rf-db/app-db assoc-in [:communities community-id] community)
       (swap! rf-db/app-db assoc-in [:communities/permissions-check-all community-id] checks)

--- a/src/status_im/subs/community/account_selection.cljs
+++ b/src/status_im/subs/community/account_selection.cljs
@@ -40,6 +40,13 @@
  (fn [permissions [_ id]]
    (get permissions id)))
 
+(re-frame/reg-sub
+ :communities/permissions-check-for-selection-checking?
+ (fn [[_ community-id]]
+   (re-frame/subscribe [:communities/permissions-check-for-selection community-id]))
+ (fn [check]
+   (:checking? check)))
+
 (re-frame/reg-sub :communities/highest-role-for-selection
  (fn [[_ community-id]]
    [(re-frame/subscribe [:communities/permissions-check-for-selection community-id])])


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19371

This PR fixes an issue with the button not being disabled when the request is in flight.

I have made a few changes:
1) split bottom actions in a separate component. This potentially helps reduce rendering of other components, so we isolate dependencies.
2) Rename `outroMessage` -> `outro-message`
3) Fixes some typos
4) refactors some subs so that they leverage caching more effectively

There's still a flickering issue, that's due to the fact that the component combines local state and subcriptions from re-frame.
Local state triggers a re-render earlier than re-frame subscriptions, so the flow is something like:

1) Something change in the UI, we set state & dispatch event
2) The state change in the component, triggers a re-render, but it's still using the old database values
3) The event is processed, causing the component to re-render using the new database values

Between 2 and 3 there's a flicker, it's an interesting issue, I think it's better than before since the use has not time to click on the confirm changes button (before it was dependent on a network request), but will need to be addressed, but ideally in a separate PR, also there's a discussion to be had on whether we want to mix state/react for child components.