### PR TITLE
don't kill metro server when its already running

### DIFF
--- a/scripts/run-metro.sh
+++ b/scripts/run-metro.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
-pkill -f 'react-native start'
-
-react-native start --reset-cache
+if pgrep -f 'react-native start' > /dev/null; then
+    echo "Info: metro is already running in another terminal"
+else
+    echo "Info: starting a new metro terminal"
+    react-native start --reset-cache
+fi


### PR DESCRIPTION
The killing of metro terminal upset a few people and this PR fixes that.

## Summary
Modify build step to check if metro is running already.
If so then we do not attempt to start metro again.
If not then we start metro after building android / iOS.

## Review notes
* case 1 
    - `make run-clojure`
    - `make run-metro`
    - `make run-android` or `make run-ios` should work the way it did before.
* case 2
    - `make run-clojure`
    - `make run-android` or `make run-ios` should also work.

## Platforms
- Android
- iOS

status: ready
