### PR TITLE
[#19544] Show preselected networks in QR code

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -176,12 +176,10 @@
                                       ;; the preloads namespaces because they
                                       ;; will be used directly by Jest in the
                                       ;; option setupFilesAfterEnv.
-                                      status-im.contexts.shell.share.wallet.component-spec
                                       test-helpers.component-tests-preload
                                       status-im.setup.schema-preload
-                                      ;quo.core-spec
-                                      ;status-im.core-spec
-                                      ]
+                                      quo.core-spec
+                                      status-im.core-spec]
                    :ns-regexp        "component-spec$"
                    :output-dir       "component-spec"
                    :closure-defines  {schema.core/throw-on-error? true}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -176,10 +176,12 @@
                                       ;; the preloads namespaces because they
                                       ;; will be used directly by Jest in the
                                       ;; option setupFilesAfterEnv.
+                                      status-im.contexts.shell.share.wallet.component-spec
                                       test-helpers.component-tests-preload
                                       status-im.setup.schema-preload
-                                      quo.core-spec
-                                      status-im.core-spec]
+                                      ;quo.core-spec
+                                      ;status-im.core-spec
+                                      ]
                    :ns-regexp        "component-spec$"
                    :output-dir       "component-spec"
                    :closure-defines  {schema.core/throw-on-error? true}

--- a/src/status_im/contexts/shell/share/wallet/component_spec.cljs
+++ b/src/status_im/contexts/shell/share/wallet/component_spec.cljs
@@ -18,12 +18,12 @@
   (h/setup-restorable-re-frame)
   (h/before-each
    (fn []
-     (h/setup-subs {:dimensions/window-width                  500
-                    :mediaserver/port                         200
-                    :wallet/accounts                          [{:address "0x707f635951193ddafbb40971a0fcaab8a6415160"
-                                                                :name    "Wallet One"
-                                                                :emoji   "😆"
-                                                                :color   :blue}]
+     (h/setup-subs {:dimensions/window-width 500
+                    :mediaserver/port 200
+                    :wallet/accounts [{:address "0x707f635951193ddafbb40971a0fcaab8a6415160"
+                                       :name    "Wallet One"
+                                       :emoji   "😆"
+                                       :color   :blue}]
                     :wallet/preferred-chain-names-for-address #{:eth :opt :arb1}})))
 
   (h/test "should display the wallet tab"

--- a/src/status_im/contexts/shell/share/wallet/component_spec.cljs
+++ b/src/status_im/contexts/shell/share/wallet/component_spec.cljs
@@ -18,12 +18,13 @@
   (h/setup-restorable-re-frame)
   (h/before-each
    (fn []
-     (h/setup-subs {:dimensions/window-width 500
-                    :mediaserver/port        200
-                    :wallet/accounts         [{:address "0x707f635951193ddafbb40971a0fcaab8a6415160"
-                                               :name    "Wallet One"
-                                               :emoji   "😆"
-                                               :color   :blue}]})))
+     (h/setup-subs {:dimensions/window-width                  500
+                    :mediaserver/port                         200
+                    :wallet/accounts                          [{:address "0x707f635951193ddafbb40971a0fcaab8a6415160"
+                                                                :name    "Wallet One"
+                                                                :emoji   "😆"
+                                                                :color   :blue}]
+                    :wallet/preferred-chain-names-for-address #{:eth :opt :arb1}})))
 
   (h/test "should display the wallet tab"
     (render-wallet-view)
@@ -37,12 +38,7 @@
                  (h/is-truthy (h/query-by-text "0x707f635951193ddafbb40971a0fcaab8a6415160"))
                  (h/is-falsy (h/query-by-text "eth:"))))))
 
-  ;; NOTE: Fails with error below possibly due to Infura outage:
-  ;;    FAIL  ./status_im.contexts.shell.share.wallet.component_spec.js
-  ;;  ● share wallet addresses › should display the multichain account
-  ;;
-  ;;   No protocol method IDeref.-deref defined for type undefined
-  (h/test-skip "should display the multichain account"
+  (h/test "should display the multichain account"
     (render-wallet-view)
     (-> (h/wait-for #(h/get-by-label-text :share-qr-code-multichain-tab))
         (.then (fn []

--- a/src/status_im/contexts/shell/share/wallet/component_spec.cljs
+++ b/src/status_im/contexts/shell/share/wallet/component_spec.cljs
@@ -24,7 +24,7 @@
                                        :name    "Wallet One"
                                        :emoji   "😆"
                                        :color   :blue}]
-                    :wallet/preferred-chain-names-for-address #{:eth :opt :arb1}})))
+                    :wallet/preferred-chain-names-for-address #{:eth :oeth :arb1}})))
 
   (h/test "should display the wallet tab"
     (render-wallet-view)

--- a/src/status_im/contexts/shell/share/wallet/component_spec.cljs
+++ b/src/status_im/contexts/shell/share/wallet/component_spec.cljs
@@ -38,7 +38,12 @@
                  (h/is-truthy (h/query-by-text "0x707f635951193ddafbb40971a0fcaab8a6415160"))
                  (h/is-falsy (h/query-by-text "eth:"))))))
 
-  (h/test "should display the multichain account"
+  ;; NOTE: Fails with error below possibly due to Infura outage:
+  ;;    FAIL  ./status_im.contexts.shell.share.wallet.component_spec.js
+  ;;  ● share wallet addresses › should display the multichain account
+  ;;
+  ;;   No protocol method IDeref.-deref defined for type undefined
+  (h/test-skip "should display the multichain account"
     (render-wallet-view)
     (-> (h/wait-for #(h/get-by-label-text :share-qr-code-multichain-tab))
         (.then (fn []

--- a/src/status_im/contexts/shell/share/wallet/view.cljs
+++ b/src/status_im/contexts/shell/share/wallet/view.cljs
@@ -5,7 +5,6 @@
     [react-native.core :as rn]
     [react-native.platform :as platform]
     [reagent.core :as reagent]
-    [status-im.constants :as constants]
     [status-im.contexts.shell.share.style :as style]
     [status-im.contexts.shell.share.wallet.style :as wallet-style]
     [status-im.contexts.wallet.common.utils :as utils]
@@ -51,9 +50,9 @@
                                                                       chain-ids)))}])}]))
 
 (defn- wallet-qr-code-item
-  [{:keys [account index]}]
+  [{:keys [account index preferred-chains]}]
   (let [{window-width :width} (rn/get-window)
-        selected-networks     (reagent/atom constants/default-network-names)
+        selected-networks     (reagent/atom preferred-chains)
         wallet-type           (reagent/atom :multichain)
         on-settings-press     #(open-preferences selected-networks account)
         on-legacy-press       #(reset! wallet-type :legacy)
@@ -97,10 +96,11 @@
      ^{:key i} [indicator (= current-index i)])])
 
 (defn render-item
-  [item]
+  [{:keys [address] :as account}]
   [wallet-qr-code-item
-   {:account item
-    :index   (:position item)}])
+   {:account          account
+    :index            (:position account)
+    :preferred-chains (rf/sub [:wallet/preferred-chain-names-for-address address])}])
 
 (defn- qr-code-visualized-index
   [offset qr-code-size num-qr-codes]

--- a/src/status_im/contexts/wallet/account/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/account/share_address/view.cljs
@@ -47,13 +47,10 @@
                    :shell?  true
                    :content sheet-content}])))
 
-
 (defn view
   []
   (let [padding-top         (:top (safe-area/get-insets))
         wallet-type         (reagent/atom :legacy)
-        ;; Design team is yet to confirm the default selected networks here. Should be the current
-        ;; selected for the account or all the networks always
         selected-networks   (reagent/atom constants/default-network-names)
         on-settings-press   #(open-preferences selected-networks)
         on-legacy-press     #(reset! wallet-type :legacy)
@@ -61,11 +58,11 @@
     (fn []
       (let [{:keys [address color emoji watch-only?]
              :as   account}     (rf/sub [:wallet/current-viewing-account])
+            preferred-networks  (rf/sub [:wallet/preferred-chains-for-address address])
             share-title         (str (:name account) " " (i18n/label :t/address))
-            qr-url              (utils/get-wallet-qr {:wallet-type @wallet-type
-                                                      :selected-networks
-                                                      @selected-networks
-                                                      :address address})
+            qr-url              (utils/get-wallet-qr {:wallet-type       @wallet-type
+                                                      :selected-networks @selected-networks
+                                                      :address           address})
             qr-media-server-uri (image-server/get-qr-image-uri-for-any-url
                                  {:url         qr-url
                                   :port        (rf/sub [:mediaserver/port])
@@ -76,6 +73,9 @@
                                   :share   (i18n/label :t/share-address)
                                   :receive (i18n/label :t/receive)
                                   nil)]
+
+        (rn/use-mount #(reset! selected-networks (mapv :network-name preferred-networks)))
+
         [quo/overlay {:type :shell}
          [rn/view
           {:flex        1

--- a/src/status_im/contexts/wallet/account/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/account/share_address/view.cljs
@@ -58,7 +58,7 @@
     (fn []
       (let [{:keys [address color emoji watch-only?]
              :as   account}     (rf/sub [:wallet/current-viewing-account])
-            preferred-networks  (rf/sub [:wallet/preferred-chains-for-address address])
+            preferred-networks  (rf/sub [:wallet/preferred-chain-names-for-address address])
             share-title         (str (:name account) " " (i18n/label :t/address))
             qr-url              (utils/get-wallet-qr {:wallet-type       @wallet-type
                                                       :selected-networks @selected-networks
@@ -74,7 +74,7 @@
                                   :receive (i18n/label :t/receive)
                                   nil)]
 
-        (rn/use-mount #(reset! selected-networks (mapv :network-name preferred-networks)))
+        (rn/use-mount #(reset! selected-networks preferred-networks))
 
         [quo/overlay {:type :shell}
          [rn/view

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -422,6 +422,13 @@
      (filter #(preferred-chains-ids (:chain-id %)) network-details))))
 
 (rf/reg-sub
+ :wallet/preferred-chain-names-for-address
+ (fn [[_ address]]
+   (rf/subscribe [:wallet/preferred-chains-for-address address]))
+ (fn [preferred-chains-for-address _]
+   (map :network-name preferred-chains-for-address)))
+
+(rf/reg-sub
  :wallet/transactions
  :<- [:wallet]
  :-> :transactions)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -409,6 +409,19 @@
         accounts)))
 
 (rf/reg-sub
+ :wallet/preferred-chains-for-address
+ :<- [:wallet/accounts]
+ :<- [:wallet/network-details]
+ :<- [:profile/test-networks-enabled?]
+ (fn [[accounts network-details test-networks-enabled?] [_ address]]
+   (let [preferred-chains-ids (some #(when (= (:address %) address)
+                                       (if test-networks-enabled?
+                                         (:test-preferred-chain-ids %)
+                                         (:prod-preferred-chain-ids %)))
+                                    accounts)]
+     (filter #(preferred-chains-ids (:chain-id %)) network-details))))
+
+(rf/reg-sub
  :wallet/transactions
  :<- [:wallet]
  :-> :transactions)


### PR DESCRIPTION
fixes #19544 

### Summary

While displaying a QR code we didn't show the preconfigured preferred networks, this PR fixes that:

[Screencast from 2024-05-16 09-44-09.webm](https://github.com/status-im/status-mobile/assets/90291778/43ba1098-cecf-47b8-bd4d-db260c4e5582)

And we are still able to edit the networks in the Share screen whithout saving the changes:

[Screencast from 2024-05-16 09-48-58.webm](https://github.com/status-im/status-mobile/assets/90291778/c249e126-e83a-4771-9d2f-c2ce40367caa)


### Testing notes
The saved preferred networks in normal mode are different than the ones saved in testnet mode. So a user may prefer `:eth` in normal mode and `:arb1` in testnet. This is being properly handled.

#### Platforms

- Android
- iOS

status: ready
