### PR TITLE
fix: page top is rendering empty avatar icon if no avatar props are sent

### DIFF
--- a/src/quo/components/text_combinations/page_top/view.cljs
+++ b/src/quo/components/text_combinations/page_top/view.cljs
@@ -37,7 +37,8 @@
   [{:keys        [title title-accessibility-label input counter-top counter-bottom
                   title-right title-right-props]
     avatar-props :avatar}]
-  (let [avatar-props (assoc avatar-props :size :size-32)
+  (let [avatar-props (when avatar-props
+                       (assoc avatar-props :size :size-32))
         title-props  (assoc title-right-props
                             :title               title
                             :right               title-right


### PR DESCRIPTION
fixes ?

From design review during offsite note:
`There is extra padding on screen titles`

| Before | Fix |
| ------- | --- |
| <img width="350" src="https://github.com/status-im/status-mobile/assets/18485527/3c3cb93e-d2b4-4ab4-aa1c-76c850fd5601"> | <img width="350" src="https://github.com/status-im/status-mobile/assets/18485527/244d3dcc-d93b-4a32-9aa5-2f1d2b3f4e51"> |

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in
- Go to wallet tab
- Complete different flows (send / bridge / add account / etc) and check different screens with titles
- Verify titles has not extra padding (example screenshots shown in the description)

status: ready