### PR TITLE
Fix: nil pointer exception due to dynamic data being treated as a function

### DIFF
--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -148,7 +148,7 @@
    (let [tokens     (data-store/rpc->tokens raw-tokens-data)
          add-tokens (fn [stored-accounts tokens-per-account]
                       (reduce-kv (fn [accounts address tokens-data]
-                                   (if (accounts address)
+                                   (if (contains? accounts address)
                                      (update accounts address assoc :tokens tokens-data)
                                      accounts))
                                  stored-accounts


### PR DESCRIPTION
### Summary

This is a super straightforward PR, but the bug interrupted me for a while trying to figure out why sometimes an integration test was throwing `TypeError: Cannot read properties of null (reading 'call')`.

I identified that the original code wasn't respecting Clojure's nil punning good practices. In Clojure, it's often **recommended to not use dynamic data as functions**, because if they're nil, in CLJS we'll get an exception and as usual in CLJS, the stacktrace won't be very readable.

We should prefer `contains?` or `get`, which will work just fine with nil values, and only use data as a function if it's static, e.g. a map defined in a `def`.

#### Areas that may be impacted

PR is safe to be merged without manual testing.

status: ready
