### PR TITLE
fix(wallets): no routes render on input amount

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -274,7 +274,9 @@
            (set-input-state #(controlled-input/set-upper-limit % current-limit)))
          [current-limit])
         (rn/use-effect
-         #(when input-error (debounce/clear-all))
+         (fn []
+           (when input-error (debounce/clear-all))
+           (when (and limit-insufficient? routes) (rf/dispatch [:wallet/reset-network-amounts-to-zero])))
          [input-error])
         [rn/view
          {:style               style/screen
@@ -326,12 +328,12 @@
                     sender-network-values
                     token-not-supported-in-receiver-networks?)
            [token-not-available token-symbol receiver-networks token-networks])
-         (when (or loading-routes? (seq route))
+         (when (or loading-routes? fee-formatted)
            [estimated-fees
             {:loading-routes? loading-routes?
              :fees            fee-formatted
              :amount          amount-text}])
-         (when (or no-routes-found? limit-insufficient?)
+         (when (and (or no-routes-found? limit-insufficient?) (not-empty sender-network-values))
            [rn/view {:style style/no-routes-found-container}
             [quo/info-message
              {:type  :error

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -116,6 +116,17 @@
     {:content (fn []
                 [unpreferred-networks-alert/view
                  {:on-confirm on-confirm}])}]))
+
+(defn- no-routes-found
+  []
+  [rn/view {:style style/no-routes-found-container}
+   [quo/info-message
+    {:type  :error
+     :icon  :i/alert
+     :size  :default
+     :style {:margin-top 15}}
+    (i18n/label :t/no-routes-found)]])
+
 (defn view
   ;; crypto-decimals, limit-crypto and initial-crypto-currency? args are needed
   ;; for component tests only
@@ -334,13 +345,7 @@
              :fees            fee-formatted
              :amount          amount-text}])
          (when (and (or no-routes-found? limit-insufficient?) (not-empty sender-network-values))
-           [rn/view {:style style/no-routes-found-container}
-            [quo/info-message
-             {:type  :error
-              :icon  :i/alert
-              :size  :default
-              :style {:margin-top 15}}
-             (i18n/label :t/no-routes-found)]])
+           [no-routes-found])
          [quo/bottom-actions
           {:actions          :one-action
            :button-one-label (if should-try-again?

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -347,7 +347,8 @@
                                (i18n/label :t/try-again)
                                button-one-label)
            :button-one-props (merge (when-not should-try-again? button-one-props)
-                                    {:disabled? (and (not should-try-again?) confirm-disabled?)
+                                    {:disabled? (or loading-routes?
+                                                    (and (not should-try-again?) confirm-disabled?))
                                      :on-press  (cond
                                                   should-try-again?
                                                   #(let [input-amount (controlled-input/input-value

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -83,7 +83,7 @@
 (def ^:private available-networks-count
   (count (set (keys network-priority-score))))
 
-(defn reset-network-amounts-to-zero
+(defn reset-loading-network-amounts-to-zero
   [network-amounts]
   (map
    (fn [network-amount]
@@ -91,6 +91,20 @@
        (= (:type network-amount) :loading)
        (assoc :total-amount (money/bignumber "0")
               :type         :default)))
+   network-amounts))
+
+(defn reset-network-amounts-to-zero
+  [{:keys [network-amounts disabled-chain-ids]}]
+  (map
+   (fn [network-amount]
+     (let [disabled-chain-ids-set (set disabled-chain-ids)
+           disabled?              (contains? disabled-chain-ids-set
+                                             (:chain-id network-amount))]
+       (cond-> network-amount
+         (and (not= (:type network-amount) :add)
+              (not= (:type network-amount) :not-available))
+         (assoc :total-amount (money/bignumber "0")
+                :type         (if disabled? :disabled :default)))))
    network-amounts))
 
 (defn network-amounts

--- a/src/status_im/contexts/wallet/send/utils_test.cljs
+++ b/src/status_im/contexts/wallet/send/utils_test.cljs
@@ -209,13 +209,13 @@
                                                                    :disabled-chain-ids
                                                                    disabled-chain-ids}))))))
 
-(deftest test-reset-network-amounts-to-zero
+(deftest test-reset-loading-network-amounts-to-zero
   (testing "Correctly resets loading network amounts to zero and changes type to default"
     (let [network-amounts [{:chain-id 1 :total-amount (money/bignumber "100") :type :loading}
                            {:chain-id 10 :total-amount (money/bignumber "200") :type :default}]
           expected        [{:chain-id 1 :total-amount (money/bignumber "0") :type :default}
                            {:chain-id 10 :total-amount (money/bignumber "200") :type :default}]
-          result          (utils/reset-network-amounts-to-zero network-amounts)
+          result          (utils/reset-loading-network-amounts-to-zero network-amounts)
           comparisons     (map #(map/deep-compare %1 %2)
                                expected
                                result)]
@@ -226,7 +226,7 @@
                            {:chain-id 10 :total-amount (money/bignumber "0") :type :disabled}]
           expected        [{:chain-id 1 :total-amount (money/bignumber "100") :type :default}
                            {:chain-id 10 :total-amount (money/bignumber "0") :type :disabled}]
-          result          (utils/reset-network-amounts-to-zero network-amounts)
+          result          (utils/reset-loading-network-amounts-to-zero network-amounts)
           comparisons     (map #(map/deep-compare %1 %2)
                                expected
                                result)]
@@ -235,7 +235,7 @@
   (testing "Processes an empty list without error"
     (let [network-amounts []
           expected        []
-          result          (utils/reset-network-amounts-to-zero network-amounts)
+          result          (utils/reset-loading-network-amounts-to-zero network-amounts)
           comparisons     (map #(map/deep-compare %1 %2)
                                expected
                                result)]
@@ -246,7 +246,7 @@
                            {:chain-id 10 :total-amount (money/bignumber "200") :type :loading}]
           expected        [{:chain-id 1 :total-amount (money/bignumber "0") :type :default}
                            {:chain-id 10 :total-amount (money/bignumber "0") :type :default}]
-          result          (utils/reset-network-amounts-to-zero network-amounts)
+          result          (utils/reset-loading-network-amounts-to-zero network-amounts)
           comparisons     (map #(map/deep-compare %1 %2)
                                expected
                                result)]
@@ -261,7 +261,7 @@
                            {:chain-id 10 :total-amount (money/bignumber "200") :type :default}
                            {:chain-id 42161 :total-amount (money/bignumber "0") :type :default}
                            {:chain-id 59144 :total-amount (money/bignumber "0") :type :disabled}]
-          result          (utils/reset-network-amounts-to-zero network-amounts)
+          result          (utils/reset-loading-network-amounts-to-zero network-amounts)
           comparisons     (map #(map/deep-compare %1 %2)
                                expected
                                result)]


### PR DESCRIPTION
fixes #19910 
fixes #20111
fixes #20136

### Summary
Render "No routes Found" only based on the flows in [1](https://www.figma.com/design/xLs1KYmF4e6WwRTZVJKeUK/Descoped-Wallet?node-id=14748-115594&t=lQvwHHeejDvtoUFB-0) and [2](https://www.figma.com/design/xLs1KYmF4e6WwRTZVJKeUK/Descoped-Wallet?node-id=14748-115593&t=cm5o3qlBgSmYQwo3-0)


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Go to wallet tab
- Click on account
- Click on send
- Paste wallet address
- Select token
- Input amount and then disabled networks with balance
   -  "No routes Found" should show immediately
- Input an invalid amount initially, "No routes Found" should not be show, just the error state


![Simulator Screen Recording - iPhone 11 Pro - 2024-05-20 at 14 11 47](https://github.com/status-im/status-mobile/assets/45393944/6c939cc2-2a6a-44aa-b34e-c5331a3477e7)

