### PR TITLE
point statusgo to gomobile xcode 15 patch

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.2",
-    "commit-sha1": "18cc3a16d5db25e653e9f90add48a6807f6f96c5",
-    "src-sha256": "1zswv57kd7z2ccad7kjad31a3f5dgj16g36wipb6xfd6qklkd54y"
+    "version": "v0.179.3",
+    "commit-sha1": "b744ff4386751bd3e7cb8e30164678a8d557fbc2",
+    "src-sha256": "1yj76khas4g8xbgp2ymr1hwga662hsjmzpgb95x34vl42hdpirns"
 }


### PR DESCRIPTION
## Summary
A patch is added to `gomobile` on status-go side to fix building with Xcode 15.
related status go PR -> https://github.com/status-im/status-go/pull/5035

## Testing notes
This should only impact build compatibility with Xcode 15.
But may also impact other stuff related to status-go since its a change on `gomobile` side

#### Platforms
- Android
- iOS

status: ready
