### PR TITLE
Truncate text inside contact request notifications

### DIFF
--- a/src/quo/components/notifications/notification/view.cljs
+++ b/src/quo/components/notifications/notification/view.cljs
@@ -39,6 +39,7 @@
    {:size                :paragraph-2
     :weight              :medium
     :style               (style/text theme)
+    :number-of-lines     2
     :accessibility-label :notification-content}
    text])
 

--- a/src/status_im/contexts/shell/activity_center/notification/contact_requests/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification/contact_requests/view.cljs
@@ -113,7 +113,8 @@
       :unread? (not (:read notification))
       :context [[common/user-avatar-tag author]
                 (i18n/label :t/contact-request-sent)]
-      :message {:body (get-in message [:content :text])}
+      :message {:body                 (get-in message [:content :text])
+                :body-number-of-lines 2}
       :items
       (condp = (:contact-request-state message)
         constants/contact-request-message-state-accepted


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19322 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to truncate the text for:
  * the contact request notifications that appear as toasts 
  * and contact request notifications that appear inside the activity center.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Contact request notifications as toasts
- Contact request notifications inside activity center

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile on two devices with different accounts
- Send a contact request between the two accounts with a multiline contact-request message (3 lines or more)
- View the contact request notification toast on the receiving device
- View the contact request notification inside the activity center on the receiving device

### Before and after screenshots comparison

#### Before

This issue outlines the existing behaviour before this PR: #19322 

#### After

https://github.com/status-im/status-mobile/assets/2845768/31e27aa0-fcb0-427e-890b-54e09a5a6ed1

status: ready
