### PR TITLE
Fix: category settings item separator line color

### DIFF
--- a/src/quo/components/settings/category/settings/view.cljs
+++ b/src/quo/components/settings/category/settings/view.cljs
@@ -23,4 +23,4 @@
         [:<>
          [settings-item/view item]
          (when-not (= item (last settings-item))
-           [rn/view {:style (style/settings-separator props)}])])]]))
+           [rn/view {:style (style/settings-separator props theme)}])])]]))

--- a/src/quo/components/settings/category/style.cljs
+++ b/src/quo/components/settings/category/style.cljs
@@ -32,7 +32,7 @@
   {:margin-top 12})
 
 (defn settings-separator
-  [{:keys [blur? theme]}]
+  [{:keys [blur?]} theme]
   {:height           1
    :background-color (if blur?
                        colors/white-opa-5


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19718

Before
<img src="https://github.com/status-im/status-mobile/assets/29354102/5db409a9-1df6-4904-904c-1ee05f5edac1" alt="Screenshot_20240402_141910_Status" width="270" height="600">


After
<img src="https://github.com/status-im/status-mobile/assets/29354102/672112cb-4e7a-4aee-974d-0913d05e7907" alt="Screenshot_20240402_141910_Status" width="270" height="600">
