### PR TITLE
hide not implemented composer features

### DIFF
--- a/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
@@ -8,6 +8,7 @@
     [reagent.core :as reagent]
     [status-im.common.alert.effects :as alert.effects]
     [status-im.common.device-permissions :as device-permissions]
+    [status-im.config :as config]
     [status-im.constants :as constants]
     [status-im.contexts.chat.messenger.composer.actions.style :as style]
     [status-im.contexts.chat.messenger.composer.constants :as comp-constants]
@@ -235,10 +236,12 @@
                :display        (if @(:recording? state) :none :flex)}}
       [camera-button edit]
       [image-button props animations edit]
-      [reaction-button]
-      [format-button]]
+      (when config/show-not-implemented-features?
+        [reaction-button])
+      (when config/show-not-implemented-features?
+        [format-button])]
      [:f> send-button props state animations window-height images edit send-btn-opacity]
-     (when (and (not edit) (not images))
+     (when (and (not edit) (not images) config/show-not-implemented-features?)
        ;; TODO(alwx): needs to be replaced with an `audio-button` later. See
        ;; https://github.com/status-im/status-mobile/issues/16084 for more details.
        [:f> disabled-audio-button audio-btn-opacity])]))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19872
fixes https://github.com/status-im/status-mobile/issues/19871
fixes https://github.com/status-im/status-mobile/issues/19870

### Testing Note
Manual testing is not needed because no changes in the functionality, just not implemented elements are hidden now

status: ready