### PR TITLE
swap @react-native-camera-roll/camera-roll fork with patches & upgrade to 7.5.2

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -881,7 +881,9 @@ PODS:
     - React-Core
   - react-native-blur (4.3.3):
     - React-Core
-  - react-native-cameraroll (5.10.0):
+  - react-native-cameraroll (7.5.2):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
     - React-Core
   - react-native-config (1.5.0):
     - react-native-config/App (= 1.5.0)
@@ -1475,7 +1477,7 @@ SPEC CHECKSUMS:
   react-native-biometrics: 352e5a794bfffc46a0c86725ea7dc62deb085bdc
   react-native-blob-util: 600972b1782380a5a7d5db61a3817ea32349dae9
   react-native-blur: c6d0a1dc2b4b519f7afe3b14d8151998632b6d18
-  react-native-cameraroll: 4701ae7c3dbcd3f5e9e150ca17f250a276154b35
+  react-native-cameraroll: af8eec1e585d053ff485d98ec837f9a8a11b5745
   react-native-config: 5330c8258265c1e5fdb8c009d2cabd6badd96727
   react-native-hole-view: 6935448993bac79f2b5a4ad7e9741094cf810679
   react-native-image-resizer: 2f1577efa3bc762597681f530c8e8d05ce0ceeb3

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.19.3",
-    "@react-native-camera-roll/camera-roll": "git+https://github.com/status-im/react-native-camera-roll.git#refs/tags/v5.1.1.1",
+    "@react-native-camera-roll/camera-roll": "7.5.2",
     "@react-native-clipboard/clipboard": "1.13.2",
     "@react-native-community/audio-toolkit": "git+https://github.com/tbenr/react-native-audio-toolkit.git#refs/tags/v2.0.3-status-v6",
     "@react-native-community/blur": "git+https://github.com/status-im/react-native-blur.git#refs/tags/v4.3.3-status",

--- a/patches/CameraRoll.ts.patch
+++ b/patches/CameraRoll.ts.patch
@@ -1,0 +1,22 @@
+--- /tmp/tmp-status-mobile-3907e6b2e/tmp.re8kHerusA/CameraRoll.ts	2024-04-16 15:17:12.942432000 +0200
++++ ./node_modules/@react-native-camera-roll/camera-roll/src/CameraRoll.ts	2024-04-16 15:17:42.455250986 +0200
+@@ -239,6 +239,19 @@
+   }
+ 
+   /**
++   * Returns total iOS image count
++   */
++  static getPhotosCountiOS(): Promise<number> {
++    return RNCCameraRoll.getPhotosCountiOS('');
++  }
++  /**
++   * Returns favorites and their count iOS
++   */
++  static getFavoritesiOS(): Promise<Album> {
++    return RNCCameraRoll.getFavoritesiOS('');
++  }
++
++  /**
+    * Saves the photo or video to the camera roll or photo library, and returns the URI of the newly created asset.
+    *
+    * @deprecated `save(...)` is deprecated - use `saveAsset(...)` instead.

--- a/patches/NativeCameraRollModule.ts.patch
+++ b/patches/NativeCameraRollModule.ts.patch
@@ -1,0 +1,11 @@
+--- /tmp/tmp-status-mobile-3907e6b2e/tmp.juxTO1BeCM/NativeCameraRollModule.ts	2024-04-16 15:21:28.379979000 +0200
++++ ./node_modules/@react-native-camera-roll/camera-roll/src/NativeCameraRollModule.ts	2024-04-16 15:21:40.490391291 +0200
+@@ -81,6 +81,8 @@
+   getPhotos(params: Object): Promise<PhotoIdentifiersPage>;
+   getAlbums(params: Object): Promise<Album[]>;
+   deletePhotos(photoUris: Array<string>): Promise<void>;
++  getPhotosCountiOS(arg: string): Promise<number>;
++  getFavoritesiOS(arg: string): Promise<Album>;
+   getPhotoByInternalID(
+     internalID: string,
+     options: Object,

--- a/patches/RNCCameraRoll.mm.patch
+++ b/patches/RNCCameraRoll.mm.patch
@@ -1,0 +1,56 @@
+--- /tmp/tmp-status-mobile-3907e6b2e/tmp.O0mkyjqnsy/RNCCameraRoll.mm	2024-04-16 15:26:23.070258000 +0200
++++ ./node_modules/@react-native-camera-roll/camera-roll/ios/RNCCameraRoll.mm	2024-04-16 15:26:32.664996066 +0200
+@@ -955,6 +955,53 @@
+     return [albumTitles copy];
+ }
+ 
++RCT_EXPORT_METHOD(getPhotosCountiOS:(NSString *)blank
++                  resolve:(RCTPromiseResolveBlock)resolve
++                  reject:(RCTPromiseRejectBlock)reject)
++{
++    __block NSInteger intTotalCount=0;
++    PHFetchOptions *allPhotosOptions = [PHFetchOptions new];
++    allPhotosOptions.predicate = [NSPredicate predicateWithFormat:@"mediaType == %d ",PHAssetMediaTypeImage];
++    PHFetchResult *allPhotosResult = [PHAsset fetchAssetsWithOptions:allPhotosOptions];
++    intTotalCount+=allPhotosResult.count;
++
++    resolve(@(intTotalCount));
++}
++
++RCT_EXPORT_METHOD(getFavoritesiOS:(NSString *)blank
++                  resolve:(RCTPromiseResolveBlock)resolve
++                  reject:(RCTPromiseRejectBlock)reject)
++{
++    __block NSInteger intTotalCount=0;
++    PHFetchOptions *fetchOptions = [PHFetchOptions new];
++    NSString *format = @"(favorite == true)";
++    fetchOptions.predicate = [NSPredicate predicateWithFormat:format];
++    PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsWithOptions:fetchOptions];
++    PHAsset *imageAsset = [assetsFetchResult firstObject];
++    NSMutableArray * result = [NSMutableArray new];
++
++    for (PHAsset* asset in assetsFetchResult) {
++        NSArray *resources = [PHAssetResource assetResourcesForAsset:asset ];
++        if ([resources count] < 1) continue;
++        NSString *orgFilename = ((PHAssetResource*)resources[0]).originalFilename;
++        NSString *uit = ((PHAssetResource*)resources[0]).uniformTypeIdentifier;
++        NSString *mimeType = (NSString *)CFBridgingRelease(UTTypeCopyPreferredTagWithClass((__bridge CFStringRef _Nonnull)(uit), kUTTagClassMIMEType));
++        CFStringRef extension = UTTypeCopyPreferredTagWithClass((__bridge CFStringRef _Nonnull)(uit), kUTTagClassFilenameExtension);
++        [result addObject:@{
++            @"width": @([asset pixelWidth]),
++            @"height": @([asset pixelHeight]),
++            @"filename": orgFilename ?: @"",
++            @"mimeType": mimeType ?: @"",
++            @"id": [asset localIdentifier],
++            @"creationDate": [asset creationDate],
++            @"uri": [NSString stringWithFormat:@"ph://%@", [asset localIdentifier]],
++            @"duration": @([asset duration])
++        }];
++    }
++    [result addObject:@{@"count": @(assetsFetchResult.count)}];
++    resolve(result);
++}
++
+ static void checkPhotoLibraryConfig()
+ {
+ #if RCT_DEV

--- a/yarn.lock
+++ b/yarn.lock
@@ -2576,9 +2576,10 @@
   dependencies:
     merge-options "^3.0.4"
 
-"@react-native-camera-roll/camera-roll@git+https://github.com/status-im/react-native-camera-roll.git#refs/tags/v5.1.1.1":
-  version "5.10.0"
-  resolved "git+https://github.com/status-im/react-native-camera-roll.git#174f8c6ad88e5bad9d9bd207f42173e567ec3138"
+"@react-native-camera-roll/camera-roll@7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@react-native-camera-roll/camera-roll/-/camera-roll-7.5.2.tgz#2b248a835fbb8b53d04fc0c2957adba1474d9c99"
+  integrity sha512-XiVIrW17EFXrFzqB48q6cQOaYeVnw0iC3tH+Jhl+MAHDYGLJp+ulzxCNNwngaMvnVAA5Q2mUMzRocUiJPy8q0g==
 
 "@react-native-clipboard/clipboard@1.13.2":
   version "1.13.2"


### PR DESCRIPTION
## Summary

This PR swaps the fork of @react-native-camera-roll/camera-roll with a patch and upgrades this library to the latest version.

needed for : https://github.com/status-im/status-mobile/issues/18138

## Review & Test notes

Verify if camera album related features still work.

## Platforms
- iOS

status: ready
