### PR TITLE
Reuse controlled input logic in collectibles sending page

### DIFF
--- a/src/status_im/common/controlled_input/utils.cljs
+++ b/src/status_im/common/controlled_input/utils.cljs
@@ -1,11 +1,13 @@
 (ns status-im.common.controlled-input.utils
   (:require
-    [clojure.string :as string]))
+    [clojure.string :as string]
+    [status-im.contexts.chat.messenger.messages.list.state :as state]))
 
 (def init-state
   {:value       ""
    :error?      false
-   :upper-limit nil})
+   :upper-limit nil
+   :lower-limit nil})
 
 (defn input-value
   [state]
@@ -23,9 +25,13 @@
   [state error?]
   (assoc state :error? error?))
 
-(defn- upper-limit
+(defn upper-limit
   [state]
   (:upper-limit state))
+
+(defn lower-limit
+  [state]
+  (:lower-limit state))
 
 (defn upper-limit-exceeded?
   [state]
@@ -33,9 +39,16 @@
    (upper-limit state)
    (> (numeric-value state) (upper-limit state))))
 
+(defn lower-limit-exceeded?
+  [state]
+  (and
+   (lower-limit state)
+   (< (numeric-value state) (lower-limit state))))
+
 (defn- recheck-errorness
   [state]
-  (set-input-error state (upper-limit-exceeded? state)))
+  (set-input-error state (or (upper-limit-exceeded? state)
+                             (lower-limit-exceeded? state))))
 
 (defn set-input-value
   [state value]
@@ -43,11 +56,32 @@
       (assoc :value value)
       recheck-errorness))
 
+(defn set-numeric-value
+  [state value]
+  (set-input-value state (str value)))
+
 (defn set-upper-limit
   [state limit]
+  (when limit
+    (-> state
+        (assoc :upper-limit limit)
+        recheck-errorness)))
+
+(defn set-lower-limit
+  [state limit]
   (-> state
-      (assoc :upper-limit limit)
+      (assoc :lower-limit limit)
       recheck-errorness))
+
+(defn increase
+  [state]
+  (let [new-val (inc (numeric-value state))]
+    (set-input-value state (str new-val))))
+
+(defn decrease
+  [state]
+  (let [new-val (dec (numeric-value state))]
+    (set-input-value state (str new-val))))
 
 (def ^:private not-digits-or-dot-pattern
   #"[^0-9+\.]")

--- a/src/status_im/common/controlled_input/utils.cljs
+++ b/src/status_im/common/controlled_input/utils.cljs
@@ -1,7 +1,6 @@
 (ns status-im.common.controlled-input.utils
   (:require
-    [clojure.string :as string]
-    [status-im.contexts.chat.messenger.messages.list.state :as state]))
+    [clojure.string :as string]))
 
 (def init-state
   {:value       ""
@@ -47,8 +46,9 @@
 
 (defn- recheck-errorness
   [state]
-  (set-input-error state (or (upper-limit-exceeded? state)
-                             (lower-limit-exceeded? state))))
+  (set-input-error state
+                   (or (upper-limit-exceeded? state)
+                       (lower-limit-exceeded? state))))
 
 (defn set-input-value
   [state value]

--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -17,7 +17,8 @@
     "image/gif"
     "image/bmp"
     "image/png"
-    "image/webp"})
+    "image/webp"
+    "image/avif"})
 
 (defn supported-file?
   [collectible-type]

--- a/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
@@ -1,13 +1,13 @@
 (ns status-im.contexts.wallet.send.select-collectible-amount.view
   (:require
-   [quo.core :as quo]
-   [react-native.core :as rn]
+    [quo.core :as quo]
+    [react-native.core :as rn]
     [status-im.common.controlled-input.utils :as controlled-input]
-   [status-im.contexts.wallet.collectible.utils :as utils]
-   [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
-   [status-im.contexts.wallet.send.select-collectible-amount.style :as style]
-   [utils.i18n :as i18n]
-   [utils.re-frame :as rf]))
+    [status-im.contexts.wallet.collectible.utils :as utils]
+    [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
+    [status-im.contexts.wallet.send.select-collectible-amount.style :as style]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (defn view
   []


### PR DESCRIPTION
### Summary

Few weeks ago send asset page was refactored and logic for controlling input was moved to a separate file. This PR reuses that logic also from collectibles sending page.
Also one more supported collectible type added - `image/avif`



https://github.com/status-im/status-mobile/assets/5786310/bb8707af-4e3a-47dc-93b2-a90fd4b998b7



#### Areas that maybe impacted
Sending multiple collectibles

### Steps to test

- Open Status
- Select collectible that has few instances
- Make sure that only correct amount of collectible items can be selected for sending

### Before and after screenshots comparison

status: ready
