### PR TITLE
Only log event payload at TRACE level

### DIFF
--- a/src/status_im/common/signals/events.cljs
+++ b/src/status_im/common/signals/events.cljs
@@ -35,7 +35,8 @@
   (let [^js data     (.parse js/JSON event-str)
         ^js event-js (.-event data)
         type         (.-type data)]
-    (log/debug "Signal received" event-str)
+    (log/debug "Signal received" {:type type})
+    (log/trace "Signal received" {:payload event-str})
     (case type
       "node.login"                 {:fx [[:dispatch
                                           [:profile.login/login-node-signal

--- a/src/status_im/contexts/wallet/signals.cljs
+++ b/src/status_im/contexts/wallet/signals.cljs
@@ -18,7 +18,7 @@
    (let [event-type  (oops/oget event-js "type")
          blockNumber (oops/oget event-js "blockNumber")
          accounts    (oops/oget event-js "accounts")]
-     (log/debug "[wallet-subs] New wallet event"
+     (log/debug "[wallet] Wallet signal received"
                 {:type         event-type
                  :block-number blockNumber
                  :accounts     accounts})


### PR DESCRIPTION
### Summary

While investigating why login is slow https://github.com/status-im/status-mobile/issues/20059 and when testing with accounts with communities, I noticed we are logging huge payloads because they include data URLs. This makes debugging the app harder.

Therefore, in this PR, we log the full event payload only at the `trace` level, and at the `debug` level we only log the event `type`.

This problem was first described by @ulisesmac.

#### Areas that may be impacted

None.

### Steps to test

There's no need to QA this PR, just e2e tests are sufficient.

status: ready
