### PR TITLE
fix(ios): autofocus input in drawer overlay won't trigger keyboard open

### DIFF
--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -205,7 +205,8 @@
                  :options (merge (options/statusbar-and-navbar-options (:theme opts) nil nil)
                                  {:layout  {:componentBackgroundColor :transparent
                                             :orientation              ["portrait"]}
-                                  :overlay {:interceptTouchOutside true}}
+                                  :overlay {:interceptTouchOutside true
+                                            :handleKeyboardEvents  true}}
                                  opts)}})))
 
 (rf/reg-fx :show-toasts


### PR DESCRIPTION
-------

fixes #19194

### Summary

add `overlay.handleKeyboardEvents` opt to `show-overlay`
before/after screenshots will be in the following comment, keyboard is not always visible in these videos

### Review notes
react native navigation doc: https://wix.github.io/react-native-navigation/api/options-overlay/#handlekeyboardevents

### Testing notes
this affects all usage of overlay (bottom sheet, toast, banner ...)
this only affects iOS platform

changes in this PR might impact some screens, and I'm not entirely sure if these are the desired outcomes. For instance, blur effects in below screen:

https://github.com/status-im/status-mobile/assets/15090582/ca08beb2-3694-42fd-be50-fcaeab563533

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- iOS

status: ready <!-- Can be ready or wip -->