### PR TITLE
fix: show no routes message when sending to an opt address and there is no enough balance on that chain

### DIFF
--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -201,12 +201,13 @@
       :on-press-to-network   on-press-to-network}]))
 
 (defn- view-internal
-  [{:keys [from-values-by-chain to-values-by-chain routes token theme fetch-routes
+  [{:keys [from-values-by-chain to-values-by-chain routes token theme fetch-routes input-value
            affordable-networks disabled-from-networks on-press-from-network on-press-to-network]}]
   (let [token-symbol              (:symbol token)
         loading-suggested-routes? (rf/sub [:wallet/wallet-send-loading-suggested-routes?])
         network-links             (if loading-suggested-routes? affordable-networks routes)]
-    (if (or (and (not-empty affordable-networks) loading-suggested-routes?) (not-empty routes))
+    (if (and (not-empty input-value)
+             (or (and (not-empty affordable-networks) loading-suggested-routes?) (not-empty routes)))
       (let [initial-network-links-count   (count network-links)
             disabled-count                (count disabled-from-networks)
             network-links                 (if (not-empty disabled-from-networks)
@@ -239,7 +240,9 @@
                                     :loading-suggested-routes? loading-suggested-routes?}
           :render-fn               render-network-link}])
       [rn/view {:style style/empty-container}
-       (when (and (not (nil? routes)) (not loading-suggested-routes?))
+       (when (and (not-empty input-value)
+                  (or (empty? affordable-networks)
+                      (and (not (nil? routes)) (not loading-suggested-routes?))))
          [quo/text (i18n/label :t/no-routes-found)])])))
 
 (def view (quo.theme/with-theme view-internal))


### PR DESCRIPTION
fixes #19676

### Summary

This PR adds "No routes error" when trying to send to an optimism address and don't have any assets on optimism itself.

### Testing notes

Receiver networks are ignored from routes calculation, #19668 adds that, so while testing you may see suggested routes are others than the specified in the multichian address.

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

- Go to wallet account with no Optimism funds
- Start sending assets to address `opt:0x000000000000000000000000000000000000dEaD`
- Select ETH to send and input amount
- Verify "no routes" message is displayed (because there are no funds on Optimism, user should edit and enable other receiver networks that sum enough funds to be able to find routes)

status: ready