### PR TITLE
Implement share button inside profile settings

### DIFF
--- a/src/react_native/core.cljs
+++ b/src/react_native/core.cljs
@@ -226,7 +226,3 @@
 (defn open-url [link] (.openURL ^js linking link))
 
 (def set-status-bar-style react-native/StatusBar.setBarStyle)
-
-(defn sharing
-  [content]
-  (.share (.-Share ^js react-native) (clj->js content)))

--- a/src/react_native/share.cljs
+++ b/src/react_native/share.cljs
@@ -3,9 +3,10 @@
     ["react-native-share" :default react-native-share]))
 
 (defn open
-  ([options]
-   (open options #() #()))
-  ([options on-success on-error]
+  ([options
+    {:keys [on-success on-error]
+     :or   {on-success #()
+            on-error   #()}}]
    (-> ^js react-native-share
        (.open (clj->js options))
        (.then on-success)

--- a/src/react_native/share.cljs
+++ b/src/react_native/share.cljs
@@ -3,11 +3,6 @@
     ["react-native-share" :default react-native-share]))
 
 (defn open
-  ([options
-    {:keys [on-success on-error]
-     :or   {on-success #()
-            on-error   #()}}]
+  ([options]
    (-> ^js react-native-share
-       (.open (clj->js options))
-       (.then on-success)
-       (.catch on-error))))
+       (.open (clj->js options)))))

--- a/src/status_im/common/lightbox/effects.cljs
+++ b/src/status_im/common/lightbox/effects.cljs
@@ -3,7 +3,6 @@
             [react-native.cameraroll :as cameraroll]
             [react-native.fs :as fs]
             [react-native.platform :as platform]
-            [react-native.share :as share]
             [utils.re-frame :as rf]))
 
 (def config
@@ -15,10 +14,11 @@
    (blob/fetch uri
                config
                (fn [downloaded-url]
-                 (share/open {:url       (str (when platform/android? "file://") downloaded-url)
-                              :isNewTask true}
-                             #(fs/unlink downloaded-url)
-                             #(fs/unlink downloaded-url))))))
+                 (rf/dispatch [:open-share
+                               {:url       (str (when platform/android? "file://") downloaded-url)
+                                :isNewTask true}
+                               {:on-success #(fs/unlink downloaded-url)
+                                :on-error   #(fs/unlink downloaded-url)}])))))
 
 (rf/reg-fx :effects.lightbox/save-image-to-gallery
  (fn [[uri on-success]]

--- a/src/status_im/common/lightbox/effects.cljs
+++ b/src/status_im/common/lightbox/effects.cljs
@@ -15,9 +15,10 @@
                config
                (fn [downloaded-url]
                  (rf/dispatch [:open-share
-                               {:url       (str (when platform/android? "file://") downloaded-url)
-                                :isNewTask true}
-                               {:on-success #(fs/unlink downloaded-url)
+                               {:content    {:url       (str (when platform/android? "file://")
+                                                             downloaded-url)
+                                             :isNewTask true}
+                                :on-success #(fs/unlink downloaded-url)
                                 :on-error   #(fs/unlink downloaded-url)}])))))
 
 (rf/reg-fx :effects.lightbox/save-image-to-gallery

--- a/src/status_im/common/lightbox/effects.cljs
+++ b/src/status_im/common/lightbox/effects.cljs
@@ -15,7 +15,7 @@
                config
                (fn [downloaded-url]
                  (rf/dispatch [:open-share
-                               {:content    {:url       (str (when platform/android? "file://")
+                               {:options    {:url       (str (when platform/android? "file://")
                                                              downloaded-url)
                                              :isNewTask true}
                                 :on-success #(fs/unlink downloaded-url)

--- a/src/status_im/contexts/chat/home/view.cljs
+++ b/src/status_im/contexts/chat/home/view.cljs
@@ -121,7 +121,7 @@
                            [:show-bottom-sheet {:content chat.actions.view/new-chat}])
     :accessibility-label :new-chat-button}
    :card-props
-   {:on-press    #(rf/dispatch [:open-share {:url profile-link}])
+   {:on-press    #(rf/dispatch [:open-share {:content {:url profile-link}}])
     :banner      (resources/get-image :invite-friends)
     :title       (i18n/label :t/invite-friends-to-status)
     :description (i18n/label :t/share-invite-link)}})

--- a/src/status_im/contexts/chat/home/view.cljs
+++ b/src/status_im/contexts/chat/home/view.cljs
@@ -121,7 +121,7 @@
                            [:show-bottom-sheet {:content chat.actions.view/new-chat}])
     :accessibility-label :new-chat-button}
    :card-props
-   {:on-press    #(rf/dispatch [:open-share {:content {:url profile-link}}])
+   {:on-press    #(rf/dispatch [:open-share {:options {:url profile-link}}])
     :banner      (resources/get-image :invite-friends)
     :title       (i18n/label :t/invite-friends-to-status)
     :description (i18n/label :t/share-invite-link)}})

--- a/src/status_im/contexts/chat/home/view.cljs
+++ b/src/status_im/contexts/chat/home/view.cljs
@@ -5,7 +5,6 @@
     [re-frame.core :as re-frame]
     [react-native.core :as rn]
     [react-native.reanimated :as reanimated]
-    [react-native.share :as share]
     [status-im.common.contact-list-item.view :as contact-list-item]
     [status-im.common.contact-list.view :as contact-list]
     [status-im.common.home.actions.view :as actions]
@@ -122,7 +121,7 @@
                            [:show-bottom-sheet {:content chat.actions.view/new-chat}])
     :accessibility-label :new-chat-button}
    :card-props
-   {:on-press    #(share/open {:url profile-link})
+   {:on-press    #(rf/dispatch [:open-share {:url profile-link}])
     :banner      (resources/get-image :invite-friends)
     :title       (i18n/label :t/invite-friends-to-status)
     :description (i18n/label :t/share-invite-link)}})

--- a/src/status_im/contexts/communities/sharing/events.cljs
+++ b/src/status_im/contexts/communities/sharing/events.cljs
@@ -43,7 +43,7 @@
    (let [title      (i18n/label :t/channel-on-status)
          on-success (fn [url]
                       (rf/dispatch [:open-share
-                                    {:content (if platform/ios?
+                                    {:options (if platform/ios?
                                                 {:activityItemSources
                                                  [{:placeholderItem {:type    :text
                                                                      :content title}

--- a/src/status_im/contexts/communities/sharing/events.cljs
+++ b/src/status_im/contexts/communities/sharing/events.cljs
@@ -45,9 +45,9 @@
                       (rf/dispatch [:open-share
                                     {:content (if platform/ios?
                                                 {:activityItemSources
-                                                 [{:placeholderItem {:type    "text"
+                                                 [{:placeholderItem {:type    :text
                                                                      :content title}
-                                                   :item            {:default {:type    "url"
+                                                   :item            {:default {:type    :url
                                                                                :content url}}
                                                    :linkMetadata    {:title title}}]}
                                                 {:title     title

--- a/src/status_im/contexts/communities/sharing/events.cljs
+++ b/src/status_im/contexts/communities/sharing/events.cljs
@@ -43,17 +43,18 @@
    (let [title      (i18n/label :t/channel-on-status)
          on-success (fn [url]
                       (rf/dispatch [:open-share
-                                    (if platform/ios?
-                                      {:activityItemSources [{:placeholderItem {:type    "text"
-                                                                                :content title}
-                                                              :item            {:default {:type    "url"
-                                                                                          :content url}}
-                                                              :linkMetadata    {:title title}}]}
-                                      {:title     title
-                                       :subject   title
-                                       :message   url
-                                       :url       url
-                                       :isNewTask true})]))]
+                                    {:content (if platform/ios?
+                                                {:activityItemSources
+                                                 [{:placeholderItem {:type    "text"
+                                                                     :content title}
+                                                   :item            {:default {:type    "url"
+                                                                               :content url}}
+                                                   :linkMetadata    {:title title}}]}
+                                                {:title     title
+                                                 :subject   title
+                                                 :message   url
+                                                 :url       url
+                                                 :isNewTask true})}]))]
      {:fx [[:dispatch [:communities/get-community-channel-share-data chat-id on-success]]]})))
 
 (rf/reg-event-fx :communities/get-community-channel-share-data

--- a/src/status_im/contexts/communities/sharing/events.cljs
+++ b/src/status_im/contexts/communities/sharing/events.cljs
@@ -38,23 +38,23 @@
                                     :url     %}])]
      {:fx [[:dispatch [:communities/get-community-channel-share-data chat-id on-success]]]})))
 
-(rf/reg-event-fx :communities/share-community-url-with-data
- (fn [_ [community-id]]
-   (let [title      (i18n/label :t/community-on-status)
+(rf/reg-event-fx :communities/share-community-channel-url-with-data
+ (fn [_ [chat-id]]
+   (let [title      (i18n/label :t/channel-on-status)
          on-success (fn [url]
-                      (share/open
-                       (if platform/ios?
-                         {:activityItemSources [{:placeholderItem {:type    "text"
-                                                                   :content title}
-                                                 :item            {:default {:type    "url"
-                                                                             :content url}}
-                                                 :linkMetadata    {:title title}}]}
-                         {:title     title
-                          :subject   title
-                          :message   url
-                          :url       url
-                          :isNewTask true})))]
-     {:fx [[:dispatch [:communities/get-community-share-data community-id on-success]]]})))
+                      (rf/dispatch [:open-share
+                                    (if platform/ios?
+                                      {:activityItemSources [{:placeholderItem {:type    "text"
+                                                                                :content title}
+                                                              :item            {:default {:type    "url"
+                                                                                          :content url}}
+                                                              :linkMetadata    {:title title}}]}
+                                      {:title     title
+                                       :subject   title
+                                       :message   url
+                                       :url       url
+                                       :isNewTask true})]))]
+     {:fx [[:dispatch [:communities/get-community-channel-share-data chat-id on-success]]]})))
 
 (rf/reg-event-fx :communities/get-community-channel-share-data
  (fn [_ [chat-id on-success]]

--- a/src/status_im/contexts/profile/contact/actions/view.cljs
+++ b/src/status_im/contexts/profile/contact/actions/view.cljs
@@ -49,7 +49,7 @@
                               (rf/dispatch [:universal-links/generate-profile-url
                                             {:public-key public-key
                                              :on-success #(rf/dispatch [:open-share
-                                                                        {:content {:message %}}])}]))
+                                                                        {:options {:message %}}])}]))
                             [public-key])
         on-remove-contact  (rn/use-callback
                             (fn []

--- a/src/status_im/contexts/profile/contact/actions/view.cljs
+++ b/src/status_im/contexts/profile/contact/actions/view.cljs
@@ -48,7 +48,7 @@
                             (fn []
                               (rf/dispatch [:universal-links/generate-profile-url
                                             {:public-key public-key
-                                             :on-success #(rn/sharing {:message %})}]))
+                                             :on-success #(rf/dispatch [:open-share {:message %}])}]))
                             [public-key])
         on-remove-contact  (rn/use-callback
                             (fn []

--- a/src/status_im/contexts/profile/contact/actions/view.cljs
+++ b/src/status_im/contexts/profile/contact/actions/view.cljs
@@ -48,7 +48,8 @@
                             (fn []
                               (rf/dispatch [:universal-links/generate-profile-url
                                             {:public-key public-key
-                                             :on-success #(rf/dispatch [:open-share {:message %}])}]))
+                                             :on-success #(rf/dispatch [:open-share
+                                                                        {:content {:message %}}])}]))
                             [public-key])
         on-remove-contact  (rn/use-callback
                             (fn []

--- a/src/status_im/contexts/profile/contact/share/view.cljs
+++ b/src/status_im/contexts/profile/contact/share/view.cljs
@@ -18,7 +18,8 @@
         abbreviated-url (rn/use-memo (fn []
                                        (address/get-abbreviated-profile-url universal-profile-url))
                                      [universal-profile-url])
-        on-share-press  (rn/use-callback #(rf/dispatch [:open-share {:message universal-profile-url}])
+        on-share-press  (rn/use-callback #(rf/dispatch [:open-share
+                                                        {:content {:message universal-profile-url}}])
                                          [universal-profile-url])
         on-copy-press   (rn/use-callback (fn []
                                            (rf/dispatch [:share/copy-text-and-show-toast

--- a/src/status_im/contexts/profile/contact/share/view.cljs
+++ b/src/status_im/contexts/profile/contact/share/view.cljs
@@ -19,7 +19,7 @@
                                        (address/get-abbreviated-profile-url universal-profile-url))
                                      [universal-profile-url])
         on-share-press  (rn/use-callback #(rf/dispatch [:open-share
-                                                        {:content {:message universal-profile-url}}])
+                                                        {:options {:message universal-profile-url}}])
                                          [universal-profile-url])
         on-copy-press   (rn/use-callback (fn []
                                            (rf/dispatch [:share/copy-text-and-show-toast

--- a/src/status_im/contexts/profile/contact/share/view.cljs
+++ b/src/status_im/contexts/profile/contact/share/view.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.profile.contact.share.view
-  (:require [legacy.status-im.ui.components.list-selection :as list-selection]
-            [quo.core :as quo]
+  (:require [quo.core :as quo]
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
             [status-im.common.qr-codes.view :as qr-codes]
@@ -19,7 +18,7 @@
         abbreviated-url (rn/use-memo (fn []
                                        (address/get-abbreviated-profile-url universal-profile-url))
                                      [universal-profile-url])
-        on-share-press  (rn/use-callback #(list-selection/open-share {:message universal-profile-url})
+        on-share-press  (rn/use-callback #(rf/dispatch [:open-share {:message universal-profile-url}])
                                          [universal-profile-url])
         on-copy-press   (rn/use-callback (fn []
                                            (rf/dispatch [:share/copy-text-and-show-toast

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.profile.settings.view
-  (:require [legacy.status-im.ui.components.list-selection :as list-selection]
-            [oops.core :as oops]
+  (:require [oops.core :as oops]
             [quo.core :as quo]
             [quo.theme :as quo.theme]
             [react-native.core :as rn]
@@ -62,7 +61,9 @@
         :on-press   #(rf/dispatch [:navigate-back])
         :right-side [{:icon-name :i/qr-code
                       :on-press  #(debounce/throttle-and-dispatch [:open-modal :share-shell] 1000)}
-                     {:icon-name :i/share :on-press #(list-selection/open-share {:message (:universal-profile-url profile)})}]}]]
+                     {:icon-name :i/share
+                      :on-press  #(rf/dispatch [:open-share
+                                                {:message (:universal-profile-url profile)}])}]}]]
      [rn/flat-list
       {:key                             :list
        :header                          [settings.header/view {:scroll-y scroll-y}]

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -63,7 +63,7 @@
                       :on-press  #(debounce/throttle-and-dispatch [:open-modal :share-shell] 1000)}
                      {:icon-name :i/share
                       :on-press  #(rf/dispatch [:open-share
-                                                {:content {:message (:universal-profile-url
+                                                {:options {:message (:universal-profile-url
                                                                      profile)}}])}]}]]
      [rn/flat-list
       {:key                             :list

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -63,7 +63,8 @@
                       :on-press  #(debounce/throttle-and-dispatch [:open-modal :share-shell] 1000)}
                      {:icon-name :i/share
                       :on-press  #(rf/dispatch [:open-share
-                                                {:message (:universal-profile-url profile)}])}]}]]
+                                                {:content {:message (:universal-profile-url
+                                                                     profile)}}])}]}]]
      [rn/flat-list
       {:key                             :list
        :header                          [settings.header/view {:scroll-y scroll-y}]

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -1,11 +1,11 @@
 (ns status-im.contexts.profile.settings.view
-  (:require [oops.core :as oops]
+  (:require [legacy.status-im.ui.components.list-selection :as list-selection]
+            [oops.core :as oops]
             [quo.core :as quo]
             [quo.theme :as quo.theme]
             [react-native.core :as rn]
             [react-native.reanimated :as reanimated]
             [react-native.safe-area :as safe-area]
-            [status-im.common.not-implemented :as not-implemented]
             [status-im.contexts.profile.settings.header.view :as settings.header]
             [status-im.contexts.profile.settings.list-items :as settings.items]
             [status-im.contexts.profile.settings.style :as style]
@@ -62,7 +62,7 @@
         :on-press   #(rf/dispatch [:navigate-back])
         :right-side [{:icon-name :i/qr-code
                       :on-press  #(debounce/throttle-and-dispatch [:open-modal :share-shell] 1000)}
-                     {:icon-name :i/share :on-press not-implemented/alert}]}]]
+                     {:icon-name :i/share :on-press #(list-selection/open-share {:message (:universal-profile-url profile)})}]}]]
      [rn/flat-list
       {:key                             :list
        :header                          [settings.header/view {:scroll-y scroll-y}]

--- a/src/status_im/contexts/shell/share/profile/view.cljs
+++ b/src/status_im/contexts/shell/share/profile/view.cljs
@@ -29,7 +29,7 @@
         :width               (- window-width (* style/screen-padding 2))
         :qr-data             universal-profile-url
         :qr-data-label-shown abbreviated-url
-        :on-share-press      #(rf/dispatch [:open-share {:message universal-profile-url}])
+        :on-share-press      #(rf/dispatch [:open-share {:content {:message universal-profile-url}}])
         :on-text-press       #(rf/dispatch [:share/copy-text-and-show-toast
                                             {:text-to-copy      universal-profile-url
                                              :post-copy-message (i18n/label :t/link-to-profile-copied)}])

--- a/src/status_im/contexts/shell/share/profile/view.cljs
+++ b/src/status_im/contexts/shell/share/profile/view.cljs
@@ -29,7 +29,7 @@
         :width               (- window-width (* style/screen-padding 2))
         :qr-data             universal-profile-url
         :qr-data-label-shown abbreviated-url
-        :on-share-press      #(rf/dispatch [:open-share {:content {:message universal-profile-url}}])
+        :on-share-press      #(rf/dispatch [:open-share {:options {:message universal-profile-url}}])
         :on-text-press       #(rf/dispatch [:share/copy-text-and-show-toast
                                             {:text-to-copy      universal-profile-url
                                              :post-copy-message (i18n/label :t/link-to-profile-copied)}])

--- a/src/status_im/contexts/shell/share/profile/view.cljs
+++ b/src/status_im/contexts/shell/share/profile/view.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.shell.share.profile.view
   (:require
     [clojure.string :as string]
-    [legacy.status-im.ui.components.list-selection :as list-selection]
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
     [react-native.core :as rn]
@@ -30,7 +29,7 @@
         :width               (- window-width (* style/screen-padding 2))
         :qr-data             universal-profile-url
         :qr-data-label-shown abbreviated-url
-        :on-share-press      #(list-selection/open-share {:message universal-profile-url})
+        :on-share-press      #(rf/dispatch [:open-share {:message universal-profile-url}])
         :on-text-press       #(rf/dispatch [:share/copy-text-and-show-toast
                                             {:text-to-copy      universal-profile-url
                                              :post-copy-message (i18n/label :t/link-to-profile-copied)}])

--- a/src/status_im/contexts/shell/share/wallet/view.cljs
+++ b/src/status_im/contexts/shell/share/wallet/view.cljs
@@ -4,7 +4,6 @@
     [quo.core :as quo]
     [react-native.core :as rn]
     [react-native.platform :as platform]
-    [react-native.share :as share]
     [reagent.core :as reagent]
     [status-im.constants :as constants]
     [status-im.contexts.shell.share.style :as style]
@@ -20,18 +19,18 @@
 
 (defn- share-action
   [address share-title]
-  (share/open
-   (if platform/ios?
-     {:activityItemSources [{:placeholderItem {:type    "text"
-                                               :content address}
-                             :item            {:default {:type "text"
-                                                         :content
-                                                         address}}
-                             :linkMetadata    {:title share-title}}]}
-     {:title     share-title
-      :subject   share-title
-      :message   address
-      :isNewTask true})))
+  (rf/dispatch [:open-share
+                (if platform/ios?
+                  {:activityItemSources [{:placeholderItem {:type    "text"
+                                                            :content address}
+                                          :item            {:default {:type "text"
+                                                                      :content
+                                                                      address}}
+                                          :linkMetadata    {:title share-title}}]}
+                  {:title     share-title
+                   :subject   share-title
+                   :message   address
+                   :isNewTask true})]))
 
 (defn- open-preferences
   [selected-networks account]

--- a/src/status_im/contexts/shell/share/wallet/view.cljs
+++ b/src/status_im/contexts/shell/share/wallet/view.cljs
@@ -21,9 +21,9 @@
   [address share-title]
   (rf/dispatch [:open-share
                 {:content (if platform/ios?
-                            {:activityItemSources [{:placeholderItem {:type    "text"
+                            {:activityItemSources [{:placeholderItem {:type    :text
                                                                       :content address}
-                                                    :item            {:default {:type "text"
+                                                    :item            {:default {:type :text
                                                                                 :content
                                                                                 address}}
                                                     :linkMetadata    {:title share-title}}]}

--- a/src/status_im/contexts/shell/share/wallet/view.cljs
+++ b/src/status_im/contexts/shell/share/wallet/view.cljs
@@ -20,7 +20,7 @@
 (defn- share-action
   [address share-title]
   (rf/dispatch [:open-share
-                {:content (if platform/ios?
+                {:options (if platform/ios?
                             {:activityItemSources [{:placeholderItem {:type    :text
                                                                       :content address}
                                                     :item            {:default {:type :text

--- a/src/status_im/contexts/shell/share/wallet/view.cljs
+++ b/src/status_im/contexts/shell/share/wallet/view.cljs
@@ -20,17 +20,17 @@
 (defn- share-action
   [address share-title]
   (rf/dispatch [:open-share
-                (if platform/ios?
-                  {:activityItemSources [{:placeholderItem {:type    "text"
-                                                            :content address}
-                                          :item            {:default {:type "text"
-                                                                      :content
-                                                                      address}}
-                                          :linkMetadata    {:title share-title}}]}
-                  {:title     share-title
-                   :subject   share-title
-                   :message   address
-                   :isNewTask true})]))
+                {:content (if platform/ios?
+                            {:activityItemSources [{:placeholderItem {:type    "text"
+                                                                      :content address}
+                                                    :item            {:default {:type "text"
+                                                                                :content
+                                                                                address}}
+                                                    :linkMetadata    {:title share-title}}]}
+                            {:title     share-title
+                             :subject   share-title
+                             :message   address
+                             :isNewTask true})}]))
 
 (defn- open-preferences
   [selected-networks account]

--- a/src/status_im/contexts/wallet/account/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/account/share_address/view.cljs
@@ -19,9 +19,9 @@
   [address share-title]
   (rf/dispatch [:open-share
                 {:content (if platform/ios?
-                            {:activityItemSources [{:placeholderItem {:type    "text"
+                            {:activityItemSources [{:placeholderItem {:type    :text
                                                                       :content address}
-                                                    :item            {:default {:type "text"
+                                                    :item            {:default {:type :text
                                                                                 :content
                                                                                 address}}
                                                     :linkMetadata    {:title share-title}}]}

--- a/src/status_im/contexts/wallet/account/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/account/share_address/view.cljs
@@ -4,7 +4,6 @@
     [react-native.core :as rn]
     [react-native.platform :as platform]
     [react-native.safe-area :as safe-area]
-    [react-native.share :as share]
     [reagent.core :as reagent]
     [status-im.constants :as constants]
     [status-im.contexts.wallet.account.share-address.style :as style]
@@ -18,18 +17,18 @@
 
 (defn- share-action
   [address share-title]
-  (share/open
-   (if platform/ios?
-     {:activityItemSources [{:placeholderItem {:type    "text"
-                                               :content address}
-                             :item            {:default {:type "text"
-                                                         :content
-                                                         address}}
-                             :linkMetadata    {:title share-title}}]}
-     {:title     share-title
-      :subject   share-title
-      :message   address
-      :isNewTask true})))
+  (rf/dispatch [:open-share
+                (if platform/ios?
+                  {:activityItemSources [{:placeholderItem {:type    "text"
+                                                            :content address}
+                                          :item            {:default {:type "text"
+                                                                      :content
+                                                                      address}}
+                                          :linkMetadata    {:title share-title}}]}
+                  {:title     share-title
+                   :subject   share-title
+                   :message   address
+                   :isNewTask true})]))
 
 (defn- open-preferences
   [selected-networks]

--- a/src/status_im/contexts/wallet/account/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/account/share_address/view.cljs
@@ -18,17 +18,17 @@
 (defn- share-action
   [address share-title]
   (rf/dispatch [:open-share
-                (if platform/ios?
-                  {:activityItemSources [{:placeholderItem {:type    "text"
-                                                            :content address}
-                                          :item            {:default {:type "text"
-                                                                      :content
-                                                                      address}}
-                                          :linkMetadata    {:title share-title}}]}
-                  {:title     share-title
-                   :subject   share-title
-                   :message   address
-                   :isNewTask true})]))
+                {:content (if platform/ios?
+                            {:activityItemSources [{:placeholderItem {:type    "text"
+                                                                      :content address}
+                                                    :item            {:default {:type "text"
+                                                                                :content
+                                                                                address}}
+                                                    :linkMetadata    {:title share-title}}]}
+                            {:title     share-title
+                             :subject   share-title
+                             :message   address
+                             :isNewTask true})}]))
 
 (defn- open-preferences
   [selected-networks]

--- a/src/status_im/contexts/wallet/account/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/account/share_address/view.cljs
@@ -18,7 +18,7 @@
 (defn- share-action
   [address share-title]
   (rf/dispatch [:open-share
-                {:content (if platform/ios?
+                {:options (if platform/ios?
                             {:activityItemSources [{:placeholderItem {:type    :text
                                                                       :content address}
                                                     :item            {:default {:type :text

--- a/src/status_im/contexts/wallet/effects.cljs
+++ b/src/status_im/contexts/wallet/effects.cljs
@@ -2,12 +2,7 @@
   (:require
     [clojure.string :as string]
     [native-module.core :as native-module]
-    [re-frame.core :as rf]
-    [react-native.share :as share]))
-
-(rf/reg-fx :effects.share/open
- (fn [content]
-   (share/open content)))
+    [re-frame.core :as rf]))
 
 (rf/reg-fx
  :effects.wallet/create-account-from-mnemonic

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -402,7 +402,7 @@
 (rf/reg-event-fx :wallet/share-account
  (fn [_ [{:keys [content title]}]]
    {:fx [[:effects.share/open
-          {:content (if platform/ios?
+          {:options (if platform/ios?
                       {:activityItemSources
                        [{:placeholderItem {:type    :text
                                            :content content}

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -404,9 +404,9 @@
    {:fx [[:effects.share/open
           {:content (if platform/ios?
                       {:activityItemSources
-                       [{:placeholderItem {:type    "text"
+                       [{:placeholderItem {:type    :text
                                            :content content}
-                         :item            {:default {:type    "text"
+                         :item            {:default {:type    :text
                                                      :content content}}
                          :linkMetadata    {:title title}}]}
                       {:title   title

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -402,16 +402,16 @@
 (rf/reg-event-fx :wallet/share-account
  (fn [_ [{:keys [content title]}]]
    {:fx [[:effects.share/open
-          (if platform/ios?
-            {:activityItemSources
-             [{:placeholderItem {:type    "text"
-                                 :content content}
-               :item            {:default {:type    "text"
-                                           :content content}}
-               :linkMetadata    {:title title}}]}
-            {:title   title
-             :subject title
-             :message content})]]}))
+          {:content (if platform/ios?
+                      {:activityItemSources
+                       [{:placeholderItem {:type    "text"
+                                           :content content}
+                         :item            {:default {:type    "text"
+                                                     :content content}}
+                         :linkMetadata    {:title title}}]}
+                      {:title   title
+                       :subject title
+                       :message content})}]]}))
 
 (rf/reg-event-fx
  :wallet/blockchain-status-changed

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -39,6 +39,7 @@
     status-im.contexts.wallet.send.events
     status-im.contexts.wallet.signals
     [status-im.db :as db]
+    status-im.navigation.effects
     status-im.navigation.events
     [utils.re-frame :as rf]))
 

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -187,8 +187,8 @@
 ;;;; Share
 
 (rf/reg-fx :effects.share/open
- (fn [content]
-   (share/open content)))
+ (fn [[content handlers]]
+   (share/open content handlers)))
 
 ;;;; Overlay
 

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -183,6 +183,14 @@
 
 (rf/reg-fx :open-modal-fx open-modal)
 
+;;;; Share
+
+(defn open-share-fx
+  [content]
+  (rn/sharing content))
+
+(rf/reg-fx :open-share-fx open-share-fx)
+
 ;;;; Overlay
 
 (defn show-overlay

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -191,7 +191,9 @@
    (cond-> (share/open options)
      (fn? on-success) (.then on-success)
      :always          (.catch (fn [error]
-                                (log/error "[react-native-share]" error)
+                                (log/error "Failed to share content"
+                                           {:error  error
+                                            :effect :effects.share/open})
                                 (when (fn? on-error)
                                   (on-error error)))))))
 

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -190,7 +190,9 @@
  (fn [{:keys [content on-success on-error]}]
    (cond-> (share/open content)
      (fn? on-success) (.then on-success)
-     (fn? on-error)   (.catch on-error))))
+     :always          (.catch (fn [error]
+                                (log/error "[react-native-share]" error)
+                                (on-error error))))))
 
 ;;;; Overlay
 

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -187,7 +187,7 @@
 ;;;; Share
 
 (rf/reg-fx :effects.share/open
- (fn [[content {:keys [on-success on-error]}]]
+ (fn [{:keys [content on-success on-error]}]
    (cond-> (share/open content)
      (fn? on-success) (.then on-success)
      (fn? on-error)   (.catch on-error))))

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -186,11 +186,9 @@
 
 ;;;; Share
 
-(defn open-share-fx
-  [content]
-  (share/open content))
-
-(rf/reg-fx :open-share-fx open-share-fx)
+(rf/reg-fx :effects.share/open
+ (fn [content]
+   (share/open content)))
 
 ;;;; Overlay
 

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -192,7 +192,8 @@
      (fn? on-success) (.then on-success)
      :always          (.catch (fn [error]
                                 (log/error "[react-native-share]" error)
-                                (on-error error))))))
+                                (when (fn? on-error)
+                                  (on-error error)))))))
 
 ;;;; Overlay
 

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -5,6 +5,7 @@
     [react-native.core :as rn]
     [react-native.navigation :as navigation]
     [react-native.platform :as platform]
+    [react-native.share :as share]
     [status-im.contexts.shell.jump-to.constants :as shell.constants]
     [status-im.contexts.shell.jump-to.utils :as jump-to.utils]
     [status-im.navigation.options :as options]
@@ -187,7 +188,7 @@
 
 (defn open-share-fx
   [content]
-  (rn/sharing content))
+  (share/open content))
 
 (rf/reg-fx :open-share-fx open-share-fx)
 

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -187,8 +187,8 @@
 ;;;; Share
 
 (rf/reg-fx :effects.share/open
- (fn [{:keys [content on-success on-error]}]
-   (cond-> (share/open content)
+ (fn [{:keys [options on-success on-error]}]
+   (cond-> (share/open options)
      (fn? on-success) (.then on-success)
      :always          (.catch (fn [error]
                                 (log/error "[react-native-share]" error)

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -187,8 +187,10 @@
 ;;;; Share
 
 (rf/reg-fx :effects.share/open
- (fn [[content handlers]]
-   (share/open content handlers)))
+ (fn [[content {:keys [on-success on-error]}]]
+   (cond-> (share/open content)
+     (fn? on-success) (.then on-success)
+     (fn? on-error)   (.catch on-error))))
 
 ;;;; Overlay
 

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -146,7 +146,7 @@
   {:reload-status-nav-color-fx (or view-id (:view-id db))})
 
 (defn open-share
-  [_ [content handlers]]
-  {:fx [[:effects.share/open [content handlers]]]})
+  [_ [config]]
+  {:fx [[:effects.share/open config]]})
 
 (rf/reg-event-fx :open-share open-share)

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -148,6 +148,6 @@
 
 (defn open-share
   [_ [content]]
-  {:fx [[:open-share-fx content]]})
+  {:fx [[:effects.share/open content]]})
 
 (rf/reg-event-fx :open-share open-share)

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -1,6 +1,7 @@
 (ns status-im.navigation.events
   (:require
     [re-frame.core :as re-frame]
+    [react-native.core :as rn]
     [status-im.contexts.shell.jump-to.events :as shell.events]
     [status-im.contexts.shell.jump-to.state :as shell.state]
     [status-im.contexts.shell.jump-to.utils :as shell.utils]
@@ -144,3 +145,9 @@
   {:events [:reload-status-nav-color]}
   [{:keys [db]} view-id]
   {:reload-status-nav-color-fx (or view-id (:view-id db))})
+
+(defn open-share
+  [_ [content]]
+  {:fx [[:open-share-fx content]]})
+
+(rf/reg-event-fx :open-share open-share)

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -1,7 +1,6 @@
 (ns status-im.navigation.events
   (:require
     [re-frame.core :as re-frame]
-    [react-native.core :as rn]
     [status-im.contexts.shell.jump-to.events :as shell.events]
     [status-im.contexts.shell.jump-to.state :as shell.state]
     [status-im.contexts.shell.jump-to.utils :as shell.utils]
@@ -147,7 +146,7 @@
   {:reload-status-nav-color-fx (or view-id (:view-id db))})
 
 (defn open-share
-  [_ [content]]
-  {:fx [[:effects.share/open content]]})
+  [_ [content handlers]]
+  {:fx [[:effects.share/open [content handlers]]]})
 
 (rf/reg-event-fx :open-share open-share)


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19550 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to implement the share button inside the profile settings view
* Additionally, this PR attempts to define an `:open-share` event and `:open-share-fx` effect for managing the opening of the react share-sheet.
  * And this PR attempts to refactor several usages of opening the react share-sheet to use the newly defined `:open-share` event with re-frame dispatch.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Profile settings share button
- Contact's profile share action
- Contact's share profile screen
- Share action inside Share view
- Wallet share action
- Community channel share action
- Potentially anywhere else that involves sharing (?)

### Steps to test

Here's a video demonstrating how to test each share button while logged in as a user who has already one contact.

https://github.com/status-im/status-mobile/assets/2845768/06acf22e-4316-4463-bad5-850e0fed0a34

### Before and after screenshots comparison

#### Before 

Here's a video of the existing behaviour for the share button inside the profile-settings screen.

https://github.com/status-im/status-mobile/assets/2845768/5fd27ab4-7f96-4e3b-b20b-00cfa56ffd67

#### After

Here's a video of the updated behaviour for the share button inside the profile-settings screen.

https://github.com/status-im/status-mobile/assets/2845768/e8ef2510-eef0-4e59-bd77-9e5522834d18

status: ready <!-- Can be ready or wip -->
