### PR TITLE
'Send' button is shown for watch-only collectibles and can navigate to the 'send' flow #19743

### DIFF
--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -28,7 +28,7 @@
      collection-name]]])
 
 (defn cta-buttons
-  [chain-id token-id contract-address watch-only?]
+  [{:keys [chain-id token-id contract-address watch-only?]}]
   (let [theme (quo.theme/use-theme)]
     [rn/view {:style style/buttons-container}
      (when-not watch-only?
@@ -67,7 +67,7 @@
       (let [theme                       (quo.theme/use-theme)
             collectible                 (rf/sub [:wallet/last-collectible-details])
             animation-shared-element-id (rf/sub [:animation-shared-element-id])
-            account                     (rf/sub [:wallet/current-viewing-account])
+            collectible-owner           (rf/sub [:wallet/last-collectible-details-owner])
             {:keys [id
                     preview-url
                     collection-data
@@ -91,7 +91,7 @@
                                          :header       collectible-name
                                          :description  collection-name}
             total-owned                 (utils/total-owned-collectible (:ownership collectible)
-                                                                       (:address account))]
+                                                                       (:address collectible-owner))]
         (rn/use-unmount #(rf/dispatch [:wallet/clear-last-collectible-details]))
         [scroll-page/scroll-page
          {:navigate-back? true
@@ -129,7 +129,11 @@
                                                                          {:name  collectible-name
                                                                           :image preview-uri}])}])}])))}]
           [header collectible-name collection-name collection-image]
-          [cta-buttons chain-id token-id contract-address (:watch-only? account)]
+          [cta-buttons
+           {:chain-id         chain-id
+            :token-id         token-id
+            :contract-address contract-address
+            :watch-only?      (:watch-only? collectible-owner)}]
           [quo/tabs
            {:size           32
             :style          style/tabs

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -28,15 +28,16 @@
      collection-name]]])
 
 (defn cta-buttons
-  [chain-id token-id contract-address]
+  [chain-id token-id contract-address watch-only?]
   (let [theme (quo.theme/use-theme)]
     [rn/view {:style style/buttons-container}
-     [quo/button
-      {:container-style style/send-button
-       :type            :outline
-       :size            40
-       :icon-left       :i/send}
-      (i18n/label :t/send)]
+     (when-not watch-only?
+       [quo/button
+        {:container-style style/send-button
+         :type            :outline
+         :size            40
+         :icon-left       :i/send}
+        (i18n/label :t/send)])
      [quo/button
       {:container-style  style/opensea-button
        :type             :outline
@@ -66,7 +67,7 @@
       (let [theme                       (quo.theme/use-theme)
             collectible                 (rf/sub [:wallet/last-collectible-details])
             animation-shared-element-id (rf/sub [:animation-shared-element-id])
-            wallet-address              (rf/sub [:wallet/current-viewing-account-address])
+            account                     (rf/sub [:wallet/current-viewing-account])
             {:keys [id
                     preview-url
                     collection-data
@@ -90,7 +91,7 @@
                                          :header       collectible-name
                                          :description  collection-name}
             total-owned                 (utils/total-owned-collectible (:ownership collectible)
-                                                                       wallet-address)]
+                                                                       (:address account))]
         (rn/use-unmount #(rf/dispatch [:wallet/clear-last-collectible-details]))
         [scroll-page/scroll-page
          {:navigate-back? true
@@ -128,7 +129,7 @@
                                                                          {:name  collectible-name
                                                                           :image preview-uri}])}])}])))}]
           [header collectible-name collection-name collection-image]
-          [cta-buttons chain-id token-id contract-address]
+          [cta-buttons chain-id token-id contract-address (:watch-only? account)]
           [quo/tabs
            {:size           32
             :style          style/tabs


### PR DESCRIPTION
fixes #19743 


<img width="598" alt="Screenshot 2024-05-06 at 17 55 49" src="https://github.com/status-im/status-mobile/assets/55688834/88dfe793-e880-4a8a-ad77-31b6af1d15cf">
