### PR TITLE
fix: wallet header spacing to match other tabs

### DIFF
--- a/src/status_im/contexts/wallet/home/style.cljs
+++ b/src/status_im/contexts/wallet/home/style.cljs
@@ -23,5 +23,5 @@
 
 (defn home-container
   []
-  {:margin-top (safe-area/get-top)
+  {:margin-top (+ (safe-area/get-top) 8)
    :flex       1})


### PR DESCRIPTION
fixes ?

From design review during offsite note:
`Wallet header jumps (is higher) when switching tabs`

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in
- Go to wallet tab
- Verify top bar spacing matches the rest of the tabs (communities / messages)

status: ready