### PR TITLE
fix: blur type for community header

### DIFF
--- a/src/status_im/common/scroll_page/style.cljs
+++ b/src/status_im/common/scroll_page/style.cljs
@@ -22,7 +22,7 @@
     :height           height
     :right            0
     :left             0
-    :background-color (if platform/ios?
+    :background-color (if platform/android?
                         (colors/theme-colors
                          colors/white-opa-70
                          colors/neutral-95-opa-70

--- a/src/status_im/common/scroll_page/view.cljs
+++ b/src/status_im/common/scroll_page/view.cljs
@@ -49,7 +49,7 @@
     [:<>
      [reanimated/blur-view
       {:blur-amount   20
-       :blur-type     :transparent
+       :blur-type     :ultraThinMaterial
        :overlay-color :transparent
        :style         (style/blur-slider translate-animation height theme)}]
      [rn/view

--- a/src/status_im/common/scroll_page/view.cljs
+++ b/src/status_im/common/scroll_page/view.cljs
@@ -119,7 +119,8 @@
            :page-nav-props page-nav-props
            :overlay-shown? overlay-shown?}]
          [rn/scroll-view
-          {:content-container-style           {:flex-grow 1}
+          {:bounces                           false
+           :content-container-style           {:flex-grow 1}
            :content-inset-adjustment-behavior :never
            :shows-vertical-scroll-indicator   false
            :scroll-event-throttle             16


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes https://github.com/status-im/status-mobile/issues/19205 and item 2 from https://github.com/status-im/status-mobile/issues/19204

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR Fixes the issue top nav blur issue on Android where the top blur is not really applied to the top area. It also addresses the issue with iOS blur completely blocking out the community header image .

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->
- community

##### Functional

- community

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open a community
- Scroll through channels list
- Observe the blur of the top nav

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

| Figma (if available) | iOS (if available)    | Android (if available) |
| -------------------- | --------------------- | ---------------------- |
| ![image](https://github.com/status-im/status-mobile/assets/45393944/a17de5bb-aa01-4d8f-83f0-46c220785943) | ![Simulator Screen Recording - iPhone 11 Pro - 2024-04-16 at 12 14 21](https://github.com/status-im/status-mobile/assets/45393944/c7accd1b-6018-4384-b8af-ac560058336b) | https://github.com/status-im/status-mobile/assets/45393944/886a2f56-4819-42e6-8aee-c6a7544b8b86 |



status: ready
