### PR TITLE
[#19195] fix: communities design issues

### DIFF
--- a/src/status_im/common/scroll_page/view.cljs
+++ b/src/status_im/common/scroll_page/view.cljs
@@ -85,7 +85,7 @@
         y           (reanimated/use-shared-value scroll-height)
         animation   (reanimated/interpolate y
                                             input-range
-                                            [1.2 0.5]
+                                            [1 0.5]
                                             {:extrapolateLeft  "clamp"
                                              :extrapolateRight "clamp"})]
     (rn/use-effect #(do

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -131,6 +131,7 @@
                            #(rf/dispatch [:open-modal :community-requests-to-join {:id id}]))
     :accessibility-label :show-request-to-join-screen-button
     :customization-color color
+    :container-style     {:margin-bottom 12}
     :icon-left           :i/communities}
    (i18n/label :t/request-to-join)])
 
@@ -329,7 +330,7 @@
     (fn [id joined name images]
       (let [theme                 (quo.theme/use-theme)
             cover                 {:uri (get-in images [:banner :uri])}
-            logo                  {:uri (get-in images [:thumbnail :uri])}
+            logo                  {:uri (get-in images [:large :uri])}
             collapsed?            (and initial-joined? joined)
             first-category-height (->> @categories-heights
                                        vals


### PR DESCRIPTION
fixes #19195

### Summary

- Margin [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=4:111403&mode=design#725947430)] between top nav and community avatar is too narrow [might be caused to the issue below ⤵️]
- Avatar is too big [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=4:111403&mode=design#714500572)] 
- Avatar image quality is poor [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=4:111403&mode=design#714500572)] even though the original image is a 1080px square
- Margin is too narrow [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=4:111403&mode=design#725947650)] between the Join button and the channel list


#### Areas that maybe impacted

- Community overview



### Steps to test

- Open a Status community you're not a member of


### Result


status: ready
