### PR TITLE
fix: non supported network warning is shown on the bridge flow

### DIFF
--- a/src/quo/components/list_items/network_list/style.cljs
+++ b/src/quo/components/list_items/network_list/style.cljs
@@ -17,6 +17,7 @@
    :padding-vertical   8
    :border-radius      12
    :height             56
+   :opacity            (if (= state :disabled) 0.3 1)
    :background-color   (background-color state customization-color theme)})
 
 (def info

--- a/src/quo/components/list_items/network_list/view.cljs
+++ b/src/quo/components/list_items/network_list/view.cljs
@@ -45,7 +45,7 @@
       [:fiat-value :string]
       [:token-value :string]
       [:customization-color {:optional true} [:maybe :schema.common/customization-color]]
-      [:state {:optional true} [:enum :pressed :active :default]]
+      [:state {:optional true} [:enum :pressed :active :disabled :default]]
       [:on-press {:optional true} [:maybe fn?]]]]]
    :any])
 
@@ -60,9 +60,9 @@
         internal-state         (if pressed? :pressed state)]
     [rn/pressable
      {:style               (style/container internal-state customization-color theme)
-      :on-press-in         on-press-in
-      :on-press-out        on-press-out
-      :on-press            on-press
+      :on-press-in         (when-not (= state :disabled) on-press-in)
+      :on-press-out        (when-not (= state :disabled) on-press-out)
+      :on-press            (when-not (= state :disabled) on-press)
       :accessibility-label :network-list}
      [info props]
      [values props]]))

--- a/src/status_im/contexts/wallet/common/utils/networks.cljs
+++ b/src/status_im/contexts/wallet/common/utils/networks.cljs
@@ -125,3 +125,9 @@
                             (string/join ", "))
         formatted-text (string/replace network-names last-comma-followed-by-text-to-end-regex " and ")]
     formatted-text))
+
+(defn token-available-on-network?
+  [token-networks chain-id]
+  (let [token-networks-ids     (mapv #(:chain-id %) token-networks)
+        token-networks-ids-set (set token-networks-ids)]
+    (contains? token-networks-ids-set chain-id)))

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -95,7 +95,8 @@
                                                      :related-chain-id 1
                                                      :layer            1}]
    :wallet/wallet-send-enabled-from-chain-ids      [1]
-   :wallet/wallet-send-amount                      nil})
+   :wallet/wallet-send-amount                      nil
+   :wallet/wallet-send-tx-type                     :tx/send})
 
 (h/describe "Send > input amount screen"
   (h/setup-restorable-re-frame)

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -251,9 +251,11 @@
                                                      [:wallet/wallet-send-sender-network-values])
         receiver-network-values                     (rf/sub
                                                      [:wallet/wallet-send-receiver-network-values])
-        token-not-supported-in-receiver-networks?   (every? #(= (:type %) :not-available)
-                                                            (filter #(not= (:type %) :add)
-                                                                    receiver-network-values))
+        tx-type                                     (rf/sub [:wallet/wallet-send-tx-type])
+        token-not-supported-in-receiver-networks?   (and (not= tx-type :tx/bridge)
+                                                         (->> receiver-network-values
+                                                              (remove #(= (:type %) :add))
+                                                              (every? #(= (:type %) :not-available))))
         suggested-routes                            (rf/sub [:wallet/wallet-send-suggested-routes])
         routes                                      (when suggested-routes
                                                       (or (:best suggested-routes) []))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -161,6 +161,11 @@
  :-> :network-links)
 
 (rf/reg-sub
+ :wallet/wallet-send-tx-type
+ :<- [:wallet/wallet-send]
+ :-> :tx-type)
+
+(rf/reg-sub
  :wallet/keypairs
  :<- [:wallet]
  :-> :keypairs)


### PR DESCRIPTION
fixes #20080 

### Summary

This PR fixes warning about non supported networks being shown in the bridge flow, and disables unavailable networks for token in the `Bridge token to` screen.

<img width="350" src="https://github.com/status-im/status-mobile/assets/18485527/0f59df49-d88b-4523-ad88-7a64882d4213">

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Recover user with available assets on at least 2 networks.
- Go to bridge flow.
- Select any network to bridge.
- Enter an assets amount equal to the total assets on both networks.
- Disable some built networks in FROM section if step 4 didn't help.
- Verify non supported network warning wasn't shown
- Verify unsupported token network are disabled in the Bridge to... screen

status: ready