### PR TITLE
[Wallet]Fraschetti/Temporarily hide Activity Tab on Collectible Detail Page

### DIFF
--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -170,3 +170,4 @@
 (def community-accounts-selection-enabled? true)
 (def fetch-messages-enabled? (enabled? (get-config :FETCH_MESSAGES_ENABLED "1")))
 (def test-networks-enabled? (enabled? (get-config :TEST_NETWORKS_ENABLED "0")))
+(def wallet-collectible-actvity-enabled? false)

--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -170,4 +170,3 @@
 (def community-accounts-selection-enabled? true)
 (def fetch-messages-enabled? (enabled? (get-config :FETCH_MESSAGES_ENABLED "1")))
 (def test-networks-enabled? (enabled? (get-config :TEST_NETWORKS_ENABLED "0")))
-(def wallet-collectible-actvity-enabled? false)

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -7,6 +7,7 @@
     [react-native.svg :as svg]
     [reagent.core :as reagent]
     [status-im.common.scroll-page.view :as scroll-page]
+    [status-im.config :as config]
     [status-im.contexts.wallet.collectible.style :as style]
     [status-im.contexts.wallet.collectible.tabs.view :as tabs]
     [utils.i18n :as i18n]
@@ -44,15 +45,16 @@
     (i18n/label :t/opensea)]])
 
 (def tabs-data
-  [{:id                  :overview
-    :label               (i18n/label :t/overview)
-    :accessibility-label :overview-tab}
-   {:id                  :activity
-    :label               (i18n/label :t/activity)
-    :accessibility-label :activity-tab}
-   {:id                  :about
-    :label               (i18n/label :t/about)
-    :accessibility-label :about-tab}])
+  (let [base-tabs    [{:id                  :overview
+                       :label               (i18n/label :t/overview)
+                       :accessibility-label :overview-tab}
+                      {:id                  :about
+                       :label               (i18n/label :t/about)
+                       :accessibility-label :about-tab}]
+        activity-tab [{:id                  :activity
+                       :label               (i18n/label :t/activity)
+                       :accessibility-label :activity-tab}]]
+    (concat base-tabs (if config/wallet-collectible-actvity-enabled? activity-tab []))))
 
 (defn collectible-actions-sheet
   []

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -7,7 +7,6 @@
     [react-native.svg :as svg]
     [reagent.core :as reagent]
     [status-im.common.scroll-page.view :as scroll-page]
-    [status-im.config :as config]
     [status-im.contexts.wallet.collectible.style :as style]
     [status-im.contexts.wallet.collectible.tabs.view :as tabs]
     [utils.i18n :as i18n]
@@ -45,16 +44,12 @@
     (i18n/label :t/opensea)]])
 
 (def tabs-data
-  (let [base-tabs    [{:id                  :overview
-                       :label               (i18n/label :t/overview)
-                       :accessibility-label :overview-tab}
-                      {:id                  :about
-                       :label               (i18n/label :t/about)
-                       :accessibility-label :about-tab}]
-        activity-tab [{:id                  :activity
-                       :label               (i18n/label :t/activity)
-                       :accessibility-label :activity-tab}]]
-    (concat base-tabs (if config/wallet-collectible-actvity-enabled? activity-tab []))))
+  [{:id                  :overview
+    :label               (i18n/label :t/overview)
+    :accessibility-label :overview-tab}
+   {:id                  :about
+    :label               (i18n/label :t/about)
+    :accessibility-label :about-tab}])
 
 (defn collectible-actions-sheet
   []


### PR DESCRIPTION
fixes #19400 

### Summary

This pull request introduces a configuration option to conditionally incorporate the 'Activity' tab within the Collectibles Detail Page, facilitating ongoing development related to this feature. This option is intended for interim use and will be removed upon the completion of the feature's implementation.

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
Wallet
Collectibles

##### Functional
- Wallet 
- Transactions

### Steps to test
- Under `status-im.config `change `wallet-collectible-actvity-enabled?` to `true` or `false`
- Navigate to Wallet->Collectibles

### Before and after screenshots comparison
### Before
![image](https://github.com/status-im/status-mobile/assets/5999878/b5467b11-b5a3-4d7f-b423-1ef7691c9c9b)


### After
![image](https://github.com/status-im/status-mobile/assets/5999878/2e3c565f-b1be-4193-9248-901a7cb6b71e)

status: ready!