### PR TITLE
Mitigate long time to login on accounts with many community chats

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.22",
-    "commit-sha1": "2b1bcb48c60bb40da1f1e3e9249a53dd57434b82",
-    "src-sha256": "1fn6gwayb5ir1ym196qh774l315hccg6gkvhav3zlkdcvwfqny6i"
+    "version": "ilmotta/partially-fix-slow-login",
+    "commit-sha1": "c2625f6bee0a495047a92baa9b6387f98c9fc29e",
+    "src-sha256": "1h6pzzrhnl08fnrrwdivqb231dyq2q0axv23rq6nqxn5wb9fbzhj"
 }


### PR DESCRIPTION
Mitigates https://github.com/status-im/status-mobile/issues/20059

### Summary

This PR mitigates the long time to login on mobile devices for users with many chats. On Galaxy A71, with a user in the Status community, login goes down from 17s to 10s (still far from great). For a nice explanation, please refer to the status-go PR https://github.com/status-im/status-go/pull/5218 and to https://github.com/status-im/status-mobile/issues/20059#issuecomment-2126928008

#### Platforms

- Android
- iOS

#### Areas that may be impacted

I don't foresee any regression, but login in general can be affected.

### Steps to test

The fix should make the entire login flow take 60% of the usual time with a user account that has a large number of community chats, such as a user in the `Status` community. Other parts of the login code can also cause slowdown (like the number of contacts, other types of chats), but so far it seems that community chats dominate the hot path.

The better solution that can fully eliminate any delays during login will only come as a separate PR in status-go because we are not sure about the consequences of delaying chat setup until *after* login. We might uncover a few surprises. I'll inform the QA team as soon as I cook that PR :) For the time being, this PR seems to be a step forward.

status: ready
