### PR TITLE
Page nav component alignment fix

### DIFF
--- a/src/quo/components/navigation/page_nav/view.cljs
+++ b/src/quo/components/navigation/page_nav/view.cljs
@@ -261,7 +261,10 @@
                                           {:opacity center-opacity}
                                           nil)
                                         (style/center-content-container
-                                         (and (= type :title) (= text-align :center))))
+                                         (case type
+                                           :title                       (= text-align :center)
+                                           (:dropdown :wallet-networks) true
+                                           false)))
         props-with-style               (assoc props
                                               :center-content-container-style
                                               center-content-container-style)]


### PR DESCRIPTION
This PR addresses a regression introduced in one of my previous PRs: #19651  

Regression | Fix
-|-
<img src="https://github.com/status-im/status-mobile/assets/19279756/444a6da8-740b-49f0-bc54-bd53fe0bbd76" width=340/> | <img src="https://github.com/status-im/status-mobile/assets/19279756/2c661b21-65f6-44c8-81f2-a1fbe5efdb95" width=340/>

<img src="https://github.com/status-im/status-mobile/assets/19279756/0f833247-cbec-4e14-9875-64e788f2b662" width=340/> | <img src="https://github.com/status-im/status-mobile/assets/19279756/d6664d7e-52d8-4662-9e2c-457f48b2005d" width=340/>

When the type of the page-nav component is `dropdown` or `wallet-networks` the center content should be centered.

status: ready <!-- Can be ready or wip -->
