### PR TITLE
upgrade go to 1.21

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -59,10 +59,10 @@ in {
   xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
     versions = ["15.1" "15.2" "15.3"];
   };
-  go = super.go_1_20;
+  go = super.go_1_21;
   clang = super.clang_15;
-  buildGoPackage = super.buildGo120Package;
-  buildGoModule = super.buildGo120Module;
+  buildGoPackage = super.buildGo121Package;
+  buildGoModule = super.buildGo121Module;
   gomobile = (super.gomobile.overrideAttrs (old: {
     patches = [
       (self.fetchurl { # https://github.com/golang/mobile/pull/84

--- a/nix/status-go/library/default.nix
+++ b/nix/status-go/library/default.nix
@@ -15,6 +15,10 @@ buildGoPackage {
   # TODO: try removing when go is upgraded to 1.22
   GODEBUG = "netdns=cgo+2";
 
+  # Since go 1.21 status-go compiled library includes references to cgo runtime.
+  # FIXME: Remove this when go 1.23 or later versions fix this madness.
+  allowGoReference = true;
+
   preBuild = ''
     pushd go/src/$goPackagePath
     go run cmd/library/*.go > $NIX_BUILD_TOP/main.go

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.23",
-    "commit-sha1": "edc65e461157bb0e9ec1a24eca4f53c44d0a717f",
-    "src-sha256": "1xa8hpn9q3ry1f5ysnjl2nc2jvfhc3n9bpdvzpfxx7s4lghm1ksf"
+    "version": "v0.179.24",
+    "commit-sha1": "701b27632438a8328506cba23943bbdeb8b15b0c",
+    "src-sha256": "1jp3r6pb3q3jzjdlx8yl4js63q4av36n0wx9akb0pnarm7mwpfpb"
 }


### PR DESCRIPTION
## Summary

This PR upgrades `golang` version to `1.21` and points to status-go branch where `golang` version has been bumped to `1.21`

Related status-go PR -> https://github.com/status-im/status-go/pull/5216

## Testing notes
Might require thorough testing.

## Platforms
- Android
- iOS

status: ready
