### PR TITLE
chore: pin cmake version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -145,6 +145,14 @@ android {
         jvmTarget = JavaVersion.VERSION_17
     }
 
+    // https://developer.android.com/studio/projects/install-ndk#vanilla_cmake
+    externalNativeBuild {
+        cmake {
+            // This version must match cmakeVersions inside nix/pkgs/android-sdk/compose.nix
+            version "3.22.1"
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17

--- a/nix/pkgs/android-sdk/compose.nix
+++ b/nix/pkgs/android-sdk/compose.nix
@@ -16,6 +16,7 @@ androidenv.composeAndroidPackages {
   platformToolsVersion = "33.0.3";
   buildToolsVersions = [ "34.0.0" ];
   platformVersions = [ "34" ];
+  # This version must match cmake version inside android/app/build.gradle
   cmakeVersions = [ "3.22.1" ];
   ndkVersion = "25.2.9519653";
   includeNDK = true;


### PR DESCRIPTION
## Summary

On brand new ubuntu setup `make run-android` fails with : 

```

Task :app:mergeExtDexDebug

FAILURE: Build failed with an exception.

What went wrong:
Execution failed for task ':react-native-reanimated:configureCMakeDebug[arm64-v8a]'.
[CXX1300] CMake '3.22.1' was not found in SDK, PATH, or by cmake.dir property.

Try:
Run with --stacktrace option to get the stack trace.
Run with --info or --debug option to get more log output.
Run with --scan to get full insights.
Get more help at https://help.gradle.org/.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine 
if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.4/userguide/
command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 2m 30s
673 actionable tasks: 673 executed

error: cannot unlink '/tmp/tmp-status-mobile-a094d218d/
nix-build-status-mobile-build-debug-android.drv-0/tmp.moQHI1tJWE/caches/8.4': Directory not empty
removed '/tmp/tmp-status-mobile-a094d218d/tmp.RpThXxcRZR'
make: *** [Makefile:278: run-android] Error 1
```

we do have `cmake` present in Android Shell and yet the build process is not able to find it.
This PR makes sure that we explicitly provide that reference.


## Review notes

- `make run-clojure`
- `make run-android` should work


## Testing notes
No need for manual QA, this is only a build system level change.

## Platforms
- Android

status: ready
