### PR TITLE
Check permissions even if there's an inflight request

### DIFF
--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/events.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/events.cljs
@@ -79,7 +79,6 @@
     ;; incorrect highest permission role.
     {:db (update db :communities/permissions-checks-for-selection dissoc community-id)}
     (let [{:keys [checking?]} (get-in db [:communities/permissions-checks-for-selection community-id])]
-      (when-not checking?
         {:db (assoc-in db [:communities/permissions-checks-for-selection community-id :checking?] true)
          :fx [[:json-rpc/call
                [{:method     :wakuext_checkPermissionsToJoinCommunity
@@ -87,7 +86,7 @@
                  :on-success [:communities/check-permissions-to-join-during-selection-success
                               community-id]
                  :on-error   [:communities/check-permissions-to-join-during-selection-failure
-                              community-id addresses]}]]]}))))
+                              community-id addresses]}]]]})))
 
 ;; This event should be used to check permissions temporarily because it won't
 ;; mutate the state `:communities/permissions-check` (used by many other

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/events_test.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/events_test.cljs
@@ -103,11 +103,4 @@
                                  community-id]
                     :on-error   [:communities/check-permissions-to-join-during-selection-failure
                                  community-id addresses]}]]]}
-           (sut/check-permissions-to-join-for-selection cofx [community-id addresses])))))
-
-  (testing "when there are addresses to check permissions, but currently checking, then skip the check"
-    (let [addresses ["0xA"]
-          cofx      {:db {:communities/permissions-checks-for-selection
-                          {"other-comm-id" {}
-                           community-id    {:checking? true}}}}]
-      (is (nil? (sut/check-permissions-to-join-for-selection cofx [community-id addresses]))))))
+           (sut/check-permissions-to-join-for-selection cofx [community-id addresses]))))))


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/19407
We should always send a request, even if there's one in flight, in theory, we should ignore the result of the one in flight (in case their response comes out of order, that's still possible after this PR, though I haven't experienced it). 

This should mitigate the issue for the time being, and I can look at ignoring previous requests next.