### PR TITLE
chore: allow for overriding metro server port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,7 +436,7 @@ android-clean: ##@prepare Clean Gradle state
 	rm -rf ~/.gradle
 
 
-android-ports: export FLOWSTORM_PORT := 7722
+android-ports: export FLOWSTORM_PORT ?= 7722
 android-ports: export TARGET := android-sdk
 android-ports: export RCT_METRO_PORT ?= 8081
 android-ports: ##@other Add proxies to Android Device/Simulator

--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,7 @@ android-clean: ##@prepare Clean Gradle state
 
 android-ports: export FLOWSTORM_PORT := 7722
 android-ports: export TARGET := android-sdk
+android-ports: export RCT_METRO_PORT ?= 8081
 android-ports: ##@other Add proxies to Android Device/Simulator
 	adb reverse tcp:$(RCT_METRO_PORT) tcp:$(RCT_METRO_PORT) && \
 	adb reverse tcp:3449 tcp:3449 && \

--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ android-clean: ##@prepare Clean Gradle state
 android-ports: export FLOWSTORM_PORT := 7722
 android-ports: export TARGET := android-sdk
 android-ports: ##@other Add proxies to Android Device/Simulator
-	adb reverse tcp:8081 tcp:8081 && \
+	adb reverse tcp:$(RCT_METRO_PORT) tcp:$(RCT_METRO_PORT) && \
 	adb reverse tcp:3449 tcp:3449 && \
 	adb reverse tcp:4567 tcp:4567 && \
 	adb reverse tcp:$(FLOWSTORM_PORT) tcp:$(FLOWSTORM_PORT) && \

--- a/nix/mobile/android/build.nix
+++ b/nix/mobile/android/build.nix
@@ -89,7 +89,6 @@ in stdenv.mkDerivation rec {
   ORG_GRADLE_PROJECT_commitHash = commitHash;
   ORG_GRADLE_PROJECT_buildUrl = buildUrl;
   ORG_GRADLE_PROJECT_hermesEnabled = hermesEnabled;
-  RCT_METRO_PORT = reactMetroPort;
 
   # Fix for ERR_OSSL_EVP_UNSUPPORTED error.
   NODE_OPTIONS = "--openssl-legacy-provider";
@@ -108,7 +107,6 @@ in stdenv.mkDerivation rec {
     export ANDROID_NDK_ROOT="${androidPkgs.ndk}"
 
     export STATUS_NIX_MAVEN_REPO="${deps.gradle}"
-    export RCT_METRO_PORT=${toString reactMetroPort}
   '';
 
   unpackPhase = ''

--- a/nix/mobile/android/build.nix
+++ b/nix/mobile/android/build.nix
@@ -17,6 +17,7 @@
   hermesEnabled ? lib.getEnvWithDefault "ORG_GRADLE_PROJECT_hermesEnabled" "true",
   buildUrl ? lib.getEnvWithDefault "ORG_GRADLE_PROJECT_buildUrl" null,
   statusGoSrcOverride ? lib.getEnvWithDefault "STATUS_GO_SRC_OVERRIDE" null,
+  reactMetroPort ? lib.getEnvWithDefault "RCT_METRO_PORT" 8081,
   # If APKs should be split based on architectures
   androidAbiSplit ? lib.getEnvWithDefault "ANDROID_ABI_SPLIT" "true",
   # Android architectures to build for
@@ -88,6 +89,7 @@ in stdenv.mkDerivation rec {
   ORG_GRADLE_PROJECT_commitHash = commitHash;
   ORG_GRADLE_PROJECT_buildUrl = buildUrl;
   ORG_GRADLE_PROJECT_hermesEnabled = hermesEnabled;
+  RCT_METRO_PORT = reactMetroPort;
 
   # Fix for ERR_OSSL_EVP_UNSUPPORTED error.
   NODE_OPTIONS = "--openssl-legacy-provider";
@@ -106,6 +108,7 @@ in stdenv.mkDerivation rec {
     export ANDROID_NDK_ROOT="${androidPkgs.ndk}"
 
     export STATUS_NIX_MAVEN_REPO="${deps.gradle}"
+    export RCT_METRO_PORT=${toString reactMetroPort}
   '';
 
   unpackPhase = ''
@@ -158,6 +161,7 @@ in stdenv.mkDerivation rec {
       --no-build-cache \
       --parallel \
       -Dmaven.repo.local='${deps.gradle}' \
+      -PreactNativeDevServerPort=${toString reactMetroPort} \
       assemble${gradleBuildType}
     '';
   in

--- a/scripts/check-metro-shadow-process.sh
+++ b/scripts/check-metro-shadow-process.sh
@@ -6,7 +6,7 @@ if pgrep -f 'shadow-cljs watch mobile' > /dev/null; then
     exit 1
 fi
 
-if pgrep -f 'react-native start' > /dev/null; then
+if pgrep -f "react-native start --port=$RCT_METRO_PORT" > /dev/null; then
     echo "Error: make run-metro is already running in another terminal" >&2
     echo "Please close that terminal before running this command." >&2
     exit 1

--- a/scripts/check-metro-shadow-process.sh
+++ b/scripts/check-metro-shadow-process.sh
@@ -6,7 +6,7 @@ if pgrep -f 'shadow-cljs watch mobile' > /dev/null; then
     exit 1
 fi
 
-if pgrep -f "react-native start --port=$RCT_METRO_PORT" > /dev/null; then
+if pgrep -f "react-native start --port=${RCT_METRO_PORT:-8081}" > /dev/null; then
     echo "Error: make run-metro is already running in another terminal" >&2
     echo "Please close that terminal before running this command." >&2
     exit 1

--- a/scripts/run-metro.sh
+++ b/scripts/run-metro.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-if pgrep -f "react-native start --port=$RCT_METRO_PORT" > /dev/null; then
+if pgrep -f "react-native start --port=${RCT_METRO_PORT:-8081}" > /dev/null; then
     echo "Info: metro is already running in another terminal"
 else
     echo "Info: starting a new metro terminal"
-    react-native start --port=$RCT_METRO_PORT --reset-cache
+    react-native start --port=${RCT_METRO_PORT:-8081} --reset-cache
 fi

--- a/scripts/run-metro.sh
+++ b/scripts/run-metro.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-if pgrep -f 'react-native start' > /dev/null; then
+if pgrep -f "react-native start --port=$RCT_METRO_PORT" > /dev/null; then
     echo "Info: metro is already running in another terminal"
 else
     echo "Info: starting a new metro terminal"
-    react-native start --reset-cache
+    react-native start --port=$RCT_METRO_PORT --reset-cache
 fi

--- a/scripts/wait-for-metro-port.sh
+++ b/scripts/wait-for-metro-port.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 TIMEOUT=10 # Metro should not take this long to start.
 
 while [ "${TIMEOUT}" -gt 0 ]; do
-  if ! lsof -i:RCT_METRO_PORT &> /dev/null; then
+  if ! lsof -i:"${RCT_METRO_PORT:-8081}" &> /dev/null; then
     echo "."
     sleep 1
     ((TIMEOUT--))

--- a/scripts/wait-for-metro-port.sh
+++ b/scripts/wait-for-metro-port.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 TIMEOUT=10 # Metro should not take this long to start.
 
 while [ "${TIMEOUT}" -gt 0 ]; do
-  if ! lsof -i:8081 &> /dev/null; then
+  if ! lsof -i:RCT_METRO_PORT &> /dev/null; then
     echo "."
     sleep 1
     ((TIMEOUT--))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

* This PR attempts to allow for overriding the react-native metro server port.
  * Note that we need to run `make clean` before changing the `RCT_METRO_PORT` environment variable.