### PR TITLE
fix: node-pre-gyp warning

### DIFF
--- a/modules/react-native-status/nodejs/status.cpp
+++ b/modules/react-native-status/nodejs/status.cpp
@@ -1147,10 +1147,13 @@ void _PollSignal(const FunctionCallbackInfo<Value>& args) {
         v8::Local<v8::Function> func = v8::Local<v8::Function>::Cast(args[0]);
         if (!q.empty()) {
           const unsigned argc = 1;
-          v8::Local<v8::Value> argv[argc] =
-          { v8::String::NewFromUtf8(isolate,q.front().c_str()).ToLocalChecked()};
-
-          func->Call(isolate->GetCurrentContext(), v8::Null(isolate), argc, argv);
+          v8::Local<v8::Value> argv[argc] = {v8::String::NewFromUtf8(isolate, q.front().c_str()).ToLocalChecked()};
+          v8::MaybeLocal<v8::Value> result = func->Call(isolate->GetCurrentContext(), v8::Null(isolate), argc, argv);
+          if (result.IsEmpty()) {
+            isolate->ThrowException(Exception::Error(
+                String::NewFromUtf8Literal(isolate, "Error calling the callback function")));
+            return;
+          }
           q.pop();
         }
 }


### PR DESCRIPTION
## Summary

any `yarn` command calls `node-pre-gyp rebuild` which prints out this warning message : 

```
make[1]: Entering directory '/Users/siddarthkumar/code/experiments/status-mobile/build'
  CXX(target) Release/obj.target/status_nodejs_addon/modules/react-native-status/nodejs/status.o
../modules/react-native-status/nodejs/status.cpp:1153:11: warning: ignoring return value of function 
declared with 'warn_unused_result' attribute [-Wunused-result]
          func->Call(isolate->GetCurrentContext(), v8::Null(isolate), argc, argv);
          ^~~~ ~~~~~~~~~~~~~
1 warning generated.
```

This happens due to return value of `func->Call` here :
https://github.com/status-im/status-mobile/blob/52a6f5c17d3055a98a403505a354cde135b1966f/modules/react-native-status/nodejs/status.cpp#L1153
not being used. 
Which is not a huge red flag but produces a warning which is not nice when looking at logs and can be sometimes misleading for other devs.

This PR fixes that warning by assigning return value of that function and checking if its empty or not.

## Testing notes
not needed since this impacts only the integration tests.

## Platforms
- macOS

status: ready
