### PR TITLE
Fix loading screen for fetching community

### DIFF
--- a/src/status_im/contexts/communities/overview/style.cljs
+++ b/src/status_im/contexts/communities/overview/style.cljs
@@ -21,12 +21,10 @@
    :align-items    :center
    :margin-top     20})
 
-(def fetching-placeholder
-  {:align-items     :center
-   :justify-content :center
-   :flex            1})
-
-(def fetching-text {:color :red})
+(defn fetching-placeholder
+  [top-inset]
+  {:flex       1
+   :margin-top top-inset})
 
 (def blur-channel-header
   {:position :absolute

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -6,9 +6,10 @@
     [quo.theme]
     [react-native.blur :as blur]
     [react-native.core :as rn]
+    [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
     [status-im.common.home.actions.view :as actions]
-    [status-im.common.not-implemented :as not-implemented]
+    [status-im.common.resources :as resources]
     [status-im.common.scroll-page.style :as scroll-page.style]
     [status-im.common.scroll-page.view :as scroll-page]
     [status-im.config :as config]
@@ -369,18 +370,25 @@
 
 (defn- community-fetching-placeholder
   [id]
-  (let [fetching? (rf/sub [:communities/fetching-community id])]
+  (let [theme     (quo.theme/use-theme)
+        top-inset (safe-area/get-top)
+        fetching? (rf/sub [:communities/fetching-community id])]
     [rn/view
-     {:style               style/fetching-placeholder
+     {:style               (style/fetching-placeholder top-inset)
       :accessibility-label (if fetching?
                              :fetching-community-overview
                              :failed-to-fetch-community-overview)}
-     [not-implemented/not-implemented
-      [rn/text
-       {:style style/fetching-text}
-       (if fetching?
-         "Fetching community..."
-         "Failed to fetch community")]]]))
+     [quo/page-nav
+      {:title      "Community Overview"
+       :type       :title
+       :text-align :left
+       :icon-name  :i/close
+       :on-press   #(rf/dispatch [:navigate-back])}]
+     [quo/empty-state
+      {:image           (resources/get-themed-image :cat-in-box theme)
+       :description     (when-not fetching? (i18n/label :t/here-is-a-cat-in-a-box-instead))
+       :title           (if fetching? "Fetching community..." "Failed to fetch community")
+       :container-style {:flex 1 :justify-content :center}}]]))
 
 (defn- community-card-page-view
   [id]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19555

### Summary
> I guess any solution works for now, but most important is to get rid of the red square around the text

Please let me know if this looks ok or needs to be improved.


<table border="0">
 <tr>
    <td><b style="font-size:30px">Develop</b></td>
    <td><b style="font-size:30px">Fetching Community</b></td>
    <td><b style="font-size:30px">Failed to fetch</b></td>
 </tr>
 <tr>
    <td>

<div align="center">
<img src="https://github.com/status-im/status-mobile/assets/17097240/a1e6a5dd-ea3d-4cec-9f0f-e9b4763e1877" alt="Screenshot" height="400"/>
</div>





</td>
    <td>

<div align="center">
<img src="https://github.com/status-im/status-mobile/assets/17097240/75d81bbe-ba98-4c06-ac40-99d95e14a098" alt="Screenshot" height="400"/>
</div>

</td>

<td> 

<div align="center">
<img src="https://github.com/status-im/status-mobile/assets/17097240/24d97347-8fcf-43db-a6f2-4a80dfcd891c" alt="Screenshot" height="400"/>
</div>

</td>

 </tr>
</table>

### Testing
Please lightly test PR for fetching community screen and let me know if anything needs to be improved. (including design)


status: ready