### PR TITLE
fix ens name verication text alignment

### DIFF
--- a/src/status_im/contexts/chat/home/add_new_contact/style.cljs
+++ b/src/status_im/contexts/chat/home/add_new_contact/style.cljs
@@ -5,32 +5,25 @@
   [theme]
   {:flex               1
    :background-color   (colors/theme-colors colors/white colors/neutral-95 theme)
-   :justify-content    :space-between
-   :align-items        :center
    :margin-top         2
    :padding-horizontal 20})
 
 (def container-invalid
-  {:style {:flex-direction :row
-           :align-items    :center
-           :margin-top     8}})
+  {:flex-direction :row
+   :margin-top     8})
 
 (defn text-description
   [theme]
-  {:size   :paragraph-2
-   :weight :medium
-   :style  {:margin-bottom 6
-            :color         (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)}})
+  {:margin-bottom 6
+   :color         (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)})
 
 (def icon-invalid
   {:size  16
    :color colors/danger-50})
 
 (def text-invalid
-  {:size  :paragraph-2
-   :align :left
-   :style {:margin-left 4
-           :color       colors/danger-50}})
+  {:margin-left 4
+   :color       colors/danger-50})
 
 (def input-and-scan-container
   {:flex-direction :row

--- a/src/status_im/contexts/chat/home/add_new_contact/views.cljs
+++ b/src/status_im/contexts/chat/home/add_new_contact/views.cljs
@@ -18,7 +18,10 @@
         theme                                 (quo.theme/use-theme)]
     (when primary-name
       [rn/view style/found-user
-       [quo/text (style/text-description theme)
+       [quo/text
+        {:size   :paragraph-2
+         :weight :medium
+         :style  (style/text-description theme)}
         (i18n/label :t/user-found)]
        [rn/view (style/found-user-container theme)
         [quo/user-avatar
@@ -105,7 +108,9 @@
   [message]
   [rn/view style/container-invalid
    [quo/icon :i/alert style/icon-invalid]
-   [quo/text style/text-invalid
+   [quo/text
+    {:size  :paragraph-2
+     :style style/text-invalid}
     (i18n/label (or message :t/invalid-ens-or-key))]])
 
 (defn navigate-back [] (rf/dispatch [:navigate-back]))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20010

### Summary
This pr. fixes the verification text for an ENS or a Chat key and refactors the some styles acording to our guidelines

### Before and after screenshots comparison
<img src="https://github.com/status-im/status-mobile/assets/28704507/153a0188-8d9b-4048-be03-707e57a29101" width="325">
<img src="https://github.com/status-im/status-mobile/assets/28704507/1c4a3769-4195-4495-951e-086204354e46" width="325">

status: ready 
