### PR TITLE
feat: recalculate network max value

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -53,6 +53,7 @@
                                                                                      "2500")
                                                                                     :has-error false}}
                                                     :total-balance              100
+                                                    :available-balance          100
                                                     :market-values-per-currency {:usd {:price 10}}}
    :wallet/wallet-send-loading-suggested-routes?   false
    :wallet/wallet-send-route                       [{:from       {:chainid                1
@@ -77,7 +78,15 @@
    :wallet/wallet-send-sender-network-values       nil
    :wallet/wallet-send-receiver-network-values     nil
    :wallet/wallet-send-network-links               nil
-   :wallet/wallet-send-receiver-preferred-networks [1]})
+   :wallet/wallet-send-receiver-preferred-networks [1]
+   :wallet/wallet-send-enabled-networks            [{:source           879
+                                                     :short-name       "eth"
+                                                     :network-name     :mainnet
+                                                     :abbreviated-name "Eth."
+                                                     :chain-id         1
+                                                     :related-chain-id 1
+                                                     :layer            1}]
+   :wallet/wallet-send-enabled-from-chain-ids      [1]})
 
 (h/describe "Send > input amount screen"
   (h/setup-restorable-re-frame)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -290,11 +290,13 @@
  :wallet/current-viewing-account-tokens-filtered
  :<- [:wallet/current-viewing-account]
  :<- [:wallet/network-details]
- (fn [[account networks] [_ query]]
+ (fn [[account networks] [_ query chain-ids]]
    (let [tokens        (map (fn [token]
                               (assoc token
-                                     :networks      (network-utils/network-list token networks)
-                                     :total-balance (utils/calculate-total-token-balance token)))
+                                     :networks          (network-utils/network-list token networks)
+                                     :available-balance (utils/calculate-total-token-balance token)
+                                     :total-balance     (utils/calculate-total-token-balance token
+                                                                                             chain-ids)))
                             (:tokens account))
          sorted-tokens (sort-by :name compare tokens)]
      (if query

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -454,3 +454,19 @@
  :wallet/public-address
  :<- [:wallet/create-account]
  :-> :public-address)
+
+(rf/reg-sub
+ :wallet/wallet-send-enabled-networks
+ :<- [:wallet/wallet-send-token]
+ :<- [:wallet/wallet-send-disabled-from-chain-ids]
+ (fn [[{:keys [networks]} disabled-from-chain-ids]]
+   (->> networks
+        (filter #(not (contains? (set disabled-from-chain-ids)
+                                 (:chain-id %))))
+        set)))
+
+(rf/reg-sub
+ :wallet/wallet-send-enabled-from-chain-ids
+ :<- [:wallet/wallet-send-enabled-networks]
+ (fn [send-enabled-networks]
+   (map :chain-id send-enabled-networks)))


### PR DESCRIPTION
Fixes 
https://github.com/status-im/status-mobile/issues/19791
https://github.com/status-im/status-mobile/issues/19910

### Summary
Recalculates the max value based on the chain the user select in the from column


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Go to wallet tab
- Click on account
- Click on send
- Paste wallet address
- Select asset
- Input amount and toggle the different chains in the from column to see the max get recalculated
- Also try to input an amount more than max value, validation should show the input as red alongside network tags
  - No routes should be displayed immediately (not after the request to get suggested routes)
  - Confirm button should be disabled



![Simulator Screen Recording - iPhone 11 Pro - 2024-05-15 at 17 14 11](https://github.com/status-im/status-mobile/assets/45393944/19bf1f53-3b82-4a45-9b95-1462a6ff06e9)



status: ready 
