### PR TITLE
Collectibles not displayed after account recovery #18613

### DIFF
--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -111,14 +111,14 @@
 
 (rf/reg-event-fx
  :wallet/request-collectibles-for-current-viewing-account
- (fn [{:keys [db]} _]
+ (fn [{:keys [db]} [address]]
    (let [current-viewing-account (-> db :wallet :current-viewing-account-address)
          [request-id]            (get-unique-collectible-request-id 1)]
      {:db (assoc-in db [:wallet :ui :collectibles :pending-requests] 1)
       :fx [[:dispatch
             [:wallet/request-new-collectibles-for-account
              {:request-id request-id
-              :account    current-viewing-account
+              :account    (if address address current-viewing-account)
               :amount     collectibles-request-batch-size}]]]})))
 
 (defn- update-fetched-collectibles-progress

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -184,7 +184,7 @@
                 :new-account?        true)
     :fx [[:dispatch [:wallet/get-accounts]]
          [:dispatch [:wallet/clear-new-keypair]]
-         [:dispatch [:wallet/request-collectibles-for-current-viewing-account]]
+         [:dispatch [:wallet/request-collectibles-for-current-viewing-account address]]
          [:dispatch [:wallet/request-collectibles-for-all-accounts]]]}))
 
 (rf/reg-event-fx :wallet/add-account

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -184,7 +184,8 @@
                 :new-account?        true)
     :fx [[:dispatch [:wallet/get-accounts]]
          [:dispatch [:wallet/clear-new-keypair]]
-         [:dispatch [:wallet/request-collectibles-for-current-viewing-account]]]}))
+         [:dispatch [:wallet/request-collectibles-for-current-viewing-account]]
+         [:dispatch [:wallet/request-collectibles-for-all-accounts]]]}))
 
 (rf/reg-event-fx :wallet/add-account
  (fn [{:keys [db]}

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -183,7 +183,8 @@
                 :navigate-to-account address
                 :new-account?        true)
     :fx [[:dispatch [:wallet/get-accounts]]
-         [:dispatch [:wallet/clear-new-keypair]]]}))
+         [:dispatch [:wallet/clear-new-keypair]]
+         [:dispatch [:wallet/request-collectibles-for-current-viewing-account]]]}))
 
 (rf/reg-event-fx :wallet/add-account
  (fn [{:keys [db]}


### PR DESCRIPTION
fixes #18613 

When a new account address is added successfully:

https://github.com/status-im/status-mobile/assets/55688834/28775426-7098-430b-850c-3b56c7c8db1e


When an account is recovered (i.e. using recovery phrase), this is the list of accounts that are returned from back end which is only one account address:

<img width="834" alt="Screenshot 2024-04-10 at 15 35 12" src="https://github.com/status-im/status-mobile/assets/55688834/200de314-7cd6-409f-9a58-16e1dc9cb595">

But when the same account is logged in, all of the accounts are returned:

<img width="1357" alt="Screenshot 2024-04-10 at 15 32 35" src="https://github.com/status-im/status-mobile/assets/55688834/709de658-729b-4d19-bb04-61e9b7e70f45">


