### PR TITLE
feat(wallet): add recent recipients tab

### DIFF
--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -33,7 +33,7 @@
                                                                   [options-drawer/view
                                                                    {:name  (:name collectible-details)
                                                                     :image (:uri preview-url)}])}]))}]
-       :activity     [activity/view {:activities []}]
+       :activity     [activity/view]
        :permissions  [empty-tab/view
                       {:title        (i18n/label :t/no-permissions)
                        :description  (i18n/label :t/no-collectibles-description)

--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -64,9 +64,6 @@
            :default-active   @selected-tab
            :data             (tabs-data watch-only?)
            :on-change        (rn/use-callback (fn [tab]
-                                                (when (and (= :activity tab)
-                                                           (ff/enabled? :FLAG_WALLET_ACTIVITY_ENABLED))
-                                                  (rf/dispatch [:wallet/fetch-activities]))
                                                 (reset! selected-tab tab)))
            :scrollable?      true
            :scroll-on-press? true}]

--- a/src/status_im/contexts/wallet/common/temp.cljs
+++ b/src/status_im/contexts/wallet/common/temp.cljs
@@ -4,8 +4,6 @@
     [status-im.common.resources :as status.resources]
     [utils.i18n :as i18n]))
 
-(def address "0x39cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd4")
-
 (def buy-tokens-list
   [{:title             "Ramp"
     :description       :text

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -31,7 +31,8 @@
 (rf/reg-event-fx :wallet/navigate-to-account
  (fn [{:keys [db]} [address]]
    {:db (assoc-in db [:wallet :current-viewing-account-address] address)
-    :fx [[:dispatch [:navigate-to :screen/wallet.accounts address]]]}))
+    :fx [[:dispatch [:navigate-to :screen/wallet.accounts address]]
+         [:dispatch [:wallet/fetch-activities]]]}))
 
 (rf/reg-event-fx :wallet/navigate-to-new-account
  (fn [{:keys [db]} [address]]

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -8,7 +8,7 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn my-accounts
+(defn- my-accounts
   [theme]
   (let [other-accounts (rf/sub [:wallet/accounts-without-current-viewing-account])]
     (if (zero? (count other-accounts))
@@ -27,15 +27,30 @@
                                                     :stack-id  :screen/wallet.select-address}])}]))
             other-accounts))))
 
+(defn- recent-transactions
+  [theme]
+  (let [recent-recipients (rf/sub [:wallet/recent-recipients])]
+    (if (zero? (count recent-recipients))
+      [quo/empty-state
+       {:title           (i18n/label :t/no-recent-transactions)
+        :description     (i18n/label :t/make-one-it-is-easy-we-promise)
+        :image           (resources/get-themed-image :angry-man theme)
+        :container-style style/empty-container-style}]
+      (into [rn/view {:style style/my-accounts-container}]
+            (map (fn [address]
+                   [quo/address
+                    {:address  address
+                     :on-press #(rf/dispatch [:wallet/select-send-address
+                                              {:address   address
+                                               :recipient address
+                                               :stack-id  :screen/wallet.select-address}])}]))
+            recent-recipients))))
+
 (defn view
   [{:keys [selected-tab]}]
   (let [theme (quo.theme/use-theme)]
     (case selected-tab
-      :tab/recent      [quo/empty-state
-                        {:title           (i18n/label :t/no-recent-transactions)
-                         :description     (i18n/label :t/make-one-it-is-easy-we-promise)
-                         :image           (resources/get-themed-image :angry-man theme)
-                         :container-style style/empty-container-style}]
+      :tab/recent      [recent-transactions theme]
       :tab/saved       [quo/empty-state
                         {:title           (i18n/label :t/no-saved-addresses)
                          :description     (i18n/label :t/you-like-to-type-43-characters)

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -14,7 +14,6 @@
    ::settings.wallet-settings           (enabled-in-env? :FLAG_WALLET_SETTINGS_ENABLED)
    ::settings.keypairs-and-accounts     (enabled-in-env?
                                          :FLAG_WALLET_SETTINGS_KEYPAIRS_AND_ACCOUNTS_ENABLED)
-   ::wallet.activities                  (enabled-in-env? :FLAG_WALLET_ACTIVITY_ENABLED)
    ::wallet.assets-modal-hide           (enabled-in-env? :FLAG_ASSETS_MODAL_HIDE)
    ::wallet.assets-modal-manage-tokens  (enabled-in-env? :FLAG_ASSETS_MODAL_MANAGE_TOKENS)
    ::wallet.bridge-token                (enabled-in-env? :FLAG_BRIDGE_TOKEN_ENABLED)

--- a/src/status_im/subs/wallet/send.cljs
+++ b/src/status_im/subs/wallet/send.cljs
@@ -32,3 +32,13 @@
    (let [send-tx-ids (set (keys transactions))]
      (select-keys transactions
                   (filter send-tx-ids tx-ids)))))
+
+(rf/reg-sub
+ :wallet/recent-recipients
+ :<- [:wallet/activities-for-current-viewing-account]
+ :<- [:wallet/current-viewing-account-address]
+ (fn [[activities current-viewing-account-address]]
+   (let [users-sent-transactions (filter (fn [{:keys [sender]}]
+                                           (= sender current-viewing-account-address))
+                                         activities)]
+     (set (map :recipient users-sent-transactions)))))

--- a/src/status_im/subs/wallet/send_test.cljs
+++ b/src/status_im/subs/wallet/send_test.cljs
@@ -53,3 +53,16 @@
                      :id       100
                      :chain-id 5}}
            (rf/sub [sub-name])))))
+
+(h/deftest-sub :wallet/recent-recipients
+  [sub-name]
+  (testing "returns recent tab for selecting address"
+    (swap! rf-db/app-db
+      (fn [db]
+        (-> db
+            (assoc-in [:wallet :activities]
+                      [{:sender "acc1" :recipient "acc2" :timestamp 1588291200}
+                       {:sender "acc2" :recipient "acc1" :timestamp 1588377600}
+                       {:sender "acc3" :recipient "acc4" :timestamp 1588464000}])
+            (assoc-in [:wallet :current-viewing-account-address] "acc1"))))
+    (is (= #{"acc2"} (rf/sub [sub-name])))))


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/16991

This pr fetches the data for a user to send to a user they have recently sent to.

Note: 
This pr is only version 1 in what is needed for this feature as in the design there is multiple versions of types of "recent" senders, i.e it can be an account, saved address or a contact. 

The reason being is that the data from activities currently is not handling that information but there is a new backend end point we can update to which will get us this info moving forward.

https://github.com/status-im/status-mobile/assets/22799766/cf9bfc75-fa95-4bb7-ac1d-b4cff7a6bf0c

Testing notes:
Go to account page,
Hit Send button
select recent tab(default)
select an address and ensure it gets sent to them

Note:
This pr does not add a new address when you send a transaction, to keep this pr smaller I will add this in a follow up pr. 
For that reason feel free to feature test this pr in one go in that pr:
https://github.com/status-im/status-mobile/pull/19984