### PR TITLE
Fix QR share screen for community channel

### DIFF
--- a/src/quo/components/share/share_qr_code/schema.cljs
+++ b/src/quo/components/share/share_qr_code/schema.cljs
@@ -25,6 +25,11 @@
    [:type [:= :profile]]
    [:profile-picture [:maybe :schema.quo/profile-picture-source]]])
 
+(def ?channel
+  [:map
+   [:type [:= :channel]]
+   [:emoji {:optional true} [:maybe ?emoji]]])
+
 (def ?wallet
   [:map
    [:type [:= :wallet]]
@@ -60,6 +65,7 @@
    [:catn
     [:props
      [:multi {:dispatch :type}
+      [:channel [:merge ?base ?channel]]
       [:profile [:merge ?base ?profile]]
       [:wallet [:merge ?base ?address-base ?wallet]]
       [:saved-address [:merge ?base ?address-base ?saved-address]]

--- a/src/quo/components/share/share_qr_code/view.cljs
+++ b/src/quo/components/share/share_qr_code/view.cljs
@@ -160,7 +160,7 @@
          {:color           colors/white-opa-40
           :container-style style/watched-account-icon}])]
      [share-button {:on-press on-share-press}]]
-    (when (not= share-qr-type :profile)
+    (when (not (contains? #{:profile :channel} share-qr-type))
       [header props])
     [quo.theme/provider :light
      [qr-code/view

--- a/src/quo/components/share/share_qr_code/view.cljs
+++ b/src/quo/components/share/share_qr_code/view.cljs
@@ -140,6 +140,12 @@
                                  :full-name           full-name}]
     nil))
 
+(defn- has-header?
+  [share-qr-type]
+  (case share-qr-type
+    (:profile :channel) false
+    true))
+
 (defn- share-qr-code
   [{:keys [share-qr-type qr-image-uri component-width customization-color full-name
            profile-picture emoji on-share-press address]
@@ -160,7 +166,7 @@
          {:color           colors/white-opa-40
           :container-style style/watched-account-icon}])]
      [share-button {:on-press on-share-press}]]
-    (when (not (contains? #{:profile :channel} share-qr-type))
+    (when (has-header? share-qr-type)
       [header props])
     [quo.theme/provider :light
      [qr-code/view

--- a/src/quo/components/share/share_qr_code/view.cljs
+++ b/src/quo/components/share/share_qr_code/view.cljs
@@ -163,6 +163,7 @@
                               :profile                   :profile
                               (:watched-address :wallet) :wallet-account
                               :saved-address             :saved-address
+                              :channel                   :channel
                               nil)
        :customization-color customization-color
        :full-name           full-name

--- a/src/quo/components/share/share_qr_code/view.cljs
+++ b/src/quo/components/share/share_qr_code/view.cljs
@@ -143,8 +143,10 @@
 (defn- has-header?
   [share-qr-type]
   (case share-qr-type
-    (:profile :channel) false
-    true))
+    (:wallet
+     :watched-address
+     :saved-address) true
+    false))
 
 (defn- share-qr-code
   [{:keys [share-qr-type qr-image-uri component-width customization-color full-name

--- a/src/quo/components/share/share_qr_code/view.cljs
+++ b/src/quo/components/share/share_qr_code/view.cljs
@@ -2,6 +2,7 @@
   (:require [clojure.set]
             [oops.core :as oops]
             [quo.components.avatars.account-avatar.view :as account-avatar]
+            [quo.components.avatars.channel-avatar.view :as channel-avatar]
             [quo.components.avatars.user-avatar.view :as user-avatar]
             [quo.components.avatars.wallet-user-avatar.view :as wallet-user-avatar]
             [quo.components.buttons.button.view :as button]
@@ -129,6 +130,12 @@
                                  :size                32}]
     :saved-address             [wallet-user-avatar/wallet-user-avatar
                                 {:size                :size-32
+                                 :customization-color customization-color
+                                 :full-name           full-name}]
+    :channel                   [channel-avatar/view
+                                {:size                :size-32
+                                 :emoji               emoji
+                                 :locked-state        :not-set
                                  :customization-color customization-color
                                  :full-name           full-name}]
     nil))

--- a/src/status_im/contexts/communities/actions/share_community/view.cljs
+++ b/src/status_im/contexts/communities/actions/share_community/view.cljs
@@ -12,6 +12,10 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
+(defn navigate-back
+  []
+  (rf/dispatch [:navigate-back]))
+
 (defn view
   []
   (let [{:keys [url community-id]} (rf/sub [:get-screen-params])
@@ -19,7 +23,6 @@
         {thumbnail-uri  :logo
          color          :color
          community-name :name}     (rf/sub [:communities/for-context-tag community-id])
-        navigate-back              (rn/use-callback #(rf/dispatch [:navigate-back]))
         on-press-share             (rn/use-callback
                                     (fn []
                                       (rf/dispatch

--- a/src/status_im/contexts/communities/actions/share_community/view.cljs
+++ b/src/status_im/contexts/communities/actions/share_community/view.cljs
@@ -18,7 +18,10 @@
 
 (defn view
   []
-  (let [{:keys [url community-id]} (rf/sub [:get-screen-params])
+  (let [params                     (rf/sub [:get-screen-params])
+        ;; NOTE(seanstrom): We need to store these screen params for when the modal closes
+        ;; because the screen params will be cleared.
+        {:keys [url community-id]} @(rn/use-ref-atom params)
         window-width               (rf/sub [:dimensions/window-width])
         {thumbnail-uri  :logo
          color          :color

--- a/src/status_im/contexts/communities/actions/share_community_channel/style.cljs
+++ b/src/status_im/contexts/communities/actions/share_community_channel/style.cljs
@@ -1,6 +1,10 @@
 (ns status-im.contexts.communities.actions.share-community-channel.style
   (:require [quo.foundations.colors :as colors]))
 
+(defn container
+  [safe-area-top]
+  {:padding-top safe-area-top})
+
 (def header-container
   {:padding-horizontal 20
    :padding-vertical   12})

--- a/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
+++ b/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
@@ -11,7 +11,10 @@
 (defn view
   []
   (fn []
-    (let [{:keys [url chat-id]}           (rf/sub [:get-screen-params])
+    (let [params                          (rf/sub [:get-screen-params])
+          ;; NOTE(seanstrom): We need to store these screen params for when the modal closes
+          ;; because the screen params will be cleared.
+          {:keys [url chat-id]}           @(rn/use-ref-atom params)
           {:keys [color emoji chat-name]} (rf/sub [:chats/community-channel-ui-details-by-id chat-id])
           on-share-community-channel      (rn/use-callback
                                            #(rf/dispatch

--- a/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
+++ b/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
@@ -8,6 +8,8 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
+(defn navigate-back [] (rf/dispatch [:navigate-back]))
+
 (defn view
   []
   (fn []
@@ -27,7 +29,7 @@
          :key   :share-community}
         [quo/page-nav
          {:icon-name           :i/close
-          :on-press            #(rf/dispatch [:navigate-back])
+          :on-press            navigate-back
           :background          :blur
           :accessibility-label :top-bar}]
         [quo/text-combinations

--- a/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
+++ b/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
@@ -25,7 +25,7 @@
                                            [chat-id])]
       [quo/overlay {:type :shell}
        [rn/view
-        {:style {:padding-top (safe-area/get-top)}
+        {:style (style/container (safe-area/get-top))
          :key   :share-community}
         [quo/page-nav
          {:icon-name           :i/close

--- a/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
+++ b/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
@@ -12,8 +12,7 @@
   []
   (fn []
     (let [{:keys [url chat-id]}           (rf/sub [:get-screen-params])
-          {:keys [color emoji chat-name]} (rf/sub [:chats/community-channel-ui-details-by-id chat-id])
-          window-width                    (rf/sub [:dimensions/window-width])]
+          {:keys [color emoji chat-name]} (rf/sub [:chats/community-channel-ui-details-by-id chat-id])]
       [quo/overlay {:type :shell}
        [rn/view
         {:style {:padding-top (safe-area/get-top)}
@@ -27,19 +26,12 @@
          {:container-style style/header-container
           :title           (i18n/label :t/share-channel)}]
         [rn/view {:style style/qr-code-wrapper}
-         [quo/gradient-cover
-          {:container-style
-           (style/gradient-cover-wrapper window-width)
-           :customization-color color}]
-         [rn/view
-          {:style {:padding-vertical 12}}
-          [qr-codes/qr-code
-           {:size                (style/qr-code-size window-width)
-            :url                 url
-            :avatar              :channel
-            :customization-color color
-            :emoji               emoji
-            :full-name           chat-name}]]]
+         [qr-codes/share-qr-code
+          {:type                :channel
+           :qr-data             url
+           :customization-color color
+           :emoji               emoji
+           :full-name           chat-name}]]
         [quo/text
          {:size   :paragraph-2
           :weight :regular

--- a/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
+++ b/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
@@ -12,7 +12,12 @@
   []
   (fn []
     (let [{:keys [url chat-id]}           (rf/sub [:get-screen-params])
-          {:keys [color emoji chat-name]} (rf/sub [:chats/community-channel-ui-details-by-id chat-id])]
+          {:keys [color emoji chat-name]} (rf/sub [:chats/community-channel-ui-details-by-id chat-id])
+          on-share-community-channel      (rn/use-callback
+                                           #(rf/dispatch
+                                             [:communities/share-community-channel-url-with-data
+                                              chat-id])
+                                           [chat-id])]
       [quo/overlay {:type :shell}
        [rn/view
         {:style {:padding-top (safe-area/get-top)}
@@ -31,7 +36,8 @@
            :qr-data             url
            :customization-color color
            :emoji               emoji
-           :full-name           chat-name}]]
+           :full-name           chat-name
+           :on-share-press      on-share-community-channel}]]
         [quo/text
          {:size   :paragraph-2
           :weight :regular

--- a/src/status_im/contexts/preview/quo/share/share_qr_code.cljs
+++ b/src/status_im/contexts/preview/quo/share/share_qr_code.cljs
@@ -16,7 +16,8 @@
     :options [{:key :profile}
               {:key :wallet}
               {:key :saved-address}
-              {:key :watched-address}]}])
+              {:key :watched-address}
+              {:key :channel}]}])
 
 (def possible-networks [:ethereum :optimism :arbitrum :myNet])
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19608

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to fix the alignment issues and add missing UI elements when opening the QR share screen for a community channel.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Sharing QR code for community channel

### Steps to test

Reproduction steps are described in #19608 

### Before and after screenshots comparison

#### Before

https://github.com/status-im/status-mobile/assets/2845768/bdce346d-f701-4e0b-ac02-a118afc81fb7

#### After

https://github.com/status-im/status-mobile/assets/2845768/bca3e0b3-18ab-4987-aa35-2e20f6081fb9

status: ready
