### PR TITLE
fix: add/rename missing sub :current-chat/one-to-one-chat?

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/content/pin/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/pin/view.cljs
@@ -30,7 +30,7 @@
 (defn pinned-message
   [{:keys [from quoted-message timestamp-str]}]
   (let [[primary-name _]            (rf/sub [:contacts/contact-two-names-by-identity from])
-        one-to-one-chat?            (rf/sub [:current-chat/one-to-one-chat?])
+        one-to-one-chat?            (rf/sub [:chats/current-chat-one-to-one?])
         current-chat-color          (rf/sub [:chats/current-chat-color])
         contact-customization-color (rf/sub [:contacts/contact-customization-color-by-address from])]
     [quo/system-message

--- a/src/status_im/subs/chats.cljs
+++ b/src/status_im/subs/chats.cljs
@@ -242,6 +242,12 @@
       :can-delete-message-for-everyone? can-delete-message-for-everyone?})))
 
 (re-frame/reg-sub
+ :chats/current-chat-one-to-one?
+ :<- [:chats/current-raw-chat]
+ (fn [{:keys [chat-type]}]
+   (= chat-type constants/one-to-one-chat-type)))
+
+(re-frame/reg-sub
  :chats/photo-path
  :<- [:contacts/contacts]
  :<- [:profile/profile-with-image]


### PR DESCRIPTION
### Summary
add missing sub back, or error when there's pinned message
sub removed in 8b417524faef2c3ad45326fdf9a5cc7ae2dcb2fa and used in 00b0755a732d33f9c1a72d074e8378fabaae1c1c

### Testing notes
pinned message should work

#### Areas that maybe impacted
pinned message

### Steps to test

- open chat
- send message
- pin message

status: ready <!-- Can be ready or wip -->
