### PR TITLE
fix: wallet account back button

### DIFF
--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -370,8 +370,7 @@
      :component emoji-picker/view}
 
     {:name      :screen/wallet.accounts
-     :options   {:insets             {:top? true}
-                 :popGesture         false}
+     :options   {:insets             {:top? true}}
      :component wallet-accounts/view}
 
     {:name      :screen/wallet.edit-account

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -370,7 +370,7 @@
      :component emoji-picker/view}
 
     {:name      :screen/wallet.accounts
-     :options   {:insets             {:top? true}}
+     :options   {:insets {:top? true}}
      :component wallet-accounts/view}
 
     {:name      :screen/wallet.edit-account

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -371,9 +371,7 @@
 
     {:name      :screen/wallet.accounts
      :options   {:insets             {:top? true}
-                 :popGesture         false
-                 :hardwareBackButton {:dismissModalOnPress false
-                                      :popStackOnPress     false}}
+                 :popGesture         false}
      :component wallet-accounts/view}
 
     {:name      :screen/wallet.edit-account


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19717

### Summary
This PR fixes hardware back button not working on the wallet account screen (and the pop gesture).