### PR TITLE
fix: apply border radius on authentication bottom sheet

### DIFF
--- a/src/status_im/common/bottom_sheet/style.cljs
+++ b/src/status_im/common/bottom_sheet/style.cljs
@@ -8,6 +8,7 @@
 (defn sheet
   [{:keys [max-height]}]
   {:position                :absolute
+   :overflow                :hidden
    :bottom                  0
    :left                    0
    :right                   0


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19662

When the user is prompted to enter a password during the syncing, the bottom sheet does not seem to properly apply top border radius. This pr address that 

### Steps to test

- Open Status
- Navigate to setting screen
- Navigate to syncing
- Slide to enter your password
- Notice the bottom sheet top border radius is not applied

### Before and after screenshots comparison
<img src="https://github.com/status-im/status-mobile/assets/28704507/9fc22049-f847-46c8-8e6e-48973c0b42fc" width="325">

<img src="https://github.com/status-im/status-mobile/assets/28704507/38862419-f6ac-411c-9030-f3fc49da046c" width="325">

status: ready 
