### PR TITLE
tidy: remove extra event handler for `:communities/set-airdrop-address`

### DIFF
--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -223,10 +223,6 @@
                      (get-in db [:communities community-id :previous-share-all-addresses?]))
       :fx [[:dispatch [:communities/check-permissions-to-join-community community-id]]]})))
 
-(rf/reg-event-fx :communities/set-airdrop-address
- (fn [{:keys [db]} [address community-id]]
-   {:db (assoc-in db [:communities community-id :airdrop-address] address)}))
-
 (defn community-fetched
   [{:keys [db]} [community-id community]]
   (when community


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

* This PR attempts to remove a duplicated event handler for `:communities/set-airdrop-address`.
  * There seems to already be an event handler for `:communities/set-airdrop-address` here: https://github.com/status-im/status-mobile/blob/e8008d0aa91e97036597855656f74c810f4bfb80/src/status_im/contexts/communities/actions/airdrop_addresses/events.cljs#L5-L9
  * This PR should be able to `skip-manual-qa` because it removes a duplicate event handler.
 
#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Choosing Airdrop address

### Steps to test

WIP

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

WIP

status: ready
