### PR TITLE
Fix for "no routes found" on transaction confirmation page

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -115,10 +115,10 @@
                                                token-balance))
             fiat-limit                    (.toFixed (* token-balance conversion-rate) 2)
             current-limit                 (if @crypto-currency? crypto-limit fiat-limit)
-            valid-input?        (not (or (empty? (controlled-input/input-value input-state))
-                                         (<= (controlled-input/numeric-value input-state) 0)
-                                         (> (controlled-input/numeric-value input-state)
-                                            current-limit)))
+            valid-input?                  (not (or (empty? (controlled-input/input-value input-state))
+                                                   (<= (controlled-input/numeric-value input-state) 0)
+                                                   (> (controlled-input/numeric-value input-state)
+                                                      current-limit)))
             current-currency              (if @crypto-currency? token-symbol fiat-currency)
             input-num-value               (controlled-input/numeric-value input-state)
             confirm-disabled?             (or (nil? route)
@@ -189,9 +189,9 @@
            :on-swap         #(reset! crypto-currency? %)
            :on-token-press  show-select-asset-sheet}]
          [routes/view
-          {:token                  token
-           :input-value            (controlled-input/input-value input-state)
-           :valid-input? valid-input?
+          {:token             token
+           :input-value       (controlled-input/input-value input-state)
+           :valid-input?      valid-input?
            :current-screen-id current-screen-id}]
          (when (or loading-routes? (seq route))
            [estimated-fees

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -105,7 +105,6 @@
 
             route                         (rf/sub [:wallet/wallet-send-route])
             to-address                    (rf/sub [:wallet/wallet-send-to-address])
-            nav-current-screen-id         (rf/sub [:view-id])
 
             on-confirm                    (or default-on-confirm handle-on-confirm)
             crypto-decimals               (or default-crypto-decimals
@@ -115,20 +114,18 @@
                                                token
                                                token-balance))
             fiat-limit                    (.toFixed (* token-balance conversion-rate) 2)
-            current-limit                 #(if @crypto-currency? crypto-limit fiat-limit)
-            routes-can-be-fetched?        (and (= nav-current-screen-id current-screen-id)
-                                               (not
-                                                (or (empty? (controlled-input/input-value input-state))
-                                                    (<= (controlled-input/numeric-value input-state) 0)
-                                                    (> (controlled-input/numeric-value input-state)
-                                                       (current-limit)))))
+            current-limit                 (if @crypto-currency? crypto-limit fiat-limit)
+            valid-input?        (not (or (empty? (controlled-input/input-value input-state))
+                                         (<= (controlled-input/numeric-value input-state) 0)
+                                         (> (controlled-input/numeric-value input-state)
+                                            current-limit)))
             current-currency              (if @crypto-currency? token-symbol fiat-currency)
             input-num-value               (controlled-input/numeric-value input-state)
             confirm-disabled?             (or (nil? route)
                                               (empty? route)
                                               (empty? (controlled-input/input-value input-state))
                                               (<= input-num-value 0)
-                                              (> input-num-value (current-limit)))
+                                              (> input-num-value current-limit))
             amount-text                   (str (controlled-input/input-value input-state)
                                                " "
                                                token-symbol)
@@ -167,8 +164,8 @@
              #(.remove app-keyboard-listener))))
         (rn/use-effect
          (fn []
-           (set-input-state #(controlled-input/set-upper-limit % (current-limit))))
-         [@crypto-currency?])
+           (set-input-state #(controlled-input/set-upper-limit % current-limit)))
+         [current-limit])
         [rn/view
          {:style               style/screen
           :accessibility-label (str "container"
@@ -185,7 +182,7 @@
            :error?          (controlled-input/input-error input-state)
            :networks        (seq token-networks)
            :title           (i18n/label :t/send-limit
-                                        {:limit (make-limit-label (current-limit) current-currency)})
+                                        {:limit (make-limit-label current-limit current-currency)})
            :conversion      conversion-rate
            :show-keyboard?  false
            :value           (controlled-input/input-value input-state)
@@ -194,7 +191,8 @@
          [routes/view
           {:token                  token
            :input-value            (controlled-input/input-value input-state)
-           :routes-can-be-fetched? routes-can-be-fetched?}]
+           :valid-input? valid-input?
+           :current-screen-id current-screen-id}]
          (when (or loading-routes? (seq route))
            [estimated-fees
             {:loading-suggested-routes? loading-routes?

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -115,7 +115,8 @@
                                                token-balance))
             fiat-limit                    (.toFixed (* token-balance conversion-rate) 2)
             current-limit                 (if @crypto-currency? crypto-limit fiat-limit)
-            valid-input?                  (not (or (empty? (controlled-input/input-value input-state))
+            valid-input?                  (not (or (string/blank? (controlled-input/input-value
+                                                                   input-state))
                                                    (<= (controlled-input/numeric-value input-state) 0)
                                                    (> (controlled-input/numeric-value input-state)
                                                       current-limit)))
@@ -123,7 +124,7 @@
             input-num-value               (controlled-input/numeric-value input-state)
             confirm-disabled?             (or (nil? route)
                                               (empty? route)
-                                              (empty? (controlled-input/input-value input-state))
+                                              (string/blank? (controlled-input/input-value input-state))
                                               (<= input-num-value 0)
                                               (> input-num-value current-limit))
             amount-text                   (str (controlled-input/input-value input-state)

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -202,18 +202,20 @@
       :on-press-to-network   on-press-to-network}]))
 
 (defn fetch-routes
-  [amount routes-can-be-fetched? bounce-duration-ms]
-  (if routes-can-be-fetched?
+  [amount valid-input? bounce-duration-ms]
+  (if valid-input?
     (debounce/debounce-and-dispatch
      [:wallet/get-suggested-routes {:amount amount}]
      bounce-duration-ms)
     (rf/dispatch [:wallet/clean-suggested-routes])))
 
 (defn view
-  [{:keys [token theme input-value routes-can-be-fetched?
-           on-press-to-network]}]
+  [{:keys [token theme input-value valid-input?
+           on-press-to-network current-screen-id]}]
 
   (let [token-symbol                                   (:symbol token)
+        nav-current-screen-id         (rf/sub [:view-id])
+        active-screen?                    (= nav-current-screen-id current-screen-id)
         loading-suggested-routes?                      (rf/sub
                                                         [:wallet/wallet-send-loading-suggested-routes?])
         from-values-by-chain                           (rf/sub
@@ -241,12 +243,12 @@
                                                            (not-empty routes))]
 
     (rn/use-effect
-     #(when (> (count affordable-networks) 0)
-        (fetch-routes input-value routes-can-be-fetched? 2000))
-     [input-value routes-can-be-fetched?])
+     #(when (and active-screen? (> (count affordable-networks) 0))
+        (fetch-routes input-value valid-input? 2000))
+     [input-value valid-input?])
     (rn/use-effect
-     #(when (> (count affordable-networks) 0)
-        (fetch-routes input-value routes-can-be-fetched? 0))
+     #(when (and active-screen? (> (count affordable-networks) 0))
+        (fetch-routes input-value valid-input? 0))
      [disabled-from-chain-ids])
     (if show-routes?
       (let [initial-network-links-count   (count network-links)
@@ -275,7 +277,7 @@
           {:from-values-by-chain      from-values-by-chain
            :to-values-by-chain        to-values-by-chain
            :theme                     theme
-           :fetch-routes              #(fetch-routes % routes-can-be-fetched? 2000)
+           :fetch-routes              #(fetch-routes % valid-input? 2000)
            :on-press-from-network     (fn [chain-id _]
                                         (let [disabled-chain-ids (if (contains? (set
                                                                                  disabled-from-chain-ids)

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -214,8 +214,8 @@
            on-press-to-network current-screen-id]}]
 
   (let [token-symbol                                   (:symbol token)
-        nav-current-screen-id         (rf/sub [:view-id])
-        active-screen?                    (= nav-current-screen-id current-screen-id)
+        nav-current-screen-id                          (rf/sub [:view-id])
+        active-screen?                                 (= nav-current-screen-id current-screen-id)
         loading-suggested-routes?                      (rf/sub
                                                         [:wallet/wallet-send-loading-suggested-routes?])
         from-values-by-chain                           (rf/sub


### PR DESCRIPTION
fixes #19780

### Summary
This pr fixes:
- issue with the transaction confirmation page when routes were not found.
- a problem when the value inputed by the user was displayed in red even when it doesn't exceed the limit

https://github.com/status-im/status-mobile/assets/5786310/b8f3952e-a6d2-41cc-b79c-4629bf5c377b


### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Go to wallet
- Go to send flow
- Enter available asset value for assets sending
- Attempt to confirm the transaction

<!-- (PRs will only be accepted if squashed into single commit.) -->


status: ready 
