### PR TITLE
fix: overlapping send details

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -15,7 +15,6 @@
     [status-im.contexts.wallet.send.routes.view :as routes]
     [status-im.contexts.wallet.send.utils :as send-utils]
     [status-im.contexts.wallet.sheets.unpreferred-networks-alert.view :as unpreferred-networks-alert]
-    [utils.address :as address]
     [utils.debounce :as debounce]
     [utils.i18n :as i18n]
     [utils.money :as money]
@@ -35,7 +34,7 @@
   (str currency-symbol amount))
 
 (defn- estimated-fees
-  [{:keys [loading-routes? fees amount receiver]}]
+  [{:keys [loading-routes? fees amount]}]
   [rn/view {:style style/estimated-fees-container}
    [rn/view {:style style/estimated-fees-content-container}
     [quo/button
@@ -162,7 +161,6 @@
             loading-routes? (rf/sub
                              [:wallet/wallet-send-loading-suggested-routes?])
             route (rf/sub [:wallet/wallet-send-route])
-            to-address (rf/sub [:wallet/wallet-send-to-address])
             on-confirm (or default-on-confirm handle-on-confirm)
             crypto-decimals (or token-decimals default-crypto-decimals)
             current-crypto-limit (or default-limit-crypto
@@ -332,8 +330,7 @@
            [estimated-fees
             {:loading-routes? loading-routes?
              :fees            fee-formatted
-             :amount          amount-text
-             :receiver        (address/get-shortened-key to-address)}])
+             :amount          amount-text}])
          (when (or no-routes-found? limit-insufficient?)
            [rn/view {:style style/no-routes-found-container}
             [quo/info-message

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -59,7 +59,7 @@
      :label           :none
      :status          (if loading-routes? :loading :default)
      :size            :small
-     :title           (i18n/label :t/recipient-gets)
+     :title           (i18n/label :t/user-gets {:name receiver})
      :subtitle        amount}]])
 
 (defn- every-network-value-is-zero?

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -59,7 +59,7 @@
      :label           :none
      :status          (if loading-routes? :loading :default)
      :size            :small
-     :title           (i18n/label :t/user-gets {:name receiver})
+     :title           (i18n/label :t/recipient-gets)
      :subtitle        amount}]])
 
 (defn- every-network-value-is-zero?

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -165,7 +165,7 @@
     :subtitle        subtitle}])
 
 (defn- transaction-details
-  [{:keys [estimated-time-min max-fees token-display-name amount to-address to-network route
+  [{:keys [estimated-time-min max-fees token-display-name amount to-network route
            transaction-type
            theme]}]
   (let [currency-symbol           (rf/sub [:profile/currency-symbol])
@@ -297,7 +297,6 @@
              :max-fees           max-fees
              :token-display-name token-display-name
              :amount             amount
-             :to-address         to-address
              :to-network         bridge-to-network
              :theme              theme
              :route              route

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -201,7 +201,7 @@
           {:title    (if (= transaction-type :tx/bridge)
                        (i18n/label :t/bridged-to
                                    {:network (:abbreviated-name to-network)})
-                       (i18n/label :t/user-gets {:name (utils/get-shortened-address to-address)}))
+                       (i18n/label :t/recipient-gets))
            :subtitle (str amount " " token-display-name)}]]
         :else
         [quo/text {:style {:align-self :center}}

--- a/translations/en.json
+++ b/translations/en.json
@@ -2516,7 +2516,7 @@
     "this-address-has-no-activity": "This address has no activity",
     "details": "Details",
     "est-time": "Est. time",
-    "user-gets": "{{name}} gets",
+    "recipient-gets": "Recipient gets",
     "slide-to-send": "Slide to send",
     "generate-new-keypair": "Generate new key pair",
     "import-using-phrase": "Import using recovery phrase",

--- a/translations/en.json
+++ b/translations/en.json
@@ -2516,6 +2516,7 @@
     "this-address-has-no-activity": "This address has no activity",
     "details": "Details",
     "est-time": "Est. time",
+    "user-gets": "{{name}} gets",
     "recipient-gets": "Recipient gets",
     "slide-to-send": "Slide to send",
     "generate-new-keypair": "Generate new key pair",

--- a/translations/en.json
+++ b/translations/en.json
@@ -2516,7 +2516,6 @@
     "this-address-has-no-activity": "This address has no activity",
     "details": "Details",
     "est-time": "Est. time",
-    "user-gets": "{{name}} gets",
     "recipient-gets": "Recipient gets",
     "slide-to-send": "Slide to send",
     "generate-new-keypair": "Generate new key pair",


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/20039

### Summary

This PR fixes the overlapping details on the transaction confirmation screen

Skipping QA as it is a minor ui detail.

### Demo

https://github.com/status-im/status-mobile/assets/29354102/a620f5fd-1431-4417-ba48-f20674e6a4e6

