### PR TITLE
Improve navigate-to-jump-to

### DIFF
--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -169,10 +169,7 @@
                                         :admin?  admin?}
        :render-fn                      contact-item-render}]
      [quo/floating-shell-button
-      {:jump-to {:on-press            (fn []
-                                        (rf/dispatch [:navigate-back])
-                                        (rf/dispatch [:shell/navigate-to-jump-to])
-                                      )
+      {:jump-to {:on-press            #(rf/dispatch [:shell/navigate-to-jump-to])
                  :customization-color profile-color
                  :label               (i18n/label :t/jump-to)}}
       style/floating-shell-button]]))

--- a/src/status_im/contexts/chat/messenger/messages/contact_requests/bottom_drawer/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/contact_requests/bottom_drawer/view.cljs
@@ -39,8 +39,7 @@
          (i18n/label :t/contact-request-chat-pending))]]
      [quo/floating-shell-button
       {:jump-to
-       {:on-press            (fn []
-                               (rf/dispatch [:shell/navigate-to-jump-to]))
+       {:on-press            #(rf/dispatch [:shell/navigate-to-jump-to])
         :customization-color customization-color
         :label               (i18n/label :t/jump-to)}}
       {:position :absolute

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -80,9 +80,7 @@
      [quo/floating-shell-button
       {:key :shell
        :jump-to
-       {:on-press            (fn []
-                               (rf/dispatch [:navigate-back])
-                               (debounce/throttle-and-dispatch [:shell/navigate-to-jump-to] 500))
+       {:on-press            #(rf/dispatch [:shell/navigate-to-jump-to])
         :customization-color customization-color
         :label               (i18n/label :t/jump-to)}}
       (style/floating-shell-button-style insets)]]))

--- a/src/status_im/contexts/shell/jump_to/events.cljs
+++ b/src/status_im/contexts/shell/jump_to/events.cljs
@@ -83,30 +83,37 @@
 (rf/defn navigate-to-jump-to
   {:events [:shell/navigate-to-jump-to]}
   [{:keys [db]}]
-  (let [open-floating-screens (shell.utils/open-floating-screens)]
-    {:db
-     (cond-> db
+  (let [current-view-id                   (:view-id db)
+        open-floating-screens             (shell.utils/open-floating-screens)
+        chat-screen-open?                 (get open-floating-screens shell.constants/chat-screen)
+        community-screen-open?            (get open-floating-screens shell.constants/community-screen)
+        discover-communities-screen-open? (get open-floating-screens
+                                               shell.constants/discover-communities-screen)]
+    (assoc
+     (if (shell.utils/shell-navigation? current-view-id)
+       {:db
+        (cond-> db
 
-       (get open-floating-screens shell.constants/chat-screen)
-       (assoc-in [:shell/floating-screens shell.constants/chat-screen :animation]
-        shell.constants/close-screen-with-shell-animation)
+          chat-screen-open?
+          (assoc-in [:shell/floating-screens shell.constants/chat-screen :animation]
+           shell.constants/close-screen-with-shell-animation)
 
-       (and (get open-floating-screens shell.constants/chat-screen)
-            (get open-floating-screens shell.constants/community-screen))
-       (assoc-in [:shell/floating-screens shell.constants/community-screen :animation]
-        shell.constants/close-screen-without-animation)
+          (and chat-screen-open? community-screen-open?)
+          (assoc-in [:shell/floating-screens shell.constants/community-screen :animation]
+           shell.constants/close-screen-without-animation)
 
-       (and (not (get open-floating-screens shell.constants/chat-screen))
-            (get open-floating-screens shell.constants/community-screen))
-       (assoc-in [:shell/floating-screens shell.constants/community-screen :animation]
-        shell.constants/close-screen-with-shell-animation)
+          (and (not chat-screen-open?) community-screen-open?)
+          (assoc-in [:shell/floating-screens shell.constants/community-screen :animation]
+           shell.constants/close-screen-with-shell-animation)
 
-       (get open-floating-screens shell.constants/discover-communities-screen)
-       (assoc-in [:shell/floating-screens shell.constants/discover-communities-screen :animation]
-        shell.constants/close-screen-without-animation))
+          discover-communities-screen-open?
+          (assoc-in [:shell/floating-screens shell.constants/discover-communities-screen :animation]
+           shell.constants/close-screen-without-animation))
 
-     :dispatch [:set-view-id :shell]
-     :effects.shell/navigate-to-jump-to nil}))
+        :dispatch [:set-view-id :shell]}
+       {:dispatch [:pop-to-root :shell-stack]})
+     :effects.shell/navigate-to-jump-to
+     nil)))
 
 (rf/defn shell-navigate-to
   {:events [:shell/navigate-to]}

--- a/src/status_im/contexts/shell/jump_to/utils.cljs
+++ b/src/status_im/contexts/shell/jump_to/utils.cljs
@@ -92,7 +92,7 @@
     (doseq [screen-id (seq shell.constants/floating-screens)]
       (reanimated/set-shared-value
        (:screen-state (get @state/shared-values-atom screen-id))
-       shell.constants/close-screen-without-animation))))
+       shell.constants/close-screen-with-shell-animation))))
 
 ;;; Floating screen
 (defn- screen-state-open?


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19433

### Summary

Navigate-to-jump-to was originally implemented only for shell screens (chat, communities, etc...).
But now we are also adding jump-to button to other screens. And then we manually need to call navigate-back.
PR improves it, so that all cases will be handled by event itself.

### Testing note:
Please test jump-to is behaving as expected in all screens

status: ready