### PR TITLE
[#19172] fix: new to status design issue

### DIFF
--- a/src/quo/components/buttons/predictive_keyboard/view.cljs
+++ b/src/quo/components/buttons/predictive_keyboard/view.cljs
@@ -70,6 +70,6 @@
                  :type (if (= type :error) :error :default)}
                 (when blur?
                   {:text-color colors/white-opa-70
-                   :icon-color colors/white-opa-70}))
+                   :icon-color colors/white-opa-40}))
          text]
         nil)]]))

--- a/src/quo/components/inputs/recovery_phrase/view.cljs
+++ b/src/quo/components/inputs/recovery_phrase/view.cljs
@@ -40,7 +40,7 @@
 (defn recovery-phrase-input
   [{:keys [customization-color blur? on-focus on-blur mark-errors?
            error-pred-current-word error-pred-written-words word-limit
-           container-style]
+           container-style placeholder-text-color]
     :or   {customization-color      :blue
            word-limit               ##Inf
            error-pred-current-word  (constantly false)
@@ -62,7 +62,8 @@
      [rn/text-input
       (merge {:accessibility-label    :recovery-phrase-input
               :style                  (style/input theme)
-              :placeholder-text-color (style/placeholder-color state theme blur?)
+              :placeholder-text-color (or placeholder-text-color
+                                          (style/placeholder-color state theme blur?))
               :cursor-color           (style/cursor-color customization-color theme)
               :keyboard-appearance    theme
               :multiline              true

--- a/src/status_im/common/enter_seed_phrase/view.cljs
+++ b/src/status_im/common/enter_seed_phrase/view.cljs
@@ -63,6 +63,7 @@
       [quo/recovery-phrase-input
        {:accessibility-label      :passphrase-input
         :placeholder              (i18n/label :t/seed-phrase-placeholder)
+        :placeholder-text-color   colors/white-opa-30
         :auto-capitalize          :none
         :auto-correct             false
         :auto-focus               true


### PR DESCRIPTION
fixes #19172

### Summary

- Overlay color [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=94:35495&mode=design#725923985)] is different from design, resulting in a wrong blur background throughout the screen
- Recovery phrase input [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=94:35494&mode=design#725924211)] has a wrong color
- Info message icon [[comment](https://www.figma.com/file/oznddnBnDbLlLQIaACYNuj?node-id=1:32044&mode=design#727149088)] in the predictive keyboard has a wrong color


#### Areas that maybe impacted

-  I'm new to Status option
- Use recovery phrase



### Steps to test

1. Open Status
2. Select I'm new to Status option


### Result

<img src="https://github.com/status-im/status-mobile/assets/71308738/fffa7be7-fda3-4091-81ae-5b5b61cfd10f" width="390px"/>

status: ready
