### PR TITLE
feature/hide-all-alert-under-not-implemented-flag

### DIFF
--- a/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
+++ b/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
@@ -4,6 +4,7 @@
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
     [status-im.common.not-implemented :as not-implemented]
+    [status-im.config :as config]
     [status-im.contexts.communities.actions.airdrop-addresses.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -64,16 +65,17 @@
          :context-tag               {:type           :community
                                      :community-logo logo
                                      :community-name name}}]
-       [quo/drawer-top
-        {:type                :context-tag
-         :context-tag-type    :community
-         :title               (i18n/label :t/airdrop-addresses)
-         :community-name      name
-         :button-icon         :i/info
-         :button-type         :grey
-         :on-button-press     not-implemented/alert
-         :community-logo      logo
-         :customization-color color}])
+       (when config/show-not-implemented-features?
+         [quo/drawer-top
+          {:type                :context-tag
+           :context-tag-type    :community
+           :title               (i18n/label :t/airdrop-addresses)
+           :community-name      name
+           :button-icon         :i/info
+           :button-type         :grey
+           :on-button-press     not-implemented/alert
+           :community-logo      logo
+           :customization-color color}]))
 
      [gesture/flat-list
       {:data                    accounts

--- a/src/status_im/contexts/communities/actions/chat/view.cljs
+++ b/src/status_im/contexts/communities/actions/chat/view.cljs
@@ -39,18 +39,20 @@
 
 (defn- action-token-requirements
   []
-  {:icon                :i/token
-   :right-icon          :i/chevron-right
-   :accessibility-label :chat-view-token-requirements
-   :on-press            not-implemented/alert
-   :label               (i18n/label :t/view-token-gating)})
+  (when config/show-not-implemented-features?
+    {:icon                :i/token
+     :right-icon          :i/chevron-right
+     :accessibility-label :chat-view-token-requirements
+     :on-press            not-implemented/alert
+     :label               (i18n/label :t/view-token-gating)}))
 
 (defn- action-mark-as-read
   []
-  {:icon                :i/mark-as-read
-   :accessibility-label :chat-mark-as-read
-   :on-press            not-implemented/alert
-   :label               (i18n/label :t/mark-as-read)})
+  (when config/show-not-implemented-features?
+    {:icon                :i/mark-as-read
+     :accessibility-label :chat-mark-as-read
+     :on-press            not-implemented/alert
+     :label               (i18n/label :t/mark-as-read)}))
 
 (defn- action-toggle-muted
   [id muted? muted-till chat-type]
@@ -71,12 +73,13 @@
 
 (defn- action-notification-settings
   []
-  {:icon                :i/notifications
-   :right-icon          :i/chevron-right
-   :accessibility-label :chat-notification-settings
-   :on-press            not-implemented/alert
-   :label               (i18n/label :t/notification-settings)
-   :sub-label           (i18n/label :t/only-mentions)})
+  (when config/show-not-implemented-features?
+    {:icon                :i/notifications
+     :right-icon          :i/chevron-right
+     :accessibility-label :chat-notification-settings
+     :on-press            not-implemented/alert
+     :label               (i18n/label :t/notification-settings)
+     :sub-label           (i18n/label :t/only-mentions)}))
 
 (defn- action-pinned-messages
   [chat-id]
@@ -91,10 +94,11 @@
 
 (defn- action-invite-people
   []
-  {:icon                :i/add-user
-   :accessibility-label :chat-invite-people
-   :on-press            not-implemented/alert
-   :label               (i18n/label :t/invite-people-from-contacts)})
+  (when config/show-not-implemented-features?
+    {:icon                :i/add-user
+     :accessibility-label :chat-invite-people
+     :on-press            not-implemented/alert
+     :label               (i18n/label :t/invite-people-from-contacts)}))
 
 (defn- action-qr-code
   [chat-id]

--- a/src/status_im/contexts/profile/contact/actions/view.cljs
+++ b/src/status_im/contexts/profile/contact/actions/view.cljs
@@ -3,6 +3,7 @@
             [quo.core :as quo]
             [react-native.core :as rn]
             [status-im.common.not-implemented :as not-implemented]
+            [status-im.config :as config]
             [status-im.constants :as constants]
             [status-im.contexts.profile.contact.add-nickname.view :as add-nickname]
             [status-im.contexts.profile.contact.block-contact.view :as block-contact]
@@ -86,12 +87,13 @@
              :add-divider?        true
              :accessibility-label :remove-nickname
              :danger?             true})
-          {:icon                :i/untrustworthy
-           :label               (i18n/label :t/mark-untrustworthy)
-           :on-press            not-implemented/alert
-           :accessibility-label :mark-untrustworthy
-           :add-divider?        (when-not has-nickname? true)
-           :danger?             true}
+          (when config/show-not-implemented-features?
+            {:icon                :i/untrustworthy
+             :label               (i18n/label :t/mark-untrustworthy)
+             :on-press            not-implemented/alert
+             :accessibility-label :mark-untrustworthy
+             :add-divider?        (when-not has-nickname? true)
+             :danger?             true})
           (when (= constants/contact-request-state-mutual contact-request-state)
             {:icon                :i/remove-user
              :label               (i18n/label :t/remove-contact)

--- a/src/status_im/contexts/profile/settings/screens/password/view.cljs
+++ b/src/status_im/contexts/profile/settings/screens/password/view.cljs
@@ -3,6 +3,7 @@
             [quo.theme :as quo.theme]
             [status-im.common.biometric.utils :as biometric]
             [status-im.common.not-implemented :as not-implemented]
+            [status-im.config :as config]
             [status-im.constants :as constants]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
@@ -46,12 +47,13 @@
 
 (defn- get-change-password-item
   []
-  {:title       (i18n/label :t/change-password)
-   :on-press    not-implemented/alert
-   :blur?       true
-   :image       :icon
-   :image-props :i/password
-   :action      :arrow})
+  (when config/show-not-implemented-features?
+    {:title       (i18n/label :t/change-password)
+     :on-press    not-implemented/alert
+     :blur?       true
+     :image       :icon
+     :image-props :i/password
+     :action      :arrow}))
 
 (defn- navigate-back
   []


### PR DESCRIPTION
Manual testing is not needed because no changes in the functionality, just not implemented elements are hidden now