### PR TITLE
fix: keypair name continue not disabled

### DIFF
--- a/src/status_im/contexts/wallet/add_account/create_account/new_keypair/keypair_name/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/new_keypair/keypair_name/view.cljs
@@ -48,7 +48,9 @@
                  :button-one-label (i18n/label :t/continue)
                  :button-one-props {:disabled?           (or (pos? error)
                                                              (< (count keypair-name)
-                                                                keypair-name-min-length))
+                                                                keypair-name-min-length)
+                                                             (> (count keypair-name)
+                                                                keypair-name-max-length))
                                     :customization-color customization-color
                                     :on-press            on-continue}
                  :container-style  style/bottom-action}]}


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19807

### Summary
This PR fixes keypair name continue button not being disabled if character exceed the max limit.

### Demo

https://github.com/status-im/status-mobile/assets/29354102/b09a863c-b453-486d-92b4-5c476a60cc4a

