### PR TITLE
attach target to test-watch-for-repl command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,17 +333,14 @@ shadow-server: export TARGET := clojure
 shadow-server:##@ Start shadow-cljs in server mode for watching
 	yarn shadow-cljs server
 
-_test-clojure: export TARGET := clojure
+_test-clojure: export TARGET := default
 _test-clojure: export WATCH ?= false
-_test-clojure: status-go-library
 _test-clojure:
 ifeq ($(WATCH), true)
-	yarn node-pre-gyp rebuild && \
-	yarn shadow-cljs compile mocks && \
+	yarn install && shadow-cljs compile mocks && \
 	nodemon --exec "yarn shadow-cljs compile test && node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO" -e cljs
 else
-	yarn node-pre-gyp rebuild && \
-	yarn shadow-cljs compile mocks && \
+	yarn install && shadow-cljs compile mocks && \
 	yarn shadow-cljs compile test && \
 	node --require ./test-resources/override.js "$$SHADOW_OUTPUT_TO"
 endif
@@ -356,11 +353,8 @@ test: _test-clojure
 test-watch-for-repl: export TARGET := default
 test-watch-for-repl: export SHADOW_OUTPUT_TO := target/test/test.js
 test-watch-for-repl: export SHADOW_NS_REGEXP := .*-test$$
-test-watch-for-repl: status-go-library
 test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connections
-	yarn node-pre-gyp rebuild
-	rm -f target/test/test.js
-	yarn shadow-cljs compile mocks && \
+	yarn install && shadow-cljs compile mocks && \
 	concurrently --kill-others --prefix-colors 'auto' --names 'build,repl' \
 		'yarn shadow-cljs watch test --verbose' \
 		"until [ -f $$SHADOW_OUTPUT_TO ] ; do sleep 1 ; done ; node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO --repl"

--- a/Makefile
+++ b/Makefile
@@ -353,6 +353,7 @@ test: export SHADOW_NS_REGEXP := .*-test$$
 test: ##@test Run all Clojure tests
 test: _test-clojure
 
+test-watch-for-repl: export TARGET := default
 test-watch-for-repl: export SHADOW_OUTPUT_TO := target/test/test.js
 test-watch-for-repl: export SHADOW_NS_REGEXP := .*-test$$
 test-watch-for-repl: status-go-library

--- a/yarn.lock
+++ b/yarn.lock
@@ -9372,10 +9372,6 @@ react-native-svg@13.10.0:
     css-select "^5.1.0"
     css-tree "^1.1.3"
 
-"react-native-transparent-video@git+https://github.com/status-im/react-native-transparent-video.git#refs/tags/0.1.1":
-  version "0.1.0"
-  resolved "git+https://github.com/status-im/react-native-transparent-video.git#1327fc622f7521269f66299c3aca610494c76fe1"
-
 react-native-url-polyfill@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz#db714520a2985cff1d50ab2e66279b9f91ffd589"


### PR DESCRIPTION
## Summary

This PR fixes broken `make test-watch-for-repl` on MacOS.
We make sure that default target is passed for this make command because the `node-pre-gyp` requires `python 3.1`

This PR also adds the missing `yarn.lock` file which was missed in this PR https://github.com/status-im/status-mobile/pull/20026

This PR also modifies the `_test_clojure` command a bit to swap out its dependence on `status-go-library` since we do that on `yarn install` anyways.

## Platforms
- macOS

## Steps to test
not required since this impacts running tests repl locally for devs

status: ready 

fixes: #20041 
