### PR TITLE
pick between JSC & Hermes for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,6 @@ def jscFlavor = 'org.webkit:android-jsc:+'
  */
 def enableHermes = hermesEnabled.toBoolean();
 
-
 def getCommitHash = { ->
     if (project.hasProperty("commitHash")) {
         return project.commitHash
@@ -278,11 +277,14 @@ dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
     implementation("androidx.core:core-splashscreen:1.0.0")
-    // we don't use hermes for debug but we need its pom file for release builds
-    // https://github.com/status-im/status-mobile/pull/18675
-    implementation("com.facebook.react:hermes-android")
-    // FIXME: implementing both hermes & JSC increases bundle size by ~ 2MB
-    implementation(jscFlavor)
+
+    if (enableHermes) {
+        implementation("com.facebook.react:hermes-android")
+    } else {
+        // https://github.com/status-im/status-mobile/issues/18493
+        // we don't use hermes for debug builds because it crashes too often
+        implementation(jscFlavor)
+    }
 
     // react-native-screens
     implementation("androidx.appcompat:appcompat:1.1.0-rc01")

--- a/nix/deps/gradle/generate.sh
+++ b/nix/deps/gradle/generate.sh
@@ -55,7 +55,8 @@ com.android.tools.build:gradle:8.1.1
 com.google.errorprone:error_prone_annotations:2.7.1
 com.android.tools.lint:lint-gradle:31.1.1
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0
-com.android.tools.build:gradle:3.5.4' \
+com.android.tools.build:gradle:3.5.4
+com.facebook.react:hermes-android:0.73.5' \
         >> "${DEPS_LIST}"
 }
 


### PR DESCRIPTION
## Summary

We implement both `JSC` and `Hermes` in build phase of `Android` which increases our `APK` size by ~ `2 MB`.
This was fine before but currently we have to get below the `100 MB` limit.

This PR implements the preferred engine after inferring `hermesEnabled`  property from `gradle.properties`
This property is modified at build time for release here 
https://github.com/status-im/status-mobile/blob/178d62bd276afffef5fe7a3f773e390d83336d9c/nix/mobile/android/build.nix#L17
and set for debug here 
https://github.com/status-im/status-mobile/blob/178d62bd276afffef5fe7a3f773e390d83336d9c/Makefile#L280


Which should further reduce the `APK` size by `2 MB`.

## Testing notes
Not needed.

## Platforms
- Android

status: ready 
