### PR TITLE
Persist in-app feature flags (dev-only feature)

### DIFF
--- a/src/status_im/contexts/preview/feature_flags/view.cljs
+++ b/src/status_im/contexts/preview/feature_flags/view.cljs
@@ -15,7 +15,9 @@
      :text-align :left
      :title      "Features Flags"
      :icon-name  :i/arrow-left
-     :on-press   #(rf/dispatch [:navigate-back])}]
+     :on-press   #(rf/dispatch [:navigate-back])
+     :right-side [{:icon-name :i/rotate
+                   :on-press  #(ff/reset-flags)}]}]
    (doall
     (for [context-name ff/feature-flags-categories
           :let         [context-flags (filter (fn [[k]]
@@ -36,4 +38,3 @@
              :container-style {:margin-right 8}
              :on-change       #(ff/toggle flag)}]
            [quo/text (second (string/split (name flag) "."))]]))]))])
-

--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -21,10 +21,10 @@
     [status-im.contexts.profile.push-notifications.events :as notifications]
     [status-im.contexts.shell.jump-to.state :as shell.state]
     [status-im.contexts.shell.jump-to.utils :as shell.utils]
+    [status-im.feature-flags :as ff]
     [status-im.navigation.core :as navigation]
     status-im.contexts.wallet.signals
     status-im.events
-    status-im.navigation.core
     [status-im.setup.dev :as dev]
     [status-im.setup.global-error :as global-error]
     [status-im.setup.interceptors :as interceptors]
@@ -62,6 +62,9 @@
   ;; Shell
   (async-storage/get-item :selected-stack-id #(shell.utils/change-selected-stack-id % nil nil))
   (async-storage/get-item :screen-height #(reset! shell.state/screen-height %))
+
+  (when config/quo-preview-enabled?
+    (ff/load-flags))
 
   (dev/setup)
   (log/info "hermesEnabled ->" (is-hermes))

--- a/src/status_im/setup/dev.cljs
+++ b/src/status_im/setup/dev.cljs
@@ -2,6 +2,7 @@
   (:require
     ["react-native" :refer (DevSettings LogBox)]
     [react-native.platform :as platform]
+    [status-im.feature-flags :as ff]
     [status-im.setup.schema :as schema]
     [utils.re-frame :as rf]))
 
@@ -48,6 +49,7 @@
                            :json-rpc/call})
   (when ^:boolean js/goog.DEBUG
     (schema/setup!)
+    (ff/load-flags)
     (when (and platform/ios? DevSettings)
       ;;on Android this method doesn't work
       (when-let [nm (.-_nativeModule DevSettings)]

--- a/src/status_im/setup/dev.cljs
+++ b/src/status_im/setup/dev.cljs
@@ -2,7 +2,6 @@
   (:require
     ["react-native" :refer (DevSettings LogBox)]
     [react-native.platform :as platform]
-    [status-im.feature-flags :as ff]
     [status-im.setup.schema :as schema]
     [utils.re-frame :as rf]))
 
@@ -49,7 +48,6 @@
                            :json-rpc/call})
   (when ^:boolean js/goog.DEBUG
     (schema/setup!)
-    (ff/load-flags)
     (when (and platform/ios? DevSettings)
       ;;on Android this method doesn't work
       (when-let [nm (.-_nativeModule DevSettings)]

--- a/test/jest/jestSetup.js
+++ b/test/jest/jestSetup.js
@@ -1,7 +1,7 @@
 const WebSocket = require('ws');
 const { NativeModules } = require('react-native');
 
-require('@react-native-async-storage/async-storage/jest/async-storage-mock');
+mockAsyncStorage = require('@react-native-async-storage/async-storage/jest/async-storage-mock');
 require('react-native-gesture-handler/jestSetup');
 require('react-native-reanimated/src/reanimated2/jestUtils').setUpTests();
 


### PR DESCRIPTION
### Summary

This PR improves in-app feature flags to persist what is currently only stored in a Reagent atom. This should make them more convenient to use, which is a good thing overall for developers.

Additionally, there's now a top-right button in screen `Settings > Feature Flags` that will reset the flags to the initial values obtained from environment variables. Just a handy little addition.

These in-app feature flags are exclusively available in debug builds in `Settings > Feature Flags`, and only visible when flag `ENABLE_QUO_PREVIEW` is enabled. There's no impact whatsoever in prod builds. A reminder that they are not meant to be used by users.

That's why I think the simple solution presented in this PR is good enough. The developer will now be able to close and reopen the app, and the flags will be recovered using [RN Async Storage](https://reactnative.dev/docs/asyncstorage) during app initialization.

It's worth noting that RN has deprecated  Async Storage and now recommends other community solutions, but for a dev-only feature, I think it's fine. Regarding this, I don't know if the mobile team has an official recommendation to replace Async Storage.

This PR is kind of a natural progression from the original work done in [PR #18602 Add a UI for toggling developer feature flags](https://github.com/status-im/status-mobile/pull/18602). We knew from the start it would be useful to persist, but that we could do it later.

### Areas that may be impacted

None.

### Steps to test

Toggle in-app feature flags, then close and reopen the app. Check if the values were persisted in `Settings > Feature Flags`.

status: ready
