### PR TITLE
fix: pinned messages empty state drawer margin issues

### DIFF
--- a/src/quo/components/empty_state/empty_state/styles.cljs
+++ b/src/quo/components/empty_state/empty_state/styles.cljs
@@ -7,8 +7,14 @@
    :align-items :center})
 
 (def image
-  {:width  80
-   :height 80})
+  {:width  72
+   :height 72})
+
+(def image-container
+  {:width           80
+   :height          80
+   :align-items     :center
+   :justify-content :center})
 
 (def text-container
   {:margin-top  12

--- a/src/quo/components/empty_state/empty_state/view.cljs
+++ b/src/quo/components/empty_state/empty_state/view.cljs
@@ -15,9 +15,10 @@
   [rn/view {:style (merge styles/container container-style)}
    (if placeholder?
      [rn/view {:style styles/image-placeholder}]
-     [fast-image/fast-image
-      {:style  styles/image
-       :source image}])
+     [rn/view {:style styles/image-container}
+      [fast-image/fast-image
+       {:style  styles/image
+        :source image}]])
    [rn/view {:style styles/text-container}
     [text/text
      {:style           (styles/title blur?)

--- a/src/status_im/contexts/chat/messenger/menus/pinned_messages/style.cljs
+++ b/src/status_im/contexts/chat/messenger/menus/pinned_messages/style.cljs
@@ -8,13 +8,13 @@
    :margin-bottom      (when-not community? 12)})
 
 (def community-tag-container
-  {:margin-horizontal 20 :margin-top 4 :margin-bottom 12})
+  {:margin-horizontal 20
+   :margin-top        4
+   :margin-bottom     12})
 
 (def no-pinned-messages-container
   {:justify-content :center
-   :align-items     :center
-   :margin          12
-   :margin-bottom   (when platform/android? 12)})
+   :align-items     :center})
 
 (def list-footer
   {:height (when platform/android? 12)})

--- a/src/status_im/contexts/chat/messenger/messages/pin/events.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/pin/events.cljs
@@ -130,6 +130,9 @@
   [cofx chat-id]
   (navigation/show-bottom-sheet
    cofx
-   {:content (fn [] [pinned-messages-menu/view
-                     {:chat-id                     chat-id
-                      :disable-message-long-press? (not= :chat (get-in cofx [:db :view-id]))}])}))
+   {:padding-bottom-override 21
+    :content                 (fn [] [pinned-messages-menu/view
+                                     {:chat-id                     chat-id
+                                      :disable-message-long-press? (not= :chat
+                                                                         (get-in cofx
+                                                                                 [:db :view-id]))}])}))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19282

### Summary
This PR fixes the drawer spacing issues on pinned messages  empty state

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->
<img src="https://github.com/status-im/status-mobile/assets/28704507/8a0698ef-bf78-42fa-861c-9a0baa0c12fe" width="325">
<img src="https://github.com/status-im/status-mobile/assets/28704507/bb093b2e-c72f-4e47-b7c8-2405545e3638" width="325">

| Figma (if available) | iOS (if available)    | Android (if available)

https://www.figma.com/file/PPWkgOYlZZDxZv5SDGsZVV/Posts-%26-Attachments-for-Mobile?type=design&node-id=6775%3A474216&mode=design&t=YcYdqfCaEiJAxPlD-1

<img width="540" alt="Screenshot 2024-04-09 at 13 50 33" src="https://github.com/status-im/status-mobile/assets/28704507/fc965fca-abf4-4935-9b1f-f961730b5d1e">


status: ready <!-- Can be ready or wip -->
