### PR TITLE
chore(wallet): move bridge to its own folder

### DIFF
--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/events.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/events.cljs
@@ -78,15 +78,14 @@
     ;; status-go will consider all possible addresses and the user will see the
     ;; incorrect highest permission role.
     {:db (update db :communities/permissions-checks-for-selection dissoc community-id)}
-    (let [{:keys [checking?]} (get-in db [:communities/permissions-checks-for-selection community-id])]
-        {:db (assoc-in db [:communities/permissions-checks-for-selection community-id :checking?] true)
-         :fx [[:json-rpc/call
-               [{:method     :wakuext_checkPermissionsToJoinCommunity
-                 :params     [{:communityId community-id :addresses addresses}]
-                 :on-success [:communities/check-permissions-to-join-during-selection-success
-                              community-id]
-                 :on-error   [:communities/check-permissions-to-join-during-selection-failure
-                              community-id addresses]}]]]})))
+    {:db (assoc-in db [:communities/permissions-checks-for-selection community-id :checking?] true)
+     :fx [[:json-rpc/call
+           [{:method     :wakuext_checkPermissionsToJoinCommunity
+             :params     [{:communityId community-id :addresses addresses}]
+             :on-success [:communities/check-permissions-to-join-during-selection-success
+                          community-id]
+             :on-error   [:communities/check-permissions-to-join-during-selection-failure
+                          community-id addresses]}]]]}))
 
 ;; This event should be used to check permissions temporarily because it won't
 ;; mutate the state `:communities/permissions-check` (used by many other

--- a/src/status_im/contexts/wallet/account/bridge_send/style.cljs
+++ b/src/status_im/contexts/wallet/account/bridge_send/style.cljs
@@ -1,4 +1,0 @@
-(ns status-im.contexts.wallet.account.bridge-send.style)
-
-(def bridge-send-wrapper
-  {:flex 1})

--- a/src/status_im/contexts/wallet/account/bridge_to/style.cljs
+++ b/src/status_im/contexts/wallet/account/bridge_to/style.cljs
@@ -1,5 +1,0 @@
-(ns status-im.contexts.wallet.account.bridge-to.style)
-
-(def content-container
-  {:padding-horizontal 8})
-

--- a/src/status_im/contexts/wallet/bridge/bridge_to/style.cljs
+++ b/src/status_im/contexts/wallet/bridge/bridge_to/style.cljs
@@ -1,0 +1,5 @@
+(ns status-im.contexts.wallet.bridge.bridge-to.style)
+
+(def content-container
+  {:padding-horizontal 8})
+

--- a/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
@@ -1,11 +1,11 @@
-(ns status-im.contexts.wallet.account.bridge-to.view
+(ns status-im.contexts.wallet.bridge.bridge-to.view
   (:require
     [clojure.string :as string]
     [quo.core :as quo]
     [quo.foundations.resources :as quo.resources]
     [quo.theme]
     [react-native.core :as rn]
-    [status-im.contexts.wallet.account.bridge-to.style :as style]
+    [status-im.contexts.wallet.bridge.bridge-to.style :as style]
     [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im.contexts.wallet.common.utils :as utils]
     [utils.i18n :as i18n]

--- a/src/status_im/contexts/wallet/bridge/input_amount/style.cljs
+++ b/src/status_im/contexts/wallet/bridge/input_amount/style.cljs
@@ -1,0 +1,4 @@
+(ns status-im.contexts.wallet.bridge.input-amount.style)
+
+(def bridge-send-wrapper
+  {:flex 1})

--- a/src/status_im/contexts/wallet/bridge/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/input_amount/view.cljs
@@ -1,8 +1,8 @@
-(ns status-im.contexts.wallet.account.bridge-send.view
+(ns status-im.contexts.wallet.bridge.input-amount.view
   (:require
     [quo.theme]
     [react-native.core :as rn]
-    [status-im.contexts.wallet.account.bridge-send.style :as style]
+    [status-im.contexts.wallet.bridge.input-amount.style :as style]
     [status-im.contexts.wallet.send.input-amount.view :as input-amount]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -11,7 +11,7 @@
   []
   [rn/view {:style style/bridge-send-wrapper}
    [input-amount/view
-    {:current-screen-id :screen/wallet.bridge-send
+    {:current-screen-id :screen/wallet.bridge-input-amount
      :button-one-label  (i18n/label :t/confirm-bridge)
      :button-one-props  {:icon-left :i/bridge}
      :on-navigate-back  (fn []

--- a/src/status_im/contexts/wallet/bridge/select_asset/style.cljs
+++ b/src/status_im/contexts/wallet/bridge/select_asset/style.cljs
@@ -1,4 +1,4 @@
-(ns status-im.contexts.wallet.account.bridge.style)
+(ns status-im.contexts.wallet.bridge.select-asset.style)
 
 (def input-container
   {:padding-horizontal 20

--- a/src/status_im/contexts/wallet/bridge/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/select_asset/view.cljs
@@ -1,9 +1,9 @@
-(ns status-im.contexts.wallet.account.bridge.view
+(ns status-im.contexts.wallet.bridge.select-asset.view
   (:require
     [quo.core :as quo]
     [react-native.core :as rn]
     [reagent.core :as reagent]
-    [status-im.contexts.wallet.account.bridge.style :as style]
+    [status-im.contexts.wallet.bridge.select-asset.style :as style]
     [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im.contexts.wallet.common.asset-list.view :as asset-list]
     [utils.i18n :as i18n]
@@ -28,4 +28,4 @@
          :on-token-press (fn [token]
                            (rf/dispatch [:wallet/bridge-select-token
                                          {:token    token
-                                          :stack-id :screen/wallet.bridge}]))}]])))
+                                          :stack-id :screen/wallet.bridge-select-asset}]))}]])))

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -245,12 +245,12 @@
 (rf/reg-event-fx :wallet/start-bridge
  (fn [{:keys [db]}]
    {:db (assoc-in db [:wallet :ui :send :tx-type] :bridge)
-    :fx [[:dispatch [:open-modal :screen/wallet.bridge]]]}))
+    :fx [[:dispatch [:open-modal :screen/wallet.bridge-select-asset]]]}))
 
 (rf/reg-event-fx :wallet/select-bridge-network
  (fn [{:keys [db]} [{:keys [network-chain-id stack-id]}]]
    {:db (assoc-in db [:wallet :ui :send :bridge-to-chain-id] network-chain-id)
-    :fx [[:dispatch [:navigate-to-within-stack [:screen/wallet.bridge-send stack-id]]]]}))
+    :fx [[:dispatch [:navigate-to-within-stack [:screen/wallet.bridge-input-amount stack-id]]]]}))
 
 (rf/reg-event-fx
  :wallet/get-ethereum-chains

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -55,13 +55,13 @@
     [status-im.contexts.syncing.scan-sync-code-page.view :as scan-sync-code-page]
     [status-im.contexts.syncing.setup-syncing.view :as settings-setup-syncing]
     [status-im.contexts.syncing.syncing-devices-list.view :as settings-syncing]
-    [status-im.contexts.wallet.account.bridge-send.view :as wallet-bridge-send]
-    [status-im.contexts.wallet.account.bridge-to.view :as wallet-bridge-to]
-    [status-im.contexts.wallet.account.bridge.view :as wallet-bridge]
     [status-im.contexts.wallet.account.view :as wallet-accounts]
     [status-im.contexts.wallet.add-address-to-watch.confirm-address.view :as
      wallet-confirm-address-to-watch]
     [status-im.contexts.wallet.add-address-to-watch.view :as wallet-add-address-to-watch]
+    [status-im.contexts.wallet.bridge.bridge-to.view :as wallet-bridge-to]
+    [status-im.contexts.wallet.bridge.input-amount.view :as wallet-bridge-input-amount]
+    [status-im.contexts.wallet.bridge.select-asset.view :as wallet-bridge-select-asset]
     [status-im.contexts.wallet.collectible.view :as wallet-collectible]
     [status-im.contexts.wallet.create-account.edit-derivation-path.view :as wallet-edit-derivation-path]
     [status-im.contexts.wallet.create-account.new-keypair.backup-recovery-phrase.view :as
@@ -361,18 +361,18 @@
     {:name      :screen/wallet.confirm-address-to-watch
      :component wallet-confirm-address-to-watch/view}
 
-    {:name      :screen/wallet.bridge
+    {:name      :screen/wallet.bridge-select-asset
      :options   {:insets                 {:top? true}
                  :modalPresentationStyle :overCurrentContext}
-     :component wallet-bridge/view}
+     :component wallet-bridge-select-asset/view}
 
     {:name      :screen/wallet.bridge-to
      :options   {:insets {:top? true}}
      :component wallet-bridge-to/view}
 
-    {:name      :screen/wallet.bridge-send
+    {:name      :screen/wallet.bridge-input-amount
      :options   {:insets {:top? true}}
-     :component wallet-bridge-send/view}
+     :component wallet-bridge-input-amount/view}
 
     {:name      :screen/wallet.edit-derivation-path
      :component wallet-edit-derivation-path/view}


### PR DESCRIPTION
Going to make a set of pr's to organise the wallet folder a bit better. 

This pr moves the bridge related code to its own folder which aligns better with the associated design file. 

I also updated the names of the bridge related screens to be more expressive of what is done on those pages.

Note:
I believe this pr can skip manual QA as it is rather straightforward.