### PR TITLE
feat: add feature flag for swaps

### DIFF
--- a/src/quo/components/buttons/wallet_ctas/view.cljs
+++ b/src/quo/components/buttons/wallet_ctas/view.cljs
@@ -24,7 +24,7 @@
               :color      (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)}} text]])
 
 (defn view
-  [{:keys [buy-action send-action receive-action bridge-action container-style]}]
+  [{:keys [buy-action send-action receive-action bridge-action swap-action container-style]}]
   (let [theme (quo.theme/use-theme)]
     [rn/view {:style container-style}
      [rn/view {:style style/inner-container}
@@ -46,6 +46,13 @@
         :on-press            receive-action
         :theme               theme
         :accessibility-label :receive}]
+      (when swap-action
+        [action-button
+         {:icon                :i/swap
+          :text                (i18n/label :t/swap)
+          :on-press            swap-action
+          :theme               theme
+          :accessibility-label :swap}])
       [action-button
        {:icon                :i/bridge
         :text                (i18n/label :t/bridge)

--- a/src/status_im/contexts/preview/quo/buttons/wallet_ctas.cljs
+++ b/src/status_im/contexts/preview/quo/buttons/wallet_ctas.cljs
@@ -14,4 +14,5 @@
      :buy-action      #(js/alert "Buy button pressed")
      :send-action     #(js/alert "Send button pressed")
      :receive-action  #(js/alert "Receive button pressed")
-     :bridge-action   #(js/alert "Bridge button pressed")}]])
+     :bridge-action   #(js/alert "Bridge button pressed")
+     :swap-action     #(js/alert "Swap button pressed")}]])

--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -51,6 +51,8 @@
                                              {:status :receive}])
              :buy-action      #(rf/dispatch [:show-bottom-sheet
                                              {:content buy-token/view}])
+             :swap-action     (when (ff/enabled? ::ff/wallet.swap)
+                                #(rf/dispatch [:wallet/start-swap]))
              :bridge-action   #(rf/dispatch [:wallet/start-bridge])}])
          [quo/tabs
           {:style            style/tabs

--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -1,0 +1,10 @@
+(ns status-im.contexts.wallet.swap.events
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-event-fx :wallet/start-swap
+ (fn [{:keys [_db]}]
+   {:fx [[:dispatch
+          [:toasts/upsert
+           {:id   :swap-error
+            :type :negative
+            :text "Swap is under construction"}]]]}))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -39,6 +39,7 @@
     status-im.contexts.wallet.events
     status-im.contexts.wallet.send.events
     status-im.contexts.wallet.signals
+    status-im.contexts.wallet.swap.events
     [status-im.db :as db]
     status-im.navigation.effects
     status-im.navigation.events

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -20,6 +20,7 @@
     ::wallet.graph                       (enabled-in-env? :FLAG_GRAPH_ENABLED)
     ::wallet.import-private-key          (enabled-in-env? :FLAG_IMPORT_PRIVATE_KEY_ENABLED)
     ::wallet.long-press-watch-only-asset (enabled-in-env? :FLAG_LONG_PRESS_WATCH_ONLY_ASSET_ENABLED)
+    ::wallet.swap                        (enabled-in-env? :FLAG_SWAP_ENABLED)
     ::wallet.wallet-connect              (enabled-in-env? :FLAG_WALLET_CONNECT_ENABLED)}))
 
 (defn feature-flags [] @feature-flags-config)


### PR DESCRIPTION
fixes #19919 

### Summary

This PR adds a feature flag for wallet swaps

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in
- Go to settings > Feature flags
- Enable swap
- Go to an account and verify there is a new Swap button when enabling Swap feature flag

status: ready