### PR TITLE
chore: rename backup screen

### DIFF
--- a/src/status_im/contexts/wallet/add_account/create_account/events.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/events.cljs
@@ -27,7 +27,7 @@
   {:db (-> db
            (assoc-in [:wallet :ui :create-account :seed-phrase] seed-phrase)
            (assoc-in [:wallet :ui :create-account :random-phrase] random-phrase))
-   :fx [[:dispatch-later [{:ms 20 :dispatch [:navigate-to :screen/wallet.check-your-backup]}]]]})
+   :fx [[:dispatch-later [{:ms 20 :dispatch [:navigate-to :screen/wallet.confirm-backup]}]]]})
 
 (rf/reg-event-fx :wallet/store-seed-phrase store-seed-phrase)
 

--- a/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/style.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/style.cljs
@@ -1,4 +1,4 @@
-(ns status-im.contexts.wallet.add-account.create-account.new-keypair.check-your-backup.style)
+(ns status-im.contexts.wallet.add-account.create-account.new-keypair.confirm-backup.style)
 
 (def header-container
   {:margin-horizontal 20

--- a/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/view.cljs
@@ -1,9 +1,9 @@
-(ns status-im.contexts.wallet.add-account.create-account.new-keypair.check-your-backup.view
+(ns status-im.contexts.wallet.add-account.create-account.new-keypair.confirm-backup.view
   (:require
     [quo.core :as quo]
     [react-native.core :as rn]
     [reagent.core :as reagent]
-    [status-im.contexts.wallet.add-account.create-account.new-keypair.check-your-backup.style :as style]
+    [status-im.contexts.wallet.add-account.create-account.new-keypair.confirm-backup.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
@@ -95,7 +95,7 @@
            :on-press            #(rf/dispatch [:navigate-back])
            :accessibility-label :top-bar}]
          [quo/page-top
-          {:title            (i18n/label :t/check-your-backup)
+          {:title            (i18n/label :t/confirm-backup)
            :description      :text
            :description-text (i18n/label :t/confirm-the-position)}]
          [rn/flat-list

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -85,8 +85,8 @@
      wallet-key-pair-name]
     [status-im.contexts.wallet.add-account.create-account.new-keypair.backup-recovery-phrase.view :as
      wallet-backup-recovery-phrase]
-    [status-im.contexts.wallet.add-account.create-account.new-keypair.check-your-backup.view :as
-     wallet-check-your-backup]
+    [status-im.contexts.wallet.add-account.create-account.new-keypair.confirm-backup.view :as
+     wallet-confirm-backup]
     [status-im.contexts.wallet.add-account.create-account.select-keypair.view :as wallet-select-keypair]
     [status-im.contexts.wallet.add-account.create-account.view :as wallet-create-account]
     [status-im.contexts.wallet.bridge.bridge-to.view :as wallet-bridge-to]
@@ -430,9 +430,9 @@
      :options   {:insets {:top? true :bottom? true}}
      :component wallet-backup-recovery-phrase/view}
 
-    {:name      :screen/wallet.check-your-backup
+    {:name      :screen/wallet.confirm-backup
      :options   {:insets {:top? true :bottom? true}}
-     :component wallet-check-your-backup/view}
+     :component wallet-confirm-backup/view}
 
     {:name      :screen/wallet.keypair-name
      :options   {:insets {:top? true}}

--- a/translations/en.json
+++ b/translations/en.json
@@ -2557,7 +2557,7 @@
     "watched-account-removed": "Watched address has been removed",
     "account-removed": "Account has been removed",
     "share-address-title": "{{address}} address",
-    "check-your-backup": "Check your backup",
+    "confirm-backup": "Confirm backup",
     "confirm-the-position": "Confirm the position of certain words in your recovery phrase",
     "do-not-cheat": "Don't try to cheat",
     "do-not-cheat-description": "These 12 words give access to all of your funds so it is important that you write them in the correct order, take it seriously.",


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/20013

### Summary

This PR renames `Check your backup` screen to `Confirm backup`

### Demo
<img src="https://github.com/status-im/status-mobile/assets/29354102/d344bee0-4e6d-41f3-b8ea-2f91aea29bc0" width="300" height="600">
