### PR TITLE
ci: bump jenkins-lib to fix sepolia token typo

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -34,10 +34,10 @@ pipeline {
   }
 
   environment {
-    LANG     = "en_US.UTF-8"
-    LC_ALL   = "en_US.UTF-8"
-    LANGUAGE = "en_US.UTF-8"
-    TARGET   = "android${utils.isE2EBuild() ? "-e2e" : ""}"
+    LANG     = 'en_US.UTF-8'
+    LC_ALL   = 'en_US.UTF-8'
+    LANGUAGE = 'en_US.UTF-8'
+    PLATFORM = "android${utils.isE2EBuild() ? "-e2e" : ""}"
     BUILD_ENV = 'prod'
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
     FASTLANE_DISABLE_COLORS = 1

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.e2e-nightly
+++ b/ci/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -34,10 +34,10 @@ pipeline {
   }
 
   environment {
-    LANG     = "en_US.UTF-8"
-    LC_ALL   = "en_US.UTF-8"
-    LANGUAGE = "en_US.UTF-8"
-    TARGET   = 'ios'
+    LANG     = 'en_US.UTF-8'
+    LC_ALL   = 'en_US.UTF-8'
+    LANGUAGE = 'en_US.UTF-8'
+    PLATFORM = 'ios'
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
     FASTLANE_DISABLE_COLORS = 1
     BUNDLE_PATH = "${HOME}/.bundle"

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -32,10 +32,10 @@ pipeline {
   }
 
   environment {
-    LANG     = "en_US.UTF-8"
-    LC_ALL   = "en_US.UTF-8"
-    LANGUAGE = "en_US.UTF-8"
-    TARGET   = 'tests'
+    LANG     = 'en_US.UTF-8'
+    LC_ALL   = 'en_US.UTF-8'
+    LANGUAGE = 'en_US.UTF-8'
+    PLATFORM = 'tests'
     BUILD_ENV = 'prod'
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
     LOG_FILE = utils.pkgFilename(ext: 'log', arch: 'tests')

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,14 +1,14 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 pipeline {
   agent { label 'macos' }
 
   environment {
-    LANG      = 'en_US.UTF-8'
-    LANGUAGE  = 'en_US.UTF-8'
-    LC_ALL    = 'en_US.UTF-8'
-    TARGET    = 'ios'
+    LANG     = 'en_US.UTF-8'
+    LANGUAGE = 'en_US.UTF-8'
+    LC_ALL   = 'en_US.UTF-8'
+    PLATFORM = 'ios'
     FASTLANE_DISABLE_COLORS = 1
     /* avoid writing to r/o /nix */
     GEM_HOME  = '~/.rubygems'

--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,14 +1,14 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 pipeline {
   agent { label 'linux' }
 
   environment {
-    LANG      = 'en_US.UTF-8'
-    LANGUAGE  = 'en_US.UTF-8'
-    LC_ALL    = 'en_US.UTF-8'
-    TARGET    = 'ios'
+    LANG     = 'en_US.UTF-8'
+    LANGUAGE = 'en_US.UTF-8'
+    LC_ALL   = 'en_US.UTF-8'
+    PLATFORM = 'ios'
     FASTLANE_DISABLE_COLORS = 1
     /* avoid writing to r/o /nix */
     GEM_HOME  = '~/.rubygems'

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.7'
+library 'status-jenkins-lib@v1.8.11'
 
 pipeline {
   agent {


### PR DESCRIPTION
Depends on:
- [`status-jenkins-lib#8331a433`](https://github.com/status-im/status-jenkins-lib/commit/8331a433) - android,ios: fix Alchemy var name for Sepolia

Also replaces `TARGET` with `PLATFORM` to not conflict with Nix shell.