### PR TITLE
Truncate secondary names in username and author components

### DIFF
--- a/src/quo/components/messages/author/style.cljs
+++ b/src/quo/components/messages/author/style.cljs
@@ -9,6 +9,7 @@
 
 (def name-container
   {:margin-right   8
+   :flex-shrink    1
    :flex-direction :row
    :align-items    :flex-end
   })

--- a/src/quo/components/messages/author/style.cljs
+++ b/src/quo/components/messages/author/style.cljs
@@ -32,14 +32,13 @@
 
 (defn secondary-name
   [theme]
-  {:padding-top 1
-   :flex-shrink 999999
+  {:flex-shrink 999999
    :color       (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)})
 
 (defn icon-container
   [is-first?]
   {:margin-left   (if is-first? 4 2)
-   :margin-bottom 4})
+   :margin-bottom 2})
 
 (defn time-text
   [theme]

--- a/src/quo/components/messages/author/view.cljs
+++ b/src/quo/components/messages/author/view.cljs
@@ -13,7 +13,11 @@
   [{:keys [primary-name secondary-name style short-chat-key time-str contact? verified? untrustworthy?
            muted? size theme]
     :or   {size 13}}]
-  [rn/view {:style (merge style/container style {:height (if (= size 15) 21.75 18.2)})}
+  [rn/view
+   {:style (merge style/container
+                  style
+                  {:height         (if (= size 15) 21.75 18.2)
+                   :padding-bottom (if (= size 15) 2 0.5)})}
    [rn/view {:style style/name-container}
     [text/text
      {:weight              :semi-bold

--- a/src/quo/components/text_combinations/username/style.cljs
+++ b/src/quo/components/text_combinations/username/style.cljs
@@ -2,22 +2,27 @@
   (:require [quo.foundations.colors :as colors]))
 
 (def container
-  {:flex-direction :row
-   :height         32})
+  {:flex-direction  :row
+   :justify-content :flex-start
+   :height          32})
 
 (def username-text-container
   {:flex-direction :row
-   :align-items    :flex-end})
+   :align-items    :flex-end
+   :flex-shrink    1})
 
 (defn real-name-text
   [theme blur?]
-  {:color (if blur?
-            (colors/theme-colors colors/neutral-80-opa-40 colors/white-opa-40 theme)
-            (colors/theme-colors colors/neutral-60 colors/neutral-40 theme))})
+  {:color       (if blur?
+                  (colors/theme-colors colors/neutral-80-opa-40 colors/white-opa-40 theme)
+                  (colors/theme-colors colors/neutral-60 colors/neutral-40 theme))
+   :flex-shrink 1})
 
 (defn real-name-dot
   [theme blur?]
-  (assoc (real-name-text theme blur?) :margin-horizontal 6))
+  (merge (real-name-text theme blur?)
+         {:margin-horizontal 6
+          :flex-shrink       0}))
 
 (defn status-icon-container
   [name-type status]

--- a/src/quo/components/text_combinations/username/view.cljs
+++ b/src/quo/components/text_combinations/username/view.cljs
@@ -26,7 +26,8 @@
        {:style               (style/real-name-text theme blur?)
         :size                :paragraph-1
         :accessibility-label :real-name
-        :weight              :medium}
+        :weight              :medium
+        :number-of-lines     1}
        real-name]])])
 
 (defn- icon-20

--- a/src/status_im/contexts/chat/home/chat_list_item/style.cljs
+++ b/src/status_im/contexts/chat/home/chat_list_item/style.cljs
@@ -21,6 +21,11 @@
    :justify-content :center
    :align-items     :center})
 
+(def notification-container-layout
+  {:flex-grow       1
+   :justify-content :center
+   :margin-left     8})
+
 ;; TODO: duplicate of `quo.components.common.unread-grey-dot.style`
 ;; Replace it when this component is defined as part of `quo.components`
 (defn grey-dot

--- a/src/status_im/contexts/chat/home/chat_list_item/style.cljs
+++ b/src/status_im/contexts/chat/home/chat_list_item/style.cljs
@@ -11,9 +11,8 @@
    :align-items        :center})
 
 (def chat-data-container
-  {:flex         1
-   :margin-left  8
-   :margin-right 16})
+  {:flex        1
+   :margin-left 8})
 
 (def notification-container
   {:margin-left     :auto

--- a/src/status_im/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im/contexts/chat/home/chat_list_item/view.cljs
@@ -231,14 +231,15 @@
        :color     color
        :muted?    muted}]
      [rn/view {:style style/chat-data-container}
-      [quo/author
-       {:primary-name   primary-name
-        :secondary-name secondary-name
-        :size           15
-        :verified?      ens-verified
-        :contact?       added?
-        :muted?         muted
-        :time-str       (datetime/to-short-str timestamp)}]
+      [rn/view {:style {:flex-direction :row}}
+       [quo/author
+        {:primary-name   primary-name
+         :secondary-name secondary-name
+         :size           15
+         :verified?      ens-verified
+         :contact?       added?
+         :muted?         muted
+         :time-str       (datetime/to-short-str timestamp)}]]
       [last-message-preview group-chat last-message muted]]
      [notification item]]))
 

--- a/src/status_im/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im/contexts/chat/home/chat_list_item/view.cljs
@@ -184,38 +184,44 @@
      {:customization-color color
       :size                :size-32}]))
 
+(defn- notification-layout
+  [child]
+  (when (seq child)
+    [rn/view
+     {:style {:flex-grow       1
+              :justify-content :center
+              :margin-left     8}}
+     (into [rn/view {:style style/notification-container}] [child])]))
+
 (defn notification
   [{:keys [muted group-chat unviewed-messages-count unviewed-mentions-count]}]
   (let [customization-color (rf/sub [:profile/customization-color])
         unread-messages?    (pos? unviewed-messages-count)
         unread-mentions?    (pos? unviewed-mentions-count)]
-    [rn/view {:style {:flex-grow 1
-                      :justify-content :center
-                      :margin-left 8}}
-     [rn/view {:style style/notification-container}
-      (cond
-        muted
-        [quo/icon :i/muted {:color colors/neutral-40}]
+    [notification-layout
+     (cond
+       muted
+       [quo/icon :i/muted {:color colors/neutral-40}]
 
-        (and group-chat unread-mentions?)
-        [quo/counter
-         {:container-style     {:position :relative :right 0}
-          :customization-color customization-color
-          :accessibility-label :new-message-counter}
-         unviewed-mentions-count]
+       (and group-chat unread-mentions?)
+       [quo/counter
+        {:container-style     {:position :relative :right 0}
+         :customization-color customization-color
+         :accessibility-label :new-message-counter}
+        unviewed-mentions-count]
 
        ;; TODO: use the grey-dot component when chat-list-item is moved to quo.components
-        (and group-chat unread-messages?)
-        [rn/view
-         {:style               (style/grey-dot)
-          :accessibility-label :unviewed-messages-public}]
+       (and group-chat unread-messages?)
+       [rn/view
+        {:style               (style/grey-dot)
+         :accessibility-label :unviewed-messages-public}]
 
-        unread-messages?
-        [quo/counter
-         {:container-style     {:position :relative :right 0}
-          :customization-color customization-color
-          :accessibility-label :new-message-counter}
-         unviewed-messages-count])]]))
+       unread-messages?
+       [quo/counter
+        {:container-style     {:position :relative :right 0}
+         :customization-color customization-color
+         :accessibility-label :new-message-counter}
+        unviewed-messages-count])]))
 
 (defn chat-item
   [{:keys [chat-id group-chat color name last-message timestamp muted]

--- a/src/status_im/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im/contexts/chat/home/chat_list_item/view.cljs
@@ -189,30 +189,33 @@
   (let [customization-color (rf/sub [:profile/customization-color])
         unread-messages?    (pos? unviewed-messages-count)
         unread-mentions?    (pos? unviewed-mentions-count)]
-    [rn/view {:style style/notification-container}
-     (cond
-       muted
-       [quo/icon :i/muted {:color colors/neutral-40}]
+    [rn/view {:style {:flex-grow 1
+                      :justify-content :center
+                      :margin-left 8}}
+     [rn/view {:style style/notification-container}
+      (cond
+        muted
+        [quo/icon :i/muted {:color colors/neutral-40}]
 
-       (and group-chat unread-mentions?)
-       [quo/counter
-        {:container-style     {:position :relative :right 0}
-         :customization-color customization-color
-         :accessibility-label :new-message-counter}
-        unviewed-mentions-count]
+        (and group-chat unread-mentions?)
+        [quo/counter
+         {:container-style     {:position :relative :right 0}
+          :customization-color customization-color
+          :accessibility-label :new-message-counter}
+         unviewed-mentions-count]
 
        ;; TODO: use the grey-dot component when chat-list-item is moved to quo.components
-       (and group-chat unread-messages?)
-       [rn/view
-        {:style               (style/grey-dot)
-         :accessibility-label :unviewed-messages-public}]
+        (and group-chat unread-messages?)
+        [rn/view
+         {:style               (style/grey-dot)
+          :accessibility-label :unviewed-messages-public}]
 
-       unread-messages?
-       [quo/counter
-        {:container-style     {:position :relative :right 0}
-         :customization-color customization-color
-         :accessibility-label :new-message-counter}
-        unviewed-messages-count])]))
+        unread-messages?
+        [quo/counter
+         {:container-style     {:position :relative :right 0}
+          :customization-color customization-color
+          :accessibility-label :new-message-counter}
+         unviewed-messages-count])]]))
 
 (defn chat-item
   [{:keys [chat-id group-chat color name last-message timestamp muted]
@@ -223,24 +226,26 @@
           (rf/sub [:contacts/contact-two-names-by-identity chat-id]))
         {:keys [ens-verified added?] :as contact} (when-not group-chat
                                                     (rf/sub [:contacts/contact-by-address chat-id]))]
-    [:<>
+    [rn/view {:style {:flex-direction :row}}
      [avatar-view
       {:contact   contact
        :chat-id   chat-id
        :full-name primary-name
        :color     color
        :muted?    muted}]
-     [rn/view {:style style/chat-data-container}
-      [rn/view {:style {:flex-direction :row}}
-       [quo/author
-        {:primary-name   primary-name
-         :secondary-name secondary-name
-         :size           15
-         :verified?      ens-verified
-         :contact?       added?
-         :muted?         muted
-         :time-str       (datetime/to-short-str timestamp)}]]
-      [last-message-preview group-chat last-message muted]]
+     [rn/view {:style {:flex-shrink 1}}
+      [rn/view {:style style/chat-data-container}
+       [rn/view {:style {:flex-direction :row}}
+        [quo/author
+         {:primary-name   primary-name
+          :secondary-name secondary-name
+          :size           15
+          :verified?      ens-verified
+          :contact?       added?
+          :muted?         muted
+          :time-str       (datetime/to-short-str timestamp)
+          :style          {:flex-shrink 1}}]]
+       [last-message-preview group-chat last-message muted]]]
      [notification item]]))
 
 (defn chat-user

--- a/src/status_im/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im/contexts/chat/home/chat_list_item/view.cljs
@@ -186,42 +186,43 @@
 
 (defn- notification-layout
   [child]
-  (when (seq child)
-    [rn/view
-     {:style {:flex-grow       1
-              :justify-content :center
-              :margin-left     8}}
-     (into [rn/view {:style style/notification-container}] [child])]))
+  [rn/view
+   {:style style/notification-container-layout}
+   [rn/view {:style style/notification-container}
+    child]])
 
 (defn notification
   [{:keys [muted group-chat unviewed-messages-count unviewed-mentions-count]}]
   (let [customization-color (rf/sub [:profile/customization-color])
         unread-messages?    (pos? unviewed-messages-count)
         unread-mentions?    (pos? unviewed-mentions-count)]
-    [notification-layout
-     (cond
-       muted
-       [quo/icon :i/muted {:color colors/neutral-40}]
+    (cond
+      muted
+      [notification-layout
+       [quo/icon :i/muted {:color colors/neutral-40}]]
 
-       (and group-chat unread-mentions?)
+      (and group-chat unread-mentions?)
+      [notification-layout
        [quo/counter
         {:container-style     {:position :relative :right 0}
          :customization-color customization-color
          :accessibility-label :new-message-counter}
-        unviewed-mentions-count]
+        unviewed-mentions-count]]
 
-       ;; TODO: use the grey-dot component when chat-list-item is moved to quo.components
-       (and group-chat unread-messages?)
+      ;; TODO: use the grey-dot component when chat-list-item is moved to quo.components
+      (and group-chat unread-messages?)
+      [notification-layout
        [rn/view
         {:style               (style/grey-dot)
-         :accessibility-label :unviewed-messages-public}]
+         :accessibility-label :unviewed-messages-public}]]
 
-       unread-messages?
+      unread-messages?
+      [notification-layout
        [quo/counter
         {:container-style     {:position :relative :right 0}
          :customization-color customization-color
          :accessibility-label :new-message-counter}
-        unviewed-messages-count])]))
+        unviewed-messages-count]])))
 
 (defn chat-item
   [{:keys [chat-id group-chat color name last-message timestamp muted]

--- a/src/status_im/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im/contexts/chat/home/chat_list_item/view.cljs
@@ -241,16 +241,15 @@
        :muted?    muted}]
      [rn/view {:style {:flex-shrink 1}}
       [rn/view {:style style/chat-data-container}
-       [rn/view {:style {:flex-direction :row}}
-        [quo/author
-         {:primary-name   primary-name
-          :secondary-name secondary-name
-          :size           15
-          :verified?      ens-verified
-          :contact?       added?
-          :muted?         muted
-          :time-str       (datetime/to-short-str timestamp)
-          :style          {:flex-shrink 1}}]]
+       [quo/author
+        {:primary-name   primary-name
+         :secondary-name secondary-name
+         :size           15
+         :verified?      ens-verified
+         :contact?       added?
+         :muted?         muted
+         :time-str       (datetime/to-short-str timestamp)
+         :style          {:flex-shrink 1}}]
        [last-message-preview group-chat last-message muted]]]
      [notification item]]))
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19397 

### Summary

* This PR attempts to fix issues relating a user's secondary name not being truncated when displaying their nickname in the following UIs:
  * Home chat list
  * Home contact list
  * 1-1 chats
  * Contact profile
* This PR modifies the `quo/username` and `quo/author` components to support shrinking the secondary name field when reaching the flex width of the UI.
* This PR could **skip-manual-qa** since it mainly affect visual layouts.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats
- Contact profile
- Home chat list 
- Home contact list

#### Steps to Reproduce

The key areas of impact and steps to reproduce are described here: https://github.com/status-im/status-mobile/issues/19397

### Before and after screenshots comparison

#### Before

https://github.com/status-im/status-mobile/assets/2845768/32afb635-74b3-4670-9bc8-0be45a3485d0

#### After

https://github.com/status-im/status-mobile/assets/2845768/4d7f04eb-ffb3-4285-91ca-53dc7d721b8b

status: ready
