### PR TITLE
fix: vertical align texts in multiline input on iOS

### DIFF
--- a/src/quo/components/inputs/input/style.cljs
+++ b/src/quo/components/inputs/input/style.cljs
@@ -1,7 +1,8 @@
 (ns quo.components.inputs.input.style
   (:require
     [quo.components.markdown.text :as text]
-    [quo.foundations.colors :as colors]))
+    [quo.foundations.colors :as colors]
+    [react-native.platform :as platform]))
 
 (defn variants-colors
   [blur? theme]
@@ -97,9 +98,12 @@
       (assoc base-props
              :text-align-vertical :top
              :line-height         22)
-      (assoc base-props
-             :height      (if small? 30 38)
-             :line-height nil))))
+      (cond-> base-props
+        :always
+        (assoc :height      (if small? 30 38)
+               :line-height nil)
+        platform/ios?
+        (assoc :padding-top (+ padding 2))))))
 
 (defn right-icon-touchable-area
   [small?]

--- a/translations/en.json
+++ b/translations/en.json
@@ -606,7 +606,7 @@
     "skip": "Skip",
     "password-placeholder": "Password...",
     "confirm-password-placeholder": "Confirm your password...",
-    "ens-or-chat-key": "ENS or Chat key",
+    "ens-or-chat-key": "ENS or Chatkey",
     "user-found": "User found",
     "enter-pin": "Enter 6-digit passcode",
     "enter-puk-code": "Enter PUK code",


### PR DESCRIPTION
fixes #17668
fixes #19263

### Summary

add a 2px padding-top to `rn/text-input` when `:multiline` is `true` but there's only a single line in the input

`not small?`
![CleanShot 2024-04-09 at 15 20 07](https://github.com/status-im/status-mobile/assets/15090582/4f1ec558-b60a-475e-ab86-f1e6d0762ac6)

`small?`
![CleanShot 2024-04-09 at 15 27 13](https://github.com/status-im/status-mobile/assets/15090582/a6e03eb6-a27b-4aa9-92cb-9d7ba54fcc9e)


### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->
multiline text input while contains only a single line of text

### Steps to test
can be tested in the add contact view
or using the input view in quo preview and toggle the multiline on

### Before and after screenshots comparison

before screen can be found at https://github.com/status-im/status-mobile/issues/19263

status: ready <!-- Can be ready or wip -->
