### PR TITLE
feat: send button and system messge icon based on chat/contact customization color

### DIFF
--- a/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
@@ -41,8 +41,13 @@
 
 (defn f-send-button
   [props state animations window-height images? btn-opacity z-index edit]
-  (let [{:keys [text-value]} state
-        customization-color  (rf/sub [:profile/customization-color])]
+  (let [{:keys [text-value]}        state
+        profile-customization-color (rf/sub [:profile/customization-color])
+        {:keys      [chat-id chat-type]
+         chat-color :color}         (rf/sub [:chats/current-chat-chat-view])
+        contact-customization-color (when (= chat-type constants/one-to-one-chat-type)
+                                      (rf/sub [:contacts/contact-customization-color-by-address
+                                               chat-id]))]
     (rn/use-effect (fn []
                      ;; Handle send button opacity animation and z-index when input content changes
                      (if (or (seq @text-value) images?)
@@ -60,7 +65,7 @@
      [quo/button
       {:icon-only?          true
        :size                32
-       :customization-color customization-color
+       :customization-color (or contact-customization-color chat-color profile-customization-color)
        :accessibility-label :send-message-button
        :on-press            #(send-message props state animations window-height edit)}
       :i/arrow-up]]))

--- a/src/status_im/contexts/chat/messenger/messages/content/pin/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/pin/view.cljs
@@ -29,11 +29,15 @@
 
 (defn pinned-message
   [{:keys [from quoted-message timestamp-str]}]
-  (let [[primary-name _]    (rf/sub [:contacts/contact-two-names-by-identity from])
-        customization-color (rf/sub [:profile/customization-color])]
+  (let [[primary-name _]            (rf/sub [:contacts/contact-two-names-by-identity from])
+        one-to-one-chat?            (rf/sub [:current-chat/one-to-one-chat?])
+        current-chat-color          (rf/sub [:chats/current-chat-color])
+        contact-customization-color (rf/sub [:contacts/contact-customization-color-by-address from])]
     [quo/system-message
      {:type                :pinned
       :pinned-by           primary-name
-      :customization-color customization-color
+      :customization-color (if one-to-one-chat?
+                             contact-customization-color
+                             current-chat-color)
       :child               [reply/quoted-message quoted-message false true]
       :timestamp           timestamp-str}]))

--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -79,16 +79,17 @@
 
 (defn system-message-contact-request
   [{:keys [chat-id timestamp-str from]} type]
-  (let [[primary-name _]    (rf/sub [:contacts/contact-two-names-by-identity chat-id])
-        contact             (rf/sub [:contacts/contact-by-address chat-id])
-        photo-path          (when (seq (:images contact)) (rf/sub [:chats/photo-path chat-id]))
-        customization-color (rf/sub [:profile/customization-color])
-        public-key          (rf/sub [:profile/public-key])]
+  (let [[primary-name _]       (rf/sub [:contacts/contact-two-names-by-identity chat-id])
+        {:keys [images]
+         contact-customization-color
+         :customization-color} (rf/sub [:contacts/contact-by-address chat-id])
+        photo-path             (when (seq images) (rf/sub [:chats/photo-path chat-id]))
+        public-key             (rf/sub [:profile/public-key])]
     [quo/system-message
      {:type                type
       :timestamp           timestamp-str
       :display-name        primary-name
-      :customization-color customization-color
+      :customization-color contact-customization-color
       :photo-path          photo-path
       :incoming?           (not= public-key from)}]))
 

--- a/src/status_im/subs/chats.cljs
+++ b/src/status_im/subs/chats.cljs
@@ -188,6 +188,12 @@
                  :last-message])))
 
 (re-frame/reg-sub
+ :chats/current-chat-color
+ :<- [:chats/current-raw-chat]
+ (fn [current-chat]
+   (:color current-chat)))
+
+(re-frame/reg-sub
  :chats/community-channel-ui-details-by-id
  :<- [:chats/chats]
  (fn [chats [_ chat-id]]

--- a/src/status_im/subs/contact.cljs
+++ b/src/status_im/subs/contact.cljs
@@ -254,6 +254,13 @@
      (contact.db/find-contact-by-address contacts address))))
 
 (re-frame/reg-sub
+ :contacts/contact-customization-color-by-address
+ (fn [[_ address]]
+   [(re-frame/subscribe [:contacts/contact-by-address address])])
+ (fn [[contact]]
+   (:customization-color contact)))
+
+(re-frame/reg-sub
  :contacts/filtered-active-sections
  :<- [:contacts/active-sections]
  :<- [:contacts/search-query]


### PR DESCRIPTION
fixes #19503
fxies #18829

### Summary
follow up of PR #19087

update system icon color based on chat contexts

- in group/community channel, use group/channel color
- in one-to-one chat, use contact customization color

![CleanShot 2024-04-08 at 15 42 27](https://github.com/status-im/status-mobile/assets/15090582/3fef767b-7c37-466c-83df-750566124f5a)


### Testing notes
I've tested one-one, group and community channel on iOS simulator

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
system message and send button color

status: ready <!-- Can be ready or wip -->
