### PR TITLE
Composer-photo selection drawer issues

### DIFF
--- a/src/status_im/contexts/chat/messenger/photo_selector/album_selector/style.cljs
+++ b/src/status_im/contexts/chat/messenger/photo_selector/album_selector/style.cljs
@@ -31,5 +31,5 @@
 
 (def divider
   {:padding-horizontal 20
-   :margin-top         16
+   :margin-top         12
    :margin-bottom      8})

--- a/src/status_im/contexts/chat/messenger/photo_selector/album_selector/view.cljs
+++ b/src/status_im/contexts/chat/messenger/photo_selector/album_selector/view.cljs
@@ -53,7 +53,8 @@
   [{:keys [title]}]
   (when-not (= title no-title)
     [quo/divider-label
-     {:container-style style/divider}
+     {:container-style style/divider
+      :tight?          false}
      title]))
 
 (defn key-fn

--- a/src/status_im/contexts/chat/messenger/photo_selector/style.cljs
+++ b/src/status_im/contexts/chat/messenger/photo_selector/style.cljs
@@ -7,7 +7,7 @@
   [bottom-inset]
   {:left     0
    :right    0
-   :height   (+ bottom-inset (if platform/ios? 65 85))
+   :height   (+ bottom-inset (if platform/ios? 51 85))
    :position :absolute
    :bottom   0})
 


### PR DESCRIPTION
fixes #19312 

### Summary
- Fix confirm action button space in photo selector
- Fix photo selector divider space

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->
1. Open a chat / group chat / channel
2. Tap the photo action button in the composer
<!-- (PRs will only be accepted if squashed into single commit.) -->

###Result

<img src="https://github.com/status-im/status-mobile/assets/39961806/a37e9b15-8e74-4467-b8a0-b52017893030" width="320px"/>
<img src="https://github.com/status-im/status-mobile/assets/39961806/1d395380-785f-4b38-970f-1a0f9feffd3d" width="320px"/>


status: ready <!-- Can be ready or wip -->
