### PR TITLE
Remove watch-only accounts from bridging

### DIFF
--- a/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
@@ -50,7 +50,8 @@
      [account-switcher/view
       {:on-press            #(rf/dispatch [:navigate-back])
        :icon-name           :i/arrow-left
-       :accessibility-label :top-bar}]
+       :accessibility-label :top-bar
+       :switcher-type :select-account}]
      [quo/page-top {:title bridge-to-title}]
      [rn/view style/content-container
       [bridge-token-component (assoc mainnet :network-name :t/mainnet) account-token]]

--- a/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
@@ -51,7 +51,7 @@
       {:on-press            #(rf/dispatch [:navigate-back])
        :icon-name           :i/arrow-left
        :accessibility-label :top-bar
-       :switcher-type :select-account}]
+       :switcher-type       :select-account}]
      [quo/page-top {:title bridge-to-title}]
      [rn/view style/content-container
       [bridge-token-component (assoc mainnet :network-name :t/mainnet) account-token]]

--- a/src/status_im/contexts/wallet/bridge/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/select_asset/view.cljs
@@ -17,7 +17,7 @@
        [account-switcher/view
         {:on-press            #(rf/dispatch [:navigate-back])
          :accessibility-label :top-bar
-         :switcher-type :select-account}]
+         :switcher-type       :select-account}]
        [quo/page-top {:title (i18n/label :t/bridge)}]
        [quo/input
         {:container-style style/input-container

--- a/src/status_im/contexts/wallet/bridge/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/select_asset/view.cljs
@@ -16,7 +16,8 @@
       [rn/view {:style {:flex 1}}
        [account-switcher/view
         {:on-press            #(rf/dispatch [:navigate-back])
-         :accessibility-label :top-bar}]
+         :accessibility-label :top-bar
+         :switcher-type :select-account}]
        [quo/page-top {:title (i18n/label :t/bridge)}]
        [quo/input
         {:container-style style/input-container

--- a/src/status_im/contexts/wallet/sheets/account_options/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/account_options/view.cljs
@@ -112,6 +112,10 @@
   (let [options-height (reagent/atom 0)]
     (fn [{:keys [theme]}]
       (let [accounts               (rf/sub [:wallet/accounts-without-current-viewing-account])
+            view-id                (rf/sub [:view-id])
+            accounts               (if (= view-id :screen/wallet.bridge-select-asset)
+                                     (filter #(not (:watch-only? %)) accounts)
+                                     accounts)
             show-account-selector? (pos? (count accounts))]
         [:<>
          (when show-account-selector?

--- a/src/status_im/contexts/wallet/sheets/account_options/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/account_options/view.cljs
@@ -112,10 +112,6 @@
   (let [options-height (reagent/atom 0)]
     (fn [{:keys [theme]}]
       (let [accounts               (rf/sub [:wallet/accounts-without-current-viewing-account])
-            view-id                (rf/sub [:view-id])
-            accounts               (if (= view-id :screen/wallet.bridge-select-asset)
-                                     (filter #(not (:watch-only? %)) accounts)
-                                     accounts)
             show-account-selector? (pos? (count accounts))]
         [:<>
          (when show-account-selector?


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/18737

This PR fixes an issue where watch-only accounts were available for bridging.

Demo:


https://github.com/status-im/status-mobile/assets/29354102/b9ca5184-2d5a-44d8-9535-36147ea501e7

