### PR TITLE
Wallet - add opensea link to collecibles overview call to action button

### DIFF
--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -35,6 +35,9 @@
 (def arbitrum-sepolia-chain-explorer-link "https://sepolia.arbiscan.io/address/")
 (def goerli-chain-explorer-link "https://goerli.etherscan.io/address/")
 (def optimism-goerli-chain-explorer-link "https://goerli-optimistic.etherscan.io/address/")
+(def opensea-link "https://opensea.io")
+(def opensea-tesnet-link "https://testnets.opensea.io")
+
 (def opensea-api-key OPENSEA_API_KEY)
 (def bootnodes-settings-enabled? (enabled? (get-config :BOOTNODES_SETTINGS_ENABLED "1")))
 (def mailserver-confirmations-enabled? (enabled? (get-config :MAILSERVER_CONFIRMATIONS_ENABLED)))

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -436,6 +436,15 @@
 (def ^:const optimism-goerli-chain-id 420)
 (def ^:const optimism-sepolia-chain-id 11155420)
 
+(def opensea-url-names
+  {:ethereum "ethereum"
+   :sepolia  "sepolia"
+   :goerli   "goerli"})
+
+(def ^:const ethereum "ethereum")
+(def ^:const sepolia "sepolia")
+(def ^:const goerli "goerli")
+
 (def ^:const mainnet-chain-ids
   #{ethereum-mainnet-chain-id arbitrum-mainnet-chain-id optimism-mainnet-chain-id})
 

--- a/src/status_im/contexts/shell/share/wallet/view.cljs
+++ b/src/status_im/contexts/shell/share/wallet/view.cljs
@@ -9,6 +9,7 @@
     [status-im.contexts.shell.share.style :as style]
     [status-im.contexts.shell.share.wallet.style :as wallet-style]
     [status-im.contexts.wallet.common.utils :as utils]
+    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.sheets.network-preferences.view :as network-preferences]
     [utils.i18n :as i18n]
     [utils.image-server :as image-server]
@@ -46,7 +47,7 @@
                   :button-label      (i18n/label :t/display)
                   :on-save           (fn [chain-ids]
                                        (rf/dispatch [:hide-bottom-sheet])
-                                       (reset! selected-networks (map #(get utils/id->network %)
+                                       (reset! selected-networks (map #(get network-utils/id->network %)
                                                                       chain-ids)))}])}]))
 
 (defn- wallet-qr-code-item

--- a/src/status_im/contexts/wallet/account/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/account/share_address/view.cljs
@@ -8,6 +8,7 @@
     [status-im.constants :as constants]
     [status-im.contexts.wallet.account.share-address.style :as style]
     [status-im.contexts.wallet.common.utils :as utils]
+    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.sheets.network-preferences.view :as network-preferences]
     [utils.i18n :as i18n]
     [utils.image-server :as image-server]
@@ -34,7 +35,7 @@
   [selected-networks]
   (let [on-save       (fn [chain-ids]
                         (rf/dispatch [:hide-bottom-sheet])
-                        (reset! selected-networks (map utils/id->network chain-ids)))
+                        (reset! selected-networks (map network-utils/id->network chain-ids)))
         sheet-content (fn []
                         [network-preferences/view
                          {:blur?             true

--- a/src/status_im/contexts/wallet/add_account/add_address_to_watch/events.cljs
+++ b/src/status_im/contexts/wallet/add_account/add_address_to_watch/events.cljs
@@ -1,6 +1,6 @@
 (ns status-im.contexts.wallet.add-account.add-address-to-watch.events
   (:require [clojure.string :as string]
-            [status-im.contexts.wallet.common.utils :as utils]
+            [status-im.contexts.wallet.common.utils.networks :as network-utils]
             [taoensso.timbre :as log]
             [utils.re-frame :as rf]))
 
@@ -35,7 +35,7 @@
  :wallet/get-address-details
  (fn [{db :db} [address-or-ens]]
    (let [ens?           (string/includes? address-or-ens ".")
-         chain-id       (utils/network->chain-id db :mainnet)
+         chain-id       (network-utils/network->chain-id db :mainnet)
          request-params [chain-id address-or-ens]]
      {:db (-> db
               (assoc-in [:wallet :ui :add-address-to-watch :activity-state] :scanning)

--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.wallet.collectible.events
   (:require [camel-snake-kebab.extras :as cske]
+            [status-im.contexts.wallet.collectible.utils :as collectible-utils]
             [taoensso.timbre :as log]
             [utils.ethereum.chain :as chain]
             [utils.re-frame :as rf]
@@ -204,3 +205,16 @@
             [:wallet/trigger-share-collectible
              {:title title
               :uri   uri}]]]})))
+
+(rf/reg-event-fx
+ :wallet/navigate-to-opensea
+ (fn [{:keys [db]} [chain-id token-id contract-address]]
+   {:fx [[:dispatch [:hide-bottom-sheet]]
+         [:dispatch
+          [:browser.ui/open-url
+           (collectible-utils/get-opensea-collectible-url
+            {:chain-id               chain-id
+             :token-id               token-id
+             :contract-address       contract-address
+             :test-networks-enabled? (get-in db [:profile/profile :test-networks-enabled?])
+             :is-goerli-enabled?     (get-in db [:profile/profile :is-goerli-enabled?])})]]]}))

--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -1,4 +1,7 @@
-(ns status-im.contexts.wallet.collectible.utils)
+(ns status-im.contexts.wallet.collectible.utils
+  (:require [status-im.config :as config]
+            [status-im.constants :as constants]
+            [status-im.contexts.wallet.common.utils.networks :as network-utils]))
 
 (defn collectible-balance
   [collectible]
@@ -37,3 +40,41 @@
 (defn collectible-owned-counter
   [total]
   (when (> total 1) (str "x" total)))
+
+(defn- get-opensea-network-name
+  [chain-id test-networks-enabled? is-goerli-enabled?]
+  (let [network-kw   (network-utils/id->network chain-id)
+        network-name (name network-kw)
+        mainnet?     (= :mainnet network-kw)]
+    (cond (and test-networks-enabled? is-goerli-enabled? mainnet?)
+          (:goerli constants/opensea-url-names)
+
+          (and test-networks-enabled? is-goerli-enabled?)
+          (str network-name "-" (:goerli constants/opensea-url-names))
+
+          (and test-networks-enabled? mainnet?)
+          (:sepolia constants/opensea-url-names)
+
+          test-networks-enabled?
+          (str network-name "-" (:sepolia constants/opensea-url-names))
+
+          mainnet?
+          (:ethereum constants/opensea-url-names)
+
+          :else
+          network-name)))
+
+(defn- get-opensea-base-url
+  [test-networks-enabled?]
+  (cond
+    test-networks-enabled? config/opensea-tesnet-link
+    :else                  config/opensea-link))
+
+(defn get-opensea-collectible-url
+  [{:keys [chain-id token-id contract-address
+           test-networks-enabled? is-goerli-enabled?]}]
+  (let [base-link            (get-opensea-base-url test-networks-enabled?)
+        opensea-network-name (get-opensea-network-name chain-id
+                                                       test-networks-enabled?
+                                                       is-goerli-enabled?)]
+    (str base-link "/assets/" opensea-network-name "/" contract-address "/" token-id)))

--- a/src/status_im/contexts/wallet/collectible/utils_test.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils_test.cljs
@@ -1,0 +1,70 @@
+(ns status-im.contexts.wallet.collectible.utils-test
+  (:require
+    [cljs.test :refer [deftest is testing]]
+    [status-im.constants :as constants]
+    [status-im.contexts.wallet.collectible.utils :as utils]))
+
+(def token-id "0xT")
+(def contract-address "0xC")
+
+(deftest test-network->chain-id
+  (testing "get-opensea-collectible-url mainnet"
+    (is (= (utils/get-opensea-collectible-url {:chain-id         constants/ethereum-mainnet-chain-id
+                                               :contract-address contract-address
+                                               :token-id         token-id})
+           "https://opensea.io/assets/ethereum/0xC/0xT")))
+  (testing "get-opensea-collectible-url mainnet arbitrum"
+    (is (= (utils/get-opensea-collectible-url {:chain-id         constants/arbitrum-mainnet-chain-id
+                                               :contract-address contract-address
+                                               :token-id         token-id})
+           "https://opensea.io/assets/arbitrum/0xC/0xT")))
+
+  (testing "get-opensea-collectible-url mainnet optimism"
+    (is (= (utils/get-opensea-collectible-url {:chain-id         constants/optimism-mainnet-chain-id
+                                               :contract-address contract-address
+                                               :token-id         token-id})
+           "https://opensea.io/assets/optimism/0xC/0xT")))
+
+  (testing "get-opensea-collectible-url sepolia"
+    (is (= (utils/get-opensea-collectible-url {:chain-id constants/ethereum-sepolia-chain-id
+                                               :contract-address contract-address
+                                               :token-id token-id
+                                               :test-networks-enabled? true})
+           "https://testnets.opensea.io/assets/sepolia/0xC/0xT")))
+  (testing "get-opensea-collectible-url sepolia arbitrum"
+    (is (= (utils/get-opensea-collectible-url {:chain-id constants/arbitrum-sepolia-chain-id
+                                               :contract-address contract-address
+                                               :token-id token-id
+                                               :test-networks-enabled? true})
+           "https://testnets.opensea.io/assets/arbitrum-sepolia/0xC/0xT")))
+
+  (testing "get-opensea-collectible-url sepolia optimism"
+    (is (= (utils/get-opensea-collectible-url {:chain-id constants/optimism-sepolia-chain-id
+                                               :contract-address contract-address
+                                               :token-id token-id
+                                               :test-networks-enabled? true})
+           "https://testnets.opensea.io/assets/optimism-sepolia/0xC/0xT")))
+  (testing "get-opensea-collectible-url goerli"
+    (is (= (utils/get-opensea-collectible-url {:chain-id               constants/ethereum-goerli-chain-id
+                                               :contract-address       contract-address
+                                               :token-id               token-id
+                                               :test-networks-enabled? true
+                                               :is-goerli-enabled?     true})
+           "https://testnets.opensea.io/assets/goerli/0xC/0xT")))
+  (testing "get-opensea-collectible-url goerli arbitrum"
+    (is (= (utils/get-opensea-collectible-url {:chain-id               constants/arbitrum-goerli-chain-id
+                                               :contract-address       contract-address
+                                               :token-id               token-id
+                                               :test-networks-enabled? true
+                                               :is-goerli-enabled?     true})
+           "https://testnets.opensea.io/assets/arbitrum-goerli/0xC/0xT")))
+
+  (testing "get-opensea-collectible-url goerli optimism"
+    (is (= (utils/get-opensea-collectible-url {:chain-id               constants/optimism-goerli-chain-id
+                                               :contract-address       contract-address
+                                               :token-id               token-id
+                                               :test-networks-enabled? true
+                                               :is-goerli-enabled?     true})
+           "https://testnets.opensea.io/assets/optimism-goerli/0xC/0xT"))))
+
+

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -28,7 +28,7 @@
      collection-name]]])
 
 (defn cta-buttons
-  []
+  [chain-id token-id contract-address]
   (let [theme (quo.theme/use-theme)]
     [rn/view {:style style/buttons-container}
      [quo/button
@@ -41,6 +41,9 @@
       {:container-style  style/opensea-button
        :type             :outline
        :size             40
+       :on-press         (fn []
+                           (rf/dispatch [:wallet/navigate-to-opensea chain-id token-id
+                                         contract-address]))
        :icon-left        :i/opensea
        :icon-left-color  (colors/theme-colors colors/neutral-100 colors/neutral-40 theme)
        :icon-right       :i/external
@@ -71,6 +74,8 @@
             {svg?        :svg?
              preview-uri :uri}          preview-url
             token-id                    (:token-id id)
+            chain-id                    (get-in id [:contract-id :chain-id])
+            contract-address            (get-in id [:contract-id :address])
             {collection-image :image-url
              collection-name  :name}    collection-data
             {collectible-name :name}    collectible-data
@@ -123,7 +128,7 @@
                                                                          {:name  collectible-name
                                                                           :image preview-uri}])}])}])))}]
           [header collectible-name collection-name collection-image]
-          [cta-buttons]
+          [cta-buttons chain-id token-id contract-address]
           [quo/tabs
            {:size           32
             :style          style/tabs

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -159,15 +159,6 @@
         {})
        vals))
 
-(defn network-list
-  [{:keys [balances-per-chain]} networks]
-  (into #{}
-        (mapv (fn [chain-id]
-                (first (filter #(or (= (:chain-id %) chain-id)
-                                    (= (:related-chain-id %) chain-id))
-                               networks)))
-              (keys balances-per-chain))))
-
 (defn get-wallet-qr
   [{:keys [wallet-type selected-networks address]}]
   (if (= wallet-type :multichain)
@@ -176,61 +167,6 @@
       (apply str $)
       (str $ address))
     address))
-
-(def id->network
-  {constants/ethereum-mainnet-chain-id constants/mainnet-network-name
-   constants/ethereum-goerli-chain-id  constants/mainnet-network-name
-   constants/ethereum-sepolia-chain-id constants/mainnet-network-name
-   constants/optimism-mainnet-chain-id constants/optimism-network-name
-   constants/optimism-goerli-chain-id  constants/optimism-network-name
-   constants/optimism-sepolia-chain-id constants/optimism-network-name
-   constants/arbitrum-mainnet-chain-id constants/arbitrum-network-name
-   constants/arbitrum-goerli-chain-id  constants/arbitrum-network-name
-   constants/arbitrum-sepolia-chain-id constants/arbitrum-network-name})
-
-(defn- get-chain-id
-  [{:keys [mainnet-chain-id sepolia-chain-id goerli-chain-id testnet-enabled? goerli-enabled?]}]
-  (cond
-    (and testnet-enabled? goerli-enabled?)
-    goerli-chain-id
-
-    testnet-enabled?
-    sepolia-chain-id
-
-    :else
-    mainnet-chain-id))
-
-(defn network->chain-id
-  ([db network]
-   (let [{:keys [test-networks-enabled? is-goerli-enabled?]} (:profile/profile db)]
-     (network->chain-id {:network          network
-                         :testnet-enabled? test-networks-enabled?
-                         :goerli-enabled?  is-goerli-enabled?})))
-  ([{:keys [network testnet-enabled? goerli-enabled?]}]
-   (condp contains? (keyword network)
-     #{constants/mainnet-network-name (keyword constants/mainnet-short-name)}
-     (get-chain-id
-      {:mainnet-chain-id constants/ethereum-mainnet-chain-id
-       :sepolia-chain-id constants/ethereum-sepolia-chain-id
-       :goerli-chain-id  constants/ethereum-goerli-chain-id
-       :testnet-enabled? testnet-enabled?
-       :goerli-enabled?  goerli-enabled?})
-
-     #{constants/optimism-network-name (keyword constants/optimism-short-name)}
-     (get-chain-id
-      {:mainnet-chain-id constants/optimism-mainnet-chain-id
-       :sepolia-chain-id constants/optimism-sepolia-chain-id
-       :goerli-chain-id  constants/optimism-goerli-chain-id
-       :testnet-enabled? testnet-enabled?
-       :goerli-enabled?  goerli-enabled?})
-
-     #{constants/arbitrum-network-name (keyword constants/arbitrum-short-name)}
-     (get-chain-id
-      {:mainnet-chain-id constants/arbitrum-mainnet-chain-id
-       :sepolia-chain-id constants/arbitrum-sepolia-chain-id
-       :goerli-chain-id  constants/arbitrum-goerli-chain-id
-       :testnet-enabled? testnet-enabled?
-       :goerli-enabled?  goerli-enabled?}))))
 
 (defn get-standard-fiat-format
   [crypto-value currency-symbol fiat-value]
@@ -309,18 +245,6 @@
     label-props
     (assoc :label       :text
            :label-props label-props)))
-
-(defn get-default-chain-ids-by-mode
-  [{:keys [test-networks-enabled? is-goerli-enabled?]}]
-  (cond
-    (and test-networks-enabled? is-goerli-enabled?)
-    constants/goerli-chain-ids
-
-    test-networks-enabled?
-    constants/sepolia-chain-ids
-
-    :else
-    constants/mainnet-chain-ids))
 
 (defn filter-tokens-in-chains
   [tokens chain-ids]

--- a/src/status_im/contexts/wallet/common/utils/networks.cljs
+++ b/src/status_im/contexts/wallet/common/utils/networks.cljs
@@ -1,7 +1,83 @@
 (ns status-im.contexts.wallet.common.utils.networks
   (:require [clojure.string :as string]
             [status-im.constants :as constants]
-            [status-im.contexts.wallet.common.utils :as utils]))
+            [utils.number]))
+
+(def id->network
+  {constants/ethereum-mainnet-chain-id constants/mainnet-network-name
+   constants/ethereum-goerli-chain-id  constants/mainnet-network-name
+   constants/ethereum-sepolia-chain-id constants/mainnet-network-name
+   constants/optimism-mainnet-chain-id constants/optimism-network-name
+   constants/optimism-goerli-chain-id  constants/optimism-network-name
+   constants/optimism-sepolia-chain-id constants/optimism-network-name
+   constants/arbitrum-mainnet-chain-id constants/arbitrum-network-name
+   constants/arbitrum-goerli-chain-id  constants/arbitrum-network-name
+   constants/arbitrum-sepolia-chain-id constants/arbitrum-network-name})
+
+(defn- get-chain-id
+  [{:keys [mainnet-chain-id sepolia-chain-id goerli-chain-id testnet-enabled? goerli-enabled?]}]
+  (cond
+    (and testnet-enabled? goerli-enabled?)
+    goerli-chain-id
+
+    testnet-enabled?
+    sepolia-chain-id
+
+    :else
+    mainnet-chain-id))
+
+(defn network->chain-id
+  ([db network]
+   (let [{:keys [test-networks-enabled? is-goerli-enabled?]} (:profile/profile db)]
+     (network->chain-id {:network          network
+                         :testnet-enabled? test-networks-enabled?
+                         :goerli-enabled?  is-goerli-enabled?})))
+  ([{:keys [network testnet-enabled? goerli-enabled?]}]
+   (condp contains? (keyword network)
+     #{constants/mainnet-network-name (keyword constants/mainnet-short-name)}
+     (get-chain-id
+      {:mainnet-chain-id constants/ethereum-mainnet-chain-id
+       :sepolia-chain-id constants/ethereum-sepolia-chain-id
+       :goerli-chain-id  constants/ethereum-goerli-chain-id
+       :testnet-enabled? testnet-enabled?
+       :goerli-enabled?  goerli-enabled?})
+
+     #{constants/optimism-network-name (keyword constants/optimism-short-name)}
+     (get-chain-id
+      {:mainnet-chain-id constants/optimism-mainnet-chain-id
+       :sepolia-chain-id constants/optimism-sepolia-chain-id
+       :goerli-chain-id  constants/optimism-goerli-chain-id
+       :testnet-enabled? testnet-enabled?
+       :goerli-enabled?  goerli-enabled?})
+
+     #{constants/arbitrum-network-name (keyword constants/arbitrum-short-name)}
+     (get-chain-id
+      {:mainnet-chain-id constants/arbitrum-mainnet-chain-id
+       :sepolia-chain-id constants/arbitrum-sepolia-chain-id
+       :goerli-chain-id  constants/arbitrum-goerli-chain-id
+       :testnet-enabled? testnet-enabled?
+       :goerli-enabled?  goerli-enabled?}))))
+
+(defn network-list
+  [{:keys [balances-per-chain]} networks]
+  (into #{}
+        (mapv (fn [chain-id]
+                (first (filter #(or (= (:chain-id %) chain-id)
+                                    (= (:related-chain-id %) chain-id))
+                               networks)))
+              (keys balances-per-chain))))
+
+(defn get-default-chain-ids-by-mode
+  [{:keys [test-networks-enabled? is-goerli-enabled?]}]
+  (cond
+    (and test-networks-enabled? is-goerli-enabled?)
+    constants/goerli-chain-ids
+
+    test-networks-enabled?
+    constants/sepolia-chain-ids
+
+    :else
+    constants/mainnet-chain-ids))
 
 (defn resolve-receiver-networks
   [{:keys [prefix testnet-enabled? goerli-enabled?]}]
@@ -12,7 +88,7 @@
     (->> prefix-seq
          (remove string/blank?)
          (mapv
-          #(utils/network->chain-id
+          #(network->chain-id
             {:network          %
              :testnet-enabled? testnet-enabled?
              :goerli-enabled?  goerli-enabled?})))))

--- a/src/status_im/contexts/wallet/common/utils/networks_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils/networks_test.cljs
@@ -1,0 +1,22 @@
+(ns status-im.contexts.wallet.common.utils.networks-test
+  (:require
+    [cljs.test :refer [deftest is testing]]
+    [status-im.constants :as constants]
+    [status-im.contexts.wallet.common.utils.networks :as utils]))
+
+(deftest test-network->chain-id
+  (testing "network->chain-id function"
+    (is (= (utils/network->chain-id {:network :mainnet :testnet-enabled? false :goerli-enabled? false})
+           constants/ethereum-mainnet-chain-id))
+    (is (= (utils/network->chain-id {:network :eth :testnet-enabled? true :goerli-enabled? false})
+           constants/ethereum-sepolia-chain-id))
+    (is (= (utils/network->chain-id {:network "optimism" :testnet-enabled? true :goerli-enabled? false})
+           constants/optimism-sepolia-chain-id))
+    (is (= (utils/network->chain-id {:network "opt" :testnet-enabled? false :goerli-enabled? true})
+           constants/optimism-mainnet-chain-id))
+    (is (= (utils/network->chain-id {:network :opt :testnet-enabled? true :goerli-enabled? true})
+           constants/optimism-goerli-chain-id))
+    (is (= (utils/network->chain-id {:network :arb1 :testnet-enabled? false :goerli-enabled? false})
+           constants/arbitrum-mainnet-chain-id))
+    (is (= (utils/network->chain-id {:network :arbitrum :testnet-enabled? true :goerli-enabled? false})
+           constants/arbitrum-sepolia-chain-id))))

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.wallet.common.utils-test
   (:require
     [cljs.test :refer [deftest is testing]]
-    [status-im.constants :as constants]
     [status-im.contexts.wallet.common.utils :as utils]
     [utils.money :as money]))
 
@@ -116,20 +115,3 @@
     (is (= (utils/prettify-percentage-change 1.113454) "1.11"))
     (is (= (utils/prettify-percentage-change -0.35) "0.35"))
     (is (= (utils/prettify-percentage-change -0.78234) "0.78"))))
-
-(deftest test-network->chain-id
-  (testing "network->chain-id function"
-    (is (= (utils/network->chain-id {:network :mainnet :testnet-enabled? false :goerli-enabled? false})
-           constants/ethereum-mainnet-chain-id))
-    (is (= (utils/network->chain-id {:network :eth :testnet-enabled? true :goerli-enabled? false})
-           constants/ethereum-sepolia-chain-id))
-    (is (= (utils/network->chain-id {:network "optimism" :testnet-enabled? true :goerli-enabled? false})
-           constants/optimism-sepolia-chain-id))
-    (is (= (utils/network->chain-id {:network "opt" :testnet-enabled? false :goerli-enabled? true})
-           constants/optimism-mainnet-chain-id))
-    (is (= (utils/network->chain-id {:network :opt :testnet-enabled? true :goerli-enabled? true})
-           constants/optimism-goerli-chain-id))
-    (is (= (utils/network->chain-id {:network :arb1 :testnet-enabled? false :goerli-enabled? false})
-           constants/arbitrum-mainnet-chain-id))
-    (is (= (utils/network->chain-id {:network :arbitrum :testnet-enabled? true :goerli-enabled? false})
-           constants/arbitrum-sepolia-chain-id))))

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -4,7 +4,7 @@
     [react-native.background-timer :as background-timer]
     [react-native.platform :as platform]
     [status-im.constants :as constants]
-    [status-im.contexts.wallet.common.utils :as utils]
+    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.data-store :as data-store]
     [status-im.contexts.wallet.db :as db]
     [status-im.contexts.wallet.item-types :as item-types]
@@ -301,7 +301,7 @@
    (let [ens      (if (string/includes? input ".")
                     input
                     (str input domain))
-         chain-id (utils/network->chain-id db :mainnet)]
+         chain-id (network-utils/network->chain-id db :mainnet)]
      {:fx [[:json-rpc/call
             [{:method     "ens_addressOf"
               :params     [chain-id ens]
@@ -425,13 +425,13 @@
                                      keys)
          test-networks-enabled?  (get-in db [:profile/profile :test-networks-enabled?])
          is-goerli-enabled?      (get-in db [:profile/profile :is-goerli-enabled?])
-         chain-ids-by-mode       (utils/get-default-chain-ids-by-mode
+         chain-ids-by-mode       (network-utils/get-default-chain-ids-by-mode
                                   {:test-networks-enabled? test-networks-enabled?
                                    :is-goerli-enabled?     is-goerli-enabled?})
          chains-filtered-by-mode (remove #(not (contains? chain-ids-by-mode %)) down-chain-ids)
          chains-down?            (seq chains-filtered-by-mode)
          chain-names             (when chains-down?
-                                   (->> (map #(-> (utils/id->network %)
+                                   (->> (map #(-> (network-utils/id->network %)
                                                   name
                                                   string/capitalize)
                                              chains-filtered-by-mode)

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -7,7 +7,7 @@
     [react-native.core :as rn]
     [reagent.core :as reagent]
     [status-im.constants :as constants]
-    [status-im.contexts.wallet.common.utils :as utils]
+    [status-im.contexts.wallet.common.utils.networks :as networks-utils]
     [status-im.contexts.wallet.common.utils.send :as send-utils]
     [status-im.contexts.wallet.send.routes.style :as style]
     [utils.debounce :as debounce]
@@ -35,14 +35,15 @@
 
 (defn- find-network-link-insertion-index
   [network-links chain-id loading-suggested-routes?]
-  (let [network                              (utils/id->network chain-id)
+  (let [network                              (networks-utils/id->network chain-id)
         inserted-network-link-priority-score (network-priority-score network)]
     (or (->> network-links
              (keep-indexed (fn [idx network-link]
-                             (let [network-link (utils/id->network (if loading-suggested-routes?
-                                                                     network-link
-                                                                     (get-in network-link
-                                                                             [:from :chain-id])))]
+                             (let [network-link (networks-utils/id->network (if loading-suggested-routes?
+                                                                              network-link
+                                                                              (get-in network-link
+                                                                                      [:from
+                                                                                       :chain-id])))]
                                (when (> (network-priority-score network-link)
                                         inserted-network-link-priority-score)
                                  idx))))
@@ -51,14 +52,15 @@
 
 (defn- add-disabled-networks
   [network-links disabled-from-networks loading-suggested-routes?]
-  (let [sorted-networks (sort-by (comp network-priority-score utils/id->network) disabled-from-networks)]
+  (let [sorted-networks (sort-by (comp network-priority-score networks-utils/id->network)
+                                 disabled-from-networks)]
     (reduce (fn [acc-network-links chain-id]
               (let [index                 (find-network-link-insertion-index acc-network-links
                                                                              chain-id
                                                                              loading-suggested-routes?)
                     disabled-network-link {:status   :disabled
                                            :chain-id chain-id
-                                           :network  (utils/id->network chain-id)}]
+                                           :network  (networks-utils/id->network chain-id)}]
                 (vector-utils/insert-element-at acc-network-links disabled-network-link index)))
             network-links
             sorted-networks)))
@@ -184,20 +186,20 @@
       :to-chain-id           (or to-chain-id (:chain-id item))
       :from-network          (cond (and loading-suggested-routes?
                                         (not disabled-network?))
-                                   (utils/id->network item)
+                                   (networks-utils/id->network item)
                                    disabled-network?
-                                   (utils/id->network (:chain-id
-                                                       item))
+                                   (networks-utils/id->network (:chain-id
+                                                                item))
                                    :else
-                                   (utils/id->network from-chain-id))
+                                   (networks-utils/id->network from-chain-id))
       :to-network            (cond (and loading-suggested-routes?
                                         (not disabled-network?))
-                                   (utils/id->network item)
+                                   (networks-utils/id->network item)
                                    disabled-network?
-                                   (utils/id->network (:chain-id
-                                                       item))
+                                   (networks-utils/id->network (:chain-id
+                                                                item))
                                    :else
-                                   (utils/id->network to-chain-id))
+                                   (networks-utils/id->network to-chain-id))
       :on-press-from-network on-press-from-network
       :on-press-to-network   on-press-to-network}]))
 

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -8,7 +8,7 @@
     [react-native.safe-area :as safe-area]
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.common.standard-authentication.core :as standard-auth]
-    [status-im.contexts.wallet.common.utils :as wallet-utils]
+    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.send.transaction-confirmation.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
@@ -129,7 +129,7 @@
   (let [network-values
         (reduce-kv
          (fn [acc chain-id amount]
-           (let [network-name (wallet-utils/id->network chain-id)]
+           (let [network-name (network-utils/id->network chain-id)]
              (assoc acc
                     (if (= network-name :mainnet) :ethereum network-name)
                     {:amount amount :token-symbol token-display-name})))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -2,6 +2,7 @@
   (:require [clojure.string :as string]
             [re-frame.core :as rf]
             [status-im.contexts.wallet.common.utils :as utils]
+            [status-im.contexts.wallet.common.utils.networks :as network-utils]
             [status-im.subs.wallet.add-account.address-to-watch]
             [utils.number]))
 
@@ -136,7 +137,7 @@
  :<- [:profile/test-networks-enabled?]
  :<- [:profile/is-goerli-enabled?]
  (fn [[selected-networks testnet-enabled? goerli-enabled?]]
-   (set (map #(utils/network->chain-id
+   (set (map #(network-utils/network->chain-id
                {:network          %
                 :testnet-enabled? testnet-enabled?
                 :goerli-enabled?  goerli-enabled?})
@@ -236,7 +237,7 @@
  (fn [[account networks] [_ query]]
    (let [tokens        (map (fn [token]
                               (assoc token
-                                     :networks      (utils/network-list token networks)
+                                     :networks      (network-utils/network-list token networks)
                                      :total-balance (utils/calculate-total-token-balance token)))
                             (:tokens account))
          sorted-tokens (sort-by :name compare tokens)]
@@ -254,7 +255,7 @@
  (fn [[account networks] [_ token-symbol]]
    (let [tokens (map (fn [token]
                        (assoc token
-                              :networks      (utils/network-list token networks)
+                              :networks      (network-utils/network-list token networks)
                               :total-balance (utils/calculate-total-token-balance token)))
                      (:tokens account))
          token  (first (filter #(= (string/lower-case (:symbol %))


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19470


Note: this link for opensea is also in the options menu, however I have not added this yet as I wanted to reduce the scope of this pr, that is an easy follow up.


This pr also includes some moving of utils files, nothing is changed, just where the code lives.


To test this pr, there are 9 variants.

Mainnet, Optimism & Arbitrum

Sepolia - Mainnet, Optimism & Arbitrum (enable testnet)
Goerli - Mainnet, Optimism & Arbitrum (enable testnet and goerli) - no so important since this will be dropped.

To get collectibles to test it's easiest with a watch only account, and you can find these by going to opensea
and filtering by network and go to a particular collectible, then there is an "owned by" property. 
Click into the user and then copy their address 🎯 

e.g 
https://opensea.io/assets/ethereum/0xc3ba828f25ef6a4ead4d3afe6c48e54ddc1773f8/2030
owned by https://opensea.io/0x3Ab6EBcE2aD183cA65B432D715512CF8640111e2

same for testnet
https://testnets.opensea.io/assets/goerli/0xdb6f6f88b32793349ca121421777a7615c4b8848/10
https://testnets.opensea.io/0xDA32A6662069B20329BBC89C86c304921DF8B483