### PR TITLE
Fix: manage members gesture

### DIFF
--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -27,10 +27,10 @@
 
 (defn add-member-contact-item-render
   [{:keys [public-key] :as item} _ _ {:keys [group]}]
-  (let [current-pk (rf/sub [:multiaccount/public-key])
+  (let [current-pk         (rf/sub [:multiaccount/public-key])
         {:keys [contacts]} group
-        member?    (contains? contacts public-key)
-        checked?   (reagent/atom member?)]
+        member?            (contains? contacts public-key)
+        checked?           (reagent/atom member?)]
     (fn []
       (let [on-toggle #(group-chat-member-toggle member? (swap! checked? not) public-key)]
         [contact-list-item/contact-list-item
@@ -80,7 +80,7 @@
                                (rf/dispatch [:navigate-back])
                                (js/setTimeout (fn []
                                                 (rf/dispatch
-                                                  [:group-chats.ui/remove-members-pressed chat-id]))
+                                                 [:group-chats.ui/remove-members-pressed chat-id]))
                                               500)
                                (rf/dispatch [:group-chats.ui/add-members-pressed chat-id]))
         :disabled?           (and (zero? (count selected-participants))
@@ -114,7 +114,7 @@
   []
   (let [chat-id         (rf/sub [:get-screen-params :group-details])
         {:keys [admins chat-id chat-name color muted contacts image]
-         :as   group} (rf/sub [:chats/chat-by-id chat-id])
+         :as   group}   (rf/sub [:chats/chat-by-id chat-id])
         members         (rf/sub [:contacts/group-members-sections chat-id])
         pinned-messages (rf/sub [:chats/pinned chat-id])
         current-pk      (rf/sub [:multiaccount/public-key])

--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -27,10 +27,10 @@
 
 (defn add-member-contact-item-render
   [{:keys [public-key] :as item} _ _ {:keys [group]}]
-  (let [current-pk         (rf/sub [:multiaccount/public-key])
+  (let [current-pk (rf/sub [:multiaccount/public-key])
         {:keys [contacts]} group
-        member?            (contains? contacts public-key)
-        checked?           (reagent/atom member?)]
+        member?    (contains? contacts public-key)
+        checked?   (reagent/atom member?)]
     (fn []
       (let [on-toggle #(group-chat-member-toggle member? (swap! checked? not) public-key)]
         [contact-list-item/contact-list-item
@@ -43,7 +43,7 @@
          item]))))
 
 (defn add-manage-members
-  []
+  [{:keys [scroll-enabled? on-scroll]}]
   (let [selected-participants (rf/sub [:group-chat/selected-participants])
         deselected-members    (rf/sub [:group-chat/deselected-members])
         chat-id               (rf/sub [:get-screen-params :group-add-manage-members])
@@ -62,6 +62,8 @@
       (i18n/label :t/manage-members)]
      [gesture/section-list
       {:key-fn                         :title
+       :scroll-enabled                 @scroll-enabled?
+       :on-scroll                      on-scroll
        :sticky-section-headers-enabled false
        :sections                       (rf/sub [:contacts/grouped-by-first-letter])
        :render-section-header-fn       contact-list/contacts-section-header
@@ -78,7 +80,7 @@
                                (rf/dispatch [:navigate-back])
                                (js/setTimeout (fn []
                                                 (rf/dispatch
-                                                 [:group-chats.ui/remove-members-pressed chat-id]))
+                                                  [:group-chats.ui/remove-members-pressed chat-id]))
                                               500)
                                (rf/dispatch [:group-chats.ui/add-members-pressed chat-id]))
         :disabled?           (and (zero? (count selected-participants))
@@ -112,7 +114,7 @@
   []
   (let [chat-id         (rf/sub [:get-screen-params :group-details])
         {:keys [admins chat-id chat-name color muted contacts image]
-         :as   group}   (rf/sub [:chats/chat-by-id chat-id])
+         :as   group} (rf/sub [:chats/chat-by-id chat-id])
         members         (rf/sub [:contacts/group-members-sections chat-id])
         pinned-messages (rf/sub [:chats/pinned chat-id])
         current-pk      (rf/sub [:multiaccount/public-key])


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19948

This PR fixes the gesture on the "Manage members" screen by passing the `scroll-enabled? on-scroll` props.

Simple fix, QA can be skipped.

Demo:

https://github.com/status-im/status-mobile/assets/29354102/0132ee37-dd27-4817-909e-f6eb4bdba1d0

