### PR TITLE
fix: dismiss keyboard when opening a modal

### DIFF
--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -36,6 +36,7 @@
             (assoc :view-id component)
             (all-screens-params component screen-params))
     :fx [[:dispatch [:hide-bottom-sheet]]
+         [:dispatch [:dismiss-keyboard]]
          [:open-modal-fx component]]}))
 
 (rf/defn dismiss-modal


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19396 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to resolve an issue on Android devices where the keyboard is not dismissed when opening a contact's profile from pressing a profile-link inside a 1-1 chat.
  * This PR modifies the existing `:open-modal` event handler to always dismiss the keyboard before transitioning to the modal.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- Other places where modals could be opened with a keyboard already present

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

Reproduction steps are described in this issue: https://github.com/status-im/status-mobile/issues/19396

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before

This issue describes the existing and problematic behaviour: https://github.com/status-im/status-mobile/issues/19396

#### After

https://github.com/status-im/status-mobile/assets/2845768/ed33d70d-1985-4361-baa7-5a6ea1133bfa

status: ready <!-- Can be ready or wip -->
