### PR TITLE
No opacity on the text on inactive buttons on the dark-themed screens

### DIFF
--- a/src/quo/components/buttons/button/view.cljs
+++ b/src/quo/components/buttons/button/view.cljs
@@ -117,7 +117,8 @@
            {:size            (when (#{56 24} size) :paragraph-2)
             :weight          :medium
             :number-of-lines 1
-            :style           {:color label-color}}
+            :style           {:color   label-color
+                              :opacity (when (and disabled? (= theme :dark)) 0.3)}}
            children]
 
           (vector? children)


### PR DESCRIPTION


fixes #20185

