### PR TITLE
[Fix] Wallet - Keypair name in the about tab

### DIFF
--- a/src/quo/components/wallet/account_origin/schema.cljs
+++ b/src/quo/components/wallet/account_origin/schema.cljs
@@ -5,9 +5,12 @@
    [:type {:optional true} [:enum :default-keypair :recovery-phrase :private-key]]
    [:stored {:optional true} [:enum :on-device :on-keycard]]])
 
+(def ^:private ?keypair-name
+  [:map
+   [:keypair-name {:optional true} [:maybe :string]]])
+
 (def ^:private ?default-keypair
   [:map
-   [:user-name {:optional true} [:maybe :string]]
    [:profile-picture {:optional true} [:maybe :schema.common/image-source]]
    [:derivation-path {:optional true} [:maybe :string]]
    [:on-press {:optional true} [:maybe fn?]]
@@ -23,7 +26,7 @@
    [:catn
     [:props
      [:multi {:dispatch :type}
-      [:default-keypair [:merge ?base ?default-keypair]]
-      [:recovery-phrase [:merge ?base ?recovery-phrase]]
+      [:default-keypair [:merge ?base ?default-keypair ?keypair-name]]
+      [:recovery-phrase [:merge ?base ?recovery-phrase ?keypair-name]]
       [:private-key ?base]]]]
    :any])

--- a/src/quo/components/wallet/account_origin/view.cljs
+++ b/src/quo/components/wallet/account_origin/view.cljs
@@ -12,14 +12,14 @@
     [utils.i18n :as i18n]))
 
 (defn- row-title
-  [type user-name]
+  [type keypair-name]
   [text/text
    {:weight :medium
     :size   :paragraph-1}
    (case type
-     :default-keypair (i18n/label :t/user-keypair {:name user-name})
+     :default-keypair (i18n/label :t/user-keypair {:name keypair-name})
      :derivation-path (i18n/label :t/derivation-path)
-     (i18n/label :t/trip-accounts))])
+     keypair-name)])
 
 (defn- row-icon
   [customization-color profile-picture type secondary-color]
@@ -72,7 +72,7 @@
        {:color secondary-color}]])])
 
 (defn- list-view
-  [{:keys [type stored customization-color profile-picture user-name theme secondary-color]}]
+  [{:keys [type stored customization-color profile-picture keypair-name theme secondary-color]}]
   (let [stored-name (if (= :on-device stored)
                       (i18n/label :t/on-device)
                       (i18n/label :t/on-keycard))]
@@ -81,7 +81,7 @@
       :stored              stored
       :customization-color customization-color
       :profile-picture     profile-picture
-      :title               user-name
+      :title               keypair-name
       :subtitle            stored-name
       :theme               theme
       :secondary-color     secondary-color}]))

--- a/src/status_im/contexts/wallet/account/tabs/about/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/about/view.cljs
@@ -67,6 +67,8 @@
   []
   (let [{:keys [customization-color] :as profile} (rf/sub [:profile/profile-with-image])
         {:keys [address path watch-only?]}        (rf/sub [:wallet/current-viewing-account])
+        {keypair-name :name
+         keypair-type :type}                      (rf/sub [:wallet/current-viewing-account-keypair])
         networks                                  (rf/sub [:wallet/network-preference-details])]
     [rn/scroll-view
      {:style                   style/about-tab
@@ -88,10 +90,10 @@
        :on-press        #(rf/dispatch [:show-bottom-sheet {:content about-options}])}]
      (when (not watch-only?)
        [quo/account-origin
-        {:type                :default-keypair
+        {:type                (if (= keypair-type "seed") :recovery-phrase :default-keypair)
          :stored              :on-device
          :profile-picture     (profile.utils/photo profile)
          :customization-color customization-color
          :derivation-path     path
-         :user-name           (profile.utils/displayed-name profile)
+         :keypair-name        keypair-name
          :on-press            #(js/alert "To be implemented")}])]))

--- a/src/status_im/contexts/wallet/add_account/create_account/select_keypair/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/select_keypair/view.cljs
@@ -71,7 +71,6 @@
         selected-keypair                        (rf/sub [:wallet/selected-keypair-uid])
         profile-picture                         (rf/sub [:profile/image])
         [selected-key-uid set-selected-key-uid] (rn/use-state selected-keypair)]
-    (rn/use-mount #(rf/dispatch [:wallet/get-keypairs]))
     [rn/view {:style {:flex 1}}
      [quo/page-nav
       {:icon-name           :i/close

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -99,6 +99,7 @@
  :wallet/remove-account-success
  (fn [_ [toast-message _]]
    {:fx [[:dispatch [:wallet/get-accounts]]
+         [:dispatch [:wallet/get-keypairs]]
          [:dispatch-later
           {:ms       100
            :dispatch [:hide-bottom-sheet]}]
@@ -183,6 +184,7 @@
                 :navigate-to-account address
                 :new-account?        true)
     :fx [[:dispatch [:wallet/get-accounts]]
+         [:dispatch [:wallet/get-keypairs]]
          [:dispatch [:wallet/clear-new-keypair]]]}))
 
 (rf/reg-event-fx :wallet/add-account

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -216,6 +216,13 @@
                 :formatted-balance formatted-balance)))))
 
 (rf/reg-sub
+ :wallet/current-viewing-account-keypair
+ :<- [:wallet/current-viewing-account]
+ :<- [:wallet/keypairs]
+ (fn [[{:keys [key-uid]} keypairs]]
+   (first (filter #(= key-uid (:key-uid %)) keypairs))))
+
+(rf/reg-sub
  :wallet/current-viewing-account-tokens-in-selected-networks
  :<- [:wallet/current-viewing-account]
  :<- [:wallet/selected-networks->chain-ids]


### PR DESCRIPTION
fixes #19382

### Summary

This PR fixes the display of the correct keypair name (where the account is generated from) in the About tab.

<img width="250" src="https://github.com/status-im/status-mobile/assets/19339952/1350312b-2a75-4fd2-bc93-a1cd03afb2fd" />

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the Wallet tab
- Navigate to Create Account flow
- Create a new Keypair
- Select that Keypair and generate an account
- Verify the keypair name is shown in the About tab


status: ready
