### PR TITLE
fix: crash when user changes token and goes to transaction confirmation screen

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -220,14 +220,15 @@
 (rf/reg-event-fx
  :wallet/edit-token-to-send
  (fn [{:keys [db]} [token]]
-   (let [{token-networks :networks}                token
+   (let [{token-networks :networks
+          token-symbol   :symbol}                  token
          receiver-networks                         (get-in db [:wallet :ui :send :receiver-networks])
          token-networks-ids                        (mapv #(:chain-id %) token-networks)
          token-not-supported-in-receiver-networks? (not (some (set receiver-networks)
                                                               token-networks-ids))]
      {:db (-> db
               (assoc-in [:wallet :ui :send :token] token)
-              (assoc-in [:wallet :ui :send :token-display-name] token)
+              (assoc-in [:wallet :ui :send :token-display-name] token-symbol)
               (assoc-in [:wallet :ui :send :token-not-supported-in-receiver-networks?]
                         token-not-supported-in-receiver-networks?))
       :fx [[:dispatch [:hide-bottom-sheet]]


### PR DESCRIPTION
fixes #20184

### Summary

This PR fixes a crash when user edits the token in the input amount screen in the wallet send flow and then goes to transaction confirmation screen after finding a route.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

1. Restore user with 2 different tokens.
2. Select asset 1 for sending.
3. Go to 'routes generation' screen.
4. Enter an available value to generate routes.
5. Change to assets 2.
6. Enter an available value to generate routes.
7. Try to confirm the transaction.
8. Verify it doesn't crash anymore

status: ready