### PR TITLE
Fix background color on communities/chat home

### DIFF
--- a/src/status_im/common/home/banner/style.cljs
+++ b/src/status_im/common/home/banner/style.cljs
@@ -1,5 +1,6 @@
 (ns status-im.common.home.banner.style
   (:require
+    [quo.foundations.colors :as colors]
     [react-native.platform :as platform]
     [react-native.reanimated :as reanimated]
     [react-native.safe-area :as safe-area]))
@@ -26,24 +27,26 @@
   [scroll-shared-value]
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y (animated-card-translation-y scroll-shared-value)}]}
-   {:overflow (if platform/ios? :visible :hidden)
-    :z-index  1
-    :position :absolute
-    :top      0
-    :right    0
-    :left     0
-    :height   (+ (safe-area/get-top) 244)}))
+   {:overflow         (if platform/ios? :visible :hidden)
+    :z-index          1
+    :position         :absolute
+    :top              0
+    :background-color (colors/theme-colors colors/white colors/neutral-95)
+    :right            0
+    :left             0
+    :height           (+ (safe-area/get-top) 244)}))
 
 (defn banner-card-hiding-layer
   [scroll-shared-value]
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y (animated-card-translation-y-reverse scroll-shared-value)}]}
-   {:z-index     2
-    :position    :absolute
-    :top         0
-    :right       0
-    :left        0
-    :padding-top (safe-area/get-top)}))
+   {:z-index          2
+    :position         :absolute
+    :top              0
+    :right            0
+    :background-color (colors/theme-colors colors/white colors/neutral-95)
+    :left             0
+    :padding-top      (+ (safe-area/get-top) 8)}))
 
 (defn animated-banner-card
   [scroll-shared-value]
@@ -56,11 +59,12 @@
   [scroll-shared-value]
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y (animated-card-translation-y scroll-shared-value)}]}
-   {:z-index  3
-    :position :absolute
-    :top      (+ (safe-area/get-top) 192)
-    :right    0
-    :left     0}))
+   {:z-index          3
+    :position         :absolute
+    :top              (+ (safe-area/get-top) 192)
+    :right            0
+    :background-color (colors/theme-colors colors/white colors/neutral-95)
+    :left             0}))
 
 (def banner-card-tabs
   {:padding-horizontal 20

--- a/src/status_im/common/home/banner/style.cljs
+++ b/src/status_im/common/home/banner/style.cljs
@@ -25,7 +25,6 @@
 
 (defn banner-card-blur-layer
   [scroll-shared-value theme]
-  (prn theme "Hey")
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y (animated-card-translation-y scroll-shared-value)}]}
    {:overflow         (if platform/ios? :visible :hidden)

--- a/src/status_im/common/home/banner/style.cljs
+++ b/src/status_im/common/home/banner/style.cljs
@@ -24,27 +24,28 @@
   (reanimated/interpolate scroll-shared-value [0 max-scroll] [0 (+ max-scroll)] :clamp))
 
 (defn banner-card-blur-layer
-  [scroll-shared-value]
+  [scroll-shared-value theme]
+  (prn theme "Hey")
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y (animated-card-translation-y scroll-shared-value)}]}
    {:overflow         (if platform/ios? :visible :hidden)
     :z-index          1
     :position         :absolute
     :top              0
-    :background-color (colors/theme-colors colors/white colors/neutral-95)
+    :background-color (colors/theme-colors colors/white colors/neutral-95 theme)
     :right            0
     :left             0
     :height           (+ (safe-area/get-top) 244)}))
 
 (defn banner-card-hiding-layer
-  [scroll-shared-value]
+  [scroll-shared-value theme]
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y (animated-card-translation-y-reverse scroll-shared-value)}]}
    {:z-index          2
     :position         :absolute
     :top              0
     :right            0
-    :background-color (colors/theme-colors colors/white colors/neutral-95)
+    :background-color (colors/theme-colors colors/white colors/neutral-95 theme)
     :left             0
     :padding-top      (+ (safe-area/get-top) 8)}))
 
@@ -56,14 +57,14 @@
    {}))
 
 (defn banner-card-tabs-layer
-  [scroll-shared-value]
+  [scroll-shared-value theme]
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y (animated-card-translation-y scroll-shared-value)}]}
    {:z-index          3
     :position         :absolute
     :top              (+ (safe-area/get-top) 192)
     :right            0
-    :background-color (colors/theme-colors colors/white colors/neutral-95)
+    :background-color (colors/theme-colors colors/white colors/neutral-95 theme)
     :left             0}))
 
 (def banner-card-tabs

--- a/src/status_im/common/home/banner/style.cljs
+++ b/src/status_im/common/home/banner/style.cljs
@@ -68,5 +68,5 @@
 
 (def banner-card-tabs
   {:padding-horizontal 20
-   :padding-top        8
-   :padding-bottom     12})
+   :padding-top        12
+   :padding-bottom     16})


### PR DESCRIPTION
fixes #19518 

![image](https://github.com/status-im/status-mobile/assets/33176106/65131a8e-9b0e-470d-83dd-b702689248b4)
Fixes an issue with background color on dark mode on iOS on communities/chats home screen

status: ready <!-- Can be ready or wip -->
