### PR TITLE
Add support to import keypairs by using a seed phrase

### DIFF
--- a/src/status_im/contexts/wallet/add_account/create_account/events.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/events.cljs
@@ -41,14 +41,18 @@
 
 (defn seed-phrase-validated
   [{:keys [db]} [seed-phrase key-uid on-error]]
-  (let [keypair-already-added? (->> db :wallet :keypairs (some #(= key-uid (:key-uid %))))]
+  (let [keypair-already-added? (->> db
+                                    :wallet
+                                    :keypairs
+                                    (some #(= key-uid (:key-uid %))))]
     (if keypair-already-added?
       (do
         (on-error)
-        {:fx [[:dispatch [:toasts/upsert
-                          {:id   :already-existing-keypair
-                           :type :negative
-                           :text "This keypair already exists in the device"}]]]})
+        {:fx [[:dispatch
+               [:toasts/upsert
+                {:id   :already-existing-keypair
+                 :type :negative
+                 :text "This keypair already exists in the device"}]]]})
       {:db (assoc-in db [:wallet :ui :create-account :new-keypair :seed-phrase] seed-phrase)
        :fx [[:dispatch [:navigate-to :screen/wallet.keypair-name {:workflow :recovery-phrase}]]]})))
 

--- a/src/status_im/contexts/wallet/add_account/create_account/events.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/events.cljs
@@ -41,8 +41,8 @@
 
 (defn seed-phrase-validated
   [{:keys [db]} [seed-phrase]]
-  {:db (assoc-in db [:wallet :ui :create-account :seed-phrase] seed-phrase)
-   :fx [[:dispatch [:navigate-to :screen/wallet.keypair-name]]]})
+  {:db (assoc-in db [:wallet :ui :create-account :new-keypair :seed-phrase] seed-phrase)
+   :fx [[:dispatch [:navigate-to :screen/wallet.keypair-name {:workflow :recovery-phrase}]]]})
 
 (rf/reg-event-fx :wallet/seed-phrase-validated seed-phrase-validated)
 

--- a/src/status_im/contexts/wallet/add_account/create_account/events.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/events.cljs
@@ -40,9 +40,17 @@
 (rf/reg-event-fx :wallet/store-new-seed-phrase store-new-seed-phrase)
 
 (defn seed-phrase-validated
-  [{:keys [db]} [seed-phrase]]
-  {:db (assoc-in db [:wallet :ui :create-account :new-keypair :seed-phrase] seed-phrase)
-   :fx [[:dispatch [:navigate-to :screen/wallet.keypair-name {:workflow :recovery-phrase}]]]})
+  [{:keys [db]} [seed-phrase key-uid on-error]]
+  (let [keypair-already-added? (->> db :wallet :keypairs (some #(= key-uid (:key-uid %))))]
+    (if keypair-already-added?
+      (do
+        (on-error)
+        {:fx [[:dispatch [:toasts/upsert
+                          {:id   :already-existing-keypair
+                           :type :negative
+                           :text "This keypair already exists in the device"}]]]})
+      {:db (assoc-in db [:wallet :ui :create-account :new-keypair :seed-phrase] seed-phrase)
+       :fx [[:dispatch [:navigate-to :screen/wallet.keypair-name {:workflow :recovery-phrase}]]]})))
 
 (rf/reg-event-fx :wallet/seed-phrase-validated seed-phrase-validated)
 
@@ -51,7 +59,7 @@
   {:fx [[:multiaccount/validate-mnemonic
          [seed-phrase
           (fn [mnemonic key-uid]
-            (rf/dispatch [:wallet/seed-phrase-validated mnemonic key-uid]))
+            (rf/dispatch [:wallet/seed-phrase-validated mnemonic key-uid on-error]))
           on-error]]]})
 
 (rf/reg-event-fx :wallet/seed-phrase-entered seed-phrase-entered)

--- a/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
@@ -17,9 +17,21 @@
    :emoji        (i18n/label :t/key-name-error-emoji)
    :special-char (i18n/label :t/key-name-error-special-char)})
 
-(defn navigate-back
+(defn- navigate-back
   []
   (rf/dispatch [:navigate-back]))
+
+(defn- on-continue [workflow key-pair-name]
+  (case workflow
+    ;; TODO issue #19759. Implement creation account from private key
+    :import-private-key
+    (not-implemented/alert)
+
+    (:new-keypair :recovery-phrase)
+    (rf/dispatch [:wallet/generate-account-for-keypair
+                  {:keypair-name key-pair-name}])
+
+    (js/alert "Unknown workflow")))
 
 (defn view
   []
@@ -45,17 +57,7 @@
 
                                                :else (set-error nil))))
         on-continue                       (rn/use-callback
-                                           (fn [_]
-                                             (case workflow
-                                               ;; TODO issue #19759. Implement creation account from
-                                               ;; private key
-                                               :import-private-key
-                                               (not-implemented/alert)
-
-                                               :new-keypair
-                                               (rf/dispatch [:wallet/generate-account-for-keypair
-                                                             {:keypair-name key-pair-name}])
-                                               (js/alert "Unknown workflow")))
+                                           #(on-continue workflow key-pair-name)
                                            [workflow key-pair-name])
         disabled?                         (or (some? error) (string/blank? key-pair-name))]
     [rn/view {:style {:flex 1}}

--- a/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
@@ -57,7 +57,7 @@
                                                (set-error :special-char)
 
                                                :else (set-error nil))))
-        on-continue                       (rn/use-callback
+        on-continue-fn                    (rn/use-callback
                                            #(on-continue workflow key-pair-name)
                                            [workflow key-pair-name])
         disabled?                         (or (some? error) (string/blank? key-pair-name))]
@@ -71,7 +71,7 @@
        :footer              [quo/button
                              {:customization-color customization-color
                               :disabled?           disabled?
-                              :on-press            on-continue}
+                              :on-press            on-continue-fn}
                              (i18n/label :t/continue)]}
       [quo/page-top
        {:title            (i18n/label :t/keypair-name)

--- a/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
@@ -1,15 +1,16 @@
 (ns status-im.contexts.wallet.add-account.create-account.key-pair-name.view
   (:require
-    [clojure.string :as string]
-    [quo.core :as quo]
-    [react-native.core :as rn]
-    [status-im.common.floating-button-page.view :as floating-button-page]
-    [status-im.common.not-implemented :as not-implemented]
-    [status-im.common.validation.general :as validators]
-    [status-im.constants :as constants]
-    [status-im.contexts.wallet.add-account.create-account.key-pair-name.style :as style]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+   [clojure.string :as string]
+   [taoensso.timbre :as log]
+   [quo.core :as quo]
+   [react-native.core :as rn]
+   [status-im.common.floating-button-page.view :as floating-button-page]
+   [status-im.common.not-implemented :as not-implemented]
+   [status-im.common.validation.general :as validators]
+   [status-im.constants :as constants]
+   [status-im.contexts.wallet.add-account.create-account.key-pair-name.style :as style]
+   [utils.i18n :as i18n]
+   [utils.re-frame :as rf]))
 
 (def error-messages
   {:too-long     (i18n/label :t/key-name-error-length)
@@ -21,7 +22,7 @@
   []
   (rf/dispatch [:navigate-back]))
 
-(defn- on-continue
+(defn- next-workflow-step
   [workflow key-pair-name]
   (case workflow
     ;; TODO issue #19759. Implement creation account from private key
@@ -32,7 +33,9 @@
     (rf/dispatch [:wallet/generate-account-for-keypair
                   {:keypair-name key-pair-name}])
 
-    (js/alert "Unknown workflow")))
+    (do
+      (log/error "Unknown workflow" workflow)
+      (js/alert "Unknown workflow"))))
 
 (defn view
   []
@@ -57,8 +60,8 @@
                                                (set-error :special-char)
 
                                                :else (set-error nil))))
-        on-continue-fn                    (rn/use-callback
-                                           #(on-continue workflow key-pair-name)
+        on-continue                       (rn/use-callback
+                                           #(next-workflow-step workflow key-pair-name)
                                            [workflow key-pair-name])
         disabled?                         (or (some? error) (string/blank? key-pair-name))]
     [rn/view {:style {:flex 1}}
@@ -71,7 +74,7 @@
        :footer              [quo/button
                              {:customization-color customization-color
                               :disabled?           disabled?
-                              :on-press            on-continue-fn}
+                              :on-press            on-continue}
                              (i18n/label :t/continue)]}
       [quo/page-top
        {:title            (i18n/label :t/keypair-name)

--- a/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
@@ -1,16 +1,16 @@
 (ns status-im.contexts.wallet.add-account.create-account.key-pair-name.view
   (:require
-   [clojure.string :as string]
-   [taoensso.timbre :as log]
-   [quo.core :as quo]
-   [react-native.core :as rn]
-   [status-im.common.floating-button-page.view :as floating-button-page]
-   [status-im.common.not-implemented :as not-implemented]
-   [status-im.common.validation.general :as validators]
-   [status-im.constants :as constants]
-   [status-im.contexts.wallet.add-account.create-account.key-pair-name.style :as style]
-   [utils.i18n :as i18n]
-   [utils.re-frame :as rf]))
+    [clojure.string :as string]
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [status-im.common.floating-button-page.view :as floating-button-page]
+    [status-im.common.not-implemented :as not-implemented]
+    [status-im.common.validation.general :as validators]
+    [status-im.constants :as constants]
+    [status-im.contexts.wallet.add-account.create-account.key-pair-name.style :as style]
+    [taoensso.timbre :as log]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (def error-messages
   {:too-long     (i18n/label :t/key-name-error-length)

--- a/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
@@ -21,7 +21,8 @@
   []
   (rf/dispatch [:navigate-back]))
 
-(defn- on-continue [workflow key-pair-name]
+(defn- on-continue
+  [workflow key-pair-name]
   (case workflow
     ;; TODO issue #19759. Implement creation account from private key
     :import-private-key


### PR DESCRIPTION
fixes #20168

### Summary

This PR fixes the "Unknown workflow" alert and properly imports the new keypair given a seed phrase.

Figma designs are not considering what happens when the user adds a keypair that already exists in the device, so, to avoid bugs, I'm catching this case and showing a toast:

Figma: https://www.figma.com/design/HKncH4wnDwZDAhc4AryK8Y/Wallet-for-Mobile?node-id=2070-592394&t=MJO4UfR4RbR5rrbC-4

![image](https://github.com/status-im/status-mobile/assets/90291778/877dd0b9-7af3-46ac-b2b8-03a10001a136)

Until designers add the proper UI for it (I already started the discussion).


### Testing notes

This may be special useful for QA, since they don't need to create a new status profile to add a new keypair in the app.

#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Go to Wallet -> Add account -> add keypair -> "Import using recovery phrase" flow
(check the video in the issue)

The acconts should be properly recovered along with their balance, also we should be able to derive accounts from these new keypairs and make transactions with its accounts,

status: ready
