### PR TITLE
fix: `backup-recovery-phrase` check item pressability

### DIFF
--- a/src/status_im/contexts/wallet/add_account/create_account/new_keypair/backup_recovery_phrase/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/new_keypair/backup_recovery_phrase/view.cljs
@@ -35,9 +35,7 @@
     [rn/pressable
      {:style    style/step-item
       :hit-slop {:top 8 :bottom 8}
-      :on-press #(swap! checked? assoc
-                   (keyword (str index))
-                   (not value))}
+      :on-press #(swap! checked? assoc item-key (not value))}
      [quo/selectors
       {:type                :checkbox
        :checked?            value

--- a/src/status_im/contexts/wallet/add_account/create_account/new_keypair/backup_recovery_phrase/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/new_keypair/backup_recovery_phrase/view.cljs
@@ -30,16 +30,20 @@
 
 (defn- step-item
   [item index _ {:keys [checked? customization-color]}]
-  [rn/pressable
-   {:style    style/step-item
-    :hit-slop {:top 8 :bottom 8}
-    :on-press #(swap! checked? assoc (keyword (str index)) (not (get @checked? (keyword (str index)))))}
-   [quo/selectors
-    {:type                :checkbox
-     :checked?            (get @checked? (keyword (str index)))
-     :customization-color customization-color
-     :on-change           #(swap! checked? assoc (keyword (str index)) %)}]
-   [quo/text {:style {:margin-left 12}} (i18n/label item)]])
+  (let [item-key (keyword (str index))
+        value    (get @checked? item-key)]
+    [rn/pressable
+     {:style    style/step-item
+      :hit-slop {:top 8 :bottom 8}
+      :on-press #(swap! checked? assoc
+                   (keyword (str index))
+                   (not value))}
+     [quo/selectors
+      {:type                :checkbox
+       :checked?            value
+       :customization-color customization-color
+       :on-change           #(swap! checked? assoc item-key %)}]
+     [quo/text {:style {:margin-left 12}} (i18n/label item)]]))
 
 (defn view
   []

--- a/src/status_im/contexts/wallet/add_account/create_account/new_keypair/backup_recovery_phrase/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/new_keypair/backup_recovery_phrase/view.cljs
@@ -30,9 +30,13 @@
 
 (defn- step-item
   [item index _ {:keys [checked? customization-color]}]
-  [rn/view {:style style/step-item}
+  [rn/pressable
+   {:style    style/step-item
+    :hit-slop {:top 8 :bottom 8}
+    :on-press #(swap! checked? assoc (keyword (str index)) (not (get @checked? (keyword (str index)))))}
    [quo/selectors
     {:type                :checkbox
+     :checked?            (get @checked? (keyword (str index)))
      :customization-color customization-color
      :on-change           #(swap! checked? assoc (keyword (str index)) %)}]
    [quo/text {:style {:margin-left 12}} (i18n/label item)]])


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19704

### Summary
This PR fixes a pressability issue on the `backup-recovery-phrase` screen when pressing the checklist items: the press needs to be on the checkbox exactly. For a better user experience it would be better to make the whole item (checkbox + text) pressable.

### Demo:

https://github.com/status-im/status-mobile/assets/29354102/3878b6d9-4af4-4e41-954d-14b52e8a4e27

