### PR TITLE
pause integration tests also for now

### DIFF
--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -34,6 +34,11 @@ pipeline {
       description: 'Whether to run optional and slow contract tests.',
       defaultValue: false,
     )
+    booleanParam(
+      name: 'RUN_INTEGRATION_TESTS',
+      description: 'Whether to run optional and slow integration tests.',
+      defaultValue: false,
+    )
   }
 
   environment {
@@ -68,6 +73,7 @@ pipeline {
           steps { make('test-contract') }
         }
         stage('Integration') {
+          when { expression { params.RUN_INTEGRATION_TESTS } }
           steps { make('test-integration') }
         }
       }


### PR DESCRIPTION
As discussed with @J-Son89 

Its better to skip integration tests completely in CI until a better way is found. There seems to be some research already 
undergoing in this direction.

cc @cammellos 

status: ready
