### PR TITLE
fix: no routes are found in case of valid amount in fiat is entered

### DIFF
--- a/src/quo/components/wallet/token_input/component_spec.cljs
+++ b/src/quo/components/wallet/token_input/component_spec.cljs
@@ -6,14 +6,16 @@
 (h/describe "Wallet: Token Input"
   (h/test "Token label renders"
     (h/render-with-theme-provider [token-input/view
-                                   {:token      :snt
-                                    :currency   :eur
-                                    :conversion 1}])
+                                   {:token           :snt
+                                    :currency        :eur
+                                    :currency-symbol "€"
+                                    :conversion      1}])
     (h/is-truthy (h/get-by-text "SNT")))
 
   (h/test "Amount renders"
     (h/render-with-theme-provider [token-input/view
-                                   {:token      :snt
-                                    :currency   :eur
-                                    :conversion 1}])
+                                   {:token           :snt
+                                    :currency        :eur
+                                    :currency-symbol "€"
+                                    :conversion      1}])
     (h/is-truthy (h/get-by-text "€0.00"))))

--- a/src/quo/components/wallet/token_input/style.cljs
+++ b/src/quo/components/wallet/token_input/style.cljs
@@ -12,30 +12,22 @@
   {:padding-horizontal 20
    :padding-bottom     4
    :height             36
-   :flex-direction     :row
-   :justify-content    :space-between})
+   :flex-direction     :row})
 
 (defn token-name
   [theme]
   {:color          (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)
-   :margin-right   8
-   :padding-bottom 2})
-
-(def token-label-container
-  {:position       :absolute
-   :left           40 ; token image size + margin
-   :right          0
-   :bottom         0
-   :top            0
-   :flex-direction :row
-   :align-items    :flex-end})
+   :padding-bottom 3})
 
 (def text-input-container
-  {:position :absolute
-   :top      0
-   :bottom   0
-   :left     40 ; token image size + margin
-   :right    0})
+  {:flex-direction :row
+   :align-items    :flex-end})
+
+(defn input-container
+  [window-width]
+  {:width        (- window-width 120)
+   :margin-left  8
+   :margin-right 8})
 
 (def text-input-dimensions
   (-> typography/heading-1
@@ -54,7 +46,8 @@
          :color
          (if error?
            (colors/resolve-color :danger theme)
-           (colors/theme-colors colors/neutral-100 colors/white theme))))
+           (colors/theme-colors colors/neutral-100 colors/white theme))
+         :flex-shrink 1))
 
 (defn placeholder-text
   [theme]

--- a/src/quo/components/wallet/token_input/view.cljs
+++ b/src/quo/components/wallet/token_input/view.cljs
@@ -9,32 +9,34 @@
     [quo.components.utilities.token.view :as token]
     [quo.components.wallet.token-input.schema :as component-schema]
     [quo.components.wallet.token-input.style :as style]
-    [quo.foundations.common :as common]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
-    [schema.core :as schema]))
+    [schema.core :as schema]
+    [utils.number :as number]))
 
 (defn fiat-format
-  [currency num-value conversion]
-  (str (get common/currency-label currency) (.toFixed (* num-value conversion) 2)))
+  [currency-symbol num-value conversion]
+  (str currency-symbol (.toFixed (* num-value conversion) 2)))
 
 (defn crypto-format
   [num-value conversion crypto-decimals token]
-  (str (.toFixed (/ num-value conversion) (or crypto-decimals 2))
+  (str (number/remove-trailing-zeroes
+        (.toFixed (/ num-value conversion) (or crypto-decimals 2)))
        " "
        (string/upper-case (or (clj->js token) ""))))
 
 (defn calc-value
-  [{:keys [crypto? currency token value conversion crypto-decimals]}]
+  [{:keys [crypto? currency-symbol token value conversion crypto-decimals]}]
   (let [num-value (if (string? value)
                     (or (parse-double value) 0)
                     value)]
     (if crypto?
-      (fiat-format currency num-value conversion)
+      (fiat-format currency-symbol num-value conversion)
       (crypto-format num-value conversion crypto-decimals token))))
 
 (defn- data-info
-  [{:keys [theme token crypto-decimals conversion networks title crypto? currency amount error?]}]
+  [{:keys [theme token crypto-decimals conversion networks title crypto? currency-symbol amount
+           error?]}]
   [rn/view {:style style/data-container}
    [network-tag/view
     {:networks networks
@@ -45,7 +47,7 @@
      :weight :medium
      :style  (style/fiat-amount theme)}
     (calc-value {:crypto?         crypto?
-                 :currency        currency
+                 :currency-symbol currency-symbol
                  :token           token
                  :value           amount
                  :conversion      conversion
@@ -58,20 +60,6 @@
     :size   :paragraph-2
     :weight :semi-bold}
    (string/upper-case (or (clj->js text) ""))])
-
-(defn- token-label
-  [{:keys [theme value text]}]
-  [rn/view
-   {:style          style/token-label-container
-    :pointer-events :none}
-   [rn/text-input
-    {:max-length  12
-     :style       style/text-input-dimensions
-     :editable    false
-     :placeholder "0"
-     :opacity     0
-     :value       value}]
-   [token-name-text theme text]])
 
 (defn input-section
   [{:keys [on-change-text value value-internal set-value-internal on-selection-change
@@ -92,36 +80,45 @@
                                         (oops/oget "nativeEvent.selection")
                                         (js->clj :keywordize-keys true)
                                         (on-selection-change))))]
-    (fn [{:keys [token customization-color show-keyboard? crypto? currency value error? selection]
+    (fn [{:keys [token customization-color show-keyboard? crypto? currency value error? selection
+                 handle-on-swap]
           :or   {show-keyboard? true}}]
-      (let [theme (quo.theme/use-theme)]
-        [rn/view {:style {:flex 1}}
-         [rn/pressable {:on-press on-token-press}
-          [token/view
-           {:token token
-            :size  :size-32}]]
-         [rn/pressable
-          {:style    style/text-input-container
-           :on-press focus-input}
-          [rn/text-input
-           (cond-> {:style                    (style/text-input theme error?)
-                    :placeholder-text-color   (style/placeholder-text theme)
-                    :auto-focus               true
-                    :ref                      set-ref
-                    :placeholder              "0"
-                    :keyboard-type            :numeric
-                    :max-length               12
-                    :on-change-text           handle-on-change-text
-                    :selection-color          customization-color
-                    :show-soft-input-on-focus show-keyboard?
-                    :on-selection-change      handle-selection-change
-                    :selection                (clj->js selection)}
-             controlled-input?       (assoc :value value)
-             (not controlled-input?) (assoc :default-value value-internal))]]
-         [token-label
-          {:theme theme
-           :text  (if crypto? token currency)
-           :value (if controlled-input? value value-internal)}]]))))
+      (let [theme        (quo.theme/use-theme)
+            window-width (:width (rn/get-window))]
+        [rn/pressable
+         {:style    {:width          "100%"
+                     :flex-direction :row}
+          :on-press on-token-press}
+         [token/view
+          {:token token
+           :size  :size-32}]
+         [rn/view {:style (style/input-container window-width)}
+          [rn/pressable
+           {:style    style/text-input-container
+            :on-press focus-input}
+           [rn/text-input
+            (cond-> {:style                    (style/text-input theme error?)
+                     :placeholder-text-color   (style/placeholder-text theme)
+                     :auto-focus               true
+                     :ref                      set-ref
+                     :placeholder              "0"
+                     :keyboard-type            :numeric
+                     :on-change-text           handle-on-change-text
+                     :selection-color          customization-color
+                     :show-soft-input-on-focus show-keyboard?
+                     :on-selection-change      handle-selection-change
+                     :selection                (clj->js selection)}
+              controlled-input?       (assoc :value value)
+              (not controlled-input?) (assoc :default-value value-internal))]
+           [token-name-text theme (if crypto? token currency)]]]
+         [button/button
+          {:icon                true
+           :icon-only?          true
+           :size                32
+           :on-press            handle-on-swap
+           :type                :outline
+           :accessibility-label :reorder}
+          :i/reorder]]))))
 
 (defn- view-internal
   [{:keys [container-style value on-swap] :as props}]
@@ -141,15 +138,8 @@
               :value-internal     value-internal
               :theme              theme
               :set-value-internal set-value-internal
-              :crypto?            crypto?)]
-      [button/button
-       {:icon                true
-        :icon-only?          true
-        :size                32
-        :on-press            handle-on-swap
-        :type                :outline
-        :accessibility-label :reorder}
-       :i/reorder]]
+              :handle-on-swap     handle-on-swap
+              :crypto?            crypto?)]]
      [divider-line/view {:container-style (style/divider theme)}]
      [data-info
       (assoc props

--- a/src/quo/foundations/common.cljs
+++ b/src/quo/foundations/common.cljs
@@ -1,5 +1,0 @@
-(ns quo.foundations.common)
-
-(def currency-label
-  {:eur "€"
-   :usd "$"})

--- a/src/status_im/common/controlled_input/utils.cljs
+++ b/src/status_im/common/controlled_input/utils.cljs
@@ -37,7 +37,7 @@
   [state]
   (set-input-error state (upper-limit-exceeded? state)))
 
-(defn- set-input-value
+(defn set-input-value
   [state value]
   (-> state
       (assoc :value value)

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -4,7 +4,7 @@
             [status-im.common.qr-codes.view :as qr-codes]
             [status-im.constants :as constants]
             [utils.money :as money]
-            [utils.number]))
+            [utils.number :as number]))
 
 (defn get-first-name
   [full-name]
@@ -56,16 +56,6 @@
       (inc max-decimals)
       max-decimals)))
 
-(defn remove-trailing-zeroes
-  [num]
-  (let [parts (clojure.string/split (str num) #"\.")]
-    (str (first parts)
-         (if-let [decimals (second parts)]
-           (if (seq (clojure.string/replace decimals #"0+$" ""))
-             (str "." (clojure.string/replace decimals #"0+$" ""))
-             "")
-           ""))))
-
 (defn get-crypto-decimals-count
   [{:keys [market-values-per-currency]}]
   (let [price          (get-in market-values-per-currency [:usd :price])
@@ -83,8 +73,8 @@
           one-cent-value (if (pos? price) (/ 0.01 price) 0)
           decimals-count (calc-max-crypto-decimals one-cent-value)]
       (if (< token-units one-cent-value)
-        (str "<" (remove-trailing-zeroes (.toFixed one-cent-value decimals-count)))
-        (remove-trailing-zeroes (.toFixed token-units decimals-count))))))
+        (str "<" (number/remove-trailing-zeroes (.toFixed one-cent-value decimals-count)))
+        (number/remove-trailing-zeroes (.toFixed token-units decimals-count))))))
 
 (defn get-market-value
   [currency {:keys [market-values-per-currency]}]

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -117,6 +117,7 @@
                    dissoc
                    :suggested-routes
                    :route
+                   :amount
                    :from-values-by-chain
                    :to-values-by-chain
                    :sender-network-values

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -69,6 +69,7 @@
    :view-id                                        :screen/wallet.send-input-amount
    :wallet/wallet-send-to-address                  "0x04371e2d9d66b82f056bc128064"
    :profile/currency-symbol                        "$"
+   :profile/currency                               :usd
    :wallet/token-by-symbol                         {:symbol                     :eth
                                                     :total-balance              100
                                                     :market-values-per-currency {:usd {:price 10}}}
@@ -86,7 +87,8 @@
                                                      :chain-id         1
                                                      :related-chain-id 1
                                                      :layer            1}]
-   :wallet/wallet-send-enabled-from-chain-ids      [1]})
+   :wallet/wallet-send-enabled-from-chain-ids      [1]
+   :wallet/wallet-send-amount                      nil})
 
 (h/describe "Send > input amount screen"
   (h/setup-restorable-re-frame)
@@ -173,6 +175,6 @@
     (h/is-truthy (h/get-by-label-text :container-error))
     (h/fire-event :press (h/query-by-label-text :reorder))
 
-    (-> (h/wait-for #(h/get-by-text "Max: 1000.00 USD"))
+    (-> (h/wait-for #(h/get-by-text "Max: $1000.00"))
         (.then (fn []
                  (h/wait-for #(h/is-truthy (h/get-by-label-text :container))))))))

--- a/src/status_im/subs/wallet/send.cljs
+++ b/src/status_im/subs/wallet/send.cljs
@@ -25,6 +25,11 @@
  :-> :transaction-ids)
 
 (rf/reg-sub
+ :wallet/wallet-send-amount
+ :<- [:wallet/wallet-send]
+ :-> :amount)
+
+(rf/reg-sub
  :wallet/send-transaction-progress
  :<- [:wallet/send-transaction-ids]
  :<- [:wallet/transactions]

--- a/src/utils/number.cljs
+++ b/src/utils/number.cljs
@@ -1,4 +1,5 @@
-(ns utils.number)
+(ns utils.number
+  (:require [clojure.string :as string]))
 
 (defn naive-round
   "Quickly and naively round number `n` up to `decimal-places`.
@@ -29,3 +30,13 @@
   if `num` exceeds a given bound, then returns the bound exceeded."
   [number lower-bound upper-bound]
   (max lower-bound (min number upper-bound)))
+
+(defn remove-trailing-zeroes
+  [num]
+  (let [parts (string/split (str num) #"\.")]
+    (str (first parts)
+         (if-let [decimals (second parts)]
+           (if (seq (string/replace decimals #"0+$" ""))
+             (str "." (string/replace decimals #"0+$" ""))
+             "")
+           ""))))


### PR DESCRIPTION
fixes #18561 
fixes #19999

### Summary

This PR fixes a bug that makes no routes being fetched when the users switch the input mode to display values in fiat and a valid amount in fiat is entered. Also fixed some minor but noticeable bugs that appeared after fixing the main bug:

- Visual overflow of the suffix text of the input when swapping mode to fiat and the number is too big. Needed to refactor a bit the views and styles of Token Input component.
- Don't allow the user to use more decimals than the token supports.
- Fiat character symbol was not showing in the conversion.
- Fiat character symbol was not used when showing the max amount.
- Many trailing zeroes issues when leading with large numbers.
- Routes being fetched when swapping to fiat, and vise versa

#### Demo

https://github.com/status-im/status-mobile/assets/18485527/c67ae017-b134-4813-b716-99ba9167ef8f

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Login
- Go to wallet
- Select an account
- Tap on Send button
- Select an asset where the user has funds on
- Tap on switch button on the input to display values in fiat
- Enter a valid amount in fiat
- Wait for routes to be loaded
- Verify correct behavior of input and routes loading

status: ready