### PR TITLE
fix: store node are not available on ios

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.10",
-    "commit-sha1": "90b18d4f8801b09f68bb5b794a5b6af92001d26e",
-    "src-sha256": "0dlrnpr7wj9z2ywm90avgdzdr9wg71dy82v5jjc9wmiz537mn7wy"
+    "version": "fix_/store-nodes-not-available-ios",
+    "commit-sha1": "e6e109d64829a66e781d8a2a4aa466f55fed0f93",
+    "src-sha256": "1526mb6nm076pi7l9xi9h0ggi6prz10xp1djyxbk13w2z94r4h38"
 }


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19736

### Summary
After bumbing golang to 1.20 we experience a dns resolution failure which was fixed on specifically for android by overriding DefaultResolver in the net package as mentioned here https://github.com/status-im/status-mobile/issues/19581#issuecomment-2064099515. This pr extends overriding the dns default resolver to iOS devices which fixes the availability of store nodes issue on ios devices

### Before and after screenshots comparison
<img src="https://github.com/status-im/status-mobile/assets/28704507/03630df3-8016-4c5a-bcca-6f2d5a278a08" width="325">


status: ready wip
