### PR TITLE
Add permission for enabling perf monitor in debug on Android

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -3,7 +3,7 @@
           xmlns:tools="http://schemas.android.com/tools">
 
     <!-- These are added by React Native for debug mode, but actually aren't needed in release mode -->
-    <uses-permission tools:node="remove" android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <!-- Remove licensing permission since we don't license our app and it blocks F-Droid submissions. -->
     <uses-permission tools:node="remove" android:name="com.android.vending.CHECK_LICENSE"/>
 


### PR DESCRIPTION
in RN there is a tool for profile performance, and it's rendered over other apps, so this permission should be enabled in Android settings, but to be able to enable it we need to add `android.permission.SYSTEM_ALERT_WINDOW` to Manifest file for debug builds.