### PR TITLE
Add swap option in wallet action drawer

### DIFF
--- a/src/status_im/contexts/wallet/common/token_value/view.cljs
+++ b/src/status_im/contexts/wallet/common/token_value/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.wallet.common.token-value.view
   (:require [quo.core :as quo]
+            [status-im.common.not-implemented :as not-implemented]
             [status-im.contexts.wallet.sheets.buy-token.view :as buy-token]
             [status-im.feature-flags :as ff]
             [utils.i18n :as i18n]
@@ -40,6 +41,13 @@
                           (rf/dispatch [:hide-bottom-sheet])
                           (rf/dispatch [:wallet/bridge-select-token {:token token-data}]))})
 
+(defn- action-swap
+  []
+  {:icon                :i/swap
+   :accessibility-label :swap
+   :label               (i18n/label :t/swap)
+   :on-press            #(not-implemented/alert)})
+
 (defn- action-manage-tokens
   [watch-only?]
   {:icon                :i/settings
@@ -73,6 +81,7 @@
         (not watch-only?) (concat [(action-buy)
                                    (action-send send-params)
                                    (action-receive)
+                                   (when (ff/enabled? ::ff/wallet.swap) (action-swap))
                                    (action-bridge token-data)]))]]))
 
 (defn view


### PR DESCRIPTION
fixes #20028 

Add swap option in the wallet action drawer.


### Testing notes
This change is under the 'swap' feature flag. Enable 'swap' flag under Settings -> Feature Flags to test.

We can skip manual QA since this feature is under the swap feature flag.


### Steps to test
1. Make sure the 'swap' feature flag is enabled
2. Open wallet tab in the status app
3. Long press on any token(home screen/for a non-watch account)
4. Make sure the Swap option is available
5. Tapping on swap will show a not implemented alert

### Screenshot

<img src="https://github.com/status-im/status-mobile/assets/19279756/0a2aba80-5d56-453d-9c92-3adb6e743f5d" width=350/>


status: ready <!-- Can be ready or wip -->
