### PR TITLE
Don't autoload user & dev.user namespaces because they may not exist

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -53,14 +53,7 @@
    :dev {:devtools {:before-load-async status-im.setup.hot-reload/before-reload
                     :after-load-async  status-im.setup.hot-reload/reload
                     :build-notify      status-im.setup.hot-reload/build-notify
-                    :preloads          [;; We preload user namespaces so that
-                                        ;; their symbols are available without
-                                        ;; the developer having to manually
-                                        ;; evaluate them after app
-                                        ;; initialization.
-                                        user
-                                        dev.user
-                                        re-frisk-remote.preload
+                    :preloads          [re-frisk-remote.preload
                                         status-im.setup.schema-preload
                                         ;; In order to use component test helpers in the REPL we
                                         ;; need to preload namespaces that are not normally required


### PR DESCRIPTION
### Summary

Reverts the preloading mechanism in PR https://github.com/status-im/status-mobile/pull/19927, which introduced a problem I couldn't find any satisfactory solution. The namespaces `user` and `dev.user` were being preloaded by shadow-cljs, but the problem is that **preloading will fail if those namespaces don't exist in your file system**. Reported by @J-Son89 

I couldn't find any solution to conditionally preload namespaces via shadow-cljs and ClojureScript unfortunately doesn't support conditional requires like Clojure.

At least we got to keep the code to not lint them and the whole idea to start to commit dev-only code inside `src/dev/` 🤷🏼 

#### Areas that may be impacted

None

status: ready
