### PR TITLE
fix wrong letter and background color of the channel/group avatar

### DIFF
--- a/src/quo/components/avatars/channel_avatar/style.cljs
+++ b/src/quo/components/avatars/channel_avatar/style.cljs
@@ -7,6 +7,7 @@
 (defn outer-container
   [{:keys [size customization-color theme]}]
   (let [container-size (case size
+                         :size-80 80
                          :size-64 64
                          :size-32 32
                          24)]
@@ -21,6 +22,7 @@
   [size]
   {:text-align :center
    :font-size  (case size
+                 :size-80 36
                  :size-64 24
                  :size-32 15
                  11)})

--- a/src/quo/components/avatars/channel_avatar/view.cljs
+++ b/src/quo/components/avatars/channel_avatar/view.cljs
@@ -11,15 +11,15 @@
 
 (defn- initials
   [{:keys [full-name size customization-color theme]}]
-  (let [amount-initials (if (#{:size-32 :size-64} size) 2 1)
+  (let [amount-initials (if (#{:size-32 :size-64 :size-80} size) 2 1)
         channel-name    (utils.string/safe-replace full-name "#" "")]
     [text/text
      (cond-> {:accessibility-label :initials
               :style               {:color (colors/resolve-color customization-color theme)}
               :size                :paragraph-2
               :weight              :semi-bold}
-       (= size :size-64) (assoc :size   :heading-1
-                                :weight :medium))
+       (#{:size-64 :size-80} size) (assoc :size   :heading-1
+                                          :weight :medium))
      (utils.string/get-initials channel-name amount-initials)]))
 
 (defn- lock

--- a/src/quo/components/avatars/group_avatar/view.cljs
+++ b/src/quo/components/avatars/group_avatar/view.cljs
@@ -1,6 +1,5 @@
 (ns quo.components.avatars.group-avatar.view
   (:require
-    [clojure.string :as string]
     [quo.components.avatars.group-avatar.style :as style]
     [quo.components.icon :as icon]
     [quo.components.markdown.text :as text]
@@ -22,7 +21,7 @@
              :container 80}})
 
 (defn view
-  [{:keys [size customization-color picture icon-name emoji chat-name]
+  [{:keys [size customization-color picture icon-name emoji]
     :or   {size                :size-20
            customization-color :blue
            picture             nil
@@ -50,14 +49,6 @@
             {:size  :paragraph-1
              :style (dissoc (style/avatar-identifier theme) :font-size)}
             emoji])
-         chat-name
-         (if (= size :size-80)
-           [rn/text
-            {:style (style/avatar-identifier theme)}
-            ((comp first string/upper-case) chat-name)]
-           [text/text
-            {:size :paragraph-1}
-            ((comp first string/upper-case) chat-name)])
          :else
          [icon/icon icon-name
           {:size  icon-size

--- a/src/status_im/contexts/chat/messenger/messages/list/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/style.cljs
@@ -48,10 +48,11 @@
    {:transform [{:scale scale}]
     :top       top
     :left      left}
-   {:position      :absolute
-    :border-width  4
-    :border-radius 50
-    :border-color  (colors/theme-colors colors/white colors/neutral-95 theme)}))
+   {:position         :absolute
+    :border-width     4
+    :border-radius    50
+    :background-color (colors/theme-colors colors/white colors/neutral-95 theme)
+    :border-color     (colors/theme-colors colors/white colors/neutral-95 theme)}))
 
 (defn user-name-container
   [top left]

--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -133,15 +133,21 @@
         community-channel? (= chat-type constants/community-chat-type)]
     [reanimated/view
      {:style (style/header-image scale top left theme)}
-     (if group-chat
+     (cond
+       community-channel?
+       [quo/channel-avatar
+        {:size                :size-80
+         :full-name           chat-name
+         :customization-color color
+         :emoji               (when-not (string/blank? emoji)
+                                (string/trim emoji))}]
+       group-chat
        [quo/group-avatar
         {:customization-color color
          :size                :size-80
          :picture             profile-picture
-         :emoji               (when (and (not (string/blank? emoji))
-                                         community-channel?)
-                                (string/trim emoji))
          :chat-name           chat-name}]
+       :else
        [quo/user-avatar
         {:full-name       display-name
          :online?         online?


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19944


### Designs:

Community Avatar: https://www.figma.com/file/h9wo4GipgZURbqqr1vShFN/Communities-for-Mobile?type=design&node-id=16876-89050&mode=design&t=kXzE8JgtXAcU4AIp-0

Group Avatar: https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?type=design&node-id=179-9760&mode=design&t=pV0pn0UiszwVIz2z-0

### Testing

Please check community and group avatar in chat screen both themes.

status: ready
