### PR TITLE
fix: settings item pressability

### DIFF
--- a/src/quo/components/settings/settings_item/view.cljs
+++ b/src/quo/components/settings/settings_item/view.cljs
@@ -109,7 +109,7 @@
   [{:keys [title on-press action-props accessibility-label blur? container-style] :as props}]
   [rn/pressable
    {:style               (merge style/container container-style)
-    :on-press            on-press
+    :on-press            (or on-press (:on-change action-props))
     :accessibility-label accessibility-label}
    [rn/view {:style (style/left-sub-container props)}
     [image-component props]


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19914

This PR fixes settings item pressability. It makes the whole item pressable instead of just the checkbox for a better UX.

Demo:

https://github.com/status-im/status-mobile/assets/29354102/c3125718-be19-4b1e-bace-3417c5049632



