### PR TITLE
perf(login)!: Fix slow login by delaying messenger filters initialization

### DIFF
--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -62,7 +62,13 @@
                  [:logs/set-level log-level]
                  [:activity-center.notifications/fetch-pending-contact-requests-fx]
                  [:activity-center/update-seen-state]
-                 [:activity-center.notifications/fetch-unread-count]]
+                 [:activity-center.notifications/fetch-unread-count]
+
+                 ;; Immediately try to open last chat. We can't wait until the
+                 ;; messenger has started and has processed all chats because
+                 ;; the whole process can take a handful of seconds.
+                 (when-not (:universal-links/handling db)
+                   [:effects.chat/open-last-chat (:key-uid profile-overview)])]
 
                 (cond
                   pairing-completed?
@@ -98,8 +104,6 @@
            [:switcher-cards/fetch]
            (when (ff/enabled? ::ff/wallet.wallet-connect)
              [:dispatch [:wallet-connect/init]])
-           (when-not (:universal-links/handling db)
-             [:effects.chat/open-last-chat key-uid])
            (when notifications-enabled?
              [:effects/push-notifications-enable])]})))
 

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -53,7 +53,10 @@
                       (assoc-in [:activity-center :loading?] true))
             pairing-completed?
             (dissoc :syncing))
-      :fx (into [[:dispatch [:profile.login/start-messenger]]
+      :fx (into [[:json-rpc/call
+                  [{:method     "wakuext_startMessenger"
+                    :on-success [:profile.login/messenger-started]
+                    :on-error   #(log/error "failed to start messenger" %)}]]
                  [:dispatch [:universal-links/generate-profile-url]]
                  [:dispatch [:community/fetch]]
                  [:dispatch [:wallet/initialize]]
@@ -106,13 +109,6 @@
              [:dispatch [:wallet-connect/init]])
            (when notifications-enabled?
              [:effects/push-notifications-enable])]})))
-
-(rf/reg-event-fx :profile.login/start-messenger
- (fn []
-   {:fx [[:json-rpc/call
-          [{:method     "wakuext_startMessenger"
-            :on-success [:profile.login/messenger-started]
-            :on-error   #(log/error "failed to start messenger" %)}]]]}))
 
 (rf/reg-event-fx :profile.login/messenger-started
  (fn [{:keys [db]} [{:keys [mailservers]}]]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.28",
-    "commit-sha1": "33ccf784c52e56d98f2928b4618db5490a1e1f95",
-    "src-sha256": "0cz8cbzqbp6i3p9la0iibk73s2fmlk449zd9fznms8b02g4n3xic"
+    "version": "v0.180.30",
+    "commit-sha1": "b665d68d0cff7cd4521ac8791fcf6eac29b23cd9",
+    "src-sha256": "1bpj3x2bmrh7whhx9sb2wgwc4q8knm4c3rzvimp0s84fsvna5ynq"
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/20059

### Summary

This PR fixes the slow login when users have joined large communities, such as the Status one. Related status-go PR https://github.com/status-im/status-go/pull/5229.

**Note**: This PR stayed in WIP for a while until we were sure the solution was reliable enough to deserve code reviews.

### About the fix

What we mean by "slow" is that the user was getting stuck on the login screen for almost 20s in some devices (even on iOS things were bad). And this entire process was happening in status-go, hence this PR is not about optimizing the client directly.

By "login" we mean the process to authenticate and initialize vital data in status-go. Setting up message filters can be slow with large communities, and that's exactly this part we moved out of the login phase in status-go. This step now happens implicitly when the client calls `wakuext_startMessenger`.

In a way, the solution makes sense because setting up filters isn't essential for the user to access other parts of the app, such as the Wallet, Settings, Profile, and Activity Center.

### Demo

Login goes fast now :)

[fast-login.webm](https://github.com/status-im/status-mobile/assets/46027/3b8912cf-383d-42a5-93fe-b22752b983f2)

### Once approved, can we merge this PR?

No. This PR and the status-go one can only be merged once we get the green light from Desktop team because there could be breaking changes for them, just as there were for us.

### How can we magically eliminate the login delay?

In reality, the time we used to spent during login, blocking the user, still happens, but it happens **in the background and after the user is redirected** to the home screen. This also means that, until the filters are established, all chats are still in their "loading skeleton state".

In terms of UX, this is probably fine as long as it doesn't take too long for this setup to finish in status-go. In the future, we have room to further optimize how filters are set up in status-go.

### Steps to test

This PR was already lightly QAed, but it is recommended to check regressions in these areas:

- User can see their data after login and can interact with it. That means chat, communities, contacts, contact requests, notifications, wallet accounts, etc.
- User is correctly redirected to the last opened screen.
- User can logout successfully.
- User can send and receive messages.
- User can sync.

status: ready