### PR TITLE
Improve Settings screen opening performance

### DIFF
--- a/src/react_native/core.cljs
+++ b/src/react_native/core.cljs
@@ -199,6 +199,15 @@
   [handler deps]
   (react/useMemo handler (get-js-deps deps)))
 
+(defn delay-render
+  [content]
+  (let [[render? set-render] (use-state false)]
+    (use-mount
+     (fn []
+       (js/setTimeout #(set-render true) 0)))
+    (when render?
+      content)))
+
 (def layout-animation (.-LayoutAnimation ^js react-native))
 (def configure-next (.-configureNext ^js layout-animation))
 

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -21,12 +21,12 @@
 
 (defn- settings-category-view
   [data]
-  [rf/delay-render
+  (rn/delay-render
    [quo/category
     {:list-type       :settings
      :container-style {:padding-bottom 12}
      :blur?           true
-     :data            (filter show-settings-item? data)}]])
+     :data            (filter show-settings-item? data)}]))
 
 (defn scroll-handler
   [event scroll-y]
@@ -35,9 +35,9 @@
 
 (defn- footer
   [{:keys [bottom]} logout-press]
-  [rf/delay-render
+  (rn/delay-render
    [rn/view {:style (style/footer-container bottom)}
-    [quo/logout-button {:on-press logout-press}]]])
+    [quo/logout-button {:on-press logout-press}]]))
 
 (defn- get-item-layout
   [_ index]

--- a/src/utils/re_frame.cljs
+++ b/src/utils/re_frame.cljs
@@ -4,7 +4,6 @@
     [re-frame.core :as re-frame]
     [re-frame.interceptor :as interceptor]
     [re-frame.interop :as rf.interop]
-    [reagent.core :as reagent]
     [taoensso.timbre :as log]
     [utils.datetime :as datetime])
   (:refer-clojure :exclude [merge reduce]))
@@ -79,14 +78,6 @@
                              fx-fns)]
     (swap! handler-nesting-level dec)
     res))
-
-(defn delay-render
-  [_]
-  (let [render? (reagent/atom false)]
-    (js/setTimeout #(reset! render? true) 0)
-    (fn [content]
-      (when @render?
-        content))))
 
 (def sub (comp deref re-frame/subscribe))
 


### PR DESCRIPTION
### Summary

In this PR we're rewriting `utils.re-frame/delay-render` to use hooks. The new implementation renders significantly better than what we have today, at least on Android.

#### Current (`develop`) on a Samsung Galaxy A71, release build, Android 13

https://github.com/status-im/status-mobile/assets/46027/d9968cde-9150-4dbb-81c9-49aae9b5d412

#### New (PR) on a Samsung Galaxy A71, release build, Android 13

https://github.com/status-im/status-mobile/assets/46027/8610c29c-505a-4c67-a299-b8ac35bb5439

#### Areas that may be impacted

None.

### Why not hiccup instead of a function call to `delay-render`?

The Settings screen is rendered slightly faster if I use `delay-render` as a function call instead of hiccup. My only guess is that this is just less work to be done by Reagent, since the wrapper function is not creating a wrapper component with its own lifecycle.

#### Naming

I would keep the name `delay-render`, as a verb (like any ordinary function), because it tells the developer that it shouldn't be treated as a component (which is named as a noun most of the time).

### Steps to test

As a reviewer, I kindly ask you to check this PR's build and compare with the experience from the `develop` branch of opening the Settings screen a few times. Is it better? Could you share a screen recording on Android/iOS?

status: ready
