### PR TITLE
Fix timestamp for restored accounts

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.4",
-    "commit-sha1": "d246699c5e1c19b3f905a6c10c3526d2004de273",
-    "src-sha256": "0gnnx70g8g8yhn29qj58if91fflgl0q2ry0wipzvvpdxd07hpxin"
+    "version": "v0.179.5",
+    "commit-sha1": "a39c01d7fe1ac60dc2a34bb16d550f09c64d3a3d",
+    "src-sha256": "0g53nqkhpyzy9iwz9lfh2qq8s5wrfa69lic29ps0qb92h0ac428l"
 }


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19404
associated status-go pr: [seanstrom/fix-restored-account-timestamp](https://github.com/status-im/status-go/pull/5049)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to fix the issue with a restored accounts timestamp being `0`
  * What seems to happen is that a restored account is saved and then replaced without timestamp.
    * This seems to happen because of some the message/contact request notifications that can appear after recently restoring an account.
    * The updated status-go version has updated logic for saving the timestamp with the account, which seems to avoid accidentally replacing the timestamp.  
* Note, it seems the profile customisation color it temporarily `nil` when logging out of the app after restoring an account these changes. However, the customisation color is immediately updated, so there doesn't seem to be a flicker of color, but it does cause schema errors.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- restoring accounts

### Steps to test

Steps to reproduce the issue are described in #19404

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before

https://github.com/status-im/status-mobile/assets/2845768/4dd42fee-b014-4f39-968d-34652800ab94

#### After

https://github.com/status-im/status-mobile/assets/2845768/d8ac86d0-4c13-4eb2-b5a5-9dc153bbf3b6

status: ready <!-- Can be ready or wip -->
