### PR TITLE
[#19265] fix: cursor overlapping placeholder in android

### DIFF
--- a/src/quo/components/inputs/input/view.cljs
+++ b/src/quo/components/inputs/input/view.cljs
@@ -60,12 +60,12 @@
   "Custom properties that must be removed from properties map passed to InputText."
   [:type :blur? :error? :right-icon :left-icon :disabled? :small? :button
    :label :char-limit :on-char-limit-reach :icon-name :multiline? :on-focus :on-blur
-   :container-style :input-container-style :ref])
+   :container-style :input-container-style :ref :placeholder])
 
 (defn- base-input
   [{:keys [blur? error? right-icon left-icon disabled? small? button
            label char-limit multiline? clearable? on-focus on-blur container-style input-container-style
-           on-change-text on-char-limit-reach weight default-value on-clear]
+           on-change-text on-char-limit-reach weight default-value on-clear placeholder]
     :as   props}]
   (let [theme                  (quo.theme/use-theme-value)
         ref                    (rn/use-ref-atom nil)
@@ -110,7 +110,10 @@
                                      {:style-fn  style/clear-icon
                                       :icon-name :i/clear
                                       :on-press  clear-on-press}))
-        clean-props            (apply dissoc props custom-props)]
+        clean-props            (apply dissoc props custom-props)
+        ;; Workaround for android cursor overlapping placeholder
+        ;; https://github.com/facebook/react-native/issues/27687
+        modified-placeholder   (if platform/android? (str "\u2009" placeholder) placeholder)]
     [rn/view {:style container-style}
      (when (or label char-limit)
        [label-&-counter
@@ -134,6 +137,7 @@
                 :keyboard-appearance    (quo.theme/theme-value :light :dark theme)
                 :cursor-color           (:cursor variant-colors)
                 :editable               (not disabled?)
+                :placeholder            modified-placeholder
                 :on-focus               (fn []
                                           (when on-focus (on-focus))
                                           (internal-on-focus))


### PR DESCRIPTION
fixes #19265

### Summary

Placeholder [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=123:74317&mode=design#729019785)] in the input field overlaps with the typing cursor. This happened in the Add a contact screen

### Technical note
as i tested the issue happens when we set `placeholder-text-color` in android. workaround for this i have to add a tiny empty space before placeholder to eliminate this overlap

https://github.com/facebook/react-native/issues/27687

#### Platforms

- Android

#### Areas that maybe impacted

- Add contact screen

### Steps to test

1. Open the messages home
2. Tap the ➕ button at the top right corner
3. Tap on Add a new contact

### Result

<img src="https://github.com/status-im/status-mobile/assets/71308738/218b8ea2-be05-4517-9c0b-bdf461d61379" width="390px"/>

status: ready
