### PR TITLE
Fix re-frame warning about fx being nil

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -194,6 +194,8 @@
 
 (def ^:const community-id-length 68)
 
+(def ^:const toast-chain-down-duration 5000)
+
 ; BIP44 Wallet Root Key, the extended key from which any wallet can be derived
 (def ^:const path-wallet-root "m/44'/60'/0'/0")
 ; EIP1581 Root Key, the extended key from which any whisper key/encryption key can be derived

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -416,13 +416,13 @@
        (log/info "[wallet] Test network enabled: " (boolean test-networks-enabled?))
        (log/info "[wallet] Goerli network enabled: " (boolean is-goerli-enabled?)))
      {:db (assoc-in db [:wallet :statuses :blockchains] chains)
-      :fx (when chains-down?
-            [[:dispatch
+      :fx [(when chains-down?
+             [:dispatch
               [:toasts/upsert
                {:id       :chains-down
                 :type     :negative
                 :text     (i18n/label :t/provider-is-down {:chains chain-names})
-                :duration 10000}]]])})))
+                :duration 10000}]])]})))
 
 (defn reset-selected-networks
   [{:keys [db]}]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -422,7 +422,7 @@
                {:id       :chains-down
                 :type     :negative
                 :text     (i18n/label :t/provider-is-down {:chains chain-names})
-                :duration 10000}]])]})))
+                :duration constants/toast-chain-down-duration}]])]})))
 
 (defn reset-selected-networks
   [{:keys [db]}]


### PR DESCRIPTION
### Summary

This PR fixes a warning thrown by re-frame in the event `:wallet/blockchain-status-changed`. I noticed this while doing unrelated work.

Here's a simplified example that generates the same warning.

```clojure
(rf/reg-event-fx :user/fx-warning
 (fn []
   {:fx nil}))

;; Prints warning re-frame: ":fx" effect expects a seq, but was given null
(rf/dispatch [:user/fx-warning])
```

#### Areas that may be impacted

PR is safe to be merged without QA.

status: ready
