### PR TITLE
fix: missing author info in reply messages

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -51,7 +51,7 @@
     [rn/view {:padding-top 4 :width 32}]))
 
 (defn author
-  [{:keys [response-to
+  [{:keys [content
            compressed-key
            last-in-group?
            pinned-by
@@ -61,7 +61,7 @@
    show-reactions?
    in-reaction-and-action-menu?
    show-user-info?]
-  (when (or (and (seq response-to) quoted-message)
+  (when (or (and (seq (:response-to content)) quoted-message)
             last-in-group?
             pinned-by
             show-user-info?


### PR DESCRIPTION
fixes #19279

### Summary
Some reply messages are missing author info

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison
![Simulator Screenshot - iPhone 13 - 2024-04-08 at 08 43 54](https://github.com/status-im/status-mobile/assets/39961806/3651bb90-7418-448c-b655-b1b42f6f53f3)

status: ready <!-- Can be ready or wip -->
