### PR TITLE
fix: remove wallet graph

### DIFF
--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -33,7 +33,8 @@
           {:type     :wallet-networks
            :on-press #(rf/dispatch [:wallet/close-account-page])}]
          [quo/account-overview
-          {:current-value       formatted-balance
+          {:container-style     style/account-overview
+           :current-value       formatted-balance
            :account-name        name
            :account             (if watch-only? :watched-address :default)
            :customization-color color}]

--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -37,7 +37,7 @@
            :account-name        name
            :account             (if watch-only? :watched-address :default)
            :customization-color color}]
-         [quo/wallet-graph {:time-frame :empty}]
+         (when (ff/enabled? ::ff/wallet.graph) [quo/wallet-graph {:time-frame :empty}])
          (when (not watch-only?)
            [quo/wallet-ctas
             {:container-style style/cta-buttons


### PR DESCRIPTION
A small PR that removes wallet graph from account screen by reverting [this change](https://github.com/status-im/status-mobile/pull/19860/files#diff-7e89b0120ae03c94cf072c3a32c2c0984bfa6dcafc4c30a765d7878c997ed82fL41-R40)

![Simulator Screenshot - iPhone 15 - 2024-05-10 at 17 51 00](https://github.com/status-im/status-mobile/assets/29354102/3e1bcb87-ecb6-438d-a402-f0d320193510)
