### PR TITLE
tweak: hide not-implemented actions from the chat-home screen

### DIFF
--- a/src/status_im/common/home/actions/view.cljs
+++ b/src/status_im/common/home/actions/view.cljs
@@ -415,13 +415,16 @@
   [{:keys [chat-id public? chat-type muted-till]} inside-chat? needs-divider?]
   [(mark-as-read-entry chat-id needs-divider?)
    (mute-chat-entry chat-id chat-type muted-till)
-   (notifications-entry false)
+   (when config/show-not-implemented-features?
+     (notifications-entry false))
    (when (and config/fetch-messages-enabled? inside-chat?)
      (chat-actions/fetch-messages chat-id))
    (when public?
-     (show-qr-entry))
+     (when config/show-not-implemented-features?
+       (show-qr-entry)))
    (when public?
-     (share-group-entry))])
+     (when config/show-not-implemented-features?
+       (share-group-entry)))])
 
 (defn group-actions
   [{:keys [chat-id admins]} inside-chat?]
@@ -430,10 +433,16 @@
     [(group-details-entry chat-id)
      (when inside-chat?
        (if admin?
-         (manage-members-entry)
-         (add-members-entry)))
-     (when (and admin? inside-chat?) (edit-group-entry))
-     (when (and admin? inside-chat?) (group-privacy-entry))]))
+         (when config/show-not-implemented-features?
+           (manage-members-entry))
+         (when config/show-not-implemented-features?
+           (add-members-entry))))
+     (when (and admin? inside-chat?)
+       (when config/show-not-implemented-features?
+         (edit-group-entry)))
+     (when (and admin? inside-chat?)
+       (when config/show-not-implemented-features?
+         (group-privacy-entry)))]))
 
 (defn one-to-one-actions
   [{:keys [chat-id] :as item} inside-chat?]
@@ -456,11 +465,17 @@
   (let [current-pub-key (rf/sub [:multiaccount/public-key])]
     [quo/action-drawer
      [[(view-profile-entry public-key)
+       (when-not (= current-pub-key public-key)
+         (when config/show-not-implemented-features?
+           (rename-entry)))
+       (when config/show-not-implemented-features?
+         (show-qr-entry))
+       (when config/show-not-implemented-features?
+         (share-profile-entry))]
+      [(when-not (= current-pub-key public-key)
+         (when config/show-not-implemented-features?
+           (mark-untrustworthy-entry)))
        (when-not (= current-pub-key public-key) (remove-from-contacts-entry contact))
-       (when-not (= current-pub-key public-key) (rename-entry))
-       (show-qr-entry)
-       (share-profile-entry)]
-      [(when-not (= current-pub-key public-key) (mark-untrustworthy-entry))
        (when-not (= current-pub-key public-key) (block-user-entry contact))]
       (when (and admin? chat-id)
         [(if (= current-pub-key public-key)
@@ -485,6 +500,9 @@
   (let [current-pub-key (rf/sub [:multiaccount/public-key])
         admin?          (get admins current-pub-key)]
     [quo/action-drawer
-     [(when admin? [(edit-name-image-entry)])
-      [(notifications-entry admin?)]
+     [(when admin?
+        [(when config/show-not-implemented-features?
+           (edit-name-image-entry))])
+      [(when config/show-not-implemented-features?
+         (notifications-entry admin?))]
       (destructive-actions group false)]]))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

* This PR attempts to temporarily hide not-implemented actions from the chat home screen.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Action menus inside the chat-home screen
- Action menus inside 1-1 chats
- Action menus inside group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

To test these changes it's required that:
* the user account is in a group
* the user account has at least one contact
* the user account has a recent 1-1 chat
* the user account is in a community they've created

#### Steps to reproduce

Note, if these steps to reproduce are vague, then the provided screen captures could be helpful for finding the different actions in the app from the chat home screen.

* Open the Status mobile app
* Navigate to the chat home screen
  * Long-press on one item under each of the tabs for "Recent", "Groups", and "Contacts".
    *  This should open the action menu for that item
  * Open each item of those items and open the actions menu.

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison


#### 1-1 Chat Actions
| Before | After
|--------|--------|
| <video src="https://github.com/status-im/status-mobile/assets/2845768/db1e16b3-4e91-4517-be33-8794066bdac6"/> | <video src="https://github.com/status-im/status-mobile/assets/2845768/799d24ce-7c83-49be-9efc-f49409bdd928" /> |

#### Group Chat Actions
| Before | After
|--------|--------|
| <video src="https://github.com/status-im/status-mobile/assets/2845768/65c6ea24-4695-47cc-99be-e82a1cbb30dd"/> | <video src="https://github.com/status-im/status-mobile/assets/2845768/80aecc73-5903-453a-817b-504f39460cd1" /> |

#### Contact Actions
| Before | After
|--------|--------|
| <video src="https://github.com/status-im/status-mobile/assets/2845768/ab54175d-2c1c-4669-93b5-927e2e5fc3ea"/> | <video src="https://github.com/status-im/status-mobile/assets/2845768/d770efdd-0971-4838-9823-906ea911c7e8" /> |

status: ready
