### PR TITLE
fix: balances in network preferences after removing account

### DIFF
--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -28,6 +28,7 @@
       (let [{:keys [name color formatted-balance
                     watch-only?]} (rf/sub [:wallet/current-viewing-account])
             customization-color   (rf/sub [:profile/customization-color])]
+        (rn/use-unmount #(rf/dispatch [:wallet/close-account-page]))
         [rn/view {:style {:flex 1}}
          [account-switcher/view
           {:type     :wallet-networks

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -100,19 +100,19 @@
    {:fx [[:dispatch [:toasts/upsert {:type :positive :text toast-message}]]]}))
 
 (defn remove-account-success
-   [{:keys [db]} [toast-message _]]
-   {:db (assoc-in db [:wallet :current-viewing-account-address] nil)
-    :fx [[:dispatch [:wallet/get-accounts]]
-         [:dispatch [:wallet/get-keypairs]]
-         [:dispatch-later
-          {:ms       100
-           :dispatch [:hide-bottom-sheet]}]
-         [:dispatch-later
-          {:ms       100
-           :dispatch [:pop-to-root :shell-stack]}]
-         [:dispatch-later
-          {:ms       100
-           :dispatch [:wallet/show-account-deleted-toast toast-message]}]]})
+  [{:keys [db]} [toast-message _]]
+  {:db (assoc-in db [:wallet :current-viewing-account-address] nil)
+   :fx [[:dispatch [:wallet/get-accounts]]
+        [:dispatch [:wallet/get-keypairs]]
+        [:dispatch-later
+         {:ms       100
+          :dispatch [:hide-bottom-sheet]}]
+        [:dispatch-later
+         {:ms       100
+          :dispatch [:pop-to-root :shell-stack]}]
+        [:dispatch-later
+         {:ms       100
+          :dispatch [:wallet/show-account-deleted-toast toast-message]}]]})
 
 (rf/reg-event-fx :wallet/remove-account-success remove-account-success)
 

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -99,20 +99,21 @@
  (fn [_ [toast-message]]
    {:fx [[:dispatch [:toasts/upsert {:type :positive :text toast-message}]]]}))
 
-(defn remove-account-success
-  [_ [toast-message _]]
-  {:fx [[:dispatch [:wallet/clean-current-viewing-account]]
-        [:dispatch [:wallet/get-accounts]]
-        [:dispatch [:wallet/get-keypairs]]
-        [:dispatch-later
-         {:ms       100
-          :dispatch [:hide-bottom-sheet]}]
-        [:dispatch-later
-         {:ms       100
-          :dispatch [:pop-to-root :shell-stack]}]
-        [:dispatch-later
-         {:ms       100
-          :dispatch [:wallet/show-account-deleted-toast toast-message]}]]})
+(rf/reg-event-fx
+ :remove-account-success
+ (fn [_ [toast-message _]]
+   {:fx [[:dispatch [:wallet/clean-current-viewing-account]]
+         [:dispatch [:wallet/get-accounts]]
+         [:dispatch [:wallet/get-keypairs]]
+         [:dispatch-later
+          {:ms       100
+           :dispatch [:hide-bottom-sheet]}]
+         [:dispatch-later
+          {:ms       100
+           :dispatch [:pop-to-root :shell-stack]}]
+         [:dispatch-later
+          {:ms       100
+           :dispatch [:wallet/show-account-deleted-toast toast-message]}]]}))
 
 (rf/reg-event-fx
  :wallet/remove-account

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -99,9 +99,8 @@
  (fn [_ [toast-message]]
    {:fx [[:dispatch [:toasts/upsert {:type :positive :text toast-message}]]]}))
 
-(rf/reg-event-fx
- :wallet/remove-account-success
- (fn [{:keys [db]} [toast-message _]]
+(defn remove-account-success
+   [{:keys [db]} [toast-message _]]
    {:db (assoc-in db [:wallet :current-viewing-account-address] nil)
     :fx [[:dispatch [:wallet/get-accounts]]
          [:dispatch [:wallet/get-keypairs]]
@@ -113,7 +112,9 @@
            :dispatch [:pop-to-root :shell-stack]}]
          [:dispatch-later
           {:ms       100
-           :dispatch [:wallet/show-account-deleted-toast toast-message]}]]}))
+           :dispatch [:wallet/show-account-deleted-toast toast-message]}]]})
+
+(rf/reg-event-fx :wallet/remove-account-success remove-account-success)
 
 (rf/reg-event-fx
  :wallet/remove-account

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -101,8 +101,9 @@
 
 (rf/reg-event-fx
  :wallet/remove-account-success
- (fn [_ [toast-message _]]
-   {:fx [[:dispatch [:wallet/get-accounts]]
+ (fn [{:keys [db]} [toast-message _]]
+   {:db (assoc-in db [:wallet :current-viewing-account-address] nil)
+    :fx [[:dispatch [:wallet/get-accounts]]
          [:dispatch [:wallet/get-keypairs]]
          [:dispatch-later
           {:ms       100

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -100,9 +100,9 @@
    {:fx [[:dispatch [:toasts/upsert {:type :positive :text toast-message}]]]}))
 
 (defn remove-account-success
-  [{:keys [db]} [toast-message _]]
-  {:db (assoc-in db [:wallet :current-viewing-account-address] nil)
-   :fx [[:dispatch [:wallet/get-accounts]]
+  [_ [toast-message _]]
+  {:fx [[:dispatch [:wallet/clean-current-viewing-account]]
+        [:dispatch [:wallet/get-accounts]]
         [:dispatch [:wallet/get-keypairs]]
         [:dispatch-later
          {:ms       100
@@ -113,8 +113,6 @@
         [:dispatch-later
          {:ms       100
           :dispatch [:wallet/show-account-deleted-toast toast-message]}]]})
-
-(rf/reg-event-fx :wallet/remove-account-success remove-account-success)
 
 (rf/reg-event-fx
  :wallet/remove-account

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -100,7 +100,7 @@
    {:fx [[:dispatch [:toasts/upsert {:type :positive :text toast-message}]]]}))
 
 (rf/reg-event-fx
- :remove-account-success
+ :wallet/remove-account-success
  (fn [_ [toast-message _]]
    {:fx [[:dispatch [:wallet/clean-current-viewing-account]]
          [:dispatch [:wallet/get-accounts]]

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -124,6 +124,6 @@
   (testing "remove-account-success"
     (let [db          {:wallet {:current-viewing-account-address "0x123"}}
           expected-db {:wallet {}}
-          effects     (events/remove-account-success {:db db} ["toast message"])
+          effects     (events/remove-account-success {:db db} nil)
           result-db   (:db effects)]
       (is (match? result-db expected-db)))))

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -119,11 +119,3 @@
           effects     (events/update-selected-networks {:db db} props)
           result-fx   (:fx effects)]
       (is (match? result-fx expected-fx)))))
-
-(deftest remove-account-success
-  (testing "remove-account-success"
-    (let [db          {:wallet {:current-viewing-account-address "0x123"}}
-          expected-db {:wallet {}}
-          effects     (events/remove-account-success {:db db} nil)
-          result-db   (:db effects)]
-      (is (match? result-db expected-db)))))

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -119,3 +119,11 @@
           effects     (events/update-selected-networks {:db db} props)
           result-fx   (:fx effects)]
       (is (match? result-fx expected-fx)))))
+
+(deftest remove-account-success
+  (testing "remove-account-success"
+    (let [db          {:wallet {:current-viewing-account-address "0x123"}}
+          expected-db {:wallet {}}
+          effects     (events/remove-account-success {:db db} ["toast message"])
+          result-db   (:db effects)]
+      (is (match? result-db expected-db)))))


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19542

### Summary
This PR fixes balances not showing in network preferences after removing an account. 

Also fixes `wallet/close-account-page` not being called if back button was pressed (or swipe gesture) instead of pressing on the X button

**On a side note**: I think we need to check for X button on-press if it is called on unmount in the entire wallet/app

### Demo

https://github.com/status-im/status-mobile/assets/29354102/889f9ff9-a32c-4c17-aa35-d3f9c8c94111

