### PR TITLE
swap react-native-mail fork with patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-native-keychain": "8.1.2",
     "react-native-linear-gradient": "^2.8.0",
     "react-native-lottie-splash-screen": "^1.0.1",
-    "react-native-mail": "git+https://github.com/status-im/react-native-mail.git#refs/tags/v6.1.2-status",
+    "react-native-mail": "6.1.1",
     "react-native-navigation": "7.38.3",
     "react-native-orientation-locker": "^1.5.0",
     "react-native-permissions": "3.8.0",

--- a/patches/react-native-mail-build.gradle.patch
+++ b/patches/react-native-mail-build.gradle.patch
@@ -1,0 +1,15 @@
+--- /tmp/tmp-status-mobile-6e854428f/tmp.PSruc8WtHx/build.gradle	2024-04-17 11:08:46.857319000 +0200
++++ ./node_modules/react-native-mail/android/build.gradle	2024-04-17 11:09:22.935436792 +0200
+@@ -1,7 +1,11 @@
+ apply plugin: 'com.android.library'
+ 
++def safeExtGet(prop, fallback) {
++    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
++}
++
+ android {
+-    compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 23
++    compileSdkVersion safeExtGet('compileSdkVersion', 30)
+     buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : "23.0.1"
+ 
+     defaultConfig {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7934,9 +7934,10 @@ react-native-lottie-splash-screen@^1.0.1:
     lottie-ios "3.2.3"
     lottie-react-native "^5.1.3"
 
-"react-native-mail@git+https://github.com/status-im/react-native-mail.git#refs/tags/v6.1.2-status":
+react-native-mail@6.1.1:
   version "6.1.1"
-  resolved "git+https://github.com/status-im/react-native-mail.git#6d28780dfe156dfed87d8a4ceba520cc7db019c5"
+  resolved "https://registry.yarnpkg.com/react-native-mail/-/react-native-mail-6.1.1.tgz#f1b1f8034c84d2510a93e4a2a795f0db5a13595e"
+  integrity sha512-pTs180wwyh7hN/iyTC9SfOX579U4YhDlHOLxi47IGvhPJENqO/QFdBq+wWKxyhNqdQuVSy+LoeIxLreWnIeYmg==
 
 react-native-navigation@7.38.3:
   version "7.38.3"


### PR DESCRIPTION
## Summary

This PR swaps the fork of react-native-mail with a patch.

needed for : https://github.com/status-im/status-mobile/issues/18138

## Review & Test notes

Verify if mailing logs still works.

## Platforms
- iOS
- Android

status: ready
