### PR TITLE
Collectible header

### DIFF
--- a/src/js/worklets/header_animations.js
+++ b/src/js/worklets/header_animations.js
@@ -1,0 +1,25 @@
+import {
+  useDerivedValue,
+  interpolate,
+  interpolateColor,
+  Extrapolation,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+
+const CLAMP_MIN = 0;
+const CLAMP_MAX = 60;
+const BLUR_MIN = 1;
+const BLUR_MAX = 15;
+
+export const useBlurAmount = (sharedValue) =>
+  useDerivedValue(() =>
+    parseInt(interpolate(sharedValue.value, [CLAMP_MIN, CLAMP_MAX], [BLUR_MIN, BLUR_MAX], Extrapolation.CLAMP)),
+  );
+
+export function useLayerOpacity(sharedValue, from, to) {
+  return useAnimatedStyle(() => ({
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: interpolateColor(sharedValue.value, [0, 60], [from, to], 'RGB'),
+  }));
+}

--- a/src/mocks/js_dependencies.cljs
+++ b/src/mocks/js_dependencies.cljs
@@ -438,6 +438,7 @@
     "../src/js/worklets/parallax.js"                   #js {}
     "../src/js/worklets/profile_header.js"             #js {}
     "../src/js/worklets/identifiers_highlighting.js"   #js {}
+    "../src/js/worklets/header_animations.js"          #js {}
     "./fleets.js"                                      default-fleets
     "../translations/ar.json"                          (js/JSON.parse (slurp "./translations/ar.json"))
     "../translations/de.json"                          (js/JSON.parse (slurp "./translations/de.json"))

--- a/src/quo/components/profile/expanded_collectible/style.cljs
+++ b/src/quo/components/profile/expanded_collectible/style.cljs
@@ -1,13 +1,10 @@
 (ns quo.components.profile.expanded-collectible.style
-  (:require [quo.foundations.colors :as colors]
-            [quo.foundations.shadows :as shadows]))
+  (:require [quo.foundations.colors :as colors]))
 
-(defn container
-  [theme]
-  (merge (shadows/get 2 theme)
-         {:align-items     :center
-          :justify-content :center
-          :border-radius   16}))
+(def container
+  {:align-items     :center
+   :justify-content :center
+   :border-radius   16})
 
 (defn image
   [square? aspect-ratio]

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -34,7 +34,8 @@
     label]])
 
 (defn view-internal
-  [{:keys [container-style square? on-press counter image-src native-ID supported-file?]}]
+  [{:keys [container-style square? on-press counter image-src native-ID supported-file?
+           on-collectible-load]}]
   (let [theme                          (quo.theme/use-theme)
         [image-size set-image-size]    (rn/use-state {})
         [image-error? set-image-error] (rn/use-state false)]
@@ -48,7 +49,7 @@
     [rn/pressable
      {:on-press            (when (and (not image-error?) supported-file?) on-press)
       :accessibility-label :expanded-collectible
-      :style               (merge container-style (style/container theme))}
+      :style               (merge container-style style/container)}
      (cond
        (not supported-file?)
        [fallback-view
@@ -68,7 +69,8 @@
          {:style     (style/image square? (:aspect-ratio image-size))
           :source    image-src
           :native-ID native-ID
-          :on-error  #(set-image-error true)}]
+          :on-error  #(set-image-error true)
+          :on-load   on-collectible-load}]
         [counter-view counter]])]))
 
 (def ?schema
@@ -82,7 +84,8 @@
       [:native-ID {:optional true} [:maybe [:or string? keyword?]]]
       [:square? {:optional true} [:maybe boolean?]]
       [:counter {:optional true} [:maybe string?]]
-      [:on-press {:optional true} [:maybe fn?]]]]]
+      [:on-press {:optional true} [:maybe fn?]]
+      [:on-collectible-load {:optional true} [:maybe fn?]]]]]
    :any])
 
 (def view (schema/instrument #'view-internal ?schema))

--- a/src/status_im/common/scroll_page/view.cljs
+++ b/src/status_im/common/scroll_page/view.cljs
@@ -108,7 +108,7 @@
          children]
       (let [theme (quo.theme/use-theme)]
         [:<>
-         [:f> f-scroll-page-header
+         [f-scroll-page-header
           {:scroll-height  @scroll-height
            :height         height
            :sticky-header  sticky-header

--- a/src/status_im/contexts/wallet/collectible/style.cljs
+++ b/src/status_im/contexts/wallet/collectible/style.cljs
@@ -1,17 +1,15 @@
-(ns status-im.contexts.wallet.collectible.style)
+(ns status-im.contexts.wallet.collectible.style
+  (:require [quo.foundations.colors :as colors]
+            [react-native.core :as rn]
+            [react-native.platform :as platform]))
 
 (def container
-  {:margin-top    100
-   :margin-bottom 34})
+  {:margin-bottom 34})
 
 (def preview-container
   {:margin-horizontal 8
-   :margin-top        12})
-
-(def preview
-  {:width         "100%"
-   :aspect-ratio  1
-   :border-radius 16})
+   :margin-top        12
+   :padding-top       100})
 
 (def header
   {:margin-horizontal 20
@@ -43,3 +41,43 @@
 (def opensea-button
   {:flex        1
    :margin-left 6})
+
+(def animated-header
+  {:position :absolute
+   :top      0
+   :left     0
+   :right    0
+   :height   100
+   :z-index  1
+   :overflow :hidden})
+
+(defn scroll-view
+  [safe-area-top]
+  {:flex       1
+   :margin-top (when platform/ios? (- safe-area-top))})
+
+(def gradient-layer
+  {:position    :absolute
+   :top         0
+   :left        0
+   :right       0
+   :bottom      0
+   :flex        1
+   :align-items :center
+   :overflow    :hidden})
+
+(def image-background
+  {:height       (:height (rn/get-window))
+   :aspect-ratio 1})
+
+(def gradient
+  {:position :absolute
+   :top      0
+   :left     0
+   :right    0
+   :bottom   0})
+
+(defn background-color
+  [theme]
+  {:flex             1
+   :background-color (colors/theme-colors colors/white colors/neutral-95 theme)})

--- a/src/status_im/contexts/wallet/wallet_connect/utils.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/utils.cljs
@@ -1,10 +1,10 @@
 (ns status-im.contexts.wallet.wallet-connect.utils
   ;; NOTE: Not sorting namespaces since @walletconnect/react-native-compat should be the first
   #_{:clj-kondo/ignore [:unsorted-required-namespaces]}
-  (:require ["@walletconnect/react-native-compat"]
-            ["@walletconnect/core" :refer [Core]]
-            ["@walletconnect/web3wallet" :refer [Web3Wallet]]
+  (:require ["@walletconnect/core" :refer [Core]]
+            ["@walletconnect/react-native-compat"]
             ["@walletconnect/utils" :refer [buildApprovedNamespaces]]
+            ["@walletconnect/web3wallet" :refer [Web3Wallet]]
             [status-im.config :as config]
             [utils.i18n :as i18n]))
 

--- a/src/utils/worklets/header_animations.cljs
+++ b/src/utils/worklets/header_animations.cljs
@@ -1,0 +1,7 @@
+(ns utils.worklets.header-animations)
+
+(def worklets (js/require "../src/js/worklets/header_animations.js"))
+
+(def use-blur-amount (.-useBlurAmount worklets))
+
+(def use-layer-opacity (.-useLayerOpacity worklets))


### PR DESCRIPTION
fixes #18595 

### Summary
Improve collectible header animation.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
- Collectible detail screen

### Steps to test
- Open Status
- Navigate to the Wallet tab
- Open collectibles tab
- Open any collectible

<!-- (PRs will only be accepted if squashed into single commit.) -->

#### Known issues
- In iOS Dark mode the header has a blue tint
- When the collectible name is very long the text overflows
- Header animation won't work as expected when the collectible is unsupported

(We will handle the above issues separately)

### Screenshots
#### Android
Light Mode:

https://github.com/status-im/status-mobile/assets/19279756/ec9626d7-118a-4094-8024-20433c9a618e


Dark Mode:

https://github.com/status-im/status-mobile/assets/19279756/93df91b0-d96f-45ab-ba03-85e34e9f8158



#### iOS
Light Mode:

https://github.com/status-im/status-mobile/assets/19279756/32a69324-dc7f-45bc-b5e4-cc9201889a2e

Dark Mode:

https://github.com/status-im/status-mobile/assets/19279756/3b457b33-ea24-4404-b93e-c9ac382db55b



status: ready <!-- Can be ready or wip -->
