### PR TITLE
fix: suggested routes are not calculated with preferred receiver networks

### DIFF
--- a/src/status_im/contexts/wallet/bridge/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/input_amount/view.cljs
@@ -15,4 +15,5 @@
      :button-one-props  {:icon-left :i/bridge}
      :on-navigate-back  (fn []
                           (rf/dispatch [:wallet/clean-disabled-from-networks])
+                          (rf/dispatch [:wallet/clean-send-amount])
                           (rf/dispatch [:navigate-back]))}]])

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -64,7 +64,7 @@
                                                                   :max-priority-fee-per-gas "0.011000001"
                                                                   :eip1559-enabled true}}]
    :wallet/wallet-send-suggested-routes            {:candidates []}
-   :wallet/wallet-send-selected-networks           [1]
+   :wallet/wallet-send-receiver-networks           [1]
    :view-id                                        :screen/wallet.send-input-amount
    :wallet/wallet-send-to-address                  "0x04371e2d9d66b82f056bc128064"
    :profile/currency-symbol                        "$"

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -283,7 +283,7 @@
                                           {:content (fn []
                                                       [select-asset-bottom-sheet
                                                        clear-input!])}])
-            selected-networks          (rf/sub [:wallet/wallet-send-selected-networks])
+            selected-networks          (rf/sub [:wallet/wallet-send-receiver-networks])
             affordable-networks        (send-utils/find-affordable-networks
                                         {:balances-per-chain token-balances-per-chain
                                          :input-value        @input-value

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -66,7 +66,7 @@
   [{:keys [fetch-routes theme]}]
   (let [network-details     (rf/sub [:wallet/network-details])
         {:keys [color]}     (rf/sub [:wallet/current-viewing-account])
-        selected-networks   (rf/sub [:wallet/wallet-send-selected-networks])
+        selected-networks   (rf/sub [:wallet/wallet-send-receiver-networks])
         prefix              (rf/sub [:wallet/wallet-send-address-prefix])
         prefix-seq          (string/split prefix #":")
         grouped-details     (group-by #(contains? (set prefix-seq) (:short-name %)) network-details)

--- a/src/status_im/contexts/wallet/send/send_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/send_amount/view.cljs
@@ -12,4 +12,5 @@
     :button-one-label  (i18n/label :t/confirm)
     :on-navigate-back  (fn []
                          (rf/dispatch [:wallet/clean-disabled-from-networks])
+                         (rf/dispatch [:wallet/clean-send-amount])
                          (rf/dispatch [:navigate-back]))}])

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -81,9 +81,9 @@
  :-> :address-prefix)
 
 (rf/reg-sub
- :wallet/wallet-send-selected-networks
+ :wallet/wallet-send-receiver-networks
  :<- [:wallet/wallet-send]
- :-> :selected-networks)
+ :-> :receiver-networks)
 
 (rf/reg-sub
  :wallet/wallet-send-route


### PR DESCRIPTION
fixes #19666

### Summary

This PR adds logic to force preferred networks from the receiver address when calculating suggested routes.

https://github.com/status-im/status-mobile/assets/18485527/68152ec1-2ca4-4662-902a-c1c16fc6da3c

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Login with an account with some funds, lets say on Optimism and Mainnet
- Go to wallet
- Select an account
- Tap on Send button
- Enter a multichain address for sending funds to, for example `opt:0x000000000000000000000000000000000000dEaD`
- Select a token
- Enter an amount
- Wait for routes to be loaded, and verify that only Optimism network is taking into consideration (because the address has the `opt:` prefix)
- Aditionally, Tap on the "+" button to edit receiver networks and add Mainnet and / or Arbitrum and apply changes
- Verify routes are recalculated with the new edited preferred networks

status: ready