### PR TITLE
ci: use virtualenv to avoid race conditions

### DIFF
--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -36,6 +36,12 @@ pipeline {
     ))
   }
 
+  environment {
+    /* Avoid race conditions with other builds using virtualenv. */
+    VIRTUAL_ENV = "${WORKSPACE_TMP}/venv"
+    PATH = "${VIRTUAL_ENV}/bin:${PATH}"
+  }
+
   stages {
     stage('Fetch') {
       steps { script {
@@ -52,7 +58,8 @@ pipeline {
     stage('Setup') {
       steps { script {
         dir('test/appium') {
-          sh 'pip3 install --user -r requirements.txt'
+          sh "python3 -m venv ${VIRTUAL_ENV}"
+          sh 'pip3 install -r requirements.txt'
         }
       } }
     }

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -54,6 +54,12 @@ pipeline {
     ))
   }
 
+  environment {
+    /* Avoid race conditions with other builds using virtualenv. */
+    VIRTUAL_ENV = "${WORKSPACE_TMP}/venv"
+    PATH = "${VIRTUAL_ENV}/bin:${PATH}"
+  }
+
   stages {
     stage('Prep') {
       steps { script {
@@ -79,7 +85,8 @@ pipeline {
     stage('Setup') {
       steps { script {
         dir('test/appium') {
-          sh 'pip3 install --user -r requirements.txt'
+          sh "python3 -m venv ${VIRTUAL_ENV}"
+          sh 'pip3 install -r requirements.txt'
         }
       } }
     }

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -35,6 +35,11 @@ pipeline {
     ))
   }
 
+  environment {
+    /* Avoid race conditions with other builds using virtualenv. */
+    VIRTUAL_ENV = "${WORKSPACE_TMP}/venv"
+    PATH = "${VIRTUAL_ENV}/bin:${PATH}"
+  }
 
   stages {
     stage('Prep') {
@@ -51,7 +56,8 @@ pipeline {
     stage('Setup') {
       steps { script {
         dir('test/appium') {
-          sh 'pip3 install --user -r requirements.txt'
+          sh "python3 -m venv ${VIRTUAL_ENV}"
+          sh 'pip3 install -r requirements.txt'
         }
       } }
     }


### PR DESCRIPTION
Desktop QA tests also use Pytest packages and their versions are different, so we can't install them globally, it needs to be done per build using `WORKSPACE_TMP` as destination.

Otherwise you get this due to a race condition:
```
 > a ci-slave-linux,ci-slave-release -o -a 'sudo -u jenkins pip list --user 2>/dev/null | grep "^pytest "' | sort
linux-01.he-eu-hel1.ci.release | CHANGED | rc=0 | (stdout) pytest  7.4.0
linux-02.he-eu-hel1.ci.release | CHANGED | rc=0 | (stdout) pytest  7.4.0
linux-01.he-eu-hel1.ci.devel | CHANGED | rc=0 | (stdout) pytest    7.2.1
linux-02.he-eu-hel1.ci.devel | CHANGED | rc=0 | (stdout) pytest    7.4.0
linux-03.he-eu-hel1.ci.devel | CHANGED | rc=0 | (stdout) pytest    7.4.0
linux-04.he-eu-hel1.ci.devel | CHANGED | rc=0 | (stdout) pytest    7.4.0
linux-05.he-eu-hel1.ci.devel | CHANGED | rc=0 | (stdout) pytest    7.2.1
```