### PR TITLE
Fix schema error after logout

### DIFF
--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -279,7 +279,12 @@
  :<- [:initials-avatar-font-file]
  :<- [:theme]
  (fn [[profile ens-names port font-file theme] [_ avatar-opts]]
-   (replace-multiaccount-image-uri profile ens-names port font-file avatar-opts theme)))
+   ;; Right after logout, this subscription is recomputed, but the sub
+   ;; `:profile/profile` output will always be nil. We skip any further
+   ;; processing because it's wasteful and because it will trigger a schema
+   ;; error.
+   (when profile
+     (replace-multiaccount-image-uri profile ens-names port font-file avatar-opts theme))))
 
 (re-frame/reg-sub
  :profile/image


### PR DESCRIPTION
### Summary

This PR fixes a schema error after logout.

#### Interesting explanation...

The schema failure is due to `utils.image-server/get-initials-avatar-uri` being called with a nil profile customization color right after the user confirms logout. My first instinct was to just wrap the schema field with a `:maybe`  schema and call it a day. But under the hood, the profile customization color really shouldn't be nil, so what is going on? Malli detected a potential issue.

Right after logging out, the subscription `:profile/profile-with-image` is recomputed. I tried to find out what's causing that recomputation, but I timeboxed and gave up. One of its signal inputs is `:profile/profile`. Right after logout, the output of sub `:profile/profile` is always nil (this is correct, nobody is logged in). This means that the sub `:profile/profile-with-image` will try to calculate the multiaccount URI by passing a nil profile. This is wasteful computation and is also the cause of the schema for `utils.image-server/get-initials-avatar-uri` to fail, because it expects the profile's `customization-color` to be present.

#### Areas that may be impacted

Anything displaying a profile image.

### Steps to test

I truly expect no impact in profile images in general because the subscription `:profile/profile` is only nil on logout, which is what this PR deals with. In any case, I smoke tested the app, changed profile images, etc, all good.

I'll request manual QA after PR approval.

status: ready
