### PR TITLE
Fix "Offline" section in group chat members #19883

### DIFF
--- a/src/quo/components/community/channel_actions/view.cljs
+++ b/src/quo/components/community/channel_actions/view.cljs
@@ -8,9 +8,10 @@
   [rn/view {:style (assoc container-style :flex-direction :row)}
    (map-indexed
     (fn [index action]
-      ^{:key index}
-      [:<>
-       [channel-action/view action]
-       (when (not= action (last actions))
-         [rn/view {:width 16}])])
+      (when action
+        ^{:key index}
+        [:<>
+         [channel-action/view action]
+         (when (not= action (last actions))
+           [rn/view {:style {:width 16}}])]))
     actions)])

--- a/src/status_im/common/home/actions/view.cljs
+++ b/src/status_im/common/home/actions/view.cljs
@@ -365,23 +365,21 @@
           :sub-label           nil
           :chevron?            false}))
 
-;; TODO(OmarBasem): to be implemented.
 (defn add-members-entry
-  []
+  [chat-id]
   (entry {:icon                :i/add-user
           :label               (i18n/label :t/add-members)
-          :on-press            #(js/alert "TODO: to be implemented")
+          :on-press            #(rf/dispatch [:open-modal :group-add-manage-members chat-id])
           :danger?             false
           :accessibility-label :add-members
           :sub-label           nil
           :chevron?            false}))
 
-;; TODO(OmarBasem): to be implemented.
 (defn manage-members-entry
-  []
+  [chat-id]
   (entry {:icon                :i/add-user
           :label               (i18n/label :t/manage-members)
-          :on-press            #(js/alert "TODO: to be implemented")
+          :on-press            #(rf/dispatch [:open-modal :group-add-manage-members chat-id])
           :danger?             false
           :accessibility-label :manage-members
           :sub-label           nil
@@ -435,11 +433,8 @@
         admin?          (get admins current-pub-key)]
     [(group-details-entry chat-id)
      (when inside-chat?
-       (if admin?
-         (when config/show-not-implemented-features?
-           (manage-members-entry))
-         (when config/show-not-implemented-features?
-           (add-members-entry))))
+       (when admin?
+         (manage-members-entry chat-id)))
      (when (and admin? inside-chat?)
        (when config/show-not-implemented-features?
          (edit-group-entry)))

--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -4,6 +4,7 @@
     [quo.foundations.colors :as colors]
     [quo.theme]
     [react-native.core :as rn]
+    [react-native.gesture :as gesture]
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
     [status-im.common.contact-list-item.view :as contact-list-item]
@@ -60,7 +61,7 @@
        :weight :semi-bold
        :style  {:margin-left 20}}
       (i18n/label (if admin? :t/manage-members :t/add-members))]
-     [rn/section-list
+     [gesture/section-list
       {:key-fn                         :title
        :sticky-section-headers-enabled false
        :sections                       (rf/sub [:contacts/grouped-by-first-letter])
@@ -139,7 +140,8 @@
                 :customization-color color}}]
      [quo/channel-actions
       {:container-style style/actions-view
-       :actions         [{:accessibility-label :pinned-messages
+       :actions         [{:big?                (not admin?)
+                          :accessibility-label :pinned-messages
                           :label               (i18n/label :t/pinned-messages)
                           :customization-color color
                           :icon                :i/pin
@@ -155,16 +157,17 @@
                           :on-press            #(rf/dispatch [:chat.ui/mute chat-id (not muted)
                                                               (when-not muted
                                                                 constants/mute-till-unmuted)])}
-                         {:accessibility-label :manage-members
-                          :customization-color color
-                          :icon                :i/add-user
-                          :label               (i18n/label (if admin? :t/manage-members :t/add-members))
-                          :counter-value       (count contacts)
-                          :on-press            (fn []
-                                                 (rf/dispatch [:group/clear-added-participants])
-                                                 (rf/dispatch [:group/clear-removed-members])
-                                                 (rf/dispatch [:open-modal :group-add-manage-members
-                                                               chat-id]))}]}]
+                         (when admin?
+                           {:accessibility-label :manage-members
+                            :customization-color color
+                            :icon                :i/add-user
+                            :label               (i18n/label :t/manage-members)
+                            :counter-value       (count contacts)
+                            :on-press            (fn []
+                                                   (rf/dispatch [:group/clear-added-participants])
+                                                   (rf/dispatch [:group/clear-removed-members])
+                                                   (rf/dispatch [:open-modal :group-add-manage-members
+                                                                 chat-id]))})]}]
      [rn/section-list
       {:key-fn                         :title
        :sticky-section-headers-enabled false

--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -44,12 +44,11 @@
 
 (defn add-manage-members
   []
-  (let [selected-participants      (rf/sub [:group-chat/selected-participants])
-        deselected-members         (rf/sub [:group-chat/deselected-members])
-        chat-id                    (rf/sub [:get-screen-params :group-details])
-        {:keys [admins] :as group} (rf/sub [:chats/chat-by-id chat-id])
-        theme                      (quo.theme/use-theme)
-        admin?                     (get admins (rf/sub [:multiaccount/public-key]))]
+  (let [selected-participants (rf/sub [:group-chat/selected-participants])
+        deselected-members    (rf/sub [:group-chat/deselected-members])
+        chat-id               (rf/sub [:get-screen-params :group-add-manage-members])
+        group                 (rf/sub [:chats/chat-by-id chat-id])
+        theme                 (quo.theme/use-theme)]
     [rn/view {:flex 1 :margin-top 20}
      [rn/touchable-opacity
       {:on-press            #(rf/dispatch [:navigate-back])
@@ -60,7 +59,7 @@
       {:size   :heading-1
        :weight :semi-bold
        :style  {:margin-left 20}}
-      (i18n/label (if admin? :t/manage-members :t/add-members))]
+      (i18n/label :t/manage-members)]
      [gesture/section-list
       {:key-fn                         :title
        :sticky-section-headers-enabled false

--- a/src/status_im/subs/contact.cljs
+++ b/src/status_im/subs/contact.cljs
@@ -8,6 +8,7 @@
     [status-im.common.pixel-ratio :as pixel-ratio]
     [status-im.constants :as constants]
     [status-im.contexts.profile.utils :as profile.utils]
+    [status-im.subs.chat.utils :as chat.utils]
     [utils.address :as address]
     [utils.collection]
     [utils.i18n :as i18n]
@@ -151,7 +152,7 @@
  (fn [[members contacts]]
    (-> (reduce
         (fn [acc contact]
-          (let [first-char (first (:alias contact))]
+          (let [first-char (first (:primary-name contact))]
             (if (get acc first-char)
               (update-in acc [first-char :data] #(conj % contact))
               (assoc acc first-char {:title first-char :data [contact]}))))
@@ -165,7 +166,7 @@
  :<- [:contacts/active]
  (fn [active-contacts]
    (->> active-contacts
-        (sort-by :alias)
+        (sort-by :primary-name)
         (sort-by
          #(visibility-status-utils/visibility-status-order (:public-key %))))))
 
@@ -358,9 +359,20 @@
 (re-frame/reg-sub
  :contacts/group-members-sections
  (fn [[_ chat-id]]
-   [(re-frame/subscribe [:contacts/contacts-by-chat chat-id])])
- (fn [[members]]
-   (let [admins  (filter :admin? members)
+   [(re-frame/subscribe [:contacts/contacts-by-chat chat-id])
+    (re-frame/subscribe [:visibility-status-updates])
+    (re-frame/subscribe [:multiaccount/public-key])
+    (re-frame/subscribe [:multiaccount/current-user-visibility-status])])
+ (fn [[members status-updates current-user-public-key current-user-visibility-status]]
+   (let [members (map (fn [{:keys [public-key] :as member}]
+                        (assoc member
+                               :online?
+                               (chat.utils/online?
+                                (if (= public-key current-user-public-key)
+                                  (:status-type current-user-visibility-status)
+                                  (get-in status-updates [public-key :status-type])))))
+                      members)
+         admins  (filter :admin? members)
          online  (filter #(and (not (:admin? %)) (:online? %)) members)
          offline (filter #(and (not (:admin? %)) (not (:online? %))) members)]
      (vals (cond-> {}


### PR DESCRIPTION
fixes #19883
fixes #19895
fixes #19881

Actually offline/online sections have been fixed not removed, cc @qoqobolo 

1) Fixed offline/online sections for group chat details
2) Fixed manage members button for admin on group details screen and added it to context menu (renamed "add members" to "manage members")
3) Fixed section list sorted by the first letter for manage members screen
