### PR TITLE
fix: handle unknown contract community

### DIFF
--- a/src/status_im/common/signals/events.cljs
+++ b/src/status_im/common/signals/events.cljs
@@ -84,7 +84,9 @@
       (local-notifications/process cofx (transforms/js->clj event-js))
 
       "community.found"
-      (link-preview/cache-community-preview-data (transforms/js->clj event-js))
+      (let [community (transforms/js->clj event-js)]
+        (link-preview/cache-community-preview-data community)
+        {:fx [[:dispatch [:discover-community/maybe-found-unknown-contract-community community]]]})
 
       "status.updates.timedout"
       (visibility-status-updates/handle-visibility-status-updates cofx (transforms/js->clj event-js))


### PR DESCRIPTION
-------

fixes #20092

### Summary

status-go give mobile this discover community list looks like this
```clj
    {:communities                 {"a" {:id "a"}}
     :contractFeaturedCommunities ["a" "b"]
     :contractCommunities         ["a" "b" "c"]
     :unknownCommunities          ["b" "c"]}
```

we save it into db like this, discover community view will stay loading forever since there's only one community in the list and it's unknown
```clj
    {:featured         {"a" {:id "a"}} ;; cause there's no known data about "b" and "c"
     :other            {}}
```

this PR save the unknown communities into db and update them into `featured` or `other` once their `"community.found"` signal received
```clj
    {:featured         {"a" {:id "a"}}
     :other            {}
     :unknown-featured '("b")
     :unknown-other    '("c")}
```

### Testing notes
- won't work in testnet mode testnet RPC is broken
- I got `endpoint xxxxxx has passed its daily relay limit` on mainnet (in geth.log), this prevents status-go fetching the list as well, which leads to infinite loading
  - I fixed this by changing the `POKT_TOKEN` to a newly created one, not sure if PR/nightly build uses different token

#### Platforms
- iOS
- macOS


#### Areas that maybe impacted
discover community

### Steps to test
- create a new account, make sure testnet mode is off
- open the discover community view

status: ready <!-- Can be ready or wip -->