### PR TITLE
chore: first pass at fixing collectibles transition

### DIFF
--- a/src/quo/components/avatars/collection_avatar/view.cljs
+++ b/src/quo/components/avatars/collection_avatar/view.cljs
@@ -10,12 +10,13 @@
 
     :image - collection image
     :theme - keyword -> :light/:dark"
-  [{:keys [image size on-load-end on-error] :or {size :size-24}}]
+  [{:keys [image size on-load-start on-load-end on-error] :or {size :size-24}}]
   (let [theme (quo.theme/use-theme)]
     [rn/view {:style (style/collection-avatar-container theme size)}
      [fast-image/fast-image
       {:accessibility-label :collection-avatar
        :source              image
+       :on-load-start       on-load-start
        :on-load-end         on-load-end
        :on-error            on-error
        :style               (style/collection-avatar size)}]]))

--- a/src/quo/components/profile/collectible_list_item/style.cljs
+++ b/src/quo/components/profile/collectible_list_item/style.cljs
@@ -5,18 +5,22 @@
 (def container-border-radius 12)
 (def card-image-padding-vertical 3)
 (def card-image-padding-horizontal 3)
+(def default-opacity-for-loader 1)
+(def default-opacity-for-image 0)
 
 (defn fallback
-  [{:keys [theme]}]
-  {:background-color (colors/theme-colors colors/neutral-2_5 colors/neutral-90 theme)
-   :border-style     :dashed
-   :border-color     (colors/theme-colors colors/neutral-20 colors/neutral-80 theme)
-   :border-width     1
-   :border-radius    container-border-radius
-   :width            "100%"
-   :aspect-ratio     1
-   :align-items      :center
-   :justify-content  :center})
+  [{:keys [theme opacity]}]
+  [{:opacity opacity}
+   {:opacity          default-opacity-for-image
+    :background-color (colors/theme-colors colors/neutral-2_5 colors/neutral-90 theme)
+    :border-style     :dashed
+    :border-color     (colors/theme-colors colors/neutral-20 colors/neutral-80 theme)
+    :border-width     1
+    :border-radius    container-border-radius
+    :width            "100%"
+    :aspect-ratio     1
+    :align-items      :center
+    :justify-content  :center}])
 
 (def collectible-counter
   {:position :absolute
@@ -59,6 +63,15 @@
 (def card-detail-text
   {:flex 1})
 
+(defn card-loader
+  [opacity]
+  [{:opacity opacity}
+   {:position       :absolute
+    :opacity        default-opacity-for-loader
+    :left           8
+    :align-items    :center
+    :flex-direction :row}])
+
 (def image-view-container
   {:aspect-ratio  1
    :border-radius container-border-radius})
@@ -83,6 +96,7 @@
 (defn loading-image
   [theme]
   {:position         :absolute
+   :opacity          default-opacity-for-loader
    :top              0
    :bottom           0
    :left             0
@@ -91,8 +105,20 @@
    :background-color (colors/theme-colors colors/white-70-blur colors/neutral-95-opa-70-blur theme)
    :z-index          2})
 
+(defn loading-image-with-opacity
+  [theme opacity]
+  [{:opacity opacity}
+   (loading-image theme)])
+
 (defn avatar-container
-  [loaded?]
-  {:flex           1
-   :flex-direction :row
-   :opacity        (when-not loaded? 0)})
+  [opacity]
+  [{:opacity opacity}
+   {:flex           1
+    :flex-direction :row
+    :opacity        default-opacity-for-image}])
+
+(defn supported-file
+  [opacity]
+  [{:opacity opacity}
+   {:aspect-ratio 1
+    :opacity      default-opacity-for-image}])

--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -105,23 +105,6 @@
 (def fast-create-community-enabled?
   (enabled? (get-config :FAST_CREATE_COMMUNITY_ENABLED "0")))
 
-(def default-multiaccount
-  {:preview-privacy?                   blank-preview?
-   :wallet-legacy/visible-tokens       {:mainnet #{:SNT}}
-   :currency                           :usd
-   :appearance                         0
-   :profile-pictures-show-to           2
-   :profile-pictures-visibility        2
-   :log-level                          log-level
-   :webview-allow-permission-requests? false
-   :opensea-enabled?                   false
-   :link-previews-enabled-sites        #{}
-   :link-preview-request-enabled       true})
-
-(defn default-visible-tokens
-  [chain]
-  (get-in default-multiaccount [:wallet-legacy/visible-tokens chain]))
-
 (def waku-nodes-config
   {:status.prod
    ["enrtree://AL65EKLJAUXKKPG43HVTML5EFFWEZ7L4LOKTLZCLJASG4DSESQZEC@prod.status.nodes.status.im"]

--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -11,6 +11,22 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
+(defn- on-collectible-press
+  [{:keys [id]}]
+  (rf/dispatch [:wallet/get-collectible-details id]))
+
+(defn- on-collectible-long-press
+  [{:keys [preview-url collectible-details]}]
+  (rf/dispatch [:show-bottom-sheet
+                {:content (fn []
+                            [options-drawer/view
+                             {:name  (:name collectible-details)
+                              :image (:uri preview-url)}])}]))
+
+(defn- on-end-reached
+  []
+  (rf/dispatch [:wallet/request-collectibles-for-current-viewing-account]))
+
 (defn view
   [{:keys [selected-tab]}]
   (let [collectible-list        (rf/sub
@@ -20,19 +36,11 @@
      (case selected-tab
        :assets       [assets/view]
        :collectibles [collectibles/view
-                      {:collectibles collectible-list
-                       :current-account-address current-account-address
-                       :on-end-reached #(rf/dispatch
-                                         [:wallet/request-collectibles-for-current-viewing-account])
-                       :on-collectible-press (fn [{:keys [id]}]
-                                               (rf/dispatch [:wallet/get-collectible-details id]))
-                       :on-collectible-long-press (fn [{:keys [preview-url collectible-details]}]
-                                                    (rf/dispatch
-                                                     [:show-bottom-sheet
-                                                      {:content (fn []
-                                                                  [options-drawer/view
-                                                                   {:name  (:name collectible-details)
-                                                                    :image (:uri preview-url)}])}]))}]
+                      {:collectibles              collectible-list
+                       :current-account-address   current-account-address
+                       :on-end-reached            on-end-reached
+                       :on-collectible-press      on-collectible-press
+                       :on-collectible-long-press on-collectible-long-press}]
        :activity     [activity/view]
        :permissions  [empty-tab/view
                       {:title        (i18n/label :t/no-permissions)

--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -1,7 +1,8 @@
 (ns status-im.contexts.wallet.collectible.utils
   (:require [status-im.config :as config]
             [status-im.constants :as constants]
-            [status-im.contexts.wallet.common.utils.networks :as network-utils]))
+            [status-im.contexts.wallet.common.utils.networks :as network-utils]
+            [taoensso.timbre :as log]))
 
 (defn collectible-balance
   [collectible]
@@ -23,7 +24,7 @@
   (if (supported-collectible-types collectible-type)
     true
     (do
-      (println "unsupoorted collectible file type" collectible-type)
+      (log/debug "unsupported collectible file type:" (or collectible-type "Unknown type"))
       false)))
 
 (defn total-owned-collectible

--- a/src/status_im/contexts/wallet/common/collectibles_tab/style.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/style.cljs
@@ -4,3 +4,7 @@
 (def list-container-style
   {:margin-horizontal 12
    :padding-bottom    constants/floating-shell-button-height})
+
+(def collectible-container
+  {:padding 8
+   :flex    0.5})

--- a/src/status_im/contexts/wallet/home/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/view.cljs
@@ -8,6 +8,22 @@
     [status-im.contexts.wallet.home.tabs.style :as style]
     [utils.re-frame :as rf]))
 
+(defn- on-collectible-long-press
+  [{:keys [preview-url collectible-details id]}]
+  (let [chain-id (get-in id [:contract-id :chain-id])
+        address  (get-in id [:contract-id :address])]
+    (rf/dispatch [:show-bottom-sheet
+                  {:content (fn []
+                              [options-drawer/view
+                               {:chain-id chain-id
+                                :address  address
+                                :name     (:name collectible-details)
+                                :image    (:uri preview-url)}])}])))
+
+(defn- on-collectible-press
+  [{:keys [id]}]
+  (rf/dispatch [:wallet/get-collectible-details id]))
+
 (defn view
   [{:keys [selected-tab]}]
   (let [collectible-list     (rf/sub [:wallet/all-collectibles-list-in-selected-networks])
@@ -18,20 +34,7 @@
        :assets       [assets/view]
        :collectibles [collectibles/view
                       {:collectibles              collectible-list
-                       :on-collectible-long-press (fn [{:keys [preview-url collectible-details id]}]
-                                                    (let [chain-id (get-in id [:contract-id :chain-id])
-                                                          address  (get-in id [:contract-id :address])]
-                                                      (rf/dispatch
-                                                       [:show-bottom-sheet
-                                                        {:content (fn []
-                                                                    [options-drawer/view
-                                                                     {:chain-id chain-id
-                                                                      :address  address
-                                                                      :name     (:name
-                                                                                 collectible-details)
-                                                                      :image    (:uri
-                                                                                 preview-url)}])}])))
+                       :on-collectible-long-press on-collectible-long-press
                        :on-end-reached            request-collectibles
-                       :on-collectible-press      (fn [{:keys [id]}]
-                                                    (rf/dispatch [:wallet/get-collectible-details id]))}]
+                       :on-collectible-press      on-collectible-press}]
        [activity/view {:activities []}])]))


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19678

This pr smoothes the transition for the collectibles cards loading to a loaded image.

On implementing I realised there is an issue when the image is already loaded as the image is cached and will load quite quickly anyway. To handle this I am measuring the load time. This works fine if the user only has a small number of images.

With help from @ulisesmac we also discovered a bug where the collectibles were re rendering a lot on scroll. This is also addressed in this pr and the overall scrolling experience is a lot smoother now.

Latest reference video:

https://github.com/status-im/status-mobile/assets/22799766/7ae86321-c672-4bdc-9d92-7b3a652c53e0

Note: The animations being slower looks better for one load, but if the user goes back and forth from the tabs several times then it just becomes a bit irritating after a while.

