### PR TITLE
Support hooks OR atom state management in component previews

### DIFF
--- a/src/status_im/contexts/preview/quo/counter/step.cljs
+++ b/src/status_im/contexts/preview/quo/counter/step.cljs
@@ -1,7 +1,7 @@
 (ns status-im.contexts.preview.quo.counter.step
   (:require
     [quo.core :as quo]
-    [reagent.core :as reagent]
+    [react-native.core :as rn]
     [status-im.contexts.preview.quo.preview :as preview]))
 
 (def descriptor
@@ -17,13 +17,13 @@
 
 (defn view
   []
-  (let [state (reagent/atom {:value         "5"
-                             :type          :neutral
-                             :in-blur-view? false})]
-    (fn []
-      [preview/preview-container
-       {:state                 state
-        :descriptor            descriptor
-        :blur?                 (:in-blur-view? @state)
-        :show-blur-background? (:in-blur-view? @state)}
-       [quo/step (dissoc @state :value) (:value @state)]])))
+  (let [[state set-state] (rn/use-state {:value         "5"
+                                         :type          :neutral
+                                         :in-blur-view? false})]
+    [preview/preview-container
+     {:state                 state
+      :set-state             set-state
+      :descriptor            descriptor
+      :blur?                 (:in-blur-view? state)
+      :show-blur-background? (:in-blur-view? state)}
+     [quo/step (dissoc state :value) (:value state)]]))

--- a/src/status_im/contexts/preview/quo/selectors/react.cljs
+++ b/src/status_im/contexts/preview/quo/selectors/react.cljs
@@ -4,17 +4,16 @@
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
     [react-native.core :as rn]
-    [reagent.core :as reagent]
     [status-im.constants :as constants]
     [status-im.contexts.preview.quo.preview :as preview]))
 
-(defn- gen-quantity
+(defn gen-quantity
   [max-count _]
   (rand-int max-count))
 
-(def ^:private memo-gen-quantity (memoize gen-quantity))
+(def memo-gen-quantity (memoize gen-quantity))
 
-(def ^:private descriptor
+(def descriptor
   [{:key  :hide-new-reaction-button?
     :type :boolean}
    {:label   "Reactions"
@@ -37,40 +36,44 @@
 
 (defn preview-react
   []
-  (let [state             (reagent/atom {:hide-new-reaction-button? true
-                                         :max-count                 1000
-                                         :reaction-ids              [1 2 3]
-                                         :use-case                  :default})
-        pressed-reactions (reagent/atom #{1})]
+  (let [[state set-state]
+        (rn/use-state {:hide-new-reaction-button? true
+                       :max-count                 1000
+                       :reaction-ids              [1 2 3]
+                       :use-case                  :default})
 
-    (fn []
-      (let [reactions (mapv (fn [reaction-id]
-                              {:emoji-reaction-id reaction-id
-                               :emoji-id          reaction-id
-                               :emoji             (get constants/reactions reaction-id)
-                               :quantity          (memo-gen-quantity (:max-count @state) reaction-id)
-                               :own               (contains? @pressed-reactions reaction-id)})
-                            (:reaction-ids @state))]
-        [preview/preview-container
-         {:state      state
-          :descriptor descriptor}
-         [rn/view
-          {:padding-bottom     150
-           :padding-vertical   60
-           :padding-horizontal 20
-           :border-radius      16
-           :background-color   (when (= :pinned (:use-case @state))
-                                 (colors/custom-color :blue 50 10))
-           :align-items        :flex-start}
-          [quo/react
-           {:reactions                 reactions
-            :hide-new-reaction-button? (:hide-new-reaction-button? @state)
-            :use-case                  (:use-case @state)
-            :on-press                  (fn [reaction]
-                                         (let [reaction-id    (:emoji-id reaction)
-                                               change-pressed (partial swap! pressed-reactions)]
-                                           (if (contains? @pressed-reactions reaction-id)
-                                             (change-pressed disj reaction-id)
-                                             (change-pressed conj reaction-id))))
-            :on-long-press             identity
-            :on-press-new              identity}]]]))))
+        [pressed-reactions set-pressed-reactions] (rn/use-state #{1})
+
+        reactions (mapv (fn [reaction-id]
+                          {:emoji-reaction-id reaction-id
+                           :emoji-id          reaction-id
+                           :emoji             (get constants/reactions reaction-id)
+                           :quantity          (memo-gen-quantity (:max-count state) reaction-id)
+                           :own               (contains? pressed-reactions reaction-id)})
+                        (:reaction-ids state))
+
+        on-press (fn [reaction]
+                   (let [reaction-id (:emoji-id reaction)]
+                     (if (contains? pressed-reactions reaction-id)
+                       (set-pressed-reactions (disj pressed-reactions reaction-id))
+                       (set-pressed-reactions (conj pressed-reactions
+                                                    reaction-id)))))]
+    [preview/preview-container
+     {:state      state
+      :set-state  set-state
+      :descriptor descriptor}
+     [rn/view
+      {:padding-bottom     150
+       :padding-vertical   60
+       :padding-horizontal 20
+       :border-radius      16
+       :background-color   (when (= :pinned (:use-case state))
+                             (colors/custom-color :blue 50 10))
+       :align-items        :flex-start}
+      [quo/react
+       {:reactions                 reactions
+        :hide-new-reaction-button? (:hide-new-reaction-button? state)
+        :use-case                  (:use-case state)
+        :on-press                  on-press
+        :on-long-press             identity
+        :on-press-new              identity}]]]))


### PR DESCRIPTION
### Summary

This PR changes the underlying implementation of component previews to support receiving either `state`/`set-state` from `use-state` or a Reagent atom, thus allowing us to gradually change preview namespaces to use hooks instead of having to refactor all at once in a gigantic PR.

I tested all types of preview fields, including multi-select and it's all working. I changed only two component previews to keep this PR small because my goal here is not to rewrite preview namespaces to use hooks (we better do in separate PRs).

#### Areas that may be impacted

None. Only quo previews changed.

### Steps to test

Only the components `counter.step` and `selectors.react` previews were adapted to `use-state` if you want to check them out and prove it all works.

**Demo of the refactored component using multi-select field:**

[previews.webm](https://github.com/status-im/status-mobile/assets/46027/6a738deb-3e28-4d1a-8597-a8b5e832b1e5)

status: ready
