### PR TITLE
updated standard auth drawer title size and weight

### DIFF
--- a/src/status_im/common/standard_authentication/enter_password/view.cljs
+++ b/src/status_im/common/standard_authentication/enter_password/view.cljs
@@ -18,8 +18,8 @@
       [rn/view
        [quo/text
         {:accessibility-label :sync-code-generated
-         :weight              :bold
-         :size                :heading-1
+         :weight              :semi-bold
+         :size                :heading-2
          :style               {:margin-bottom 4}}
         (i18n/label :t/enter-password)]
        [rn/view


### PR DESCRIPTION
fixes #19525

### Summary
pr fixes the weight and size of the standard auth drawer title 

### Steps to test

- Open Status
- Select a community to join
- Slide the button to join
- The Authentication drawer is luanched

-  Notice the size and the weight of the title

### Before and after screenshots comparison
<img src="https://github.com/status-im/status-mobile/assets/28704507/d8691ba4-8cea-45da-988a-4b6e4613a8f0" width="325">
<img src="https://github.com/status-im/status-mobile/assets/28704507/f0699c43-82f5-430f-9701-8ee70d85b76a" width="325">

| Figma (if available) | iOS (if available)    | Android (if available)
https://www.figma.com/file/zG04IdiVCb4ZNC5n3nH9yg/Authentication-for-Mobile?type=design&node-id=2%3A54292&mode=design&t=vRaP8LY2YPCL58cI-1

status: ready 
