### PR TITLE
fix: test-watch-for-repl on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,13 +353,11 @@ test: export SHADOW_NS_REGEXP := .*-test$$
 test: ##@test Run all Clojure tests
 test: _test-clojure
 
+test-watch-for-repl: export TARGET := default
 test-watch-for-repl: export SHADOW_OUTPUT_TO := target/test/test.js
 test-watch-for-repl: export SHADOW_NS_REGEXP := .*-test$$
-test-watch-for-repl: status-go-library
 test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connections
-	yarn node-pre-gyp rebuild
-	rm -f target/test/test.js
-	yarn shadow-cljs compile mocks && \
+	yarn install && shadow-cljs compile mocks && \
 	concurrently --kill-others --prefix-colors 'auto' --names 'build,repl' \
 		'yarn shadow-cljs watch test --verbose' \
 		"until [ -f $$SHADOW_OUTPUT_TO ] ; do sleep 1 ; done ; node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO --repl"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1484,7 +1484,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 56e0e498dbb513b96c40bac6284729ba4e62672d
   FBReactNativeSpec: 146c741a3f40361f6bc13a4ba284678cbedb5881
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 36c15c01d70ed395c6e4f3619f98a23ee415b07a
+  glog: 530710e7949eb12c82670bd09e946becf50a3c2a
   hermes-engine: 1d1835b2cc54c381909d94d1b3c8e0a2f1a94a0e
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   Keycard: ac6df4d91525c3c82635ac24d4ddd9a80aca5fc8

--- a/yarn.lock
+++ b/yarn.lock
@@ -9372,10 +9372,6 @@ react-native-svg@13.10.0:
     css-select "^5.1.0"
     css-tree "^1.1.3"
 
-"react-native-transparent-video@git+https://github.com/status-im/react-native-transparent-video.git#refs/tags/0.1.1":
-  version "0.1.0"
-  resolved "git+https://github.com/status-im/react-native-transparent-video.git#1327fc622f7521269f66299c3aca610494c76fe1"
-
 react-native-url-polyfill@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz#db714520a2985cff1d50ab2e66279b9f91ffd589"


### PR DESCRIPTION
fixes #20041

## Summary

- fix broken `test-watch-for-repl` on MacOS
- removes `react-native-transparent-video` from `yarn.lock`

## Platforms
- macOS

status: ready 
