### PR TITLE
feat: calculate and show max fees on transaction confirmation page

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -96,7 +96,8 @@
                                                      :layer            1}]
    :wallet/wallet-send-enabled-from-chain-ids      [1]
    :wallet/wallet-send-amount                      nil
-   :wallet/wallet-send-tx-type                     :tx/send})
+   :wallet/wallet-send-tx-type                     :tx/send
+   :wallet/wallet-send-fee-fiat-formatted          "$5,00"})
 
 (h/describe "Send > input amount screen"
   (h/setup-restorable-re-frame)

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -12,7 +12,6 @@
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.send.input-amount.style :as style]
     [status-im.contexts.wallet.send.routes.view :as routes]
-    [status-im.contexts.wallet.send.utils :as send-utils]
     [status-im.contexts.wallet.sheets.unpreferred-networks-alert.view :as unpreferred-networks-alert]
     [utils.debounce :as debounce]
     [utils.i18n :as i18n]
@@ -227,22 +226,8 @@
         native-token                                (when native-currency-symbol
                                                       (rf/sub [:wallet/token-by-symbol
                                                                native-currency-symbol]))
-        fee-in-native-token                         (when-not confirm-disabled?
-                                                      (send-utils/calculate-full-route-gas-fee route))
-        fee-in-crypto-formatted                     (when fee-in-native-token
-                                                      (utils/get-standard-crypto-format
-                                                       native-token
-                                                       fee-in-native-token))
-        fee-in-fiat                                 (when-not confirm-disabled?
-                                                      (utils/calculate-token-fiat-value
-                                                       {:currency fiat-currency
-                                                        :balance  fee-in-native-token
-                                                        :token    native-token}))
-        fee-formatted                               (when fee-in-fiat
-                                                      (utils/get-standard-fiat-format
-                                                       fee-in-crypto-formatted
-                                                       currency-symbol
-                                                       fee-in-fiat))
+        fee-formatted                               (rf/sub [:wallet/wallet-send-fee-fiat-formatted
+                                                             native-token])
         show-select-asset-sheet                     #(rf/dispatch
                                                       [:show-bottom-sheet
                                                        {:content (fn []
@@ -349,7 +334,7 @@
                 sender-network-values
                 token-not-supported-in-receiver-networks?)
        [token-not-available token-symbol receiver-networks token-networks])
-     (when (or loading-routes? fee-formatted)
+     (when (or loading-routes? route)
        [estimated-fees
         {:loading-routes? loading-routes?
          :fees            fee-formatted

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/style.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/style.cljs
@@ -2,8 +2,9 @@
   (:require [quo.foundations.colors :as colors]))
 
 (def detail-item
-  {:flex   1
-   :height 36})
+  {:flex             1
+   :height           36
+   :background-color :transparent})
 
 (def content-container
   {:padding-top        12
@@ -14,22 +15,14 @@
   {:margin-right 4})
 
 (defn details-container
-  [{:keys [loading-suggested-routes? route-loaded? theme]}]
-  {:flex-direction     :row
-   :justify-content    (if route-loaded? :space-between :center)
-   :height             (when (or loading-suggested-routes? route-loaded?) 52)
-   :padding-horizontal 12
-   :padding-top        7
-   :padding-bottom     8
-   :border-radius      16
-   :border-width       1
-   :border-color       (if (or loading-suggested-routes? route-loaded?)
-                         (colors/theme-colors colors/neutral-10 colors/neutral-90 theme)
-                         :transparent)})
-
-(def details-title-container
-  {:padding-horizontal 20
-   :padding-bottom     16})
+  [{:keys [loading-suggested-routes? route-loaded?]}]
+  {:flex-direction    :row
+   :width             "100%"
+   :justify-content   (if route-loaded? :space-between :center)
+   :height            (when (or loading-suggested-routes? route-loaded?) 52)
+   :margin-horizontal 5
+   :padding-top       7
+   :margin-bottom     8})
 
 (defn section-label
   [theme]

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -4,6 +4,7 @@
             [status-im.constants :as constants]
             [status-im.contexts.wallet.common.utils :as utils]
             [status-im.contexts.wallet.common.utils.networks :as network-utils]
+            [status-im.contexts.wallet.send.utils :as send-utils]
             [status-im.subs.wallet.add-account.address-to-watch]
             [utils.number]
             [utils.security.core :as security]))
@@ -574,3 +575,23 @@
  :<- [:wallet/wallet-send-enabled-networks]
  (fn [send-enabled-networks]
    (map :chain-id send-enabled-networks)))
+
+(rf/reg-sub
+ :wallet/wallet-send-fee-fiat-formatted
+ :<- [:wallet/wallet-send-route]
+ :<- [:profile/currency]
+ :<- [:profile/currency-symbol]
+ (fn [[route currency currency-symbol] [_ token-for-fees]]
+   (let [fee-in-native-token     (send-utils/calculate-full-route-gas-fee route)
+         fee-in-crypto-formatted (utils/get-standard-crypto-format
+                                  token-for-fees
+                                  fee-in-native-token)
+         fee-in-fiat             (utils/calculate-token-fiat-value
+                                  {:currency currency
+                                   :balance  fee-in-native-token
+                                   :token    token-for-fees})
+         fee-formatted           (utils/get-standard-fiat-format
+                                  fee-in-crypto-formatted
+                                  currency-symbol
+                                  fee-in-fiat)]
+     fee-formatted)))


### PR DESCRIPTION
fixes #18408 

### Summary

This PR adds fee information on transaction confirmation page. Also it updates the UI to comply with latest designs of this screen, which shows the fees, estimated time and amount at the bottom of the screen, above the slider.

<img width="350" src="https://github.com/status-im/status-mobile/assets/18485527/41d06364-ae8b-4db2-902a-b8e6d6af49e4">

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in with an account with some funds
- Go to wallet
- Select account
- Tap on Send button
- Select an address to send to
- Select a token
- Enter a valid amount
- Wait for routes to be loaded
- Go to transaction confirmation page
- Verify fees are shown properly

status: ready