### PR TITLE
pin Xcode version to 15.1 & modify xcodeWrapper

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -56,9 +56,8 @@ in {
   ruby = super.ruby_3_1;
   yarn = super.yarn.override { nodejs = super.nodejs-18_x; };
   openjdk = super.openjdk11_headless;
-  xcodeWrapper = super.xcodeenv.composeXcodeWrapper {
-    version = "15.0";
-    allowHigher = true;
+  xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
+    versions = ["15.1"];
   };
   go = super.go_1_20;
   clang = super.clang_15;

--- a/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
+++ b/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
@@ -1,0 +1,50 @@
+{ stdenv, lib, writeShellScriptBin }:
+{ versions ? [ "15.1" ]
+, xcodeBaseDir ? "/Applications/Xcode.app" }:
+
+assert stdenv.isDarwin;
+
+let
+  xcodebuildPath = "${xcodeBaseDir}/Contents/Developer/usr/bin/xcodebuild";
+
+  xcodebuildWrapper = writeShellScriptBin "xcodebuild" ''
+    currentVer="$(${xcodebuildPath} -version | awk 'NR==1{print $2}')"
+    wrapperVers=(${lib.concatStringsSep " " versions})
+
+    for ver in "''${wrapperVers[@]}"; do
+      if [[ "$currentVer" == "$ver" ]]; then
+        # here exec replaces the shell without creating a new process
+        # https://www.gnu.org/software/bash/manual/bash.html#index-exec
+        exec "${xcodebuildPath}" "$@"
+      fi
+    done
+
+    echo "The installed Xcode version ($currentVer) does not match any of the allowed versions: ${lib.concatStringsSep ", " versions}"
+    echo "Please update your local Xcode installation to match one of the allowed versions"
+    exit 1
+  '';
+in
+stdenv.mkDerivation {
+  pname = "xcode-wrapper-plus";
+  version = lib.concatStringsSep "," versions;
+  # Fails in sandbox. Use `--option sandbox relaxed` or `--option sandbox false`.
+  __noChroot = true;
+  buildCommand = ''
+    mkdir -p $out/bin
+    cd $out/bin
+    ln -s "${xcodebuildWrapper}/bin/xcode-select"
+    ln -s /usr/bin/security
+    ln -s /usr/bin/codesign
+    ln -s /usr/bin/xcrun
+    ln -s /usr/bin/plutil
+    ln -s /usr/bin/clang
+    ln -s /usr/bin/lipo
+    ln -s /usr/bin/file
+    ln -s /usr/bin/rev
+    ln -s "${xcodebuildWrapper}/bin/xcodebuild"
+    ln -s "${xcodeBaseDir}/Contents/Developer/Applications/Simulator.app/Contents/MacOS/Simulator"
+
+    cd ..
+    ln -s "${xcodeBaseDir}/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs"
+  '';
+}


### PR DESCRIPTION
fixes #19770

## Summary
Devs are often unaware of the supported Xcode version and often run into weird build issues with either higher or lower Xcode versions.
We currently **only support Xcode 15.1**
This change ensures we convey that change when devs execute `make run-ios`
This PR also attempts to ensure `xcodebuild` command is wrapped with `XcodeWrapper`.

## Platforms
- iOS
- macOS

status: ready
