### PR TITLE
apply patches with patch files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,6 +441,10 @@ _list: SHELL := /bin/sh
 _list:
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
 
+patch-file: export TARGET := default
+patch-file: ##@other Generates patch file for npm deps
+	@scripts/patch-npm-lib.sh
+
 #--------------
 # REPLs
 #--------------

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1444,7 +1444,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 56e0e498dbb513b96c40bac6284729ba4e62672d
   FBReactNativeSpec: 146c741a3f40361f6bc13a4ba284678cbedb5881
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 37f1918ec8d57cbace2b409e117ef06bade68a64
+  glog: 530710e7949eb12c82670bd09e946becf50a3c2a
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   Keycard: ac6df4d91525c3c82635ac24d4ddd9a80aca5fc8
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef

--- a/patches/react-native-android.patch
+++ b/patches/react-native-android.patch
@@ -1,0 +1,12 @@
+# Do not add a BuildId to the generated libraries, for reproducibility
+--- ./node_modules/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
++++ ./node_modules/react-native/ReactAndroid/src/main/jni/CMakeLists-patched.txt
+@@ -21,7 +21,7 @@
+ endif(CCACHE_FOUND)
+
+ # Make sure every shared lib includes a .note.gnu.build-id header
+-add_link_options(-Wl,--build-id)
++add_link_options(-Wl,--build-id=none)
+ add_compile_options(-Wall -Werror -std=c++20)
+
+ function(add_react_android_subdir relative_path)

--- a/patches/react-native-keychain.patch
+++ b/patches/react-native-keychain.patch
@@ -1,0 +1,20 @@
+# Remove gradle-test-logger-plugin:
+# https://github.com/oblador/react-native-keychain/issues/595
+# TODO: remove this patch when we this library fixes above issue
+
+--- ./node_modules/react-native-keychain/android/build.gradle
++++ ./node_modules/react-native-keychain/android/build-patched.gradle
+@@ -4,13 +4,9 @@
+       url 'https://plugins.gradle.org/m2/'
+     }
+   }
+-  dependencies {
+-    classpath 'com.adarshr:gradle-test-logger-plugin:2.0.0'
+-  }
+ }
+
+ apply plugin: 'com.android.library'
+-apply plugin: "com.adarshr.test-logger"
+
+ def safeExtGet(prop, fallback) {
+   rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback

--- a/patches/react-native-navigation-button-presenter.patch
+++ b/patches/react-native-navigation-button-presenter.patch
@@ -1,0 +1,22 @@
+# https://github.com/wix/react-native-navigation/issues/7819
+
+--- ./node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter.kt
++++ ./node_modules/react-native-navigation/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/stack/topbar/button/ButtonPresenter-patched.kt
+@@ -194,8 +194,8 @@
+
+                 class WixAccessibilityDelegateCompat: AccessibilityDelegateCompat(){
+                     override fun onInitializeAccessibilityNodeInfo(
+-                        host: View?,
+-                        info: AccessibilityNodeInfoCompat?
++                        host: View,
++                        info: AccessibilityNodeInfoCompat
+                     ) {
+                         super.onInitializeAccessibilityNodeInfo(host, info)
+
+@@ -216,4 +216,4 @@
+     }
+
+
+-}
+\ No newline at end of file
++}

--- a/patches/react-native-navigation.patch
+++ b/patches/react-native-navigation.patch
@@ -1,0 +1,19 @@
+# https://github.com/wix/react-native-navigation/issues/7819
+
+--- ./node_modules/react-native-navigation/lib/android/app/build.gradle
++++ ./node_modules/react-native-navigation/lib/android/app/build-patched.gradle
+@@ -62,11 +62,11 @@
+         }
+     }
+     compileOptions {
+-        sourceCompatibility JavaVersion.VERSION_1_8
+-        targetCompatibility JavaVersion.VERSION_1_8
++        sourceCompatibility JavaVersion.VERSION_17
++        targetCompatibility JavaVersion.VERSION_17
+     }
+     kotlinOptions {
+-        jvmTarget = JavaVersion.VERSION_1_8
++        jvmTarget = JavaVersion.VERSION_17
+     }
+
+     flavorDimensions "RNN.reactNativeVersion"

--- a/patches/react-native-script.patch
+++ b/patches/react-native-script.patch
@@ -1,0 +1,13 @@
+# to fix https://github.com/status-im/status-mobile/issues/18548
+
+--- ./node_modules/react-native/scripts/react_native_pods_utils/script_phases.sh
++++ ./node_modules/react-native/scripts/react_native_pods_utils/script_phases-patched.sh
+@@ -104,7 +104,7 @@
+     mkdir -p "$RCT_SCRIPT_OUTPUT_DIR"
+
+     # Copy all output to output_dir
+-    cp -R -X "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR" || exit 1
++    cp -R "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR" || exit 1
+     echo "$LIBRARY_NAME output has been written to $RCT_SCRIPT_OUTPUT_DIR:" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
+     ls -1 "$RCT_SCRIPT_OUTPUT_DIR" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
+ }

--- a/patches/react-native.patch
+++ b/patches/react-native.patch
@@ -1,0 +1,15 @@
+# Fix pod issue after upgrading to MacOS Sonoma and Xcode 15
+# https://github.com/status-im/status-mobile/issues/17682
+
+--- ./node_modules/react-native/scripts/ios-configure-glog.sh
++++ ./node_modules/react-native/scripts/ios-configure-glog-patched.sh
+@@ -42,9 +42,6 @@
+     patch -p1 config.sub fix_glog_0.3.5_apple_silicon.patch
+ fi
+
+-export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
+-export CXX="$CC"
+-
+ # Remove automake symlink if it exists
+ if [ -h "test-driver" ]; then
+     rm test-driver

--- a/scripts/patch-npm-lib.sh
+++ b/scripts/patch-npm-lib.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
+
+read -p "Enter the path of the file to patch: " FILE_PATH
+
+if [ ! -f "${FILE_PATH}" ]; then
+  echo "File not found: ${FILE_PATH}" >&2
+  exit 1
+fi
+
+if [[ "${FILE_PATH}" == *"node_modules"* ]]; then
+  if [[ "${FILE_PATH}" != *"./node_modules"* ]]; then
+    echo "Please prefix the file path like this './node_modules/'. The path you provided was: ${FILE_PATH}" >&2
+    exit 1
+  fi
+fi
+
+FILE_NAME=$(basename "${FILE_PATH}")
+echo "File to patch: ${FILE_PATH}"
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TEMP_DIR}"' EXIT
+echo "Temporary directory created: ${TEMP_DIR}"
+
+cp "${FILE_PATH}" "${TEMP_DIR}"
+echo "Original file copied to temporary directory."
+
+echo "Please make the necessary changes to the file: ${FILE_PATH}"
+echo "Press any key when you are done with the changes..."
+
+ORIGINAL_MTIME=$(stat -c %Y "${FILE_PATH}")
+read -n 1 -s
+CURRENT_MTIME=$(stat -c %Y "${FILE_PATH}")
+
+if [[ "${ORIGINAL_MTIME}" -eq "${CURRENT_MTIME}" ]]; then
+  echo "Warning: No changes were made to the file. Patch file will not be generated."
+  exit 0
+fi
+
+echo "Generating patch file..."
+diff -Naur "${TEMP_DIR}/${FILE_NAME}" "${FILE_PATH}" > "${GIT_ROOT}/patches/${FILE_NAME}.patch"
+
+echo "Patch file created at ${GIT_ROOT}/patches/${FILE_NAME}.patch"
+echo "Info: Please execute 'make run-clojure' to test if the patch file works as expected."


### PR DESCRIPTION
fixes #19449

## Summary
In this PR we change the way patches are applied.
We no longer have to write patches in a patch phase like we used to, we can now place individual changes in a patch file inside the `patches` directory and they will be automatically applied.

Because of this change we can get rid of forks and instead have those changes in patch files.

To generate a patch file this make command can be used `make patch-file`
This will open an interactive shell which will allow you to specify which file you want to patch and then wait till you make those changes and generate a patch for it.

```
make patch-file
Configuring Nix shell for target 'default'...
Enter the path of the file to patch: ./node_modules/is-glob/index.js
File to patch: ./node_modules/is-glob/index.js
Temporary directory created: /tmp/tmp-status-mobile-40bc588fa/tmp.xrXarXoTPZ
Original file copied to temporary directory.
Please make the necessary changes to the file: ./node_modules/is-glob/index.js
Press any key when you are done with the changes...
Generating patch file...
Patch file created at /Users/siddarthkumar/code/status-im/PR/status-mobile/patches/index.js.patch
Info: Please execute 'make run-clojure' to test if the patch file works as expected.
```

## Platforms
- Android
- iOS

status: ready
