### PR TITLE
Tweak layout of quo/author component to use flex-baseline

### DIFF
--- a/src/quo/components/messages/author/style.cljs
+++ b/src/quo/components/messages/author/style.cljs
@@ -3,11 +3,20 @@
     [quo.foundations.colors :as colors]
     [react-native.platform :as platform]))
 
-(def container
+(defn- primary-name-offset
+  [size]
+  (when (= size 15)
+    (cond platform/ios?     1
+          platform/android? -0.5
+          :else             0)))
+
+(defn container
+  [size]
   {:flex-shrink    1
    :flex-wrap      :nowrap
    :flex-direction :row
-   :align-items    :baseline})
+   :align-items    :baseline
+   :top            (* -1 (primary-name-offset size))})
 
 (def details-container
   {:flex-direction :row
@@ -28,10 +37,7 @@
                   colors/neutral-50
                   (colors/theme-colors colors/neutral-100 colors/white theme))
    :flex-shrink 1
-   :top         (when (= size 15)
-                  (cond platform/ios?     1
-                        platform/android? -0.5
-                        :else             0))})
+   :top         (primary-name-offset size)})
 
 (defn secondary-name
   [theme]

--- a/src/quo/components/messages/author/style.cljs
+++ b/src/quo/components/messages/author/style.cljs
@@ -47,7 +47,6 @@
 (defn icon-container
   [is-first?]
   {:margin-left   (if is-first? 4 2)
-   :margin-bottom 0
    :top           (cond platform/ios?     1
                         platform/android? 2
                         :else             0)})

--- a/src/quo/components/messages/author/style.cljs
+++ b/src/quo/components/messages/author/style.cljs
@@ -3,12 +3,25 @@
     [quo.foundations.colors :as colors]
     [react-native.platform :as platform]))
 
-(defn- primary-name-offset
+(defn- primary-name-top-offset
   [size]
   (when (= size 15)
     (cond platform/ios?     1
           platform/android? -0.5
           :else             0)))
+
+(defn- primary-name-margin-bottom-offset
+  [size]
+  (when (and (= size 15)
+             (or platform/ios? platform/android?))
+    -0.25))
+
+(defn- primary-name-layout-offsets
+  [size]
+  ;; NOTE(seanstrom): We need to sometimes offset the primary-name to align the baseline of the text
+  ;; while avoiding shifting elements downward.
+  {:top           (primary-name-top-offset size)
+   :margin-bottom (primary-name-margin-bottom-offset size)})
 
 (defn container
   [size]
@@ -16,7 +29,9 @@
    :flex-wrap      :nowrap
    :flex-direction :row
    :align-items    :baseline
-   :top            (* -1 (primary-name-offset size))})
+   ;; NOTE(seanstrom): Because we're offseting the primary-name we need to inverse the offset on the
+   ;; container to avoid shifting elements downward
+   :top            (* -1 (primary-name-top-offset size))})
 
 (def details-container
   {:flex-direction :row
@@ -33,11 +48,11 @@
 
 (defn primary-name
   [muted? theme size]
-  {:color       (if muted?
-                  colors/neutral-50
-                  (colors/theme-colors colors/neutral-100 colors/white theme))
-   :flex-shrink 1
-   :top         (primary-name-offset size)})
+  (merge (primary-name-layout-offsets size)
+         {:color       (if muted?
+                         colors/neutral-50
+                         (colors/theme-colors colors/neutral-100 colors/white theme))
+          :flex-shrink 1}))
 
 (defn secondary-name
   [theme]
@@ -46,10 +61,12 @@
 
 (defn icon-container
   [is-first?]
-  {:margin-left   (if is-first? 4 2)
-   :top           (cond platform/ios?     1
-                        platform/android? 2
-                        :else             0)})
+  {:margin-left (if is-first? 4 2)
+   ;; NOTE(seanstrom): Because we're using flex baseline to align elements
+   ;; we need to offset the icon container to match the designs.
+   :top         (cond platform/ios?     1
+                      platform/android? 2
+                      :else             0)})
 
 (defn time-text
   [theme]

--- a/src/quo/components/messages/author/style.cljs
+++ b/src/quo/components/messages/author/style.cljs
@@ -1,18 +1,17 @@
 (ns quo.components.messages.author.style
   (:require
-    [quo.foundations.colors :as colors]))
+    [quo.foundations.colors :as colors]
+    [react-native.platform :as platform]))
 
 (def container
-  {:flex-wrap      :nowrap
+  {:flex-shrink    1
+   :flex-wrap      :nowrap
    :flex-direction :row
-   :align-items    :flex-end})
+   :align-items    :baseline})
 
-(def name-container
-  {:margin-right   8
-   :flex-shrink    1
-   :flex-direction :row
-   :align-items    :flex-end
-  })
+(def details-container
+  {:flex-direction :row
+   :margin-left    8})
 
 (defn middle-dot
   [theme]
@@ -24,11 +23,15 @@
   {:color (colors/theme-colors colors/neutral-40 colors/neutral-50 theme)})
 
 (defn primary-name
-  [muted? theme]
+  [muted? theme size]
   {:color       (if muted?
                   colors/neutral-50
                   (colors/theme-colors colors/neutral-100 colors/white theme))
-   :flex-shrink 1})
+   :flex-shrink 1
+   :top         (when (= size 15)
+                  (cond platform/ios?     1
+                        platform/android? -0.5
+                        :else             0))})
 
 (defn secondary-name
   [theme]
@@ -38,7 +41,10 @@
 (defn icon-container
   [is-first?]
   {:margin-left   (if is-first? 4 2)
-   :margin-bottom 2})
+   :margin-bottom 0
+   :top           (cond platform/ios?     1
+                        platform/android? 2
+                        :else             0)})
 
 (defn time-text
   [theme]

--- a/src/quo/components/messages/author/view.cljs
+++ b/src/quo/components/messages/author/view.cljs
@@ -14,7 +14,7 @@
            muted? size theme]
     :or   {size 13}}]
   [rn/view
-   {:style (merge style/container style)}
+   {:style (merge (style/container size) style)}
    [text/text
     {:weight              :semi-bold
      :size                (if (= size 15) :paragraph-1 :paragraph-2)

--- a/src/quo/components/messages/author/view.cljs
+++ b/src/quo/components/messages/author/view.cljs
@@ -14,69 +14,66 @@
            muted? size theme]
     :or   {size 13}}]
   [rn/view
-   {:style (merge style/container
-                  style
-                  {:height         (if (= size 15) 21.75 18.2)
-                   :padding-bottom (if (= size 15) 2 0.5)})}
-   [rn/view {:style style/name-container}
-    [text/text
-     {:weight              :semi-bold
-      :size                (if (= size 15) :paragraph-1 :paragraph-2)
-      :number-of-lines     1
-      :accessibility-label :author-primary-name
-      :style               (style/primary-name muted? theme)}
-     primary-name]
-    (when (not (string/blank? secondary-name))
-      [:<>
-       [text/text
-        {:size            :label
-         :number-of-lines 1
-         :style           (style/middle-dot theme)}
-        middle-dot]
-       [text/text
-        {:weight              :medium
-         :size                :label
-         :number-of-lines     1
-         :accessibility-label :author-secondary-name
-         :style               (style/secondary-name theme)}
-        secondary-name]])
-    (when contact?
-      [icons/icon :main-icons2/contact
-       {:size            12
-        :no-color        true
-        :container-style (style/icon-container true)}])
-    (cond
-      verified?
-      [icons/icon :main-icons2/verified
-       {:size            12
-        :no-color        true
-        :container-style (style/icon-container contact?)}]
-      untrustworthy?
-      [icons/icon :main-icons2/untrustworthy
-       {:size            12
-        :no-color        true
-        :container-style (style/icon-container contact?)}])]
-   (when (and (not verified?) short-chat-key)
-     [text/text
-      {:weight          :monospace
-       :size            :label
-       :number-of-lines 1
-       :style           (style/chat-key-text theme)}
-      short-chat-key])
-   (when (and (not verified?) time-str short-chat-key)
-     [text/text
-      {:monospace       true
-       :size            :label
-       :number-of-lines 1
-       :style           (style/middle-dot theme)}
-      middle-dot])
-   (when time-str
-     [text/text
-      {:monospace           true
-       :size                :label
-       :accessibility-label :message-timestamp
-       :number-of-lines     1
-       :style               (style/time-text theme)}
-      time-str])])
+   {:style (merge style/container style)}
+   [text/text
+    {:weight              :semi-bold
+     :size                (if (= size 15) :paragraph-1 :paragraph-2)
+     :number-of-lines     1
+     :accessibility-label :author-primary-name
+     :style               (style/primary-name muted? theme size)}
+    primary-name]
+   (when (not (string/blank? secondary-name))
+     [:<>
+      [text/text
+       {:size            :label
+        :number-of-lines 1
+        :style           (style/middle-dot theme)}
+       middle-dot]
+      [text/text
+       {:weight              :medium
+        :size                :label
+        :number-of-lines     1
+        :accessibility-label :author-secondary-name
+        :style               (style/secondary-name theme)}
+       secondary-name]])
+   (when contact?
+     [icons/icon :main-icons2/contact
+      {:size            12
+       :no-color        true
+       :container-style (style/icon-container true)}])
+   (cond
+     verified?
+     [icons/icon :main-icons2/verified
+      {:size            12
+       :no-color        true
+       :container-style (style/icon-container contact?)}]
+     untrustworthy?
+     [icons/icon :main-icons2/untrustworthy
+      {:size            12
+       :no-color        true
+       :container-style (style/icon-container contact?)}])
+   [rn/view {:style style/details-container}
+    (when (and (not verified?) short-chat-key)
+      [text/text
+       {:weight          :monospace
+        :size            :label
+        :number-of-lines 1
+        :style           (style/chat-key-text theme)}
+       short-chat-key])
+    (when (and (not verified?) time-str short-chat-key)
+      [text/text
+       {:monospace       true
+        :size            :label
+        :number-of-lines 1
+        :style           (style/middle-dot theme)}
+       middle-dot])
+    (when time-str
+      [text/text
+       {:monospace           true
+        :size                :label
+        :accessibility-label :message-timestamp
+        :number-of-lines     1
+        :style               (style/time-text theme)}
+       time-str])]])
 
 (def view (quo.theme/with-theme internal-view))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

* This PR follows the work from  #19468
* This PR is based on the designs found here: [Figma Designs](https://www.figma.com/file/jGs1P4RU4R1NRrY0xXmHC1/Profile-interactions?type=design&node-id=1368-136256&mode=design&t=Du3kOGa2eVFAALp3-4)
* This PR attempts to change the quo/author component to match the alignment of elements in the Figma designs.
* This PR could `skip-manual-qa` since it mainly tweaks the text alignment for the `quo/author` component.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- Home contacts list
- Home recent chats list

### Steps to test

WIP

### Before and after screenshots comparison

#### Before iOS

##### Home recent chats list
<img width="434" alt="Screenshot 2024-04-03 at 09 43 33" src="https://github.com/status-im/status-mobile/assets/2845768/170782a7-0814-4456-b2ee-6f77f0e271b7">

##### Home contacts list
<img width="432" alt="Screenshot 2024-04-03 at 09 44 52" src="https://github.com/status-im/status-mobile/assets/2845768/9af741d3-0024-4331-9afe-93ed434203d3">

##### 1-1 chat
<img width="436" alt="Screenshot 2024-04-03 at 09 46 08" src="https://github.com/status-im/status-mobile/assets/2845768/eeb29d99-df9b-408b-b36f-c14774854b40">


#### Before Android

##### Home recent chats list
<img width="518" alt="Screenshot 2024-04-03 at 09 44 07" src="https://github.com/status-im/status-mobile/assets/2845768/2b1ac0cc-205e-4f13-9744-05c87ca7f773">

##### Home contacts list
<img width="518" alt="Screenshot 2024-04-03 at 09 45 01" src="https://github.com/status-im/status-mobile/assets/2845768/69f2d885-6f04-48aa-9f8c-9649e74ffb1a">

##### 1-1 chat
<img width="519" alt="Screenshot 2024-04-03 at 09 46 30" src="https://github.com/status-im/status-mobile/assets/2845768/490db17e-d97d-4410-978c-0236c183e643">

#### After iOS

##### Home recent chats list
<img width="435" alt="Screenshot 2024-04-03 at 10 05 25" src="https://github.com/status-im/status-mobile/assets/2845768/a0f670cf-b2e2-4405-9a92-357a5cc55de3">

##### Home contacts list
<img width="430" alt="Screenshot 2024-04-03 at 10 06 01" src="https://github.com/status-im/status-mobile/assets/2845768/5cb86cfe-5572-44cd-b068-654bf0b2eebf">

##### 1-1 chat
<img width="436" alt="Screenshot 2024-04-03 at 10 07 37" src="https://github.com/status-im/status-mobile/assets/2845768/12bd2594-9358-4429-9e2c-967edba9dfc2">

#### After Android

##### Home recent chats list
<img width="520" alt="Screenshot 2024-04-03 at 10 05 40" src="https://github.com/status-im/status-mobile/assets/2845768/49185ee0-a7e7-455a-982b-a4f0dc899a31">

##### Home contacts list
<img width="519" alt="Screenshot 2024-04-03 at 10 06 46" src="https://github.com/status-im/status-mobile/assets/2845768/410bb712-0175-4fdd-bce5-07e9b0ca0a63">

##### 1-1 chat
<img width="519" alt="Screenshot 2024-04-03 at 10 07 49" src="https://github.com/status-im/status-mobile/assets/2845768/9d1531b9-b44f-4f77-91e7-bca2f6ef6684">

status: ready <!-- Can be ready or wip -->
