### PR TITLE
fix: max value is zero for some tokens

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -585,13 +585,16 @@
 
 (rf/reg-event-fx
  :wallet/select-from-account
- (fn [{db :db} [{:keys [address stack-id start-flow?]}]]
+ (fn [{db :db} [{:keys [address stack-id network-details start-flow?]}]]
    (let [token-symbol (-> db :wallet :ui :send :token-symbol)
          token        (when token-symbol
                         ;; When this flow has started in the wallet home page, we know the
                         ;; token or collectible to send, but we don't know from which
                         ;; account, so we extract the token data from the picked account.
-                        (utils/get-token-from-account db token-symbol address))]
+                        (let [token (utils/get-token-from-account db token-symbol address)]
+                          (assoc token
+                                 :networks      (network-utils/network-list token network-details)
+                                 :total-balance (utils/calculate-total-token-balance token))))]
      {:db (if token-symbol
             (-> db
                 (assoc-in [:wallet :ui :send :token] token)

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -10,10 +10,11 @@
     [utils.re-frame :as rf]))
 
 (defn- on-press
-  [address]
+  [address network-details]
   (rf/dispatch [:wallet/select-from-account
-                {:address  address
-                 :stack-id :screen/wallet.select-from}]))
+                {:address         address
+                 :network-details network-details
+                 :stack-id        :screen/wallet.select-from}]))
 
 (defn- on-close
   []
@@ -22,9 +23,10 @@
 
 (defn- render-fn
   [item]
-  [quo/account-item
-   {:on-press      #(on-press (:address item))
-    :account-props item}])
+  (let [network-details (rf/sub [:wallet/network-details])]
+    [quo/account-item
+     {:on-press      #(on-press (:address item) network-details)
+      :account-props item}]))
 
 (defn view
   []

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -40,15 +40,16 @@
                                                     :mixedcase-address "0x7bcDfc75c431"
                                                     :public-key "0x04371e2d9d66b82f056bc128064"
                                                     :removed false}
-   :wallet/wallet-send-token                       {:symbol   :eth
-                                                    :networks [{:source           879
-                                                                :short-name       "eth"
-                                                                :network-name     :mainnet
-                                                                :abbreviated-name "Eth."
-                                                                :chain-id         1
-                                                                :related-chain-id 1
-                                                                :layer            1}]}
-   :wallet/current-viewing-account-tokens-filtered {:balances-per-chain         {1 {:raw-balance
+   :wallet/wallet-send-token                       {:symbol                     :eth
+                                                    :networks                   [{:source 879
+                                                                                  :short-name "eth"
+                                                                                  :network-name :mainnet
+                                                                                  :abbreviated-name
+                                                                                  "Eth."
+                                                                                  :chain-id 1
+                                                                                  :related-chain-id 1
+                                                                                  :layer 1}]
+                                                    :balances-per-chain         {1 {:raw-balance
                                                                                     (money/bignumber
                                                                                      "2500")
                                                                                     :has-error false}}
@@ -72,6 +73,11 @@
    :profile/currency                               :usd
    :wallet/token-by-symbol                         {:symbol                     :eth
                                                     :total-balance              100
+                                                    :available-balance          100
+                                                    :balances-per-chain         {1 {:raw-balance
+                                                                                    (money/bignumber
+                                                                                     "2500")
+                                                                                    :has-error false}}
                                                     :market-values-per-currency {:usd {:price 10}}}
    :wallet/wallet-send-disabled-from-chain-ids     []
    :wallet/wallet-send-from-values-by-chain        {1 (money/bignumber "250")}

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -143,18 +143,18 @@
                                                 input-state)
                                                :stack-id current-screen-id}]))
             {fiat-currency :currency} (rf/sub [:profile/profile])
-            {token-symbol   :symbol
+            {token-symbol :symbol
              token-networks :networks
-             token-decimals :decimals} (rf/sub [:wallet/wallet-send-token])
+             token-decimals :decimals
+             :as
+             token} (rf/sub [:wallet/wallet-send-token])
             send-enabled-networks (rf/sub [:wallet/wallet-send-enabled-networks])
             enabled-from-chain-ids (rf/sub
                                     [:wallet/wallet-send-enabled-from-chain-ids])
-            {token-balance :total-balance
-             available-balance :available-balance
-             :as
-             token} (rf/sub
-                     [:wallet/current-viewing-account-tokens-filtered
-                      (str token-symbol) enabled-from-chain-ids])
+            {token-balance     :total-balance
+             available-balance :available-balance} (rf/sub [:wallet/token-by-symbol
+                                                            (str token-symbol)
+                                                            enabled-from-chain-ids])
             currency-symbol (rf/sub [:profile/currency-symbol])
             currency (rf/sub [:profile/currency])
             conversion-rate (-> token :market-values-per-currency currency :price)

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -189,9 +189,7 @@
         network-links (rf/sub [:wallet/wallet-send-network-links])
         disabled-from-chain-ids (rf/sub
                                  [:wallet/wallet-send-disabled-from-chain-ids])
-        {token-balances-per-chain :balances-per-chain} (rf/sub
-                                                        [:wallet/current-viewing-account-tokens-filtered
-                                                         (str token-symbol)])
+        {token-balances-per-chain :balances-per-chain} (rf/sub [:wallet/wallet-send-token])
         token-available-networks-for-suggested-routes
         (send-utils/token-available-networks-for-suggested-routes
          {:balances-per-chain token-balances-per-chain


### PR DESCRIPTION
fixes #19646 
fixes #19813
fixes #19739

### Summary

This PR fixes an issue where max value is 0 for some tokens and prevents it to send them

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

#### Case 1
- Open Status
- Login with an account with USDC and other tokens with same symbol
- Go to Wallet
- Select account
- Tap on Send
- Select an address
- Select USDC
- Verify user can type a valid amount

#### Case 2
- Login with an account with available assets (example: ETH)
- Go to the account overview page
- Long tap on the asset -> send
- Select account with available assets to send from (ETH)
- Navigate to sent to page
- Verify user can send assets

status: ready