### PR TITLE
skip share wallet component test

### DIFF
--- a/src/status_im/contexts/shell/share/wallet/component_spec.cljs
+++ b/src/status_im/contexts/shell/share/wallet/component_spec.cljs
@@ -37,7 +37,12 @@
                  (h/is-truthy (h/query-by-text "0x707f635951193ddafbb40971a0fcaab8a6415160"))
                  (h/is-falsy (h/query-by-text "eth:"))))))
 
-  (h/test "should display the multichain account"
+  ;; NOTE: Fails with error below possibly due to Infura outage:
+  ;;    FAIL  ./status_im.contexts.shell.share.wallet.component_spec.js
+  ;;  ● share wallet addresses › should display the multichain account
+  ;;
+  ;;   No protocol method IDeref.-deref defined for type undefined
+  (h/test-skip "should display the multichain account"
     (render-wallet-view)
     (-> (h/wait-for #(h/get-by-label-text :share-qr-code-multichain-tab))
         (.then (fn []


### PR DESCRIPTION
## Summary

This PR skips wallet share component test that keeps failing.

## Testing notes
Can skip manual QA since this just impacts the component tests

## Platforms
- Android
- iOS

status: ready
