### PR TITLE
[#18934] universal scanner in wallet receive

### DIFF
--- a/src/quo/components/gradient/gradient_cover/view.cljs
+++ b/src/quo/components/gradient/gradient_cover/view.cljs
@@ -12,9 +12,9 @@
   ;; the `:or` destructuring won't work because it's only applied when the
   ;; `:customization-color` key is non-existent. While deleting an account the key exists
   ;; and has a `nil` value.
-  (when customization-color
-    (let [color-top    (colors/resolve-color customization-color 50 20)
-          color-bottom (colors/resolve-color customization-color 50 0)]
+  (let [color-top    (colors/resolve-color customization-color 50 20)
+        color-bottom (colors/resolve-color customization-color 50 0)]
+    (when (and color-top color-bottom)
       [linear-gradient/linear-gradient
        {:accessibility-label :gradient-cover
         :colors              [color-top color-bottom]

--- a/src/quo/components/wallet/account_overview/view.cljs
+++ b/src/quo/components/wallet/account_overview/view.cljs
@@ -113,19 +113,17 @@
           :size   :heading-1
           :style  style/current-value}
          current-value]
-        [rn/view
-         {:style style/row-centered}
-         [:<>
-          (when (seq time-frame-string)
-            [text/text
-             {:weight :medium
-              :size   :paragraph-2
-              :style  (style/bottom-time-text (and (not= :custom time-frame)
-                                                   (seq time-frame-to-string)))}
-             time-frame-string])
-          (when (and (= :custom time-frame)
-                     (seq time-frame-to-string))
-            [custom-time-frame time-frame-to-string])]
+        [rn/view {:style style/row-centered}
+         (when (seq time-frame-string)
+           [text/text
+            {:weight :medium
+             :size   :paragraph-2
+             :style  (style/bottom-time-text (and (not= :custom time-frame)
+                                                  (seq time-frame-to-string)))}
+            time-frame-string])
+         (when (and (= :custom time-frame)
+                    (seq time-frame-to-string))
+           [custom-time-frame time-frame-to-string])
          (when (and (seq percentage-change)
                     (seq currency-change))
            [numeric-changes percentage-change currency-change customization-color theme up?])]])]))

--- a/src/quo/components/wallet/account_overview/view.cljs
+++ b/src/quo/components/wallet/account_overview/view.cljs
@@ -100,8 +100,7 @@
     :or   {customization-color :blue}}]
   (let [time-frame-string (time-string time-frame time-frame-string)
         up?               (= metrics :positive)]
-    [rn/view
-     {:style style/account-overview-wrapper}
+    [rn/view {:style style/account-overview-wrapper}
      (if (= :loading state)
        [loading-state (colors/theme-colors colors/neutral-5 colors/neutral-90 theme)]
        [rn/view

--- a/src/status_im/contexts/shell/qr_reader/view.cljs
+++ b/src/status_im/contexts/shell/qr_reader/view.cljs
@@ -88,7 +88,7 @@
     (load-and-show-profile scanned-text)
 
     (eth-address? scanned-text)
-    (debounce/debounce-and-dispatch [:navigate-to :wallet.accounts scanned-text] 300)
+    (debounce/debounce-and-dispatch [:navigate-to :screen/wallet.accounts scanned-text] 300)
 
     (eip681-address? scanned-text)
     (do

--- a/src/status_im/contexts/shell/qr_reader/view.cljs
+++ b/src/status_im/contexts/shell/qr_reader/view.cljs
@@ -88,7 +88,7 @@
     (load-and-show-profile scanned-text)
 
     (eth-address? scanned-text)
-    (debounce/debounce-and-dispatch [:navigate-to :wallet-accounts scanned-text] 300)
+    (debounce/debounce-and-dispatch [:navigate-to :wallet.accounts scanned-text] 300)
 
     (eip681-address? scanned-text)
     (do

--- a/src/status_im/contexts/wallet/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/share_address/view.cljs
@@ -83,7 +83,9 @@
             :on-press            #(rf/dispatch [:navigate-back])
             :background          :blur
             :right-side          [{:icon-name :i/scan
-                                   :on-press  #(js/alert "To be implemented")}]
+                                   :on-press  (fn []
+                                                (rf/dispatch [:navigate-back])
+                                                (rf/dispatch [:open-modal :shell-qr-reader]))}]
             :accessibility-label :top-bar}]
           [quo/page-top
            {:title           title


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #18934 
fixes https://github.com/status-im/status-mobile/issues/19411

### Summary

This PR mounts the universal QR code scanner in the wallet receive modal although correct redirections are not complete yet.


Additionally this PR solves some other small bugs:

- The QR code component was breaking due to the linear gradient when an unknown color is received (we received `:yinYang`).
- When an address was detected by the QR scanner, we tried to navigate to `:wallet-accounts` instead of `:wallet.accounts` (dot separated).

### Review notes

Although scanning  seems useless atm, the QR code scanner is properly dispatched, please take it into consideration  while testing.

#### Platforms

- Android
- iOS

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Go to Wallet -> Select an account -> Press the receive button -> Press the scann button, now the scanner is displayed.

status: ready
