### PR TITLE
removed support for NDEF format

### DIFF
--- a/ios/StatusIm/StatusIm.entitlements
+++ b/ios/StatusIm/StatusIm.entitlements
@@ -4,7 +4,6 @@
 <dict>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
-		<string>NDEF</string>
 		<string>TAG</string>
 	</array>
 	<key>aps-environment</key>


### PR DESCRIPTION
fixes #20190 

### Summary

A simple pr  to remove NFC NDEF reading format from the entitlements file. 

status: ready
