### PR TITLE
Allow user to manually input password when bio-metric fails

### DIFF
--- a/src/status_im/common/standard_authentication/events.cljs
+++ b/src/status_im/common/standard_authentication/events.cljs
@@ -33,6 +33,8 @@
                                             args-with-biometric-btn])
              :on-success     #(rf/dispatch [:standard-auth/on-biometric-success on-auth-success])
              :on-fail        (fn [err]
+                               (rf/dispatch [:standard-auth/authorize-with-password
+                                             args-with-biometric-btn])
                                (when on-auth-fail (on-auth-fail err))
                                (rf/dispatch [:standard-auth/on-biometric-fail err]))}]]]}))
 


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19488

### Video

https://github.com/status-im/status-mobile/assets/17097240/4140323f-6725-439a-96ca-1309ba3b502a



status: ready