### PR TITLE
chore_:Add keyUID to table when migrating from v1 to v2

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.26",
-    "commit-sha1": "0a88ebdeae2804540f50ceff9420786921ab1125",
-    "src-sha256": "0zmkrh85z1713fhdlgziqqkn0yq7vd64hl4fn7gzcxwnjx0b4m7l"
+    "version": "v0.179.27",
+    "commit-sha1": "9e5386955c4ae271ae8794a561fd953c0407f8e7",
+    "src-sha256": "13aw37bj3xsl0glqlk7ir9kxrdkw0qn5c0fly8qac73z81y6xj0g"
 }


### PR DESCRIPTION
closes #20046

relate status-go [PR1](https://github.com/status-im/status-go/pull/5203)  [PR2](https://github.com/status-im/status-go/pull/5208)

### Summary
This PR's major goal is to ensure old mobile user can login normally after upgrading from v1 to v2

### Testing notes
- you can use this [PR](https://github.com/status-im/status-mobile/pull/20123) build to create old mobile account.
then install current PR build to upgrade. after upgrading, check if old mobile user can login normally.
- install latest `develop` build to create an account, then install current PR build to override. after that, check if the created account can still login normally.
- after upgrading from V1 to V2, pls check if we can send/receive transaction for the wallet accounts. ideally, we should check each type of wallet account(imported from `seed phrase`/`private key`), `default` and `generated` wallet account as well

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: wip <!-- Can be ready or wip -->
