### PR TITLE
chore: include Xcode 15.2 in allowed versions list

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -57,7 +57,7 @@ in {
   yarn = super.yarn.override { nodejs = super.nodejs-18_x; };
   openjdk = super.openjdk11_headless;
   xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
-    versions = ["15.1"];
+    versions = ["15.1" "15.2"];
   };
   go = super.go_1_20;
   clang = super.clang_15;


### PR DESCRIPTION
## Summary

As reported by @ajayesivan and @seanstrom 
`Xcode 15.2` worked in their local environments and I then tried to use that version and found no issues with it.

This PR adds `Xcode 15.2` to versions list in Xcode Wrapper `nix` derivation.

## Testing notes
not needed.

## Platforms
- iOS

status: ready
