### PR TITLE
fix top bar disappearing when removing or blocking contact

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/view.cljs
@@ -24,9 +24,6 @@
     [rn/keyboard-avoiding-view
      {:style                    style/keyboard-avoiding-container
       :keyboard-vertical-offset (- (:bottom insets))}
-     [messages.navigation/view
-      {:distance-from-list-top                    distance-from-list-top
-       :chat-screen-layout-calculations-complete? chat-screen-layout-calculations-complete?}]
      [list.view/messages-list-content
       {:insets                                    insets
        :layout-height                             layout-height
@@ -35,6 +32,9 @@
        :chat-screen-layout-calculations-complete? chat-screen-layout-calculations-complete?
        :distance-from-list-top                    distance-from-list-top
        :chat-list-scroll-y                        chat-list-scroll-y}]
+     [messages.navigation/view
+      {:distance-from-list-top                    distance-from-list-top
+       :chat-screen-layout-calculations-complete? chat-screen-layout-calculations-complete?}]
      [composer.view/composer
       {:insets                                    insets
        :chat-screen-layout-calculations-complete? chat-screen-layout-calculations-complete?


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19327

### Summary
When contact is removed `able-to-send-message?` param changes and causes the composer to rerender. This rerender causes something weird to happen (maybe because of the z-index of the composer) and pushes the top bar out of the screen.
The only fix that is working is changing the position of topBar in the messages view file below the messages list.
Probably because topBar is above the messages chat list. (Don't know why this order matters, because topBar has an absolute position (0,0,0) with a z-index)

status: ready