### PR TITLE
Ensure users can share a community url

### DIFF
--- a/src/status_im/contexts/communities/actions/community_options/view.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/view.cljs
@@ -112,7 +112,7 @@
   {:icon                :i/share
    :accessibility-label :share-community
    :label               (i18n/label :t/share-community)
-   :on-press            #(hide-sheet-and-dispatch [:communities/share-community-pressed id])})
+   :on-press            #(rf/dispatch [:communities/share-community-pressed id])})
 
 (defn leave-community
   [id color]

--- a/src/status_im/contexts/communities/sharing/events.cljs
+++ b/src/status_im/contexts/communities/sharing/events.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.communities.sharing.events
   (:require [legacy.status-im.data-store.chats :as data-store.chats]
             [react-native.platform :as platform]
-            [react-native.share :as share]
             [taoensso.timbre :as log]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
@@ -97,20 +96,3 @@
                                {:error        err
                                 :community-id community-id
                                 :event        :communities/get-community-share-data}))}]}))
-
-(rf/reg-event-fx :communities/share-community-channel-url-with-data
- (fn [_ [chat-id]]
-   (let [title      (i18n/label :t/channel-on-status)
-         on-success (fn [url]
-                      (share/open
-                       (if platform/ios?
-                         {:activityItemSources [{:placeholderItem {:type    "text"
-                                                                   :content title}
-                                                 :item            {:default {:type    "url"
-                                                                             :content url}}
-                                                 :linkMetadata    {:title title}}]}
-                         {:title     title
-                          :subject   title
-                          :url       url
-                          :isNewTask true})))]
-     {:fx [[:dispatch [:communities/get-community-channel-share-data chat-id on-success]]]})))

--- a/src/status_im/contexts/communities/sharing/events.cljs
+++ b/src/status_im/contexts/communities/sharing/events.cljs
@@ -83,7 +83,6 @@
                                                    :linkMetadata    {:title title}}]}
                                                 {:title     title
                                                  :subject   title
-                                                 :message   url
                                                  :url       url
                                                  :isNewTask true})}]))]
      {:fx [[:dispatch [:communities/get-community-share-data community-id on-success]]]})))

--- a/src/status_im/contexts/communities/sharing/events.cljs
+++ b/src/status_im/contexts/communities/sharing/events.cljs
@@ -71,7 +71,7 @@
 
 (rf/reg-event-fx :communities/share-community-url-with-data
  (fn [_ [community-id]]
-   (let [title      (i18n/label :t/channel-on-status)
+   (let [title      (i18n/label :t/community-on-status)
          on-success (fn [url]
                       (rf/dispatch [:open-share
                                     {:options (if platform/ios?

--- a/src/status_im/contexts/communities/sharing/events.cljs
+++ b/src/status_im/contexts/communities/sharing/events.cljs
@@ -51,7 +51,6 @@
                                                    :linkMetadata    {:title title}}]}
                                                 {:title     title
                                                  :subject   title
-                                                 :message   url
                                                  :url       url
                                                  :isNewTask true})}]))]
      {:fx [[:dispatch [:communities/get-community-channel-share-data chat-id on-success]]]})))
@@ -112,7 +111,6 @@
                                                  :linkMetadata    {:title title}}]}
                          {:title     title
                           :subject   title
-                          :message   url
                           :url       url
                           :isNewTask true})))]
      {:fx [[:dispatch [:communities/get-community-channel-share-data chat-id on-success]]]})))

--- a/src/status_im/contexts/communities/sharing/events.cljs
+++ b/src/status_im/contexts/communities/sharing/events.cljs
@@ -15,8 +15,7 @@
 (rf/reg-event-fx :communities/share-community-pressed
  (fn [{:keys [db]} [id]]
    {:db (assoc db :communities/community-id-input id)
-    :fx [[:dispatch [:hide-bottom-sheet]]
-         [:dispatch [:open-modal :legacy-invite-people-community {:id id}]]]}))
+    :fx [[:dispatch [:communities/share-community-url-with-data id]]]}))
 
 (rf/reg-event-fx :communities/share-community-confirmation-pressed
  (fn [_ [users-public-keys community-id]]

--- a/src/status_im/contexts/communities/sharing/events.cljs
+++ b/src/status_im/contexts/communities/sharing/events.cljs
@@ -70,6 +70,25 @@
                                   :chat-id chat-id
                                   :event   :communities/get-community-channel-share-data}))}]})))
 
+(rf/reg-event-fx :communities/share-community-url-with-data
+ (fn [_ [community-id]]
+   (let [title      (i18n/label :t/channel-on-status)
+         on-success (fn [url]
+                      (rf/dispatch [:open-share
+                                    {:options (if platform/ios?
+                                                {:activityItemSources
+                                                 [{:placeholderItem {:type    :text
+                                                                     :content title}
+                                                   :item            {:default {:type    :url
+                                                                               :content url}}
+                                                   :linkMetadata    {:title title}}]}
+                                                {:title     title
+                                                 :subject   title
+                                                 :message   url
+                                                 :url       url
+                                                 :isNewTask true})}]))]
+     {:fx [[:dispatch [:communities/get-community-share-data community-id on-success]]]})))
+
 (rf/reg-event-fx :communities/get-community-share-data
  (fn [_ [community-id on-success]]
    {:json-rpc/call

--- a/test/appium/tests/activity_center/test_activity_center.py
+++ b/test/appium/tests/activity_center/test_activity_center.py
@@ -275,7 +275,7 @@ class TestActivityMultipleDevicePR(MultipleSharedDeviceTestCase):
         self.channel_1.send_message(self.text_message)
 
         self.community_1, self.community_2 = self.home_1.get_community_view(), self.home_2.get_community_view()
-        self.community_1.share_community(self.community_name, self.username_2)
+        self.community_1.invite_to_community(self.community_name, self.username_2)
         self.home_1.get_to_community_channel_from_home(self.community_name)
 
         self.chat_2 = self.home_2.get_chat(self.username_1).click()
@@ -414,7 +414,7 @@ class TestActivityMultipleDevicePRTwo(MultipleSharedDeviceTestCase):
         self.channel_1.send_message(self.text_message)
 
         self.community_1, self.community_2 = self.home_1.get_community_view(), self.home_2.get_community_view()
-        self.community_1.share_community(self.community_name, self.username_2)
+        self.community_1.invite_to_community(self.community_name, self.username_2)
         self.home_1.get_to_community_channel_from_home(self.community_name)
 
         self.chat_2 = self.home_2.get_chat(self.username_1).click()
@@ -472,7 +472,7 @@ class TestActivityMultipleDevicePRTwo(MultipleSharedDeviceTestCase):
         self.channel_name = "dogs"
         self.home_1.create_community(community_type="closed")
         self.home_1.reopen_app()
-        self.community_1.share_community(community_name, self.username_2)
+        self.community_1.invite_to_community(community_name, self.username_2)
 
         self.home_2.just_fyi("Request access to community")
         self.home_2.navigate_back_to_home_view()

--- a/test/appium/tests/critical/chats/test_public_chat_browsing.py
+++ b/test/appium/tests/critical/chats/test_public_chat_browsing.py
@@ -315,7 +315,7 @@ class TestCommunityMultipleDeviceMerged(MultipleSharedDeviceTestCase):
         self.channel_1.send_message(self.text_message)
 
         self.community_1, self.community_2 = self.home_1.get_community_view(), self.home_2.get_community_view()
-        self.community_1.share_community(self.community_name, self.username_2)
+        self.community_1.invite_to_community(self.community_name, self.username_2)
         self.home_1.get_to_community_channel_from_home(self.community_name)
 
         self.home_2.just_fyi("Send message to contact (need for blocking contact) test")
@@ -831,7 +831,7 @@ class TestCommunityMultipleDeviceMergedTwo(MultipleSharedDeviceTestCase):
         self.home_1.create_community(community_type="open")
 
         self.community_1, self.community_2 = self.home_1.get_community_view(), self.home_2.get_community_view()
-        self.community_1.share_community(self.community_name, self.username_2)
+        self.community_1.invite_to_community(self.community_name, self.username_2)
         self.channel_1 = self.home_1.get_to_community_channel_from_home(self.community_name)
 
         self.home_2.just_fyi("Send message to contact (need for blocking contact) test")
@@ -1003,7 +1003,7 @@ class TestCommunityMultipleDeviceMergedTwo(MultipleSharedDeviceTestCase):
         self.home_1.just_fyi("Device 1 creates a closed community")
         self.home_1.create_community(community_type="closed")
         community_name = "closed community"
-        self.community_1.share_community(community_name, self.username_2)
+        self.community_1.invite_to_community(community_name, self.username_2)
         self.community_1.get_to_community_channel_from_home(community_name, "general")
         control_message_general_chat = "this message should be visible to the user before joining"
         self.channel_1.send_message(control_message_general_chat)
@@ -1103,7 +1103,7 @@ class TestCommunityMultipleDeviceMergedTwo(MultipleSharedDeviceTestCase):
         self.home_1.just_fyi("Device 1 creates open community")
         self.home_1.create_community(community_type="open")
         community_name = "open community"
-        self.community_1.share_community(community_name, self.username_2)
+        self.community_1.invite_to_community(community_name, self.username_2)
         self.community_1.get_to_community_channel_from_home(community_name, "general")
         control_message_general_chat = "this message should be visible to the user before joining"
         self.channel_1.send_message(control_message_general_chat)

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -322,6 +322,7 @@ class BaseView(object):
         self.qr_code_image = Button(self.driver, accessibility_id="qr-code-image")
         self.sign_in_phrase = SignInPhraseText(self.driver)
         self.toast_content_element = BaseElement(self.driver, accessibility_id="toast-content")
+        self.next_button = Button(self.driver, accessibility_id="next-button")
 
         # share contact screen
         self.show_qr_button = Button(self.driver, accessibility_id="show-qr-button")

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -386,6 +386,7 @@ class CommunityView(HomeView):
         self.leave_community_button = Button(self.driver, translation_id="leave-community")
         self.edit_community_button = Button(self.driver, translation_id="edit-community")
         self.share_community_button = Button(self.driver, accessibility_id="share-community")
+        self.invite_people_from_contacts_button = Button(self.driver, accessibility_id="invite-people-from-contacts")
 
         # Members
         self.invite_people_button = Button(self.driver, accessibility_id="community-invite-people")
@@ -471,37 +472,20 @@ class CommunityView(HomeView):
             Button(self.driver, xpath="//*[starts-with(@text,'%s')]%s" % (username, decline_suffix)).click()
         self.close_button.click()
 
-    # Should not be used anymore, outdated flow
-    def send_invite_to_community(self, community_name, user_names_to_invite):
+    def invite_to_community(self, community_name, user_names_to_invite):
         if isinstance(user_names_to_invite, str):
             user_names_to_invite = [user_names_to_invite]
-        self.driver.info("Send %s invite to community" % ', '.join(map(str, user_names_to_invite)))
-        self.jump_to_communities_home()
-        home = self.get_home_view()
-        community_element = home.get_chat(community_name, community=True)
-        community_element.long_press_until_element_is_shown(self.view_members_button)
-        self.view_members_button.click_until_presence_of_element(self.invite_button)
-        self.invite_button.click()
-        for user_name in user_names_to_invite:
-            user_contact = self.element_by_text_part(user_name)
-            user_contact.scroll_and_click()
-        self.share_invite_button.click_until_presence_of_element(self.invite_button)
-        self.back_button.click_until_presence_of_element(self.plus_button)
-
-    def share_community(self, community_name, user_names_to_share):
-        if isinstance(user_names_to_share, str):
-            user_names_to_share = [user_names_to_share]
-        self.driver.info("Share to  %s community" % ', '.join(map(str, user_names_to_share)))
+        self.driver.info("Share to  %s community" % ', '.join(map(str, user_names_to_invite)))
         self.jump_to_communities_home()
         home = self.get_home_view()
         home.communities_tab.click()
         community_element = home.get_chat(community_name, community=True)
         community_element.long_press_until_element_is_shown(self.share_community_button)
-        self.share_community_button.click()
-        for user_name in user_names_to_share:
+        self.invite_people_from_contacts_button.click()
+        for user_name in user_names_to_invite:
             xpath = "//*[@content-desc='user-avatar']/following-sibling::android.widget.TextView[@text='%s']" % user_name
             Button(self.driver, xpath=xpath).click()
-        self.share_invite_button.click()
+        self.next_button.click()
 
 
 class PreviewMessage(ChatElementByText):

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -330,7 +330,6 @@ class HomeView(BaseView):
         # New UI bottom sheet
         self.start_a_new_chat_bottom_sheet_button = Button(self.driver, accessibility_id="start-a-new-chat")
         self.add_a_contact_chat_bottom_sheet_button = Button(self.driver, accessibility_id="add-a-contact")
-        self.setup_chat_button = Button(self.driver, accessibility_id="next-button")
 
         # Activity centre
         self.all_activity_tab_button = ActivityTabButton(self.driver, translation_id="all")
@@ -459,7 +458,7 @@ class HomeView(BaseView):
                 raise NoSuchElementException(
                     "User with the name '%s' is not in contacts list so can't create a group chat" % user_name)
             check_box.click_until_presence_of_element(chat.get_username_checkbox(user_name, state_on=True))
-        self.setup_chat_button.click()
+        self.next_button.click()
         self.get_sign_in_view().profile_title_input.send_keys(group_chat_name)
         chat.create_group_chat_button.click()
         self.driver.info("## Group chat %s is created successfully!" % group_chat_name, device=False)


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19724 
fixes #19725

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to resolve some discovered issues with sharing a community url.
  * Sharing a community url from the community invite screen will now open the share-sheet
  * And sharing a community from the community action menu will now open the share-sheet

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Community invites
- Community action menu

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open the status mobile app
- Ensure that the account has access to a community
- Ensure that the account does not have contacts
  - This is important for seeing the empty contacts screen when inviting users to a community

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before

https://github.com/status-im/status-mobile/assets/2845768/bb6c7fda-e8f2-4163-acf8-d9448ea30774

##### Action Menu

https://github.com/status-im/status-mobile/assets/2845768/1dac183a-ea0c-4aa2-ba75-2293a3590b21

##### Community Invites

#### After

##### Action Menu

https://github.com/status-im/status-mobile/assets/2845768/84261d99-6583-41ac-a43b-d78d2b08cc92

##### Community Invites

https://github.com/status-im/status-mobile/assets/2845768/17cc0c61-93f2-48b3-87f0-2c34dc1ddc11

status: ready
