### PR TITLE
Display private permissions only when the requirements are met

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.6",
-    "commit-sha1": "5e9f9618cd83134b8a0d19d9bfce643b9232cb9e",
-    "src-sha256": "18cw2bpr0nrvws8gka4l3sfkvilg0g07z9sw5azpwph94k2sh0rb"
+    "version": "v0.179.7",
+    "commit-sha1": "cdac86f73ac3bf7f4f4cf09b5bc27fb1602c1820",
+    "src-sha256": "0svj36zq1v7p1d6dwa29s8m82gfy4ffdcajqcn2wyxxr7i1nwnwa"
 }


### PR DESCRIPTION
fixes #19606 

status-go pr: https://github.com/status-im/status-go/pull/5059

Hide private permissions when they are not satisfied.

In the below community member permissions, the second and last permissions are private. So those permissions should only be displayed to the user when the user holds the required tokens.
<img width="592" alt="Screenshot 2024-04-16 at 16 03 18" src="https://github.com/status-im/status-mobile/assets/19279756/d1d2a81b-e1d9-4fc5-8ea0-6b5a5c7f1f8a">

#### Community overview screen
Before | After
-|-
<img src="https://github.com/status-im/status-mobile/assets/19279756/25bd40bc-bc3e-4589-a076-a1d90f5c5c51" width=300/> | <img src="https://github.com/status-im/status-mobile/assets/19279756/110859a0-6efa-4fda-b852-0b0a1b961064" width=300/> 

Non-member permissions are always private
<img width="596" alt="Screenshot 2024-04-16 at 16 10 18" src="https://github.com/status-im/status-mobile/assets/19279756/3d5adcb7-875f-4b57-b807-85f4aeb53b98">

Before | After
-|-
<img src="https://github.com/status-im/status-mobile/assets/19279756/cd9a9013-c75f-470b-80d1-0cab578746fd" width=300/> | <img src="https://github.com/status-im/status-mobile/assets/19279756/9183c531-ef33-4095-832d-0e89077ba0d2" width=300/>


#### Community permissions sheet
Before | After
-|-
<img src="https://github.com/status-im/status-mobile/assets/19279756/9493278f-3a66-4bb3-a6a0-d03afc02e7f5" width=300/> | <img src="https://github.com/status-im/status-mobile/assets/19279756/056fa8f3-2c2d-405f-97a5-27edd2f93c3f" width=300/>


### Areas affected
- Community overview screen permissions list
- Community permissions sheet

status: ready <!-- Can be ready or wip -->
