### PR TITLE
fix_:sync contact request decision

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.16",
-    "commit-sha1": "601c80fec2e6db76dd2f5d47fdc94492b5a618f5",
-    "src-sha256": "0g8ryxz6klqfn1avp66zkj44yrbhnck14lfhpyqj92caakz35m84"
+    "version": "v0.179.17",
+    "commit-sha1": "0dbbf7c641691b3b5b6f4eb241d133aa7d42bf82",
+    "src-sha256": "0fp6zwb35pwmgb88xyqilw5dj8007cq9m186s915glnf94a45b7x"
 }


### PR DESCRIPTION
fixes #19455

after the fix, the result will looks like as screenshot shows
<img width="1149" alt="image" src="https://github.com/status-im/status-mobile/assets/12406719/09f6136d-0f7e-4970-8bed-af8f57bc1281">

15 Pro is device A and 15 Pro Max is device B in this screenshot.
you can see that there're still differences between A and B after local pair sync.

- difference on accepted CR need more time to investigate.
- difference on declined CR is because we didn't pass CR message when invoking `syncContactRequestForInstallationContact`,  `syncContactRequestForInstallationContact` will generate AC notification with `defaultContactRequestText`

however, as @cammellos said: `as long as the message is the same (i.e accepted on both, declined on both), that's perfectly fine` , I think the result is acceptable now.

relate status-go [PR](https://github.com/status-im/status-go/pull/5130)

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
