### PR TITLE
Upgrade re-frame to latest

### DIFF
--- a/nix/deps/clojure/deps.json
+++ b/nix/deps/clojure/deps.json
@@ -837,11 +837,11 @@
   },
 
   {
-    "path": "org/clojure/tools.logging/1.1.0/tools.logging-1.1.0",
+    "path": "org/clojure/tools.logging/1.2.4/tools.logging-1.2.4",
     "host": "https://repo1.maven.org/maven2",
     "jar": {
-      "sha1": "84cb5d00caa9df2ee504d46f6107f4708271f619",
-      "sha256": "0x2zzivn38z179lxkw9wbi9n9qwsf466lrd9y27khdz7wbxhscb5"
+      "sha1": "3a85764aa30c434a5b0375a2ee72924aa040fa66",
+      "sha256": "0a8riw23pfkiiyz98ccmljpbw1z13mxl73pdgyz80j93s0y0mzj6"
     }
   },
 
@@ -1008,11 +1008,11 @@
   },
 
   {
-    "path": "re-frame/re-frame/1.3.0/re-frame-1.3.0",
+    "path": "re-frame/re-frame/1.4.3/re-frame-1.4.3",
     "host": "https://repo.clojars.org",
     "jar": {
-      "sha1": "b7135a76432b8141027ba1f4eb6bb15a36acfb7c",
-      "sha256": "16wi01z0j4wn04kldwzxvj0pd9dianjyb000nv5611ikhxk1qrps"
+      "sha1": "74e132cc593ed2d72a5d4874954c58677a905f0e",
+      "sha256": "1xdmbjb0gv6dby98y1nx3brz9sdkfzxz9cjk8ajcr1f4zabcaapb"
     }
   },
 

--- a/nix/deps/clojure/deps.list
+++ b/nix/deps/clojure/deps.list
@@ -91,7 +91,7 @@ org/clojure/test.check/1.1.1/test.check-1.1.1.jar
 org/clojure/tools.analyzer/1.1.0/tools.analyzer-1.1.0.jar
 org/clojure/tools.analyzer.jvm/1.2.2/tools.analyzer.jvm-1.2.2.jar
 org/clojure/tools.cli/1.0.206/tools.cli-1.0.206.jar
-org/clojure/tools.logging/1.1.0/tools.logging-1.1.0.jar
+org/clojure/tools.logging/1.2.4/tools.logging-1.2.4.jar
 org/clojure/tools.macro/0.1.5/tools.macro-0.1.5.jar
 org/clojure/tools.reader/1.3.7/tools.reader-1.3.7.jar
 org/javassist/javassist/3.18.1-GA/javassist-3.18.1-GA.jar
@@ -110,7 +110,7 @@ prismatic/schema/1.1.7/schema-1.1.7.jar
 reagent/reagent/1.2.0/reagent-1.2.0.jar
 re-com/re-com/2.8.0/re-com-2.8.0.jar
 refactor-nrepl/refactor-nrepl/3.9.1/refactor-nrepl-3.9.1.jar
-re-frame/re-frame/1.3.0/re-frame-1.3.0.jar
+re-frame/re-frame/1.4.3/re-frame-1.4.3.jar
 re-frisk-remote/re-frisk-remote/1.6.0/re-frisk-remote-1.6.0.jar
 re-frisk/sente/1.15.0/sente-1.15.0.jar
 ring-cors/ring-cors/0.1.8/ring-cors-0.1.8.jar

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -2,7 +2,7 @@
 {:source-paths ["src" "test/cljs"]
 
  :dependencies [[reagent "1.2.0"]
-                [re-frame "1.3.0"]
+                [re-frame "1.4.3"]
                 [binaryage/oops "0.7.2"]
                 [com.andrewmcveigh/cljs-time "0.5.2"]
                 [com.taoensso/timbre "6.3.1"]


### PR DESCRIPTION
### Summary

A quick win for us. Upgrade re-frame to latest, from `v1.3.0` (released on 2022-08-27) to latest `v1.4.3` (released on 2024-01-25).

Nothing outstanding, but this upgrade might entice your curiosity for the following reasons:

- [Added] `re-frame.alpha` namespace, for testing proposed features (see [flows](https://github.com/day8/re-frame/discussions/795) and [polymorphic subscriptions](https://github.com/day8/re-frame/issues/680#issuecomment-1676487563)). If you haven't read before, you've been warned, these links can be a rabbit hole.
- [Added] `dispatch-sync` now emits a `:sync` trace to indicate when it has finished. @flexsurfer you might care about this for re-frisk.
- Re-frame upgraded its dependency on Reagent to latest `v1.2.0`.
- There are two breaking changes in `v1.4.0`, but they don't affect us because we don't use interceptors `path` and `unwrap`.

### Note

With the introduction of `re-frame.alpha`, it is my expectation that, by upgrading re-frame, we make it easier for core devs to experiment with new ideas to solve old problems 😈 

#### Areas that may be impacted

Nothing in theory.

### Steps to test

I ran smoke tests and the app is behaving the same, no warnings, which is to be expected, given the few breaking changes reported in re-frame's changelog don't affect us.

status: ready
