### PR TITLE
Selected networks are not shown as preferred if a multichain wallet with preferred networks is scanned on the 'send to' page #19775

### DIFF
--- a/src/status_im/contexts/wallet/common/scan_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/scan_account/view.cljs
@@ -1,13 +1,22 @@
 (ns status-im.contexts.wallet.common.scan-account.view
-  (:require [status-im.common.scan-qr-code.view :as scan-qr-code]
+  (:require [clojure.string :as string]
+            [status-im.common.scan-qr-code.view :as scan-qr-code]
             [status-im.constants :as constants]
             [utils.debounce :as debounce]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
-(defn- contains-address?
+(def ^:private supported-networks #{:eth :arb1 :opt})
+
+(defn- contains-supported-address?
   [s]
-  (boolean (re-find constants/regx-address-contains s)))
+  (let [address?   (boolean (re-find constants/regx-address-contains s))
+        networks   (when address?
+                     (as-> s $
+                       (string/split $ ":")
+                       (butlast $)))
+        supported? (every? supported-networks (map keyword networks))]
+    (and address? supported?)))
 
 (defn- extract-address
   [scanned-text]
@@ -20,7 +29,7 @@
      {:title           (i18n/label :t/scan-qr)
       :subtitle        (i18n/label :t/scan-an-account-qr-code)
       :error-message   (i18n/label :t/oops-this-qr-does-not-contain-an-address)
-      :validate-fn     #(contains-address? %)
+      :validate-fn     #(contains-supported-address? %)
       :on-success-scan (fn [result]
                          (let [address (extract-address result)]
                            (when on-result (on-result address))

--- a/src/status_im/contexts/wallet/common/scan_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/scan_account/view.cljs
@@ -11,7 +11,7 @@
 
 (defn- extract-address
   [scanned-text]
-  (first (re-seq constants/regx-address-contains scanned-text)))
+  (first (re-seq constants/regx-multichain-address scanned-text)))
 
 (defn view
   []


### PR DESCRIPTION
fixes #19775 

The issue was that the scanner was scanning the text successfully, but the filter we have in the `scan_account` was removing the prefixes of the address. I replaced it with the correct regex.


https://github.com/status-im/status-mobile/assets/55688834/a1606bd5-2fac-4ca0-b0c9-ee7ee25edf42


