### PR TITLE
fix: white panel when the bottom sheet is launched

### DIFF
--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -199,15 +199,16 @@
   ([component] (show-overlay component {}))
   ([component opts]
    (navigation/dissmiss-overlay component)
-   (navigation/show-overlay
-    {:component {:name    component
-                 :id      component
-                 :options (merge (options/statusbar-and-navbar-options (:theme opts) nil nil)
-                                 {:layout  {:componentBackgroundColor :transparent
-                                            :orientation              ["portrait"]}
-                                  :overlay {:interceptTouchOutside true
-                                            :handleKeyboardEvents  true}}
-                                 opts)}})))
+   (let [theme (rf/sub [:theme])]
+     (navigation/show-overlay
+      {:component {:name    component
+                   :id      component
+                   :options (merge (options/statusbar-and-navbar-options theme nil nil)
+                                   {:layout  {:componentBackgroundColor :transparent
+                                              :orientation              ["portrait"]}
+                                    :overlay {:interceptTouchOutside true
+                                              :handleKeyboardEvents  true}}
+                                   opts)}}))))
 
 (rf/reg-fx :show-toasts
  (fn [[view-id theme]]

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -199,24 +199,21 @@
   ([component] (show-overlay component {}))
   ([component opts]
    (navigation/dissmiss-overlay component)
-   (let [theme (rf/sub [:theme])]
+   (let [theme                              (rf/sub [:theme])
+         [rnn-status-bar _ nav-bar-color _] (get-status-nav-color component theme)]
      (navigation/show-overlay
       {:component {:name    component
                    :id      component
-                   :options (merge (options/statusbar-and-navbar-options theme nil nil)
-                                   {:layout  {:componentBackgroundColor :transparent
-                                              :orientation              ["portrait"]}
-                                    :overlay {:interceptTouchOutside true
-                                              :handleKeyboardEvents  true}}
-                                   opts)}}))))
+                   :options (merge
+                             (options/statusbar-and-navbar-options theme rnn-status-bar nav-bar-color)
+                             {:layout  {:componentBackgroundColor :transparent
+                                        :orientation              ["portrait"]}
+                              :overlay {:interceptTouchOutside true
+                                        :handleKeyboardEvents  true}}
+                             opts)}}))))
 
 (rf/reg-fx :show-toasts
- (fn [[view-id theme]]
-   (let [[rnn-status-bar nav-bar-color] (get-status-nav-color view-id theme)]
-     (show-overlay "toasts"
-                   (assoc (options/statusbar-and-navbar-options nil rnn-status-bar nav-bar-color)
-                          :overlay
-                          {:interceptTouchOutside false})))))
+ (fn [] (show-overlay "toasts")))
 
 (rf/reg-fx :hide-toasts
  (fn [] (navigation/dissmiss-overlay "toasts")))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20114

### Summary

The white panel appears when the user initiates any action that launches the bottom sheet. This component does not have a theme property when I inspected it using re-frisk but we do have the global theme value of the app. 

In this pr we get this global value of the applied theme and use that to determine which background needs to be applied on the navigation bar.

The issue is resolved

https://github.com/status-im/status-mobile/assets/28704507/e34cbbec-6693-4d47-a6d5-6479adec675d

status: ready 
