### PR TITLE
Log signals from the Clojure layer instead of native code

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.kt
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.kt
@@ -43,7 +43,6 @@ class StatusModule(private val reactContext: ReactApplicationContext, private va
     }
 
     override fun handleSignal(jsonEventString: String) {
-        Log.d(TAG, "Signal event")
         val params = Arguments.createMap()
         params.putString("jsonEvent", jsonEventString)
         reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java).emit("gethEvent", params)

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -38,9 +38,6 @@ static RCTBridge *bridge;
         return;
     }
 
-#if DEBUG
-    NSLog(@"[handleSignal] Received an event from Status-Go: %@", signal);
-#endif
     [bridge.eventDispatcher sendAppEventWithName:@"gethEvent"
                                             body:@{@"jsonEvent": signal}];
 

--- a/modules/react-native-status/nodejs/status.cpp
+++ b/modules/react-native-status/nodejs/status.cpp
@@ -1128,8 +1128,6 @@ Persistent<Function> r_call;
 std::queue<std::string> q;
 
 void run(char *json) {
-  printf("signal received %s\n", json);
-
   std::string str(json);
   q.push(str);
 }

--- a/src/status_im/common/signals/events.cljs
+++ b/src/status_im/common/signals/events.cljs
@@ -35,6 +35,7 @@
   (let [^js data     (.parse js/JSON event-str)
         ^js event-js (.-event data)
         type         (.-type data)]
+    (log/debug "Signal received" event-str)
     (case type
       "node.login"                 {:fx [[:dispatch
                                           [:profile.login/login-node-signal


### PR DESCRIPTION
### Summary

We log the entire signal data when it arrives from status-go. In `nodejs/status.cpp` the signal is "logged" using `printf` and in the Objective-C code we at least check if we're running in debug mode. Sometimes (usually for me), the developer may not want that much noise during development, e.g. when managing integration or contract tests.

This PR removes the native calls to log signals and adds a `timbre` `(log/debug ...)` call in the event handler `:signals/signal-received`. We know timbre will elide log calls at compile time given the minimum log level set, therefore, we don't need to worry about performance because we will log signals at the `debug` level only.

### Additional note

I sometimes control the log output from the level, but often I also change the namespace filters, which `timbre` supports with allow/deny sets of namespaces. For example, in a REPL, I can change the deny filter to ignore `status-im.common.signals.events` and still keep the log level as debug. Having such one-liners ready to be evaluated is handy 💯 

### Areas that may be impacted

None, unless a dev is grepping the log messages being removed.

status: ready
