### PR TITLE
Fail fast during app initialization if an invalid schema is found

### DIFF
--- a/src/quo/components/password/password_tips/view.cljs
+++ b/src/quo/components/password/password_tips/view.cljs
@@ -12,8 +12,8 @@
      [:lower-case? :boolean]
      [:upper-case? :boolean]
      [:numbers? :boolean]
-     [:symbols? :boolean]]
-    [:any]]])
+     [:symbols? :boolean]]]
+   :any])
 
 (defn- view-internal
   [{:keys [lower-case? upper-case? numbers? symbols?]}]

--- a/src/schema/core.clj
+++ b/src/schema/core.clj
@@ -19,5 +19,5 @@
        (catch js/Error e#
          (taoensso.timbre/error "Failed to instrument function"
                                 {:symbol ~sym :error e#})
-         ~sym))
+         (throw e#)))
      ~sym))

--- a/src/schema/core.cljs
+++ b/src/schema/core.cljs
@@ -91,5 +91,5 @@
                     {:schema-id schema-id
                      :error     e
                      :function  f})
-         f))
+         (throw e)))
      f)))

--- a/src/status_im/setup/schema.cljs
+++ b/src/status_im/setup/schema.cljs
@@ -90,19 +90,12 @@
   manually call `setup!`, otherwise you won't see any changes. It is safe and
   even expected you will call `setup!` multiple times in REPLs."
   []
-  (try
-    (schema.registry/init-global-registry)
-    (register-schemas)
+  (schema.registry/init-global-registry)
+  (register-schemas)
 
-    ;; In theory not necessary, but sometimes in a REPL session the dev needs to
-    ;; call unstrument! manually.
-    (malli.instrument/unstrument!)
+  ;; In theory not necessary, but sometimes in a REPL session the dev needs to
+  ;; call unstrument! manually.
+  (malli.instrument/unstrument!)
 
-    (malli.dev/start! {:report (schema/reporter)})
-    (log/debug "Schemas initialized.")
-
-    ;; It is relatively easy to write invalid schemas, but we don't want to
-    ;; block the app from initializing if such errors happen, at least not until
-    ;; Malli matures in the project.
-    (catch js/Error e
-      (log/error "Failed to initialize schemas" {:error e}))))
+  (malli.dev/start! {:report (schema/reporter)})
+  (log/debug "Schemas initialized."))


### PR DESCRIPTION
### Summary

Some devs reported invalid schemas in the `develop` branch during app initialization. We knew this could happen when Malli was first introduced, but we wanted to play safe in the beginning due to the overall inexperience of the team with Malli.

This PR removes the `try/catch` block that was allowing invalid schemas to be merged. This should alleviate or eliminate the problem.

#### Areas that may be impacted

None.

### Steps to test

Nothing to test except e2e tests.

status: ready
