### PR TITLE
Prevent exception when viewing contact QR code

### DIFF
--- a/src/utils/address.cljs
+++ b/src/utils/address.cljs
@@ -46,7 +46,7 @@
   with the 1st 5 characters of the encoded data followed by an ellipsis
   followed by the last 10 characters of the compressed public key"
   [universal-profile-url]
-  (when-let [re-find-result (re-find #"^https://(status.app/u/)(.*)#(.*)$" universal-profile-url)]
+  (when-let [re-find-result (re-find #"^https://(status.app/u/)(.*)#(.*)$" (str universal-profile-url))]
     (let [[_whole-url base-url encoded-data public-key] re-find-result]
       (when (> (count public-key) 9)
         (let [first-part-of-encoded-data (subs encoded-data 0 5)

--- a/src/utils/address_test.cljs
+++ b/src/utils/address_test.cljs
@@ -35,4 +35,7 @@
                "https://status.app/uwu/abcdefg#zQ3shPrnUhhR42JJn3QdhodGest8w8MjiH8hPaimrdYpzeFUa"))))
 
   (testing "Ensure the function returns nil when given a public key shorter than 10 characters"
-    (is (nil? (utils.address/get-abbreviated-profile-url "https://status.app/u/abcdefg#012345678")))))
+    (is (nil? (utils.address/get-abbreviated-profile-url "https://status.app/u/abcdefg#012345678"))))
+
+  (testing "Ensure the function returns nil when given nil"
+    (is (nil? (utils.address/get-abbreviated-profile-url nil)))))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19325 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to prevent the exception mention in #19325 
* This PR modifies the `utils.address/get-abbreviated-profile-url` function to return nil if passed nil.
  * By checking for nil we can avoid the `re-find` exception mentioned in #19325
* Note that preventing the exception avoids crashing the app, but it doesn't ensure the QR screen has valid QR data.
  * The attached screenshot in this PR displays what someone would see if they opened this screen and didn't have a valid QR code presented.
  * Perhaps this is okay if we think the QR data will be eventually populated (?)

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Contact Profile Share QR code

### Steps to test

Steps to reproduce the issue are mentioned in #19325 

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

### After

<img width="565" alt="Screenshot 2024-04-10 at 13 00 51" src="https://github.com/status-im/status-mobile/assets/2845768/b975d920-3b9a-4e06-82bc-16154e7a423f">

status: ready <!-- Can be ready or wip -->
