### PR TITLE
[#19406] fix: add min char validation for nickname

### DIFF
--- a/src/status_im/common/validation/profile.cljs
+++ b/src/status_im/common/validation/profile.cljs
@@ -55,4 +55,5 @@
                                                        {:check (i18n/label :t/emojis)})
     (validators/has-special-characters? s) (i18n/label :t/are-not-allowed
                                                        {:check (i18n/label :t/special-characters)})
+    (name-too-short? s)                    (i18n/label :t/minimum-characters {:min-chars min-length})
     (name-too-long? s)                     (i18n/label :t/nickname-is-too-long)))

--- a/src/status_im/contexts/profile/contact/add_nickname/view.cljs
+++ b/src/status_im/contexts/profile/contact/add_nickname/view.cljs
@@ -19,16 +19,19 @@
         profile-picture                         (profile.utils/photo profile)
         [unsaved-nickname set-unsaved-nickname] (rn/use-state nickname)
         [error-msg set-error-msg]               (rn/use-state nil)
+        [typing? set-typing?]                   (rn/use-state false)
         has-nickname?                           (rn/use-memo (fn [] (not (string/blank? nickname)))
                                                              [nickname])
         validate-nickname                       (rn/use-callback
                                                  (debounce/debounce
                                                   (fn [name]
                                                     (set-error-msg
-                                                     (profile-validator/validation-nickname name)))
+                                                     (profile-validator/validation-nickname name))
+                                                    (set-typing? false))
                                                   300))
         on-cancel                               (rn/use-callback #(rf/dispatch [:hide-bottom-sheet]))
         on-nickname-change                      (rn/use-callback (fn [text]
+                                                                   (set-typing? true)
                                                                    (set-unsaved-nickname text)
                                                                    (validate-nickname text)))
         on-nickname-submit                      (rn/use-callback
@@ -74,7 +77,8 @@
      [quo/bottom-actions
       {:actions          :two-actions
        :button-one-label (i18n/label (if has-nickname? :t/update-nickname-title :t/add-nickname-title))
-       :button-one-props {:disabled?           (or (string/blank? unsaved-nickname)
+       :button-one-props {:disabled?           (or typing?
+                                                   (string/blank? unsaved-nickname)
                                                    (not (string/blank? error-msg)))
                           :customization-color customization-color
                           :on-press            on-nickname-submit}


### PR DESCRIPTION
fixes #19406

### Summary

'Minimum 5 characters' validation message should be shown

#### Areas that maybe impacted

- Add/Edit nickname 

### Steps to test

1. UserA on the profile page of UserB
2. Tap three dots -> tap 'add nickname'
3. Enter less than 5 chars into nickname field

### Result

https://github.com/status-im/status-mobile/assets/71308738/7b2c54f2-bc51-49bd-9284-9836963dfcdd



status: ready
