### PR TITLE
feat: retry send raw messages

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.11",
-    "commit-sha1": "b124e2b4f27a2aa41ffebb1ccf385475c5e87781",
-    "src-sha256": "142988smak33gmz0zd21ifkn2kajh9di858hrfffbk0xsxbv59rm"
+    "version": "v0.179.12",
+    "commit-sha1": "22bea87bb2102aaffe7bb19ba07893a223f0f3d9",
+    "src-sha256": "0nh2nr5lg8f7lsqqqxpxz045ymrry787qvyn5hzvsqazda1ii1hb"
 }


### PR DESCRIPTION
relate mobile [issue](https://github.com/status-im/status-mobile/issues/18959)
relate status-go [PR](https://github.com/status-im/status-go/pull/4969)

this PR added ability of retry sending automatically for the following message types:
```
ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN 
ApplicationMetadataMessage_COMMUNITY_EDIT_SHARED_ADDRESSES
ApplicationMetadataMessage_COMMUNITY_CANCEL_REQUEST_TO_JOIN
ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE
ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_LEAVE
```

#### Testing NOTE
For testing `ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN`, 
- create 2 status account(userA/userB) on different devices
- make them as mutual contacts 
- userA create closed community and invite userB to join
- once userB received community invitation and fetched community info, turn off wifi for userB and request to join.
- turn on wifi for userB
- userA should receive request to join from userB

For other message types, pls refer above approachs, the key operation is turn off/on wifi.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
