### PR TITLE
fix: wallet send navigation flow

### DIFF
--- a/src/status_im/contexts/wallet/send/flow_config.cljs
+++ b/src/status_im/contexts/wallet/send/flow_config.cljs
@@ -18,10 +18,7 @@
     :skip-step? (fn [db] (some? (get-in db [:wallet :ui :send :recipient])))}
    {:screen-id  :screen/wallet.select-asset
     :skip-step? (fn [db] (or (token-selected? db) (collectible-selected? db)))}
-   {:screen-id  :screen/wallet.send-input-amount
-    :skip-step? (fn [db]
-                  (or (not (token-selected? db))
-                      (some? (get-in db [:wallet :ui :send :amount]))))}
+   {:screen-id :screen/wallet.send-input-amount}
    {:screen-id  :screen/wallet.select-collectible-amount
     :skip-step? (fn [db]
                   (or (not (collectible-selected? db))

--- a/src/status_im/contexts/wallet/send/flow_config.cljs
+++ b/src/status_im/contexts/wallet/send/flow_config.cljs
@@ -18,7 +18,7 @@
     :skip-step? (fn [db] (some? (get-in db [:wallet :ui :send :recipient])))}
    {:screen-id  :screen/wallet.select-asset
     :skip-step? (fn [db] (or (token-selected? db) (collectible-selected? db)))}
-   {:screen-id :screen/wallet.send-input-amount
+   {:screen-id  :screen/wallet.send-input-amount
     :skip-step? (fn [db] (= (get-in db [:wallet :ui :send :tx-type]) :collectible))}
    {:screen-id  :screen/wallet.select-collectible-amount
     :skip-step? (fn [db]

--- a/src/status_im/contexts/wallet/send/flow_config.cljs
+++ b/src/status_im/contexts/wallet/send/flow_config.cljs
@@ -18,7 +18,8 @@
     :skip-step? (fn [db] (some? (get-in db [:wallet :ui :send :recipient])))}
    {:screen-id  :screen/wallet.select-asset
     :skip-step? (fn [db] (or (token-selected? db) (collectible-selected? db)))}
-   {:screen-id :screen/wallet.send-input-amount}
+   {:screen-id :screen/wallet.send-input-amount
+    :skip-step? (fn [db] (= (get-in db [:wallet :ui :send :tx-type]) :collectible))}
    {:screen-id  :screen/wallet.select-collectible-amount
     :skip-step? (fn [db]
                   (or (not (collectible-selected? db))

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -67,7 +67,9 @@
                          (rf/dispatch [:wallet/clean-selected-token])
                          (rf/dispatch [:wallet/clean-selected-collectible])
                          (rf/dispatch [:navigate-back]))]
-    (rn/use-unmount #(rf/dispatch [:wallet/clean-selected-token]))
+    (rn/use-unmount (fn []
+                      (rf/dispatch [:wallet/clean-selected-token])
+                      (rf/dispatch [:wallet/clean-selected-collectible])))
     (fn []
       [rn/safe-area-view {:style style/container}
        [account-switcher/view

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -67,6 +67,7 @@
                          (rf/dispatch [:wallet/clean-selected-token])
                          (rf/dispatch [:wallet/clean-selected-collectible])
                          (rf/dispatch [:navigate-back]))]
+    (rn/use-unmount #(rf/dispatch [:wallet/clean-selected-token]))
     (fn []
       [rn/safe-area-view {:style style/container}
        [account-switcher/view

--- a/src/status_im/contexts/wallet/wallet_connect/utils.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/utils.cljs
@@ -1,10 +1,10 @@
 (ns status-im.contexts.wallet.wallet-connect.utils
   ;; NOTE: Not sorting namespaces since @walletconnect/react-native-compat should be the first
   #_{:clj-kondo/ignore [:unsorted-required-namespaces]}
-  (:require ["@walletconnect/react-native-compat"]
-            ["@walletconnect/core" :refer [Core]]
-            ["@walletconnect/web3wallet" :refer [Web3Wallet]]
+  (:require ["@walletconnect/core" :refer [Core]]
+            ["@walletconnect/react-native-compat"]
             ["@walletconnect/utils" :refer [buildApprovedNamespaces]]
+            ["@walletconnect/web3wallet" :refer [Web3Wallet]]
             [status-im.config :as config]
             [utils.i18n :as i18n]))
 


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19697


### Summary
This PR fixes the send navigation flow where the asset select screen or the input amount screen gets skipped after reaching the transaction page then pressing back, then going through the flow again.

### Demo

https://github.com/status-im/status-mobile/assets/29354102/280ce15d-c42e-4a6b-93f0-82b640597af9




