### PR TITLE
Add screen for key-pairs and accounts inside wallet settings

### DIFF
--- a/src/status_im/contexts/preview/feature_flags/style.cljs
+++ b/src/status_im/contexts/preview/feature_flags/style.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.preview.feature-flags.style)
 
 (def container
-  {:flex        1
-   :margin-left 20})
+  {:flex          1
+   :margin-left   20
+   :margin-bottom 20})

--- a/src/status_im/contexts/preview/feature_flags/view.cljs
+++ b/src/status_im/contexts/preview/feature_flags/view.cljs
@@ -18,23 +18,24 @@
      :on-press   #(rf/dispatch [:navigate-back])
      :right-side [{:icon-name :i/rotate
                    :on-press  #(ff/reset-flags)}]}]
-   (doall
-    (for [context-name ff/feature-flags-categories
-          :let         [context-flags (filter (fn [[k]]
-                                                (string/includes? (str k) context-name))
-                                              (ff/feature-flags))]]
-      ^{:key (str context-name)}
-      [rn/view {:style style/container}
-       [quo/text
-        context-name]
-       (doall
-        (for [i    (range (count context-flags))
-              :let [[flag] (nth context-flags i)]]
-          ^{:key (str context-name flag i)}
-          [rn/view {:style {:flex-direction :row}}
-           [quo/selectors
-            {:type            :toggle
-             :checked?        (ff/enabled? flag)
-             :container-style {:margin-right 8}
-             :on-change       #(ff/toggle flag)}]
-           [quo/text (second (string/split (name flag) "."))]]))]))])
+   [rn/scroll-view
+    (doall
+     (for [context-name ff/feature-flags-categories
+           :let         [context-flags (filter (fn [[k]]
+                                                 (string/includes? (str k) context-name))
+                                               (ff/feature-flags))]]
+       ^{:key (str context-name)}
+       [rn/view {:style style/container}
+        [quo/text
+         context-name]
+        (doall
+         (for [i    (range (count context-flags))
+               :let [[flag] (nth context-flags i)]]
+           ^{:key (str context-name flag i)}
+           [rn/view {:style {:flex-direction :row}}
+            [quo/selectors
+             {:type            :toggle
+              :checked?        (ff/enabled? flag)
+              :container-style {:margin-right 8}
+              :on-change       #(ff/toggle flag)}]
+            [quo/text (second (string/split (name flag) "."))]]))]))]])

--- a/src/status_im/contexts/preview/feature_flags/view.cljs
+++ b/src/status_im/contexts/preview/feature_flags/view.cljs
@@ -22,7 +22,8 @@
     (doall
      (for [context-name ff/feature-flags-categories
            :let         [context-flags (filter (fn [[k]]
-                                                 (string/includes? (str k) context-name))
+                                                 (= context-name
+                                                    (first (string/split (str (name k)) "."))))
                                                (ff/feature-flags))]]
        ^{:key (str context-name)}
        [rn/view {:style style/container}

--- a/src/status_im/contexts/profile/settings/list_items.cljs
+++ b/src/status_im/contexts/profile/settings/list_items.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.profile.settings.list-items
   (:require [status-im.common.not-implemented :as not-implemented]
             [status-im.config :as config]
+            [status-im.feature-flags :as ff]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
@@ -34,12 +35,13 @@
      :image       :icon
      :blur?       true
      :action      :arrow}
-    {:title       (i18n/label :t/wallet)
-     :on-press    #(rf/dispatch [:open-modal :screen/settings.wallet])
-     :image-props :i/wallet
-     :image       :icon
-     :blur?       true
-     :action      :arrow}
+    (when (ff/enabled? ::ff/wallet.wallet-settings)
+      {:title       (i18n/label :t/wallet)
+       :on-press    #(rf/dispatch [:open-modal :screen/settings.wallet])
+       :image-props :i/wallet
+       :image       :icon
+       :blur?       true
+       :action      :arrow})
     (when config/show-not-implemented-features?
       {:title       (i18n/label :t/dapps)
        :on-press    not-implemented/alert

--- a/src/status_im/contexts/profile/settings/list_items.cljs
+++ b/src/status_im/contexts/profile/settings/list_items.cljs
@@ -41,7 +41,7 @@
      :image        :icon
      :blur?        true
      :action       :arrow
-     :feature-flag ::ff/wallet.settings}
+     :feature-flag ::ff/settings.wallet-settings}
     (when config/show-not-implemented-features?
       {:title       (i18n/label :t/dapps)
        :on-press    not-implemented/alert

--- a/src/status_im/contexts/profile/settings/list_items.cljs
+++ b/src/status_im/contexts/profile/settings/list_items.cljs
@@ -35,13 +35,13 @@
      :image       :icon
      :blur?       true
      :action      :arrow}
-    (when (ff/enabled? ::ff/wallet.wallet-settings)
-      {:title       (i18n/label :t/wallet)
-       :on-press    #(rf/dispatch [:open-modal :screen/settings.wallet])
-       :image-props :i/wallet
-       :image       :icon
-       :blur?       true
-       :action      :arrow})
+    {:title        (i18n/label :t/wallet)
+     :on-press     #(rf/dispatch [:open-modal :screen/settings.wallet])
+     :image-props  :i/wallet
+     :image        :icon
+     :blur?        true
+     :action       :arrow
+     :feature-flag ::ff/wallet.wallet-settings}
     (when config/show-not-implemented-features?
       {:title       (i18n/label :t/dapps)
        :on-press    not-implemented/alert

--- a/src/status_im/contexts/profile/settings/list_items.cljs
+++ b/src/status_im/contexts/profile/settings/list_items.cljs
@@ -41,7 +41,7 @@
      :image        :icon
      :blur?        true
      :action       :arrow
-     :feature-flag ::ff/wallet.wallet-settings}
+     :feature-flag ::ff/wallet.settings}
     (when config/show-not-implemented-features?
       {:title       (i18n/label :t/dapps)
        :on-press    not-implemented/alert

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -58,8 +58,7 @@
         on-scroll           (rn/use-callback #(scroll-handler % scroll-y))]
     [quo/overlay {:type :shell}
      [rn/view
-      {:key   :header
-       :style (style/navigation-wrapper {:customization-color customization-color
+      {:style (style/navigation-wrapper {:customization-color customization-color
                                          :inset               (:top insets)
                                          :theme               theme})}
       [quo/page-nav
@@ -78,8 +77,7 @@
                                                 {:options {:message (:universal-profile-url
                                                                      profile)}}])}]}]]
      [rn/flat-list
-      {:key                             :list
-       :header                          [settings.header/view {:scroll-y scroll-y}]
+      {:header                          [settings.header/view {:scroll-y scroll-y}]
        :data                            (settings.items/items (boolean (:mnemonic profile)))
        :shows-vertical-scroll-indicator false
        :render-fn                       settings-item-view
@@ -90,8 +88,7 @@
        :bounces                         false
        :over-scroll-mode                :never}]
      [quo/floating-shell-button
-      {:key :shell
-       :jump-to
+      {:jump-to
        {:on-press            #(rf/dispatch [:shell/navigate-to-jump-to])
         :customization-color customization-color
         :label               (i18n/label :t/jump-to)}}

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -26,7 +26,7 @@
     {:list-type       :settings
      :container-style {:padding-bottom 12}
      :blur?           true
-     :data            (filterv show-settings-item? data)}]])
+     :data            (filter show-settings-item? data)}]])
 
 (defn scroll-handler
   [event scroll-y]

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -9,9 +9,15 @@
             [status-im.contexts.profile.settings.list-items :as settings.items]
             [status-im.contexts.profile.settings.style :as style]
             [status-im.contexts.profile.utils :as profile.utils]
+            [status-im.feature-flags :as ff]
             [utils.debounce :as debounce]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
+
+(defn show-settings-item?
+  [{:keys [feature-flag]}]
+  (or (ff/enabled? feature-flag)
+      (nil? feature-flag)))
 
 (defn- settings-item-view
   [data]
@@ -20,7 +26,7 @@
     {:list-type       :settings
      :container-style {:padding-bottom 12}
      :blur?           true
-     :data            data}]])
+     :data            (filterv show-settings-item? data)}]])
 
 (defn scroll-handler
   [event scroll-y]

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -19,7 +19,7 @@
   (or (ff/enabled? feature-flag)
       (nil? feature-flag)))
 
-(defn- settings-item-view
+(defn- settings-category-view
   [data]
   [rf/delay-render
    [quo/category
@@ -80,7 +80,7 @@
       {:header                          [settings.header/view {:scroll-y scroll-y}]
        :data                            (settings.items/items (boolean (:mnemonic profile)))
        :shows-vertical-scroll-indicator false
-       :render-fn                       settings-item-view
+       :render-fn                       settings-category-view
        :get-item-layout                 get-item-layout
        :footer                          [footer insets logout-press]
        :scroll-event-throttle           16

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/actions/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/actions/view.cljs
@@ -3,5 +3,4 @@
 
 (defn view
   [props]
-  [quo/drawer-top
-   (merge props {:blur? true})])
+  [quo/drawer-top props])

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/actions/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/actions/view.cljs
@@ -1,0 +1,7 @@
+(ns status-im.contexts.settings.wallet.keypairs-and-accounts.actions.view
+  (:require [quo.core :as quo]))
+
+(defn view
+  [props]
+  [quo/drawer-top
+   (merge props {:blur? true})])

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/style.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/style.cljs
@@ -5,9 +5,13 @@
    :margin-vertical    12})
 
 (defn page-wrapper
-  [inset-top]
-  {:padding-top inset-top
+  [top-inset]
+  {:padding-top top-inset
    :flex        1})
+
+(defn list-container
+  [bottom-inset]
+  {:padding-bottom bottom-inset})
 
 (def keypair-container-style
   {:margin-horizontal 20

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/style.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/style.cljs
@@ -8,3 +8,7 @@
   [inset-top]
   {:padding-top inset-top
    :flex        1})
+
+(def keypair-container-style
+  {:margin-horizontal 20
+   :margin-vertical   8})

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/style.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/style.cljs
@@ -1,0 +1,10 @@
+(ns status-im.contexts.settings.wallet.keypairs-and-accounts.style)
+
+(def title-container
+  {:padding-horizontal 20
+   :margin-vertical    12})
+
+(defn page-wrapper
+  [inset-top]
+  {:padding-top inset-top
+   :flex        1})

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -31,10 +31,6 @@
                :state         :default
                :action        :none}))))
 
-(def keypair-container-style
-  {:margin-horizontal 20
-   :margin-vertical   8})
-
 (defn on-options-press
   [{:keys [theme]
     :as   props}]
@@ -71,7 +67,7 @@
       :action              :options
       :accounts            accounts
       :customization-color customization-color
-      :container-style     keypair-container-style
+      :container-style     style/keypair-container-style
       :profile-picture     (when default-keypair? profile-picture)
       :type                (if default-keypair? :default-keypair :other)
       :on-options-press    on-press

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -18,18 +18,17 @@
 (defn- parse-accounts
   [given-accounts]
   (->> given-accounts
-       (filter (fn [{:keys [path]}]
-                 (not (string/starts-with? path constants/path-eip1581))))
-       (map (fn [{:keys [customization-color emoji name address]}]
-              {:account-props {:customization-color customization-color
-                               :size                32
-                               :emoji               emoji
-                               :type                :default
-                               :name                name
-                               :address             address}
-               :networks      []
-               :state         :default
-               :action        :none}))))
+       (keep (fn [{:keys [path customization-color emoji name address]}]
+               (when (not (string/starts-with? path constants/path-eip1581))
+                 {:account-props {:customization-color customization-color
+                                  :size                32
+                                  :emoji               emoji
+                                  :type                :default
+                                  :name                name
+                                  :address             address}
+                  :networks      []
+                  :state         :default
+                  :action        :none})))))
 
 (defn on-options-press
   [{:keys [theme]

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -1,10 +1,8 @@
 (ns status-im.contexts.settings.wallet.keypairs-and-accounts.view
-  (:require [clojure.string :as string]
-            [quo.core :as quo]
+  (:require [quo.core :as quo]
             [quo.theme]
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
-            [status-im.constants :as constants]
             [status-im.contexts.settings.wallet.keypairs-and-accounts.actions.view :as actions]
             [status-im.contexts.settings.wallet.keypairs-and-accounts.style :as style]
             [utils.address :as utils]
@@ -15,20 +13,12 @@
   []
   (rf/dispatch [:navigate-back]))
 
-(defn- parse-accounts
-  [given-accounts]
-  (->> given-accounts
-       (keep (fn [{:keys [path customization-color emoji name address]}]
-               (when (not (string/starts-with? path constants/path-eip1581))
-                 {:account-props {:customization-color customization-color
-                                  :size                32
-                                  :emoji               emoji
-                                  :type                :default
-                                  :name                name
-                                  :address             address}
-                  :networks      []
-                  :state         :default
-                  :action        :none})))))
+(defn- keypair-account
+  [account-props]
+  {:account-props account-props
+   :networks      []
+   :state         :default
+   :action        :none})
 
 (defn on-options-press
   [{:keys [theme]
@@ -42,7 +32,7 @@
    index _
    {:keys [profile-picture compressed-key customization-color]}]
   (let [theme            (quo.theme/use-theme)
-        accounts         (parse-accounts accounts)
+        accounts         (map keypair-account accounts)
         default-keypair? (zero? index)
         shortened-key    (when default-keypair?
                            (utils/get-shortened-compressed-key compressed-key))
@@ -77,11 +67,11 @@
 
 (defn view
   []
-  (let [insets              (safe-area/get-insets)
-        compressed-key      (rf/sub [:profile/compressed-key])
-        profile-picture     (rf/sub [:profile/image])
-        customization-color (rf/sub [:profile/customization-color])
-        keypairs            (rf/sub [:wallet/keypairs])]
+  (let [insets                (safe-area/get-insets)
+        compressed-key        (rf/sub [:profile/compressed-key])
+        profile-picture       (rf/sub [:profile/image])
+        customization-color   (rf/sub [:profile/customization-color])
+        quo-keypairs-accounts (rf/sub [:wallet/quo-keypairs-accounts])]
     [quo/overlay
      {:type            :shell
       :container-style (style/page-wrapper (:top insets))}
@@ -97,7 +87,7 @@
         :customization-color customization-color}]]
      [rn/view {:style {:flex 1}}
       [rn/flat-list
-       {:data                    keypairs
+       {:data                    quo-keypairs-accounts
         :render-fn               keypair
         :render-data             {:profile-picture     profile-picture
                                   :compressed-key      compressed-key

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -1,0 +1,84 @@
+(ns status-im.contexts.settings.wallet.keypairs-and-accounts.view
+  (:require [clojure.string :as string]
+            [quo.core :as quo]
+            [react-native.core :as rn]
+            [react-native.safe-area :as safe-area]
+            [status-im.common.not-implemented :as not-implemented]
+            [status-im.constants :as constants]
+            [status-im.contexts.settings.wallet.keypairs-and-accounts.style :as style]
+            [utils.address :as utils]
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]))
+
+(defn navigate-back
+  []
+  (rf/dispatch [:navigate-back]))
+
+(defn- parse-accounts
+  [given-accounts]
+  (->> given-accounts
+       (filter (fn [{:keys [path]}]
+                 (not (string/starts-with? path constants/path-eip1581))))
+       (map (fn [{:keys [customization-color emoji name address]}]
+              {:account-props {:customization-color customization-color
+                               :size                32
+                               :emoji               emoji
+                               :type                :default
+                               :name                name
+                               :address             address}
+               :networks      []
+               :state         :default
+               :action        :none}))))
+
+(def keypair-container-style
+  {:margin-horizontal 20
+   :margin-vertical   8})
+
+(defn- keypair
+  [item index _
+   {:keys [profile-picture compressed-key customization-color]}]
+  (let [accounts (parse-accounts (:accounts item))]
+    [quo/keypair
+     {:blur?               false
+      :status-indicator    false
+      :stored              :on-device
+      :action              :options
+      :accounts            accounts
+      :customization-color customization-color
+      :container-style     keypair-container-style
+      :profile-picture     (when (zero? index) profile-picture)
+      :type                (if (zero? index) :default-keypair :other)
+      :on-options-press    #(not-implemented/alert)
+      :details             {:full-name (:name item)
+                            :address   (when (zero? index)
+                                         (utils/get-shortened-compressed-key compressed-key))}}]))
+
+(defn view
+  []
+  (let [inset-top           (safe-area/get-top)
+        compressed-key      (rf/sub [:profile/compressed-key])
+        profile-picture     (rf/sub [:profile/image])
+        customization-color (rf/sub [:profile/customization-color])
+        keypairs            (rf/sub [:wallet/keypairs])]
+    [quo/overlay
+     {:type            :shell
+      :container-style (style/page-wrapper inset-top)}
+     [quo/page-nav
+      {:key        :header
+       :background :blur
+       :icon-name  :i/arrow-left
+       :on-press   navigate-back}]
+     [rn/view {:style style/title-container}
+      [quo/standard-title
+       {:title               (i18n/label :t/keypairs-and-accounts)
+        :accessibility-label :keypairs-and-accounts-header
+        :customization-color customization-color}]]
+     [rn/view {:style {:flex 1}}
+      [rn/flat-list
+       {:data                    keypairs
+        :render-fn               keypair
+        :render-data             {:profile-picture     profile-picture
+                                  :compressed-key      compressed-key
+                                  :customization-color customization-color}
+        :initial-num-to-render   1
+        :content-container-style {:padding-bottom 60}}]]]))

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -13,13 +13,6 @@
   []
   (rf/dispatch [:navigate-back]))
 
-(defn- keypair-account
-  [account-props]
-  {:account-props account-props
-   :networks      []
-   :state         :default
-   :action        :none})
-
 (defn on-options-press
   [{:keys [theme]
     :as   props}]
@@ -32,7 +25,6 @@
    index _
    {:keys [profile-picture compressed-key customization-color]}]
   (let [theme            (quo.theme/use-theme)
-        accounts         (map keypair-account accounts)
         default-keypair? (zero? index)
         shortened-key    (when default-keypair?
                            (utils/get-shortened-compressed-key compressed-key))
@@ -71,7 +63,7 @@
         compressed-key        (rf/sub [:profile/compressed-key])
         profile-picture       (rf/sub [:profile/image])
         customization-color   (rf/sub [:profile/customization-color])
-        quo-keypairs-accounts (rf/sub [:wallet/quo-keypairs-accounts])]
+        quo-keypairs-accounts (rf/sub [:wallet/settings-keypairs-accounts])]
     [quo/overlay
      {:type            :shell
       :container-style (style/page-wrapper (:top insets))}

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -21,11 +21,12 @@
                  :theme   theme}]))
 
 (defn- keypair
-  [{:keys [accounts name]}
-   index _
+  [{keypair-type :type
+    :keys        [accounts name]}
+   _ _
    {:keys [profile-picture compressed-key customization-color]}]
   (let [theme            (quo.theme/use-theme)
-        default-keypair? (zero? index)
+        default-keypair? (= keypair-type :profile)
         shortened-key    (when default-keypair?
                            (utils/get-shortened-compressed-key compressed-key))
         on-press         (rn/use-callback

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -102,5 +102,4 @@
         :render-data             {:profile-picture     profile-picture
                                   :compressed-key      compressed-key
                                   :customization-color customization-color}
-        :initial-num-to-render   1
         :content-container-style {:padding-bottom 60}}]]]))

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -39,27 +39,29 @@
                  :theme   theme}]))
 
 (defn- keypair
-  [item index _
+  [{:keys [accounts name]}
+   index _
    {:keys [profile-picture compressed-key customization-color]}]
   (let [theme            (quo.theme/use-theme)
-        accounts         (parse-accounts (:accounts item))
+        accounts         (parse-accounts accounts)
         default-keypair? (zero? index)
-        details          {:full-name (:name item)
-                          :address   (when default-keypair?
-                                       (utils/get-shortened-compressed-key compressed-key))}
+        shortened-key    (when default-keypair?
+                           (utils/get-shortened-compressed-key compressed-key))
         on-press         (rn/use-callback
                           (fn []
                             (on-options-press
                              (merge {:theme theme
-                                     :title (:full-name details)}
+                                     :blur? true
+                                     :title name}
                                     (if default-keypair?
                                       {:type                :default-keypair
-                                       :description         (:address details)
+                                       :description         shortened-key
                                        :customization-color customization-color
                                        :profile-picture     profile-picture}
                                       {:type        :keypair
                                        :icon-avatar :i/seed}))))
-                          [customization-color default-keypair? details profile-picture theme])]
+                          [customization-color default-keypair? name
+                           profile-picture shortened-key theme])]
     [quo/keypair
      {:blur?               false
       :status-indicator    false
@@ -71,7 +73,8 @@
       :profile-picture     (when default-keypair? profile-picture)
       :type                (if default-keypair? :default-keypair :other)
       :on-options-press    on-press
-      :details             details}]))
+      :details             {:full-name name
+                            :address   shortened-key}}]))
 
 (defn view
   []

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -32,16 +32,17 @@
         on-press         (rn/use-callback
                           (fn []
                             (on-options-press
-                             (merge {:theme theme
-                                     :blur? true
-                                     :title name}
-                                    (if default-keypair?
-                                      {:type                :default-keypair
-                                       :description         shortened-key
-                                       :customization-color customization-color
-                                       :profile-picture     profile-picture}
-                                      {:type        :keypair
-                                       :icon-avatar :i/seed}))))
+                             (cond-> {:theme theme
+                                      :blur? true
+                                      :title name}
+                               default-keypair?
+                               (assoc :type                :default-keypair
+                                      :description         shortened-key
+                                      :customization-color customization-color
+                                      :profile-picture     profile-picture)
+                               (not default-keypair?)
+                               (assoc :type        :keypair
+                                      :icon-avatar :i/seed))))
                           [customization-color default-keypair? name
                            profile-picture shortened-key theme])]
     [quo/keypair

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -77,14 +77,14 @@
 
 (defn view
   []
-  (let [inset-top           (safe-area/get-top)
+  (let [insets              (safe-area/get-insets)
         compressed-key      (rf/sub [:profile/compressed-key])
         profile-picture     (rf/sub [:profile/image])
         customization-color (rf/sub [:profile/customization-color])
         keypairs            (rf/sub [:wallet/keypairs])]
     [quo/overlay
      {:type            :shell
-      :container-style (style/page-wrapper inset-top)}
+      :container-style (style/page-wrapper (:top insets))}
      [quo/page-nav
       {:key        :header
        :background :blur
@@ -102,4 +102,4 @@
         :render-data             {:profile-picture     profile-picture
                                   :compressed-key      compressed-key
                                   :customization-color customization-color}
-        :content-container-style {:padding-bottom 60}}]]]))
+        :content-container-style (style/list-container (:bottom insets))}]]]))

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -40,8 +40,7 @@
 
 (defn- keypair
   [item index _
-   {:keys [profile-picture compressed-key customization-color]
-    :as   profile-info}]
+   {:keys [profile-picture compressed-key customization-color]}]
   (let [theme            (quo.theme/use-theme)
         accounts         (parse-accounts (:accounts item))
         default-keypair? (zero? index)
@@ -51,15 +50,16 @@
         on-press         (rn/use-callback
                           (fn []
                             (on-options-press
-                             (merge {:type  (if default-keypair? :default-keypair :keypair)
-                                     :title (:full-name details)
-                                     :theme theme}
+                             (merge {:theme theme
+                                     :title (:full-name details)}
                                     (if default-keypair?
-                                      {:customization-color customization-color
-                                       :profile-picture     profile-picture
-                                       :description         (:address details)}
-                                      {:icon-avatar :i/seed}))))
-                          [details index profile-info theme])]
+                                      {:type                :default-keypair
+                                       :description         (:address details)
+                                       :customization-color customization-color
+                                       :profile-picture     profile-picture}
+                                      {:type        :keypair
+                                       :icon-avatar :i/seed}))))
+                          [customization-color default-keypair? details profile-picture theme])]
     [quo/keypair
      {:blur?               false
       :status-indicator    false

--- a/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.settings.wallet.wallet-options.view
   (:require [quo.core :as quo]
-            [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
             [status-im.contexts.settings.wallet.wallet-options.style :as style]
             [utils.i18n :as i18n]
@@ -26,11 +25,13 @@
     :blur?     true
     :list-type :settings}])
 
+(defn navigate-back
+  []
+  (rf/dispatch [:navigate-back]))
+
 (defn view
   []
-  (let [inset-top     (safe-area/get-top)
-        navigate-back (rn/use-callback
-                       #(rf/dispatch [:navigate-back]))]
+  (let [inset-top (safe-area/get-top)]
     [quo/overlay
      {:type            :shell
       :container-style (style/page-wrapper inset-top)}

--- a/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
@@ -9,9 +9,17 @@
   []
   (rf/dispatch [:open-modal :screen/settings.saved-addresses]))
 
+(defn open-keypairs-and-accounts-settings-modal
+  []
+  (rf/dispatch [:open-modal :screen/settings.keypairs-and-accounts]))
+
 (defn gen-basic-settings-options
   []
-  [{:title    (i18n/label :t/saved-addresses)
+  [{:title    (i18n/label :t/keypairs-and-accounts)
+    :blur?    true
+    :on-press open-keypairs-and-accounts-settings-modal
+    :action   :arrow}
+   {:title    (i18n/label :t/saved-addresses)
     :blur?    true
     :on-press open-saved-addresses-settings-modal
     :action   :arrow}])

--- a/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
@@ -2,6 +2,7 @@
   (:require [quo.core :as quo]
             [react-native.safe-area :as safe-area]
             [status-im.contexts.settings.wallet.wallet-options.style :as style]
+            [status-im.feature-flags :as ff]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
@@ -15,10 +16,11 @@
 
 (defn gen-basic-settings-options
   []
-  [{:title    (i18n/label :t/keypairs-and-accounts)
-    :blur?    true
-    :on-press open-keypairs-and-accounts-settings-modal
-    :action   :arrow}
+  [(when (ff/enabled? ::ff/settings.keypairs-and-accounts)
+     {:title    (i18n/label :t/keypairs-and-accounts)
+      :blur?    true
+      :on-press open-keypairs-and-accounts-settings-modal
+      :action   :arrow})
    {:title    (i18n/label :t/saved-addresses)
     :blur?    true
     :on-press open-saved-addresses-settings-modal

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -22,7 +22,7 @@
    ::wallet.long-press-watch-only-asset (enabled-in-env? :FLAG_LONG_PRESS_WATCH_ONLY_ASSET_ENABLED)
    ::wallet.swap                        (enabled-in-env? :FLAG_SWAP_ENABLED)
    ::wallet.wallet-connect              (enabled-in-env? :FLAG_WALLET_CONNECT_ENABLED)
-   ::wallet.wallet-settings             (enabled-in-env? :FLAG_WALLET_SETTINGS_ENABLED)})
+   ::wallet.settings                    (enabled-in-env? :FLAG_WALLET_SETTINGS_ENABLED)})
 
 (defonce ^:private feature-flags-config
   (reagent/atom initial-flags))

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -11,6 +11,9 @@
 
 (def ^:private initial-flags
   {::community.edit-account-selection   (enabled-in-env? :FLAG_EDIT_ACCOUNT_SELECTION_ENABLED)
+   ::settings.wallet-settings           (enabled-in-env? :FLAG_WALLET_SETTINGS_ENABLED)
+   ::settings.keypairs-and-accounts     (enabled-in-env?
+                                         :FLAG_WALLET_SETTINGS_KEYPAIRS_AND_ACCOUNTS_ENABLED)
    ::wallet.activities                  (enabled-in-env? :FLAG_WALLET_ACTIVITY_ENABLED)
    ::wallet.assets-modal-hide           (enabled-in-env? :FLAG_ASSETS_MODAL_HIDE)
    ::wallet.assets-modal-manage-tokens  (enabled-in-env? :FLAG_ASSETS_MODAL_MANAGE_TOKENS)
@@ -21,8 +24,7 @@
    ::wallet.import-private-key          (enabled-in-env? :FLAG_IMPORT_PRIVATE_KEY_ENABLED)
    ::wallet.long-press-watch-only-asset (enabled-in-env? :FLAG_LONG_PRESS_WATCH_ONLY_ASSET_ENABLED)
    ::wallet.swap                        (enabled-in-env? :FLAG_SWAP_ENABLED)
-   ::wallet.wallet-connect              (enabled-in-env? :FLAG_WALLET_CONNECT_ENABLED)
-   ::wallet.settings                    (enabled-in-env? :FLAG_WALLET_SETTINGS_ENABLED)})
+   ::wallet.wallet-connect              (enabled-in-env? :FLAG_WALLET_CONNECT_ENABLED)})
 
 (defonce ^:private feature-flags-config
   (reagent/atom initial-flags))

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -21,7 +21,8 @@
    ::wallet.import-private-key          (enabled-in-env? :FLAG_IMPORT_PRIVATE_KEY_ENABLED)
    ::wallet.long-press-watch-only-asset (enabled-in-env? :FLAG_LONG_PRESS_WATCH_ONLY_ASSET_ENABLED)
    ::wallet.swap                        (enabled-in-env? :FLAG_SWAP_ENABLED)
-   ::wallet.wallet-connect              (enabled-in-env? :FLAG_WALLET_CONNECT_ENABLED)})
+   ::wallet.wallet-connect              (enabled-in-env? :FLAG_WALLET_CONNECT_ENABLED)
+   ::wallet.wallet-settings             (enabled-in-env? :FLAG_WALLET_SETTINGS_ENABLED)})
 
 (defonce ^:private feature-flags-config
   (reagent/atom initial-flags))

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -503,7 +503,9 @@
      :component saved-addresses-settings/view}
 
     {:name      :screen/settings.keypairs-and-accounts
-     :options   options/transparent-modal-screen-options
+     :options   (merge
+                 options/transparent-modal-screen-options
+                 options/dark-screen)
      :component keypairs-and-accounts/view}
 
     {:name      :screen/settings-messages

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -57,6 +57,7 @@
     [status-im.contexts.profile.settings.screens.password.change-password.view :as change-password]
     [status-im.contexts.profile.settings.screens.password.view :as settings-password]
     [status-im.contexts.profile.settings.view :as settings]
+    [status-im.contexts.settings.wallet.keypairs-and-accounts.view :as keypairs-and-accounts]
     [status-im.contexts.settings.wallet.saved-addresses.view :as saved-addresses-settings]
     [status-im.contexts.settings.wallet.wallet-options.view :as wallet-options]
     [status-im.contexts.shell.activity-center.view :as activity-center]
@@ -500,6 +501,10 @@
     {:name      :screen/settings.saved-addresses
      :options   options/transparent-modal-screen-options
      :component saved-addresses-settings/view}
+
+    {:name      :screen/settings.keypairs-and-accounts
+     :options   options/transparent-modal-screen-options
+     :component keypairs-and-accounts/view}
 
     {:name      :screen/settings-messages
      :options   options/transparent-modal-screen-options

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -159,30 +159,33 @@
                 :goerli-enabled?  goerli-enabled?})
              selected-networks))))
 
+(defn- format-settings-keypair-accounts
+  [accounts
+   {:keys [networks size]
+    :or   {networks []
+           size     32}}]
+  (->> accounts
+       (keep (fn [{:keys [path customization-color emoji name address]}]
+               (when-not (string/starts-with? path constants/path-eip1581)
+                 {:account-props {:customization-color customization-color
+                                  :size                size
+                                  :emoji               emoji
+                                  :type                :default
+                                  :name                name
+                                  :address             address}
+                  :networks      networks
+                  :state         :default
+                  :action        :none})))))
+
 (rf/reg-sub
  :wallet/settings-keypairs-accounts
  :<- [:wallet/keypairs]
- (fn [keypairs
-      [_
-       {:keys [networks size]
-        :or   {networks []
-               size     32}}]]
+ (fn [keypairs [_ format-options]]
    (->> keypairs
         (map (fn [{:keys [accounts name type]}]
                {:type     (keyword type)
                 :name     name
-                :accounts (->> accounts
-                               (keep (fn [{:keys [path customization-color emoji name address]}]
-                                       (when (not (string/starts-with? path constants/path-eip1581))
-                                         {:account-props {:customization-color customization-color
-                                                          :size                size
-                                                          :emoji               emoji
-                                                          :type                :default
-                                                          :name                name
-                                                          :address             address}
-                                          :networks      networks
-                                          :state         :default
-                                          :action        :none}))))})))))
+                :accounts (format-settings-keypair-accounts accounts format-options)})))))
 
 (rf/reg-sub
  :wallet/derivation-path-state

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -160,22 +160,29 @@
              selected-networks))))
 
 (rf/reg-sub
- :wallet/quo-keypairs-accounts
+ :wallet/settings-keypairs-accounts
  :<- [:wallet/keypairs]
- (fn [keypairs]
+ (fn [keypairs
+      [_
+       {:keys [networks size]
+        :or   {networks []
+               size     32}}]]
    (->> keypairs
-        (map (fn [{:keys [accounts name]
-                   :as keypair}]
-               {:name     name
+        (map (fn [{:keys [accounts name type]}]
+               {:type     (keyword type)
+                :name     name
                 :accounts (->> accounts
                                (keep (fn [{:keys [path customization-color emoji name address]}]
                                        (when (not (string/starts-with? path constants/path-eip1581))
-                                         {:customization-color customization-color
-                                          :size                32
-                                          :emoji               emoji
-                                          :type                :default
-                                          :name                name
-                                          :address             address}))))})))))
+                                         {:account-props {:customization-color customization-color
+                                                          :size                size
+                                                          :emoji               emoji
+                                                          :type                :default
+                                                          :name                name
+                                                          :address             address}
+                                          :networks      networks
+                                          :state         :default
+                                          :action        :none}))))})))))
 
 (rf/reg-sub
  :wallet/derivation-path-state

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -1,6 +1,7 @@
 (ns status-im.subs.wallet.wallet
   (:require [clojure.string :as string]
             [re-frame.core :as rf]
+            [status-im.constants :as constants]
             [status-im.contexts.wallet.common.utils :as utils]
             [status-im.contexts.wallet.common.utils.networks :as network-utils]
             [status-im.subs.wallet.add-account.address-to-watch]
@@ -157,6 +158,24 @@
                 :testnet-enabled? testnet-enabled?
                 :goerli-enabled?  goerli-enabled?})
              selected-networks))))
+
+(rf/reg-sub
+ :wallet/quo-keypairs-accounts
+ :<- [:wallet/keypairs]
+ (fn [keypairs]
+   (->> keypairs
+        (map (fn [{:keys [accounts name]
+                   :as keypair}]
+               {:name     name
+                :accounts (->> accounts
+                               (keep (fn [{:keys [path customization-color emoji name address]}]
+                                       (when (not (string/starts-with? path constants/path-eip1581))
+                                         {:customization-color customization-color
+                                          :size                32
+                                          :emoji               emoji
+                                          :type                :default
+                                          :name                name
+                                          :address             address}))))})))))
 
 (rf/reg-sub
  :wallet/derivation-path-state

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -599,18 +599,18 @@
 
     (let [{:keys [customization-color name address emoji]} wallet-account]
       (is
-       (= [{:name     (:name keypairs-accounts)
-            :type     (keyword (:type keypairs-accounts))
-            :accounts [{:account-props {:customization-color customization-color
-                                        :size                32
-                                        :emoji               emoji
-                                        :type                :default
-                                        :name                name
-                                        :address             address}
-                        :networks      []
-                        :state         :default
-                        :action        :none}]}]
-          (rf/sub [sub-name])))))
+       (match? [{:name     (:name keypairs-accounts)
+                 :type     (keyword (:type keypairs-accounts))
+                 :accounts [{:account-props {:customization-color customization-color
+                                             :size                32
+                                             :emoji               emoji
+                                             :type                :default
+                                             :name                name
+                                             :address             address}
+                             :networks      []
+                             :state         :default
+                             :action        :none}]}]
+               (rf/sub [sub-name])))))
 
   (testing "allows for passing account format options"
     (swap! rf-db/app-db
@@ -629,20 +629,20 @@
                            {:network-name :arbitrum :short-name "arb1"}]
           size-option     20]
       (is
-       (= [{:name     (:name keypairs-accounts)
-            :type     (keyword (:type keypairs-accounts))
-            :accounts [{:account-props {:customization-color customization-color
-                                        :size                size-option
-                                        :emoji               emoji
-                                        :type                :default
-                                        :name                name
-                                        :address             address}
-                        :networks      network-options
-                        :state         :default
-                        :action        :none}]}]
-          (rf/sub [sub-name
-                   {:networks network-options
-                    :size     size-option}])))))
+       (match? [{:name     (:name keypairs-accounts)
+                 :type     (keyword (:type keypairs-accounts))
+                 :accounts [{:account-props {:customization-color customization-color
+                                             :size                size-option
+                                             :emoji               emoji
+                                             :type                :default
+                                             :name                name
+                                             :address             address}
+                             :networks      network-options
+                             :state         :default
+                             :action        :none}]}]
+               (rf/sub [sub-name
+                        {:networks network-options
+                         :size     size-option}])))))
 
   (testing "filters non-wallet accounts"
     (swap! rf-db/app-db
@@ -652,10 +652,10 @@
                 :accounts
                 [chat-account])]))
     (is
-     (= [{:name     (:name keypairs-accounts)
-          :type     (keyword (:type keypairs-accounts))
-          :accounts []}]
-        (rf/sub [sub-name])))))
+     (match? [{:name     (:name keypairs-accounts)
+               :type     (keyword (:type keypairs-accounts))
+               :accounts []}]
+             (rf/sub [sub-name])))))
 
 (def local-suggestions ["a" "b"])
 

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -591,11 +591,11 @@
   [sub-name]
   (testing "returns formatted key-pairs and accounts"
     (swap! rf-db/app-db
-      #(assoc-in %
-        [:wallet :keypairs]
-        [(assoc keypairs-accounts
-                :accounts
-                [wallet-account])]))
+      assoc-in
+      [:wallet :keypairs]
+      [(assoc keypairs-accounts
+              :accounts
+              [wallet-account])])
 
     (let [{:keys [customization-color name address emoji]} wallet-account]
       (is
@@ -614,11 +614,11 @@
 
   (testing "allows for passing account format options"
     (swap! rf-db/app-db
-      #(assoc-in %
-        [:wallet :keypairs]
-        [(assoc keypairs-accounts
-                :accounts
-                [wallet-account])]))
+      assoc-in
+      [:wallet :keypairs]
+      [(assoc keypairs-accounts
+              :accounts
+              [wallet-account])])
 
     (let [{:keys [customization-color
                   name
@@ -646,11 +646,11 @@
 
   (testing "filters non-wallet accounts"
     (swap! rf-db/app-db
-      #(assoc-in %
-        [:wallet :keypairs]
-        [(assoc keypairs-accounts
-                :accounts
-                [chat-account])]))
+      assoc-in
+      [:wallet :keypairs]
+      [(assoc keypairs-accounts
+              :accounts
+              [chat-account])])
     (is
      (match? [{:name     (:name keypairs-accounts)
                :type     (keyword (:type keypairs-accounts))

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -554,6 +554,109 @@
      (= keypairs
         (rf/sub [sub-name])))))
 
+(def chat-account
+  {:path                "m/43'/60'/1581'/0'/0"
+   :emoji               ""
+   :key-uid             "abc"
+   :address             "address-1"
+   :color-id            ""
+   :wallet              false
+   :name                "My Profile"
+   :type                "generated"
+   :chat                true
+   :customization-color :blue
+   :hidden              false
+   :removed             false})
+
+(def wallet-account
+  {:path                "m/44'/60'/0'/0/0"
+   :emoji               "🤡"
+   :key-uid             "abc"
+   :address             "address-2"
+   :wallet              true
+   :name                "My Account"
+   :type                "generated"
+   :chat                false
+   :customization-color :primary
+   :hidden              false
+   :removed             false})
+
+(def keypairs-accounts
+  {:key-uid  "abc"
+   :name     "My Profile"
+   :type     "profile"
+   :accounts []})
+
+(h/deftest-sub :wallet/settings-keypairs-accounts
+  [sub-name]
+  (testing "returns formatted key-pairs and accounts"
+    (swap! rf-db/app-db
+      #(assoc-in %
+        [:wallet :keypairs]
+        [(assoc keypairs-accounts
+                :accounts
+                [wallet-account])]))
+
+    (let [{:keys [customization-color name address emoji]} wallet-account]
+      (is
+       (= [{:name     (:name keypairs-accounts)
+            :type     (keyword (:type keypairs-accounts))
+            :accounts [{:account-props {:customization-color customization-color
+                                        :size                32
+                                        :emoji               emoji
+                                        :type                :default
+                                        :name                name
+                                        :address             address}
+                        :networks      []
+                        :state         :default
+                        :action        :none}]}]
+          (rf/sub [sub-name])))))
+
+  (testing "allows for passing account format options"
+    (swap! rf-db/app-db
+      #(assoc-in %
+        [:wallet :keypairs]
+        [(assoc keypairs-accounts
+                :accounts
+                [wallet-account])]))
+
+    (let [{:keys [customization-color
+                  name
+                  address
+                  emoji]} wallet-account
+          network-options [{:network-name :ethereum :short-name "eth"}
+                           {:network-name :optimism :short-name "opt"}
+                           {:network-name :arbitrum :short-name "arb1"}]
+          size-option     20]
+      (is
+       (= [{:name     (:name keypairs-accounts)
+            :type     (keyword (:type keypairs-accounts))
+            :accounts [{:account-props {:customization-color customization-color
+                                        :size                size-option
+                                        :emoji               emoji
+                                        :type                :default
+                                        :name                name
+                                        :address             address}
+                        :networks      network-options
+                        :state         :default
+                        :action        :none}]}]
+          (rf/sub [sub-name
+                   {:networks network-options
+                    :size     size-option}])))))
+
+  (testing "filters non-wallet accounts"
+    (swap! rf-db/app-db
+      #(assoc-in %
+        [:wallet :keypairs]
+        [(assoc keypairs-accounts
+                :accounts
+                [chat-account])]))
+    (is
+     (= [{:name     (:name keypairs-accounts)
+          :type     (keyword (:type keypairs-accounts))
+          :accounts []}]
+        (rf/sub [sub-name])))))
+
 (def local-suggestions ["a" "b"])
 
 (h/deftest-sub :wallet/local-suggestions

--- a/translations/en.json
+++ b/translations/en.json
@@ -2484,6 +2484,7 @@
     "address-no-activity": "This address has no activity",
     "scanning": "Scanning for activity...",
     "keypairs": "Key pairs",
+    "keypairs-and-accounts": "Key pairs and accounts",
     "keypairs-accounts-and-addresses": "Key pairs, accounts and addresses",
     "keypairs-description": "Select key pair to derive your new account from",
     "confirm-account-origin": "Confirm account origin",


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #19915 
fixes #19916 

### Summary

* This PR attempts to add the initial UI for the Wallet Settings - Key pairs and accounts screen
  * The initial includes the logic and view for displaying key pairs and accounts, but not logic for the managing the items.
    * This was done so we can start sharing the work related to managing key pairs/accounts and this screen is needed as a starting point for other features.
  * This PR also adds a feature flag for the wallet settings, which is disabled by default. This flag should allow us to merge this initial UI and other PRs safely without needing a complete design review. Eventually when we start releasing functionality we can remove the feature-flag or selectively choose what should still be feature flagged.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted


##### Functional

- Wallet Settings
  - Key pairs and accounts
 
### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open the status mobile app
- Open the user profile settings menu
- Ensure the feature-flag for `wallet-settings` is activated
- Ensure the feature-flag for `keypairs-and-accounts` is activated
- Open the wallet settings
- Open the "Key pairs and accounts" settings inside wallet settings
- Press on the action menu icon for a key-pair item

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### After Changes - Initial UI for displaying key-pairs with accounts, along with opening the action-menu.

https://github.com/status-im/status-mobile/assets/2845768/ed7f27d1-acad-4367-bc49-5332918ec0c6

status: ready <!-- Can be ready or wip -->
