### PR TITLE
[#19182] fix: shell share design feedback

### DIFF
--- a/src/quo/components/share/share_qr_code/view.cljs
+++ b/src/quo/components/share/share_qr_code/view.cljs
@@ -23,16 +23,6 @@
   [{:keys [on-legacy-press on-multichain-press address]}]
   [rn/view {:style style/header-container}
    [tab/view
-    {:accessibility-label         :share-qr-code-legacy-tab
-     :id                          :wallet-legacy-tab
-     :active-item-container-style style/header-tab-active
-     :item-container-style        style/header-tab-inactive
-     :size                        24
-     :active                      (= :legacy address)
-     :on-press                    on-legacy-press}
-    (i18n/label :t/legacy)]
-   [rn/view {:style style/space-between-tabs}]
-   [tab/view
     {:accessibility-label         :share-qr-code-multichain-tab
      :id                          :wallet-multichain-tab
      :active-item-container-style style/header-tab-active
@@ -40,7 +30,17 @@
      :size                        24
      :active                      (= :multichain address)
      :on-press                    on-multichain-press}
-    (i18n/label :t/multichain)]])
+    (i18n/label :t/multichain)]
+   [rn/view {:style style/space-between-tabs}]
+   [tab/view
+    {:accessibility-label         :share-qr-code-legacy-tab
+     :id                          :wallet-legacy-tab
+     :active-item-container-style style/header-tab-active
+     :item-container-style        style/header-tab-inactive
+     :size                        24
+     :active                      (= :legacy address)
+     :on-press                    on-legacy-press}
+    (i18n/label :t/legacy)]])
 
 (defn- info-label
   [share-qr-code-type]

--- a/src/status_im/contexts/shell/share/style.cljs
+++ b/src/status_im/contexts/shell/share/style.cljs
@@ -84,7 +84,8 @@
 
 (def tabs-container
   {:padding-horizontal screen-padding
-   :margin-vertical    8})
+   :margin-top         8
+   :margin-bottom      16})
 
 (def wip-style
   {:color      colors/white

--- a/src/status_im/contexts/shell/share/wallet/component_spec.cljs
+++ b/src/status_im/contexts/shell/share/wallet/component_spec.cljs
@@ -27,8 +27,8 @@
 
   (h/test "should display the wallet tab"
     (render-wallet-view)
-    (-> (h/wait-for #(h/get-by-text "Wallet One"))
-        (.then (fn [] (h/is-truthy (h/get-by-text "Wallet One"))))))
+    (-> (h/expect (h/query-by-text "Wallet One"))
+        (h/is-truthy)))
 
   (h/test "should display the legacy account"
     (render-wallet-view)

--- a/src/status_im/contexts/shell/share/wallet/component_spec.cljs
+++ b/src/status_im/contexts/shell/share/wallet/component_spec.cljs
@@ -11,7 +11,8 @@
         share-qr-code      (h/get-by-label-text :share-qr-code)]
     ;; Fires on-layout since it's needed to render the content
     (h/fire-event :layout share-qr-code #js {:nativeEvent #js {:layout #js {:width 500}}})
-    (rerender-fn [wallet-view/wallet-tab])))
+    (rerender-fn [wallet-view/wallet-tab])
+    (h/fire-event :press (h/get-by-label-text :share-qr-code-legacy-tab))))
 
 (h/describe "share wallet addresses"
   (h/setup-restorable-re-frame)

--- a/src/status_im/contexts/shell/share/wallet/view.cljs
+++ b/src/status_im/contexts/shell/share/wallet/view.cljs
@@ -53,7 +53,7 @@
   [{:keys [account index]}]
   (let [{window-width :width} (rn/get-window)
         selected-networks     (reagent/atom constants/default-network-names)
-        wallet-type           (reagent/atom :legacy)
+        wallet-type           (reagent/atom :multichain)
         on-settings-press     #(open-preferences selected-networks account)
         on-legacy-press       #(reset! wallet-type :legacy)
         on-multichain-press   #(reset! wallet-type :multichain)]

--- a/test/appium/tests/critical/test_wallet.py
+++ b/test/appium/tests/critical/test_wallet.py
@@ -154,7 +154,7 @@ class TestWalletOneDevice(MultipleSharedDeviceTestCase):
         self.wallet_view.click_system_back_button()
         self.wallet_view.close_account_button.click_until_presence_of_element(self.home_view.show_qr_code_button)
 
-        self.wallet_view.just_fyi("Checking that the new wallet is added to the Sare QR Code menu")
+        self.wallet_view.just_fyi("Checking that the new wallet is added to the Share QR Code menu")
         self.home_view.show_qr_code_button.click()
         self.home_view.share_wallet_tab_button.click()
         if self.home_view.account_name_text.text != 'Account 1':
@@ -162,10 +162,14 @@ class TestWalletOneDevice(MultipleSharedDeviceTestCase):
         self.home_view.qr_code_image_element.swipe_left_on_element()
         try:
             self.home_view.account_name_text.wait_for_element_text(text=new_account_name, wait_time=3)
-            if self.home_view.copy_wallet_address() != new_wallet_address.split(':')[-1]:
-                self.home_view.driver.fail("Incorrect address")
         except Failed:
             self.errors.append("Can't swipe between accounts, newly added account is not shown")
+        else:
+            shown_address = self.home_view.copy_wallet_address()
+            if set(shown_address.split(':')) != set(new_wallet_address.split(':')):
+                self.errors.append(
+                    "Incorrect address '%s' is shown when swiping between accounts, expected one is '%s'" % (
+                        shown_address, new_wallet_address))
         self.home_view.click_system_back_button()
 
         self.wallet_view.just_fyi("Removing newly added account")
@@ -189,7 +193,7 @@ class TestWalletOneDevice(MultipleSharedDeviceTestCase):
             pytest.fail("Account to watch was not added")
         self.wallet_view.close_account_button.click_until_presence_of_element(self.home_view.show_qr_code_button)
 
-        self.wallet_view.just_fyi("Checking that the new wallet is added to the Sare QR Code menu")
+        self.wallet_view.just_fyi("Checking that the new wallet is added to the Share QR Code menu")
         self.home_view.show_qr_code_button.click()
         self.home_view.share_wallet_tab_button.click()
         if self.home_view.account_name_text.text != 'Account 1':
@@ -197,10 +201,14 @@ class TestWalletOneDevice(MultipleSharedDeviceTestCase):
         self.home_view.qr_code_image_element.swipe_left_on_element()
         try:
             self.home_view.account_name_text.wait_for_element_text(text=new_account_name, wait_time=3)
-            if self.home_view.copy_wallet_address() != address_to_watch:
-                self.home_view.driver.fail("Incorrect address")
         except Failed:
             self.errors.append("Can't swipe between accounts, account to watch is not shown")
+        else:
+            shown_address = self.home_view.copy_wallet_address()
+            if set(shown_address.split(':')) != {'eth', 'arb1', 'opt', address_to_watch}:
+                self.home_view.driver.fail(
+                    "Incorrect address '%s' is shown when swiping between accounts, expected one is '%s'" % (
+                        shown_address, ':'.join(address_to_watch)))
         self.home_view.click_system_back_button()
 
         self.wallet_view.just_fyi("Removing account to watch")


### PR DESCRIPTION
fixes #19182

### Summary

#### Done

- Margin [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=111:82256&mode=design#727565741)] between the QR code card and the tabs above it doesn't match design
- Inverted tabs [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=111:82256&mode=design#727564635)] inside the share card: Legacy 🔄 Multichain
- Card gets cut off [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=111:82256&mode=design#726032931)] at the bottom

#### Follow up
Note: QR view is depend on data we pass to it, for example if we display legacy address like `eth:0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359`, then squares will be the same
- QRs comparison [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=111:82256&mode=design#726063350)] between legacy and multichain should be visually similar, right now squares are different sizes

#### Areas that maybe impacted

- [Shell] Sharing screen: wallet tab


### Steps to test

- Tap on the Share QR code icon on the top right of the screen

### Result
<img src="https://github.com/status-im/status-mobile/assets/71308738/53e64416-caea-491b-9cdc-c49cf931564a" width="390px"/>

status: ready
