### PR TITLE
fix: page top

### DIFF
--- a/src/quo/components/text_combinations/page_top/view.cljs
+++ b/src/quo/components/text_combinations/page_top/view.cljs
@@ -150,4 +150,3 @@
         nil)])])
 
 (def view (quo.theme/with-theme view-internal))
-

--- a/src/quo/components/text_combinations/page_top/view.cljs
+++ b/src/quo/components/text_combinations/page_top/view.cljs
@@ -150,3 +150,4 @@
         nil)])])
 
 (def view (quo.theme/with-theme view-internal))
+

--- a/src/quo/components/text_combinations/page_top/view.cljs
+++ b/src/quo/components/text_combinations/page_top/view.cljs
@@ -37,7 +37,7 @@
   [{:keys        [title title-accessibility-label input counter-top counter-bottom
                   title-right title-right-props]
     avatar-props :avatar}]
-  (let [avatar-props (assoc avatar-props :size :size-32)
+  (let [avatar-props (when avatar-props (assoc avatar-props :size :size-32))
         title-props  (assoc title-right-props
                             :title               title
                             :right               title-right


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19634

This PR fixes an issue with page-top being shifted to the right.

### Before:
<img src="https://github.com/status-im/status-mobile/assets/29354102/e2a8818e-a7fc-442e-a937-9efad0cf397c" alt="Screenshot_20240402_141910_Status" width="270" height="600">

### After:
<img src="https://github.com/status-im/status-mobile/assets/29354102/269d9741-00d5-4cf7-adb9-2e4b107243c8" alt="Screenshot_20240402_141910_Status" width="270" height="600">

