### PR TITLE
fix: show network card with zero value on the sender side if the router does not return a route for that network

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -161,7 +161,8 @@
         enabled-from-chain-ids                      (rf/sub
                                                      [:wallet/wallet-send-enabled-from-chain-ids])
         {token-balance     :total-balance
-         available-balance :available-balance}      (rf/sub [:wallet/token-by-symbol
+         available-balance :available-balance
+         :as               token-by-symbol}         (rf/sub [:wallet/token-by-symbol
                                                              (str token-symbol)
                                                              enabled-from-chain-ids])
         currency-symbol                             (rf/sub [:profile/currency-symbol])
@@ -337,7 +338,7 @@
                                 (number/remove-trailing-zeroes new-value))))))
        :on-token-press  show-select-asset-sheet}]
      [routes/view
-      {:token                                     token
+      {:token                                     token-by-symbol
        :input-value                               input-amount
        :value                                     amount
        :valid-input?                              valid-input?
@@ -373,7 +374,8 @@
                                                                                  conversion-rate)
                                                                               2))]
                                                  (rf/dispatch [:wallet/get-suggested-routes
-                                                               {:amount amount}]))
+                                                               {:amount        amount
+                                                                :updated-token token-by-symbol}]))
                                               sending-to-unpreferred-networks?
                                               #(show-unpreferred-networks-alert on-confirm)
                                               :else

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -17,10 +17,12 @@
 (def network-link-2x-height 111)
 
 (defn- fetch-routes
-  [{:keys [amount bounce-duration-ms valid-input?]}]
+  [{:keys [amount bounce-duration-ms token valid-input?]}]
   (if valid-input?
     (debounce/debounce-and-dispatch
-     [:wallet/get-suggested-routes {:amount amount}]
+     [:wallet/get-suggested-routes
+      {:amount        amount
+       :updated-token token}]
      bounce-duration-ms)
     (rf/dispatch [:wallet/clean-suggested-routes])))
 
@@ -203,14 +205,16 @@
          (fetch-routes
           {:amount             value
            :valid-input?       valid-input?
-           :bounce-duration-ms 2000})))
+           :bounce-duration-ms 2000
+           :token              token})))
      [input-value valid-input?])
     (rn/use-effect
      #(when (and active-screen? (> (count token-available-networks-for-suggested-routes) 0))
         (fetch-routes
          {:amount             value
           :valid-input?       valid-input?
-          :bounce-duration-ms 0}))
+          :bounce-duration-ms 0
+          :token              token}))
      [disabled-from-chain-ids])
     [rn/scroll-view {:content-container-style style/routes-container}
      (when show-routes?


### PR DESCRIPTION
fixes #20143

### Summary

This PR implements showing network cards with 0 value on the sender side if the account has balance for that token that network when the router does not return a route for that network.

#### Some examples:

##### User has ETH on Mainnet, Optimism and Arbitrum

https://github.com/status-im/status-mobile/assets/18485527/f7a7d734-757d-41b2-81d4-9242ec51b136

##### User has SNT only on Mainnet

https://github.com/status-im/status-mobile/assets/18485527/a25884c4-09d9-4f7f-b524-d7db3f2937ee


#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in
- Go to wallet
- Select an account
- Tap on Send button
- Select an address
- Select a token that has balance in many networks
- Enter a valid amount
- If router does not return a route for that network, network should still be shown on the sender side with 0 value

status: ready