### PR TITLE
fix: Wrong UI for network preferences bottom sheet

### DIFF
--- a/src/quo/foundations/colors.cljs
+++ b/src/quo/foundations/colors.cljs
@@ -245,6 +245,7 @@
 ;;;; Networks
 (def ^:private networks
   {:ethereum "#758EEB"
+   :mainnet  "#758EEB"
    :optimism "#E76E6E"
    :arbitrum "#6BD5F0"
    :zkSync   "#9FA0FE"

--- a/src/status_im/common/qr_codes/view.cljs
+++ b/src/status_im/common/qr_codes/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.common.qr-codes.view
   (:require
     [quo.core :as quo]
+    [status-im.constants :as constants]
     [utils.image-server :as image-server]
     [utils.re-frame :as rf]))
 
@@ -43,10 +44,10 @@
 (defn get-network-short-name-url
   [network]
   (case network
-    :ethereum "eth:"
-    :mainnet  "eth:"
-    :optimism "opt:"
-    :arbitrum "arb1:"
+    :ethereum (str constants/mainnet-short-name ":")
+    :mainnet  (str constants/mainnet-short-name ":")
+    :optimism (str constants/optimism-short-name ":")
+    :arbitrum (str constants/arbitrum-short-name ":")
     (str (name network) ":")))
 
 (defn- get-qr-data-for-wallet-multichain

--- a/src/status_im/common/qr_codes/view.cljs
+++ b/src/status_im/common/qr_codes/view.cljs
@@ -44,6 +44,7 @@
   [network]
   (case network
     :ethereum "eth:"
+    :mainnet  "eth:"
     :optimism "opt:"
     :arbitrum "arb1:"
     (str (name network) ":")))
@@ -66,7 +67,7 @@
      - customization-color:   Custom color for the QR code component.
      - unblur-on-android?:    [Android only] disables blur for this component.
      - full-name:             User full name.
-  
+
      Depending on the `type`, different properties are accepted:
      `:profile`
        - profile-picture:     map ({:source image-source}) or any image source.

--- a/src/status_im/contexts/wallet/account/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/account/share_address/view.cljs
@@ -34,7 +34,8 @@
   [selected-networks]
   (let [on-save       (fn [chain-ids]
                         (rf/dispatch [:hide-bottom-sheet])
-                        (reset! selected-networks (map utils/id->network chain-ids)))
+                        (reset! selected-networks (map #(if (= % 1) :mainnet (utils/id->network %))
+                                                       chain-ids)))
         sheet-content (fn []
                         [network-preferences/view
                          {:blur?             true

--- a/src/status_im/contexts/wallet/account/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/account/share_address/view.cljs
@@ -52,7 +52,7 @@
         wallet-type         (reagent/atom :legacy)
         ;; Design team is yet to confirm the default selected networks here. Should be the current
         ;; selected for the account or all the networks always
-        selected-networks   (reagent/atom [:ethereum :optimism :arbitrum])
+        selected-networks   (reagent/atom [:mainnet :optimism :arbitrum])
         on-settings-press   #(open-preferences selected-networks)
         on-legacy-press     #(reset! wallet-type :legacy)
         on-multichain-press #(reset! wallet-type :multichain)]

--- a/src/status_im/contexts/wallet/sheets/network_preferences/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/network_preferences/view.cljs
@@ -93,7 +93,7 @@
                             layer-2-networks)}]
          [quo/bottom-actions
           {:actions          :one-action
-           :button-one-label (i18n/label :t/update)
+           :button-one-label (i18n/label :t/display)
            :button-one-props {:disabled?           (= @state :default)
                               :on-press            (fn []
                                                      (let [chain-ids (map :chain-id current-networks)]

--- a/translations/en.json
+++ b/translations/en.json
@@ -2563,11 +2563,8 @@
         "other": "{{count}} addresses"
     },
     "max": "Max: {{number}}",
-<<<<<<< HEAD
     "key-name-error-length": "Key name too long",
     "key-name-error-emoji": "Emojis are not allowed",
-    "key-name-error-special-char": "Special characters are not allowed"
-=======
+    "key-name-error-special-char": "Special characters are not allowed",
     "display": "Display"
->>>>>>> c69f477df (networks preferences)
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -2563,7 +2563,11 @@
         "other": "{{count}} addresses"
     },
     "max": "Max: {{number}}",
+<<<<<<< HEAD
     "key-name-error-length": "Key name too long",
     "key-name-error-emoji": "Emojis are not allowed",
     "key-name-error-special-char": "Special characters are not allowed"
+=======
+    "display": "Display"
+>>>>>>> c69f477df (networks preferences)
 }


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19463

This PR fixes incorrect UI details in the network preferences:

1. Address display
2. Mainnet to be selected by default
3. button text


<img src="https://github.com/status-im/status-mobile/assets/29354102/de7c22f2-576a-4393-ad4e-aefdb45c5455" alt="Screenshot_20240402_141910_Status" width="270" height="600">


