### PR TITLE
fix: add external icon to OpenSea button in collectible page

### DIFF
--- a/src/quo/components/buttons/button/view.cljs
+++ b/src/quo/components/buttons/button/view.cljs
@@ -28,9 +28,9 @@
     :theme :light/:dark
    only icon
    [button {:icon-only? true} :i/close-circle]"
-  [{:keys [on-press on-long-press disabled? type background size icon-left icon-right icon-top
-           customization-color accessibility-label icon-only? container-style inner-style
-           pressed? on-press-in on-press-out allow-multiple-presses?]
+  [{:keys [on-press on-long-press disabled? type background size icon-left icon-left-color icon-right
+           icon-right-color icon-top icon-top-color customization-color accessibility-label icon-only?
+           container-style inner-style pressed? on-press-in on-press-out allow-multiple-presses?]
     :or   {type                :primary
            size                40
            customization-color (if (= type :primary) :blue nil)}}
@@ -94,7 +94,7 @@
           [quo.icons/icon icon-top
            {:container-style {:margin-bottom 2
                               :opacity       (when disabled? 0.3)}
-            :color           icon-color
+            :color           (or icon-top-color icon-color)
             :size            icon-size}]])
        (when icon-left
          [rn/view
@@ -103,7 +103,7 @@
                     :icon-size icon-size
                     :disabled? disabled?})}
           [quo.icons/icon icon-left
-           {:color icon-color
+           {:color (or icon-left-color icon-color)
             :size  icon-size}]])
        [rn/view
         (cond
@@ -130,5 +130,5 @@
                     :icon-size icon-size
                     :disabled? disabled?})}
           [quo.icons/icon icon-right
-           {:color icon-color
+           {:color (or icon-right-color icon-color)
             :size  icon-size}]])]]]))

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.wallet.collectible.view
   (:require
     [quo.core :as quo]
+    [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [react-native.svg :as svg]
@@ -36,10 +37,13 @@
      :icon-left       :i/send}
     (i18n/label :t/send)]
    [quo/button
-    {:container-style style/opensea-button
-     :type            :outline
-     :size            40
-     :icon-left       :i/opensea}
+    {:container-style  style/opensea-button
+     :type             :outline
+     :size             40
+     :icon-left        :i/opensea
+     :icon-left-color  (colors/theme-colors colors/neutral-100 colors/neutral-40)
+     :icon-right       :i/external
+     :icon-right-color (colors/theme-colors colors/neutral-50 colors/neutral-40)}
     (i18n/label :t/opensea)]])
 
 (def tabs-data


### PR DESCRIPTION
fixes ?

From design review during offsite note:
`16. [Collectibles] Open sea button on collectible detail page should have an arrow to represent an external link`
Also fixed left icon color to comply with Figma designs.


| Before | Fix |
| ------ | ---- |
| <img width="350" src="https://github.com/status-im/status-mobile/assets/18485527/c46c8c16-e329-4db7-8202-4517077afbef"> | <img width="350" src="https://github.com/status-im/status-mobile/assets/18485527/f3ed8c2b-48ad-49bd-9e68-0bbabe4ef88c">|

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in
- Go to wallet tab
- Go to collectibles > Select a collectible
- Check OpenSea button has the external icon on the right and correct color for icon on the left

status: ready