### PR TITLE
feat: support sending multi collectibles

### DIFF
--- a/src/quo/components/wallet/amount_input/schema.cljs
+++ b/src/quo/components/wallet/amount_input/schema.cljs
@@ -6,7 +6,8 @@
     [:props
      [:map {:closed true}
       [:status {:optional true} [:maybe [:enum :default :error]]]
-      [:on-change-text {:optional true} [:maybe fn?]]
+      [:on-inc-press {:optional true} [:maybe fn?]]
+      [:on-dec-press {:optional true} [:maybe fn?]]
       [:container-style {:optional true} [:maybe :map]]
       [:min-value {:optional true} [:maybe :int]]
       [:max-value {:optional true} [:maybe :int]]

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -513,10 +513,10 @@
 (def ^:const bridge-name-erc-1155-transfer "ERC1155Transfer")
 (def ^:const bridge-name-hop "Hop")
 
-(def ^:const contract-type-uknown 0)
-(def ^:const contract-type-erc-20 1)
-(def ^:const contract-type-erc-721 2)
-(def ^:const contract-type-erc-1155 3)
+(def ^:const wallet-contract-type-uknown 0)
+(def ^:const wallet-contract-type-erc-20 1)
+(def ^:const wallet-contract-type-erc-721 2)
+(def ^:const wallet-contract-type-erc-1155 3)
 
 (def ^:const alert-banner-height 40)
 

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -506,10 +506,17 @@
 (def ^:const send-type-stickers-buy 4)
 (def ^:const send-type-bridge 5)
 (def ^:const send-type-erc-721-transfer 6)
+(def ^:const send-type-erc-1155-transfer 7)
 
 (def ^:const bridge-name-transfer "Transfer")
 (def ^:const bridge-name-erc-721-transfer "ERC721Transfer")
+(def ^:const bridge-name-erc-1155-transfer "ERC1155Transfer")
 (def ^:const bridge-name-hop "Hop")
+
+(def ^:const contract-type-uknown 0)
+(def ^:const contract-type-erc-20 1)
+(def ^:const contract-type-erc-721 2)
+(def ^:const contract-type-erc-1155 3)
 
 (def ^:const alert-banner-height 40)
 

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -250,7 +250,7 @@
      {:db (-> db
               (assoc-in [:wallet :ui :send :token] token)
               (assoc-in [:wallet :ui :send :to-address] to-address)
-              (assoc-in [:wallet :ui :send :tx-type] :bridge))
+              (assoc-in [:wallet :ui :send :tx-type] :tx/bridge))
       :fx [[:dispatch
             [:wallet/wizard-navigate-forward
              {:current-screen stack-id
@@ -259,7 +259,7 @@
 
 (rf/reg-event-fx :wallet/start-bridge
  (fn [{:keys [db]}]
-   {:db (assoc-in db [:wallet :ui :send :tx-type] :bridge)
+   {:db (assoc-in db [:wallet :ui :send :tx-type] :tx/bridge)
     :fx [[:dispatch [:open-modal :screen/wallet.bridge-select-asset]]]}))
 
 (rf/reg-event-fx :wallet/select-bridge-network

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -144,7 +144,7 @@
                               {:prefix           prefix
                                :testnet-enabled? testnet-enabled?
                                :goerli-enabled?  goerli-enabled?})
-         collectible-tx?     (contains? #{:collectible :collectible-multi}
+         collectible-tx?     (contains? #{:collectible-erc-721 :collectible-erc-1155}
                                         (-> db :wallet :ui :send :tx-type))
          collectible         (when collectible-tx?
                                (-> db :wallet :ui :send :collectible))
@@ -236,7 +236,9 @@
                      :collectible
                      :token-display-name
                      :amount
-                     (when (contains? #{:collectible :collectible-multi} transaction-type) :tx-type))})))
+                     (when (contains? #{:collectible-erc-721 :collectible-erc-1155}
+                                      transaction-type)
+                       :tx-type))})))
 
 (rf/reg-event-fx
  :wallet/set-collectible-to-send
@@ -245,8 +247,8 @@
          collectible-data   (:collectible-data collectible)
          contract-type      (:contract-type collectible)
          tx-type            (if (= contract-type constants/contract-type-erc-1155)
-                              :collectible-multi
-                              :collectible)
+                              :collectible-erc-1155
+                              :collectible-erc-721)
          collectible-id     (get-in collectible [:id :token-id])
          one-collectible?   (= (collectible.utils/collectible-balance collectible) 1)
          token-display-name (cond
@@ -327,9 +329,9 @@
                                          network-chain-ids))
          from-locked-amount {}
          transaction-type-param (case transaction-type
-                                  :collectible       constants/send-type-erc-721-transfer
-                                  :collectible-multi constants/send-type-erc-1155-transfer
-                                  :bridge            constants/send-type-bridge
+                                  :collectible-erc-721  constants/send-type-erc-721-transfer
+                                  :collectible-erc-1155 constants/send-type-erc-1155-transfer
+                                  :bridge               constants/send-type-bridge
                                   constants/send-type-transfer)
          balances-per-chain (when token (:balances-per-chain token))
          token-available-networks-for-suggested-routes
@@ -508,9 +510,9 @@
          from-address (get-in db [:wallet :current-viewing-account-address])
          transaction-type (get-in db [:wallet :ui :send :tx-type])
          transaction-type-param (case transaction-type
-                                  :collectible       constants/send-type-erc-721-transfer
-                                  :collectible-multi constants/send-type-erc-1155-transfer
-                                  :bridge            constants/send-type-bridge
+                                  :collectible-erc-721  constants/send-type-erc-721-transfer
+                                  :collectible-erc-1155 constants/send-type-erc-1155-transfer
+                                  :bridge               constants/send-type-bridge
                                   constants/send-type-transfer)
          token (get-in db [:wallet :ui :send :token])
          collectible (get-in db [:wallet :ui :send :collectible])

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -461,6 +461,14 @@
                     :TokenID   token-id
                     :ChainID   to-chain-id))
 
+      (= bridge-name constants/bridge-name-erc-1155-transfer)
+      (assoc :ERC1155TransferTx
+             (assoc tx-data
+                    :Recipient to-address
+                    :TokenID   token-id
+                    :ChainID   to-chain-id
+                    :Amount    amount-in))
+
       (= bridge-name constants/bridge-name-transfer)
       (assoc :TransferTx tx-data)
 

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -144,7 +144,7 @@
                               {:prefix           prefix
                                :testnet-enabled? testnet-enabled?
                                :goerli-enabled?  goerli-enabled?})
-         collectible-tx?     (send-utils/is-collectible?
+         collectible-tx?     (send-utils/tx-type-collectible?
                               (-> db :wallet :ui :send :tx-type))
          collectible         (when collectible-tx?
                                (-> db :wallet :ui :send :collectible))
@@ -236,7 +236,7 @@
                      :collectible
                      :token-display-name
                      :amount
-                     (when (send-utils/is-collectible?
+                     (when (send-utils/tx-type-collectible?
                             transaction-type)
                        :tx-type))})))
 
@@ -247,8 +247,8 @@
          collectible-data   (:collectible-data collectible)
          contract-type      (:contract-type collectible)
          tx-type            (if (= contract-type constants/wallet-contract-type-erc-1155)
-                              :collectible-erc-1155
-                              :collectible-erc-721)
+                              :tx/collectible-erc-1155
+                              :tx/collectible-erc-721)
          collectible-id     (get-in collectible [:id :token-id])
          one-collectible?   (= (collectible.utils/collectible-balance collectible) 1)
          token-display-name (cond
@@ -329,9 +329,9 @@
                                          network-chain-ids))
          from-locked-amount {}
          transaction-type-param (case transaction-type
-                                  :collectible-erc-721  constants/send-type-erc-721-transfer
-                                  :collectible-erc-1155 constants/send-type-erc-1155-transfer
-                                  :bridge               constants/send-type-bridge
+                                  :tx/collectible-erc-721  constants/send-type-erc-721-transfer
+                                  :tx/collectible-erc-1155 constants/send-type-erc-1155-transfer
+                                  :bridge                  constants/send-type-bridge
                                   constants/send-type-transfer)
          balances-per-chain (when token (:balances-per-chain token))
          token-available-networks-for-suggested-routes
@@ -510,9 +510,9 @@
          from-address (get-in db [:wallet :current-viewing-account-address])
          transaction-type (get-in db [:wallet :ui :send :tx-type])
          transaction-type-param (case transaction-type
-                                  :collectible-erc-721  constants/send-type-erc-721-transfer
-                                  :collectible-erc-1155 constants/send-type-erc-1155-transfer
-                                  :bridge               constants/send-type-bridge
+                                  :tx/collectible-erc-721  constants/send-type-erc-721-transfer
+                                  :tx/collectible-erc-1155 constants/send-type-erc-1155-transfer
+                                  :bridge                  constants/send-type-bridge
                                   constants/send-type-transfer)
          token (get-in db [:wallet :ui :send :token])
          collectible (get-in db [:wallet :ui :send :collectible])

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -246,7 +246,7 @@
    (let [collection-data    (:collection-data collectible)
          collectible-data   (:collectible-data collectible)
          contract-type      (:contract-type collectible)
-         tx-type            (if (= contract-type constants/contract-type-erc-1155)
+         tx-type            (if (= contract-type constants/wallet-contract-type-erc-1155)
                               :collectible-erc-1155
                               :collectible-erc-721)
          collectible-id     (get-in collectible [:id :token-id])

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -321,7 +321,7 @@
          amount-in (send-utils/amount-in-hex amount (if token token-decimal 0))
          from-address wallet-address
          disabled-from-chain-ids disabled-from-chain-ids
-         disabled-to-chain-ids (if (= transaction-type :bridge)
+         disabled-to-chain-ids (if (= transaction-type :tx/bridge)
                                  (filter #(not= % bridge-to-chain-id) network-chain-ids)
                                  (filter (fn [chain-id]
                                            (not (some #(= chain-id %)
@@ -331,7 +331,7 @@
          transaction-type-param (case transaction-type
                                   :tx/collectible-erc-721  constants/send-type-erc-721-transfer
                                   :tx/collectible-erc-1155 constants/send-type-erc-1155-transfer
-                                  :bridge                  constants/send-type-bridge
+                                  :tx/bridge               constants/send-type-bridge
                                   constants/send-type-transfer)
          balances-per-chain (when token (:balances-per-chain token))
          token-available-networks-for-suggested-routes
@@ -512,7 +512,7 @@
          transaction-type-param (case transaction-type
                                   :tx/collectible-erc-721  constants/send-type-erc-721-transfer
                                   :tx/collectible-erc-1155 constants/send-type-erc-1155-transfer
-                                  :bridge                  constants/send-type-bridge
+                                  :tx/bridge               constants/send-type-bridge
                                   constants/send-type-transfer)
          token (get-in db [:wallet :ui :send :token])
          collectible (get-in db [:wallet :ui :send :collectible])

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -144,8 +144,8 @@
                               {:prefix           prefix
                                :testnet-enabled? testnet-enabled?
                                :goerli-enabled?  goerli-enabled?})
-         collectible-tx?     (contains? #{:collectible-erc-721 :collectible-erc-1155}
-                                        (-> db :wallet :ui :send :tx-type))
+         collectible-tx?     (send-utils/is-collectible?
+                              (-> db :wallet :ui :send :tx-type))
          collectible         (when collectible-tx?
                                (-> db :wallet :ui :send :collectible))
          one-collectible?    (when collectible-tx?
@@ -236,8 +236,8 @@
                      :collectible
                      :token-display-name
                      :amount
-                     (when (contains? #{:collectible-erc-721 :collectible-erc-1155}
-                                      transaction-type)
+                     (when (send-utils/is-collectible?
+                            transaction-type)
                        :tx-type))})))
 
 (rf/reg-event-fx

--- a/src/status_im/contexts/wallet/send/flow_config.cljs
+++ b/src/status_im/contexts/wallet/send/flow_config.cljs
@@ -7,7 +7,7 @@
   (let [collectible-stored (-> db :wallet :ui :send :collectible)
         tx-type            (-> db :wallet :ui :send :tx-type)]
     (and (some? collectible-stored)
-         (send-utils/is-collectible? tx-type))))
+         (send-utils/tx-type-collectible? tx-type))))
 
 (defn- token-selected?
   [db]
@@ -21,7 +21,8 @@
    {:screen-id  :screen/wallet.select-asset
     :skip-step? (fn [db] (or (token-selected? db) (collectible-selected? db)))}
    {:screen-id  :screen/wallet.send-input-amount
-    :skip-step? (fn [db] (= (get-in db [:wallet :ui :send :tx-type]) :collectible))}
+    :skip-step? (fn [db]
+                  (send-utils/tx-type-collectible? (get-in db [:wallet :ui :send :tx-type])))}
    {:screen-id  :screen/wallet.select-collectible-amount
     :skip-step? (fn [db]
                   (or (not (collectible-selected? db))

--- a/src/status_im/contexts/wallet/send/flow_config.cljs
+++ b/src/status_im/contexts/wallet/send/flow_config.cljs
@@ -5,7 +5,7 @@
   (let [collectible-stored (-> db :wallet :ui :send :collectible)
         tx-type            (-> db :wallet :ui :send :tx-type)]
     (and (some? collectible-stored)
-         (= tx-type :collectible))))
+         (contains? #{:collectible :collectible-multi} tx-type))))
 
 (defn- token-selected?
   [db]

--- a/src/status_im/contexts/wallet/send/flow_config.cljs
+++ b/src/status_im/contexts/wallet/send/flow_config.cljs
@@ -1,12 +1,13 @@
-(ns status-im.contexts.wallet.send.flow-config)
+(ns status-im.contexts.wallet.send.flow-config
+  (:require
+    [status-im.contexts.wallet.send.utils :as send-utils]))
 
 (defn- collectible-selected?
   [db]
   (let [collectible-stored (-> db :wallet :ui :send :collectible)
         tx-type            (-> db :wallet :ui :send :tx-type)]
     (and (some? collectible-stored)
-         (contains? #{:collectible-erc-721 :collectible-erc-1155}
-                    tx-type))))
+         (send-utils/is-collectible? tx-type))))
 
 (defn- token-selected?
   [db]

--- a/src/status_im/contexts/wallet/send/flow_config.cljs
+++ b/src/status_im/contexts/wallet/send/flow_config.cljs
@@ -5,7 +5,8 @@
   (let [collectible-stored (-> db :wallet :ui :send :collectible)
         tx-type            (-> db :wallet :ui :send :tx-type)]
     (and (some? collectible-stored)
-         (contains? #{:collectible :collectible-multi} tx-type))))
+         (contains? #{:collectible-erc-721 :collectible-erc-1155}
+                    tx-type))))
 
 (defn- token-selected?
   [db]

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -26,7 +26,7 @@
         :weight              :semi-bold
         :style               style/title-container
         :accessibility-label :send-label}
-       (if (= transaction-type :bridge)
+       (if (= transaction-type :tx/bridge)
          (i18n/label :t/bridge)
          (i18n/label :t/send))]
       [quo/summary-tag
@@ -34,7 +34,7 @@
         :label        (str amount " " token-display-name)
         :type         (if collectible? :collectible :token)
         :image-source (if collectible? image-url :eth)}]]
-     (if (= transaction-type :bridge)
+     (if (= transaction-type :tx/bridge)
        (map-indexed
         (fn [idx path]
           (let [from-network             (:from path)
@@ -98,7 +98,7 @@
         :style               style/title-container
         :accessibility-label :send-label}
        (i18n/label :t/to)]
-      (if (= transaction-type :bridge)
+      (if (= transaction-type :tx/bridge)
         [quo/summary-tag
          {:type                :network
           :image-source        (:source to-network)
@@ -107,7 +107,7 @@
         [quo/summary-tag
          {:type  :address
           :label (utils/get-shortened-address to-address)}])]
-     (when (= transaction-type :bridge)
+     (when (= transaction-type :tx/bridge)
        [rn/view
         {:style {:flex-direction :row
                  :margin-top     4}}
@@ -198,7 +198,7 @@
                                  {:amount (str max-fees)
                                   :symbol currency-symbol})}]
          [data-item
-          {:title    (if (= transaction-type :bridge)
+          {:title    (if (= transaction-type :tx/bridge)
                        (i18n/label :t/bridged-to
                                    {:network (:abbreviated-name to-network)})
                        (i18n/label :t/user-gets {:name (utils/get-shortened-address to-address)}))
@@ -249,7 +249,7 @@
            :footer                   (when (and route (seq route))
                                        [standard-auth/slide-button
                                         {:size                :size-48
-                                         :track-text          (if (= transaction-type :bridge)
+                                         :track-text          (if (= transaction-type :tx/bridge)
                                                                 (i18n/label :t/slide-to-bridge)
                                                                 (i18n/label :t/slide-to-send))
                                          :container-style     {:z-index 2}
@@ -282,12 +282,12 @@
              :theme               theme}]
            [user-summary
             {:token-display-name  token-display-name
-             :summary-type        (if (= transaction-type :bridge)
+             :summary-type        (if (= transaction-type :tx/bridge)
                                     :status-account
                                     :account)
              :accessibility-label :summary-to-label
              :label               (i18n/label :t/to-capitalized)
-             :account-props       (if (= transaction-type :bridge)
+             :account-props       (if (= transaction-type :tx/bridge)
                                     from-account-props
                                     user-props)
              :network-values      to-values-by-chain

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -208,3 +208,9 @@
                      :position-diff position-diff})))
           []
           route))
+
+(defn is-collectible?
+  [tx-type]
+  (let [tx-set #{:collectible-erc-721 :collectible-erc-1155}]
+    (contains? tx-set
+               tx-type)))

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -209,8 +209,10 @@
           []
           route))
 
-(defn is-collectible?
+(def ^:private collectible-tx-set
+  #{:tx/collectible-erc-721
+    :tx/collectible-erc-1155})
+
+(defn tx-type-collectible?
   [tx-type]
-  (let [tx-set #{:collectible-erc-721 :collectible-erc-1155}]
-    (contains? tx-set
-               tx-type)))
+  (contains? collectible-tx-set tx-type))


### PR DESCRIPTION
Fixes 
https://github.com/status-im/status-mobile/issues/19143

### Summary
Adds support for ERC1155 (Multi collectibles) send transaction

Adds constants for contract type as seen in status-go https://github.com/status-im/status-go/blob/develop/services/wallet/common/const.go#L31-L38


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Go to wallet tab
- Click on account
- Click collectible tab and select an ERC1155 type collectible to send
- Click send and paste recipient wallet address
- Choose the number you want the send by typing and then click continue to get suggested routes
- Once satisfied, slide the "Slide to send" and authorize transaction


https://github.com/status-im/status-mobile/assets/45393944/8c35a8f0-b69b-4454-8618-2eeec951165c



status: ready 
