### PR TITLE
fix failing iOS nightly build

### DIFF
--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -592,7 +592,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = "/usr/bin/env sh";
-			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\"\n";
+			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ../logs/set_xcode_version.log 2>&1\n";
 		};
 		5BEC29A10D63DFF8AFF5B788 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -716,7 +716,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = "/usr/bin/env sh";
-			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ./logs/set_xcode_version.log 2>&1\n";
+			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ../logs/set_xcode_version.log 2>&1\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Summary

iOS nightly builds were failing with : 

```
07:54:15  The following build commands failed:
07:54:15  	PhaseScriptExecution Run\ Script /Users/jenkins/Library/Developer/Xcode/DerivedData/
StatusIm-hasrsefeolwghadhqaakilqvfzrk/Build/Intermediates.noindex/ArchiveIntermediates/StatusIm/
IntermediateBuildFilesPath/StatusIm.build/Release-iphoneos/StatusIm.build/
Script-E3914A731DF919ED00EBB515.sh (in target 'StatusIm' from project 'StatusIm')
07:54:15  (1 failure)
07:54:15  [05:24:14]: Exit status: 65
.
.
.
07:54:15  [05:24:14]: ▸     /bin/sh -c /Users/jenkins/Library/Developer/Xcode/DerivedData/
StatusIm-hasrsefeolwghadhqaakilqvfzrk/Build/Intermediates.noindex/ArchiveIntermediates/StatusIm/
IntermediateBuildFilesPath/StatusIm.build/Release-iphoneos/StatusIm.build/
Script-E3914A731DF919ED00EBB515.sh

07:54:15  [05:24:14]: ▸ /Users/jenkins/Library/Developer/Xcode/DerivedData/
StatusIm-hasrsefeolwghadhqaakilqvfzrk/Build/Intermediates.noindex/ArchiveIntermediates/StatusIm/
IntermediateBuildFilesPath/StatusIm.build/Release-iphoneos/StatusIm.build/
Script-E3914A731DF919ED00EBB515.sh: line 2: ./logs/set_xcode_version.log: No such file or directory

07:54:15  [05:24:14]: ▸ Command PhaseScriptExecution failed with a nonzero exit code
```

In this PR the path to the logfile `set_xcode_version.log` has been fixed.

## Platforms
- iOS

status: ready
