### PR TITLE
DX: Preload user namespace

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,5 @@
 {:config-paths ["status-im"]
- :output       {:exclude-files ["src/user.cljs"]}
+ :output       {:exclude-files ["src/dev/user.cljs"]}
  :lint-as      {legacy.status-im.utils.views/defview clojure.core/defn
                 legacy.status-im.utils.views/letsubs clojure.core/let
                 reagent.core/with-let                clojure.core/let

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,5 @@
 {:config-paths ["status-im"]
+ :output       {:exclude-files ["src/user.cljs"]}
  :lint-as      {legacy.status-im.utils.views/defview clojure.core/defn
                 legacy.status-im.utils.views/letsubs clojure.core/let
                 reagent.core/with-let                clojure.core/let

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,5 @@
 {:config-paths ["status-im"]
- :output       {:exclude-files ["src/dev/user.cljs"]}
+ :output       {:exclude-files ["src/user.cljs" "src/dev/user.cljs"]}
  :lint-as      {legacy.status-im.utils.views/defview clojure.core/defn
                 legacy.status-im.utils.views/letsubs clojure.core/let
                 reagent.core/with-let                clojure.core/let

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ fastlane/README.md
 # Clj
 
 .cpcache/
+src/user.cljs
 
 # emacs
 .dir-locals.el

--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,7 @@ fastlane/README.md
 # Clj
 
 .cpcache/
-src/user.cljs
+src/dev/user.cljs
 
 # emacs
 .dir-locals.el

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ fastlane/README.md
 # Clj
 
 .cpcache/
+src/user.cljs
 src/dev/user.cljs
 
 # emacs

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -53,11 +53,12 @@
    :dev {:devtools {:before-load-async status-im.setup.hot-reload/before-reload
                     :after-load-async  status-im.setup.hot-reload/reload
                     :build-notify      status-im.setup.hot-reload/build-notify
-                    :preloads          [;; We require the user namespace so that
+                    :preloads          [;; We preload user namespaces so that
                                         ;; its symbols are available without the
-                                        ;; dev having to evaluate the entire
-                                        ;; namespace at least once after app
-                                        ;; initialization.
+                                        ;; developer having to evaluate the
+                                        ;; entire namespace at least once after
+                                        ;; app initialization.
+                                        user
                                         dev.user
                                         re-frisk-remote.preload
                                         status-im.setup.schema-preload

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -53,7 +53,12 @@
    :dev {:devtools {:before-load-async status-im.setup.hot-reload/before-reload
                     :after-load-async  status-im.setup.hot-reload/reload
                     :build-notify      status-im.setup.hot-reload/build-notify
-                    :preloads          [re-frisk-remote.preload
+                    :preloads          [;; We require the user namespace (src/user.cljs) so that
+                                        ;; its symbols are available without the dev having to
+                                        ;; evaluate the entire namespace at least once after app
+                                        ;; initialization.
+                                        user
+                                        re-frisk-remote.preload
                                         status-im.setup.schema-preload
                                         ;; In order to use component test helpers in the REPL we
                                         ;; need to preload namespaces that are not normally required

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -53,11 +53,12 @@
    :dev {:devtools {:before-load-async status-im.setup.hot-reload/before-reload
                     :after-load-async  status-im.setup.hot-reload/reload
                     :build-notify      status-im.setup.hot-reload/build-notify
-                    :preloads          [;; We require the user namespace (src/user.cljs) so that
-                                        ;; its symbols are available without the dev having to
-                                        ;; evaluate the entire namespace at least once after app
+                    :preloads          [;; We require the user namespace so that
+                                        ;; its symbols are available without the
+                                        ;; dev having to evaluate the entire
+                                        ;; namespace at least once after app
                                         ;; initialization.
-                                        user
+                                        dev.user
                                         re-frisk-remote.preload
                                         status-im.setup.schema-preload
                                         ;; In order to use component test helpers in the REPL we

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -54,10 +54,10 @@
                     :after-load-async  status-im.setup.hot-reload/reload
                     :build-notify      status-im.setup.hot-reload/build-notify
                     :preloads          [;; We preload user namespaces so that
-                                        ;; its symbols are available without the
-                                        ;; developer having to evaluate the
-                                        ;; entire namespace at least once after
-                                        ;; app initialization.
+                                        ;; their symbols are available without
+                                        ;; the developer having to manually
+                                        ;; evaluate them after app
+                                        ;; initialization.
                                         user
                                         dev.user
                                         re-frisk-remote.preload

--- a/src/dev/README.md
+++ b/src/dev/README.md
@@ -1,0 +1,22 @@
+# The `dev/` directory
+
+The `src/dev/` directory is a place where developers can commit non-production
+and non-test code which can facilitate development in general. The code should,
+ideally, be useful to more than one team member.
+
+**Note**: As of today (2024-05-07), we don't have further guidelines or examples
+about how mobile teams should use and maintain these dev-only namespaces. Before
+opening a PR introducing new dev-only namespaces, consider sharing and
+discussing with as many team members as you can.
+
+### The `user` namespace
+
+You may optionally create a `src/dev/user.cljs` file. This file is git-ignored
+and it is meant to be your own playground. Clojure developers usually use this
+sort of namespace to create temporary utilities and experiments that aren't
+necessarily useful to others.
+
+Be careful with `make clean` because it will delete all non-tracked git files.
+If you rely on this file, you may prefer to create a symbolic link and store the
+original `user.cljs` file outside the `status-mobile` repository. Then, after
+`make clean`, you will need to recreate the symlink.

--- a/src/dev/README.md
+++ b/src/dev/README.md
@@ -11,10 +11,11 @@ discussing with as many team members as you can.
 
 ### The `user` namespace
 
-You may optionally create a `src/dev/user.cljs` file. This file is git-ignored
-and it is meant to be your own playground. Clojure developers usually use this
-sort of namespace to create temporary utilities and experiments that aren't
-necessarily useful to others.
+You may optionally create a `src/dev/user.cljs` and/or `src/user.cljs` file.
+These files are git-ignored and are meant to be your own playground. Clojure
+developers usually use such namespaces to create temporary utilities and
+experiments that aren't necessarily useful to others. They are particularly
+valuable for developers adept at the REPL-Driven Development workflow.
 
 Be careful with `make clean` because it will delete all non-tracked git files.
 If you rely on this file, you may prefer to create a symbolic link and store the


### PR DESCRIPTION
### Summary

This PR preloads the `user` namespace (`src/user.cljs` and `src/dev/user.cljs`) for the `mobile` target and for dev-only purposes. The files are git-ignored.

Just a reminder that you'll be responsible for making sure your `user` namespace is correct. If it's broken in any way (e.g. calling non-existent code) the app will crash at initialization (dev-only environment obviously).

### Why?

When the app initializes, it loads namespaces that were required at least once. If you create a `user` namespace, it won't be automatically required for you. And if you, like some Clojure devs, like to use the `user` namespace as your safe heaven for experimentation and dev-only utilities, you'll need to remember to evaluate the namespace at least once.

This is tedious and many times I forgot to do so and the app crashed because the compiler didn't know where the symbols were coming from.

### How do I use it?

Simply create a file `src/user.cljs` or `src/dev/user.cljs` and write whatever you want there! Personally, I often use it to persist experiments during development, for example, functions to manipulate the app-db, functions I can call from Emacs directly, debugging functions (e.g. https://github.com/status-im/status-mobile/pull/19906#discussion_r1591192425), and so on.

Some Clojure teams like to commit the `user` namespace and share it with other team members. This *can* work, but to me it misses the point that I want a namespace that's already loaded and which is my own playground where I don't care about code quality.

#### Areas that may be impacted

None.

### Steps to test

Behavior-wise, nothing to test. As a dev, you can verify it works for you by creating a file like the following, and you can require any namespace inside `src/`. Once you load the app, the vars inside `user` or `dev.user` ns should be readily available for you to be used anywhere in the repo without having to require the `user` namespace in `ns` forms.

Remember to delete code using the `user` namespace before opening a PR ;)

```clojure
(ns dev.user)
```

status: ready
