### PR TITLE
fix: reaction drawer issue

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/content/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/style.cljs
@@ -16,16 +16,18 @@
     (assoc :margin-top 4)))
 
 (defn user-message-content
-  [{:keys [outgoing outgoing-status six-reactions? window-scale small-screen?]}]
+  [{:keys [outgoing outgoing-status six-reactions? window-scale small-screen? preview?]}]
   {:border-radius      16
-   :padding-horizontal 8
-   :padding-top        4
-   :padding-bottom     (if (or small-screen?
-                               (and
-                                (> 3 window-scale)
-                                six-reactions?))
-                         (* message-padding-scaling-ratio window-scale)
-                         4)
+   :padding-horizontal (if preview? 12 8)
+   :padding-top        (if preview? 8 4)
+   :padding-bottom     (if preview?
+                         12
+                         (if (or small-screen?
+                                 (and
+                                  (> 3 window-scale)
+                                  six-reactions?))
+                           (* message-padding-scaling-ratio window-scale)
+                           4))
    :opacity            (if (and outgoing (= outgoing-status :sending))
                          0.5
                          1)})

--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -196,7 +196,8 @@
                                  :outgoing-status outgoing-status
                                  :small-screen?   rn/small-screen?
                                  :window-scale    window-scale
-                                 :six-reactions?  six-reactions?})
+                                 :six-reactions?  six-reactions?
+                                 :preview?        preview?})
           :on-press            (fn []
                                  (if (and platform/ios? keyboard-shown?)
                                    (do
@@ -268,7 +269,8 @@
                 :message-data    message-data
                 :context         context
                 :keyboard-shown? keyboard-shown?
-                :show-reactions? false}]]])]]))))
+                :preview?        true
+                :show-reactions? true}]]])]]))))
 
 (defn on-long-press
   [{:keys [deleted? deleted-for-me?] :as message-data} context keyboard-shown?]

--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -227,6 +227,7 @@
               [gesture/scroll-view])
             [{:style {:margin-left 8
                       :flex        1
+                      :gap         1
                       :max-height  (when-not show-reactions?
                                      (* 0.4 height))}}
              [author message-data show-reactions? in-reaction-and-action-menu? show-user-info?]
@@ -265,12 +266,13 @@
             [reactions/message-reactions-row (assoc message-data :preview? preview?)
              [rn/view {:pointer-events :none}
               [user-message-content
-               {:theme           theme
-                :message-data    message-data
-                :context         context
-                :keyboard-shown? keyboard-shown?
-                :preview?        true
-                :show-reactions? true}]]])]]))))
+               {:theme                        theme
+                :message-data                 message-data
+                :context                      context
+                :in-reaction-and-action-menu? true
+                :keyboard-shown?              keyboard-shown?
+                :preview?                     true
+                :show-reactions?              true}]]])]]))))
 
 (defn on-long-press
   [{:keys [deleted? deleted-for-me?] :as message-data} context keyboard-shown?]


### PR DESCRIPTION
fixes #19280

### Summary
- Reaction isn't visible [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=8:140759&mode=design#717915153)] in the message preview, even if the message has correctly displayed reactions in the chat
- Bottom margin [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=8:140759&mode=design#717915153)] is too narrow

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open a chat
- React to a message
- Press on the React button to open the reaction drawer

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison
![Simulator Screenshot - iPhone 13 - 2024-04-22 at 07 36 50](https://github.com/status-im/status-mobile/assets/39961806/080a4e8f-40ca-4a0c-b60a-53ed84c40677)

status: ready <!-- Can be ready or wip -->
