### PR TITLE
[#19176] fix: onboarding illustration design issue

### DIFF
--- a/src/status_im/contexts/onboarding/enable_notifications/style.cljs
+++ b/src/status_im/contexts/onboarding/enable_notifications/style.cljs
@@ -13,6 +13,11 @@
   {:flex  1
    :width width})
 
+(def page-title
+  {:margin-top        12
+   :margin-horizontal 20
+   :margin-bottom     8})
+
 (def page-heading {:z-index 1})
 
 (defn buttons

--- a/src/status_im/contexts/onboarding/enable_notifications/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_notifications/view.cljs
@@ -16,7 +16,7 @@
 (defn page-title
   []
   [quo/text-combinations
-   {:container-style                 {:margin-top 12 :margin-horizontal 20}
+   {:container-style                 style/page-title
     :title                           (i18n/label :t/intro-wizard-title6)
     :title-accessibility-label       :notifications-title
     :description                     (i18n/label :t/enable-notifications-sub-title)

--- a/src/status_im/contexts/onboarding/welcome/style.cljs
+++ b/src/status_im/contexts/onboarding/welcome/style.cljs
@@ -8,10 +8,15 @@
    :padding-top (:top insets)})
 
 (defn page-illustration
-  [width]
-  {:width         width
-   :margin-top    12
-   :margin-bottom 4})
+  [{:keys [width height]}]
+  {:width  width
+   ;; Aspect ratio 2:3
+   :height (/ height 1.5)})
+
+(def page-title
+  {:margin-top        12
+   :margin-horizontal 20
+   :margin-bottom     8})
 
 (defn buttons
   [insets]

--- a/src/status_im/contexts/onboarding/welcome/style.cljs
+++ b/src/status_im/contexts/onboarding/welcome/style.cljs
@@ -8,10 +8,10 @@
    :padding-top (:top insets)})
 
 (defn page-illustration
-  [{:keys [width height]}]
-  {:width  width
-   ;; Aspect ratio 2:3
-   :height (/ height 1.5)})
+  [width]
+  {:width        width
+   :aspect-ratio 0.7
+   :height       :auto})
 
 (def page-title
   {:margin-top        12

--- a/src/status_im/contexts/onboarding/welcome/view.cljs
+++ b/src/status_im/contexts/onboarding/welcome/view.cljs
@@ -16,7 +16,7 @@
   []
   (let [new-account? (rf/sub [:onboarding/new-account?])]
     [quo/text-combinations
-     {:container-style                 {:margin-top 12 :margin-horizontal 20}
+     {:container-style                 style/page-title
       :title                           (i18n/label (if new-account?
                                                      :t/welcome-to-web3
                                                      :t/welcome-back))
@@ -45,10 +45,9 @@
        :on-press   #(rf/dispatch [:navigate-back])}]
      [page-title]
      [rn/image
-      {:style         (style/page-illustration (:width window))
-       :resize-mode   :stretch
-       :resize-method :scale
-       :source        (resources/get-image :welcome-illustration)}]
+      {:style       (style/page-illustration window)
+       :resize-mode :contain
+       :source      (resources/get-image :welcome-illustration)}]
      [rn/view {:style (style/buttons insets)}
       (when rn/small-screen?
         [linear-gradient/linear-gradient

--- a/src/status_im/contexts/onboarding/welcome/view.cljs
+++ b/src/status_im/contexts/onboarding/welcome/view.cljs
@@ -45,7 +45,7 @@
        :on-press   #(rf/dispatch [:navigate-back])}]
      [page-title]
      [rn/image
-      {:style       (style/page-illustration window)
+      {:style       (style/page-illustration (:width window))
        :resize-mode :contain
        :source      (resources/get-image :welcome-illustration)}]
      [rn/view {:style (style/buttons insets)}


### PR DESCRIPTION
fixes #19176

### Summary

- Enable Notifications [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=1:32044&mode=design#727627393)] illustration has spacing issues on bigger screens, resulting in the illustration being too close to the screen margins

- Welcome to Status [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=94:35487&mode=design#726014345)] illustration is stretched on bigger screens

#### Areas that maybe impacted

- Onboarding

### Steps to test

- Complete the Onboarding flow

status: ready
