### PR TITLE
fix: remove transaction progress from send flow

### DIFF
--- a/src/status_im/contexts/wallet/bridge/flow_config.cljs
+++ b/src/status_im/contexts/wallet/bridge/flow_config.cljs
@@ -7,5 +7,4 @@
     :skip-step? (fn [db] (some? (get-in db [:wallet :ui :send :bridge-to-chain-id])))}
    {:screen-id  :screen/wallet.bridge-input-amount
     :skip-step? (fn [db] (some? (get-in db [:wallet :ui :send :amount])))}
-   {:screen-id :screen/wallet.transaction-confirmation}
-   {:screen-id :screen/wallet.transaction-progress}])
+   {:screen-id :screen/wallet.transaction-confirmation}])

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -387,10 +387,7 @@
      {:db (-> db
               (assoc-in [:wallet :transactions] transaction-details)
               (assoc-in [:wallet :ui :send :transaction-ids] transaction-ids))
-      :fx [[:dispatch
-            [:wallet/wizard-navigate-forward
-             {:current-screen :screen/wallet.transaction-confirmation
-              :flow-id        :wallet-send-flow}]]]})))
+      :fx [[:dispatch [:dismiss-modal :screen/wallet.transaction-confirmation]]]})))
 
 (rf/reg-event-fx :wallet/close-transaction-progress-page
  (fn [_]
@@ -399,7 +396,7 @@
          [:dispatch [:wallet/clean-send-address]]
          [:dispatch [:wallet/clean-disabled-from-networks]]
          [:dispatch [:wallet/select-address-tab nil]]
-         [:dispatch [:dismiss-modal :screen/wallet.transaction-progress]]]}))
+         [:dispatch [:dismiss-modal :screen/wallet.transaction-confirmation]]]}))
 
 (defn- transaction-data
   [{:keys [from-address to-address token-address route data eth-transfer?]}]

--- a/src/status_im/contexts/wallet/send/flow_config.cljs
+++ b/src/status_im/contexts/wallet/send/flow_config.cljs
@@ -24,5 +24,4 @@
     :skip-step? (fn [db]
                   (or (not (collectible-selected? db))
                       (some? (get-in db [:wallet :ui :send :amount]))))}
-   {:screen-id :screen/wallet.transaction-confirmation}
-   {:screen-id :screen/wallet.transaction-progress}])
+   {:screen-id :screen/wallet.transaction-confirmation}])


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/20067

### Summary
This PR removes transaction progress screen from the send flow.

### Demo

https://github.com/status-im/status-mobile/assets/29354102/0ff3a4c7-fd23-4be4-ac96-9e9b9bbb598a

