### PR TITLE
fix: entering two zeros in a row in the 'Amount' field in wallet

### DIFF
--- a/src/status_im/common/controlled_input/utils.cljs
+++ b/src/status_im/common/controlled_input/utils.cljs
@@ -78,9 +78,10 @@
 
 (defn add-character
   [state character]
-  (when (can-add-character? state character)
+  (if (can-add-character? state character)
     (set-input-value state
-                     (normalize-value-as-numeric (input-value state) character))))
+                     (normalize-value-as-numeric (input-value state) character))
+    state))
 
 (defn delete-last
   [state]


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19908

This PR fixes an issue that caused a crash when typing zeroes in the input amout on the send screen.

Skipping QA as it is a simple fix.

Demo:

https://github.com/status-im/status-mobile/assets/29354102/1784ad30-ff6c-4b47-9429-b2d7a4f8dfee

