### PR TITLE
fix: fix fees calculation and add support for L1 fees for Optimism transactions

### DIFF
--- a/src/status_im/contexts/wallet/common/utils/send.cljs
+++ b/src/status_im/contexts/wallet/common/utils/send.cljs
@@ -4,23 +4,20 @@
 
 (defn calculate-gas-fee
   [data]
-  (let [gas-amount       (money/bignumber (get data :gas-amount))
-        gas-fees         (get data :gas-fees)
-        eip1559-enabled? (get gas-fees :eip1559-enabled)
-        billion          (money/bignumber "1000000000")]
-    (if eip1559-enabled?
-      (let [base-fee      (money/bignumber (get gas-fees :base-fee))
-            priority-fee  (money/bignumber (get gas-fees :max-priority-fee-per-gas))
-            fee-with-tip  (money/bignumber (money/add base-fee priority-fee))
-            total-gas-fee (money/mul gas-amount fee-with-tip)]
-        (money/with-precision (money/div total-gas-fee billion) 10))
-      (let [gas-price     (money/bignumber (get gas-fees :gas-price))
-            total-gas-fee (money/mul gas-amount gas-price)]
-        (money/with-precision (money/div total-gas-fee billion) 10)))))
+  (let [gas-amount         (money/bignumber (get data :gas-amount))
+        gas-fees           (get data :gas-fees)
+        eip1559-enabled?   (get gas-fees :eip-1559-enabled)
+        optimal-price-gwei (money/bignumber (if eip1559-enabled?
+                                              (get gas-fees :max-fee-per-gas-medium)
+                                              (get gas-fees :gas-price)))
+        total-gas-fee-wei  (money/mul (money/->wei :gwei optimal-price-gwei) gas-amount)
+        l1-fee-wei         (money/->wei :gwei (get gas-fees :l-1-gas-fee))]
+    (money/add total-gas-fee-wei l1-fee-wei)))
 
 (defn calculate-full-route-gas-fee
+  "Sums all the routes fees in wei and then convert the total value to ether"
   [route]
-  (reduce money/add (map calculate-gas-fee route)))
+  (money/wei->ether (reduce money/add (map calculate-gas-fee route))))
 
 (defn find-affordable-networks
   [{:keys [balances-per-chain input-value selected-networks disabled-chain-ids]}]

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -256,8 +256,9 @@
                                            (<= input-num-value 0)
                                            (> input-num-value (current-limit)))
             amount-text                (str @input-value " " token-symbol)
+            first-route                (first route)
             native-currency-symbol     (when-not confirm-disabled?
-                                         (get-in route [:from :native-currency-symbol]))
+                                         (get-in first-route [:from :native-currency-symbol]))
             native-token               (when native-currency-symbol
                                          (rf/sub [:wallet/token-by-symbol
                                                   native-currency-symbol]))


### PR DESCRIPTION
fixes #18780 
fixes #19431

### Summary

This PR fixes fees calculation and adds support for Optimism L1 fees.

cc @FFFra 

### Testing notes

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

#### General fees fix testing
- Open Status
- Login
- Go to wallet
- Go to an account with funds on any chain
- Tap on Send button
- Select an account to send funds to
- Select token
- Input an amount
- Wait for routes to be loaded
- Check that fee is correctly displayed

#### For Optimism specific L1 fees
- Open Status
- Login
- Go to wallet
- Go to an account with funds on Optimism
- Tap on Send button
- Select an account to send funds to
- Select token
- Input an amount
- Wait for routes to be loaded
- Check that fee is correctly displayed

status: ready