### PR TITLE
Add linter for inconsistent deftest name

### DIFF
--- a/.clj-kondo/status-im/cljs/test.clj
+++ b/.clj-kondo/status-im/cljs/test.clj
@@ -1,0 +1,21 @@
+(ns cljs.test
+  (:require [clj-kondo.hooks-api :as hooks]))
+
+(defn deftest
+  "Verify test name passed to `cljs.test/deftest` is suffixed with -test and not
+  prefixed with test-."
+  [{:keys [node]}]
+  (let [[_ test-name-node & _] (:children node)
+        test-name              (str (hooks/sexpr test-name-node))]
+    (when (and (hooks/token-node? test-name-node)
+               (or (not (re-find #"^.*-test$" test-name))
+                   (re-find #"^test-.*$" test-name)))
+      (hooks/reg-finding! (assoc (meta test-name-node)
+                                 :message "Test name should be suffixed with -test"
+                                 :type    :status-im.linter/inconsistent-test-name)))))
+
+(comment
+  ;; Invalid
+  (deftest {:node (hooks/parse-string "(deftest foo-tes (println :hello))")})
+  (deftest {:node (hooks/parse-string "(deftest test-foo-test (println :hello))")})
+)

--- a/.clj-kondo/status-im/config.edn
+++ b/.clj-kondo/status-im/config.edn
@@ -4,5 +4,8 @@
    test-helpers.component/get-all-by-translation-text   utils.i18n/label
    test-helpers.component/get-by-translation-text       utils.i18n/label
    test-helpers.component/query-all-by-translation-text utils.i18n/label
-   test-helpers.component/query-by-translation-text     utils.i18n/label}}
- :linters {:status-im.linter/invalid-translation-keyword {:level :error}}}
+   test-helpers.component/query-by-translation-text     utils.i18n/label
+
+   cljs.test/deftest                                    cljs.test/deftest}}
+ :linters {:status-im.linter/invalid-translation-keyword {:level :error}
+           :status-im.linter/inconsistent-test-name      {:level :error}}}

--- a/src/legacy/status_im/chat/models/message_test.cljs
+++ b/src/legacy/status_im/chat/models/message_test.cljs
@@ -106,7 +106,7 @@
                      (get-in result [:db :pagination-info chat-id :cursor-clock-value])))
               (is (= cursor (get-in result [:db :pagination-info chat-id :cursor]))))))))))
 
-(deftest message-loaded?
+(deftest message-loaded?-test
   (testing "it returns false when it's not in loaded message"
     (is
      (not
@@ -117,7 +117,7 @@
          "a"
          "message-id"))))
 
-(deftest earlier-than-deleted-at?
+(deftest earlier-than-deleted-at?-test
   (testing "it returns true when the clock-value is the same as the deleted-clock-value in chat"
     (is (#'legacy.status-im.chat.models.message/earlier-than-deleted-at?
          {:chats {"a" {:deleted-at-clock-value 1}}}

--- a/src/legacy/status_im/data_store/messages_test.cljs
+++ b/src/legacy/status_im/data_store/messages_test.cljs
@@ -8,7 +8,7 @@
 (def from
   "0x0424a68f89ba5fcd5e0640c1e1f591d561fa4125ca4e2a43592bc4123eca10ce064e522c254bb83079ba404327f6eafc01ec90a1444331fe769d3f3a7f90b0dde1")
 
-(deftest message<-rpc
+(deftest message<-rpc-test
   (testing "message from RPC"
     (let [expected {:message-id                 message-id
                     :content                    {:chat-id     chat-id

--- a/src/legacy/status_im/ethereum/mnemonic_test.cljs
+++ b/src/legacy/status_im/ethereum/mnemonic_test.cljs
@@ -4,7 +4,7 @@
     [clojure.string :as string]
     [legacy.status-im.ethereum.mnemonic :as mnemonic]))
 
-(deftest valid-length?
+(deftest valid-length?-test
   (is (not (mnemonic/valid-length? "rate rate")))
   (is (not (mnemonic/valid-length? (string/join " " (repeat 13 "rate")))))
   (is (not (mnemonic/valid-length? (string/join " " (repeat 16 "rate")))))
@@ -14,19 +14,19 @@
   (is (mnemonic/valid-length? (string/join " " (repeat 21 "rate"))))
   (is (mnemonic/valid-length? (string/join " " (repeat 24 "rate")))))
 
-(deftest valid-words?
+(deftest valid-words?-test
   (is (not (mnemonic/valid-words? "rate! rate")))
   (is (not (mnemonic/valid-words? "rate rate rate rate rate rate rate rate rate rate rate rate?")))
   (is (mnemonic/valid-words? "rate rate rate rate rate rate rate rate rate rate rate rate")))
 
-(deftest passphrase->words?
+(deftest passphrase->words?-test
   (is (= ["one" "two" "three" "for" "five" "six" "seven" "height" "nine" "ten" "eleven" "twelve"]
          (mnemonic/passphrase->words "one two three for five six seven height nine ten eleven twelve"))
       (= ["one" "two" "three" "for" "five" "six" "seven" "height" "nine" "ten" "eleven" "twelve"]
          (mnemonic/passphrase->words
           "  one two three for five   six seven height nine ten eleven twelve "))))
 
-(deftest status-generate-phrase?
+(deftest status-generate-phrase?-test
   (is (mnemonic/status-generated-phrase?
        "game buzz method pretty olympic fat quit display velvet unveil marine crater"))
   (is (not (mnemonic/status-generated-phrase?

--- a/src/legacy/status_im/multiaccounts/update/core_test.cljs
+++ b/src/legacy/status_im/multiaccounts/update/core_test.cljs
@@ -3,7 +3,7 @@
     [clojure.test :refer-macros [deftest is testing]]
     [legacy.status-im.multiaccounts.update.core :as multiaccounts.update]))
 
-(deftest test-multiaccount-update
+(deftest multiaccount-update-test
   ;;TODO this test case actually shows that we are doing a needless rpc call when
   ;;there is no changes, but it is an edge case that shouldn't really happen
   (let [efx      (multiaccounts.update/multiaccount-update
@@ -15,7 +15,7 @@
     (is (json-rpc "settings_saveSetting"))
     (is (= (get-in efx [:db :profile/profile]) {:not-empty "would throw an error if was empty"}))))
 
-(deftest test-clean-seed-phrase
+(deftest clean-seed-phrase-test
   (let [efx      (multiaccounts.update/clean-seed-phrase
                   {:db {:profile/profile {:mnemonic "lalalala"}}}
                   {})
@@ -23,7 +23,7 @@
     (is (json-rpc "settings_saveSetting"))
     (is (nil? (get-in efx [:db :profile/profile :mnemonic])))))
 
-(deftest test-update-multiaccount-account-name
+(deftest update-multiaccount-account-name-test
   (let [cofx                             {:db {:profile/profile {:key-uid        1
                                                                  :name           "name"
                                                                  :preferred-name "preferred-name"

--- a/src/legacy/status_im/utils/random_test.cljs
+++ b/src/legacy/status_im/utils/random_test.cljs
@@ -3,7 +3,7 @@
     [cljs.test :refer-macros [deftest is]]
     [legacy.status-im.utils.random :as random]))
 
-(deftest test-seeded-rand-int
+(deftest seeded-rand-int-test
   ;try with one seed
   (let [seed 0
         gen  (random/rand-gen seed)]
@@ -40,7 +40,7 @@
     (is (= (random/seeded-rand-int gen 10) 7))
     (is (= (random/seeded-rand-int gen 10) 8))))
 
-(deftest test-seeded-rand-int-boundaries
+(deftest seeded-rand-int-boundaries-test
   (let [seed   "6ec565f4fec866a54761524f603cf037e20c2bfa"
         n      10
         gen    (random/rand-gen seed)
@@ -53,7 +53,7 @@
     ;calls got us the same number.
     (is (> (count sample) 1))))
 
-(deftest test-seeded-rand-nth
+(deftest seeded-rand-nth-test
   (let [seed "6ec565f4fec866a54761524f603cf037e20c2bfa"
         gen  (random/rand-gen seed)
         coll [:a :b :c :d :e :f :g]]

--- a/src/legacy/status_im/utils/signing_phrase/core_test.cljs
+++ b/src/legacy/status_im/utils/signing_phrase/core_test.cljs
@@ -4,7 +4,7 @@
     [clojure.string :as string]
     [legacy.status-im.utils.signing-phrase.core :refer [generate]]))
 
-(deftest test-generate
+(deftest generate-test
   (doseq [_ (range 30)]
     (let [result (generate)]
       (is (not (string/starts-with? result " ")))

--- a/src/quo/components/graph/utils_test.cljs
+++ b/src/quo/components/graph/utils_test.cljs
@@ -3,7 +3,7 @@
     [cljs.test :refer-macros [deftest is testing]]
     [quo.components.graph.utils :as utils]))
 
-(deftest find-highest-value
+(deftest find-highest-value-test
   (testing "Find highest value with a single map"
     (let [data [{:value 5}]]
       (is (= (utils/find-highest-value data) 5))))
@@ -24,7 +24,7 @@
     (let [data (vec (for [num (range 1000)] {:value num}))]
       (is (= (utils/find-highest-value data) 999)))))
 
-(deftest find-lowest-value
+(deftest find-lowest-value-test
   (testing "Find lowest value with a single map"
     (let [data [{:value 5}]]
       (is (= (utils/find-lowest-value data) 5))))
@@ -45,7 +45,7 @@
     (let [data (vec (for [num (range 1000)] {:value num}))]
       (is (= (utils/find-lowest-value data) 0)))))
 
-(deftest downsample-data
+(deftest downsample-data-test
   (testing "Downsampling is applied correctly when needed"
     (let [input-data      [1 2 3 4 5 6 7 8 9 10]
           max-array-size  5
@@ -77,7 +77,7 @@
                                             ; 1000
       (is (= (utils/downsample-data large-data max-array-size) expected-output)))))
 
-(deftest format-compact-number
+(deftest format-compact-number-test
   (testing "Format a whole number less than 1000"
     (is (= (utils/format-compact-number 567) "567")))
 
@@ -105,7 +105,7 @@
   (testing "Format a number in trillions"
     (is (= (utils/format-compact-number 1234567890000) "1.23T"))))
 
-(deftest calculate-x-axis-labels
+(deftest calculate-x-axis-labels-test
   (testing "Calculate x-axis labels with a small array and fewer elements"
     (let [data [{:date "2023-01-01"} {:date "2023-01-02"} {:date "2023-01-03"} {:date "2023-01-04"}]]
       (is (= (utils/calculate-x-axis-labels data 2) '("2023-01-01" "2023-01-03")))))
@@ -123,7 +123,7 @@
     (let [data (vec (for [i (range 10)] {:date (str "2023-01-0" (inc i))}))]
       (is (= (utils/calculate-x-axis-labels data 1) '("2023-01-01"))))))
 
-(deftest calculate-y-axis-labels
+(deftest calculate-y-axis-labels-test
   (testing "Calculate y-axis labels with positive values"
     (is (= (utils/calculate-y-axis-labels 0 10 5) ["0" "10" "20" "30" "40" "50"])))
 
@@ -139,7 +139,7 @@
   (testing "Calculate y-axis labels with large step value and number of steps"
     (is (= (utils/calculate-y-axis-labels 100 1000 3) ["100" "1.1k" "2.1k" "3.1k"]))))
 
-(deftest calculate-rounded-max
+(deftest calculate-rounded-max-test
   (testing "Calculate rounded max with a whole number"
     (is (= (utils/calculate-rounded-max 100) 108)))
 
@@ -155,7 +155,7 @@
   (testing "Calculate rounded max with a large number"
     (is (= (utils/calculate-rounded-max 1000) 1052))))
 
-(deftest calculate-rounded-min
+(deftest calculate-rounded-min-test
   (testing "Calculate rounded min with a whole number"
     (is (= (utils/calculate-rounded-min 157) 100)))
 

--- a/src/quo/foundations/colors_test.cljs
+++ b/src/quo/foundations/colors_test.cljs
@@ -30,5 +30,5 @@
     "when using opacity theme is ignored and uses the light suffix resolver"
     (is (colors/resolve-color :blue :light 10) (colors/resolve-color :blue :dark 10))))
 
-(deftest test-account-colors-customization
+(deftest account-colors-customization-test
   (is (every? #(contains? colors/customization %) colors/account-colors)))

--- a/src/status_im/common/alert_banner/events_test.cljs
+++ b/src/status_im/common/alert_banner/events_test.cljs
@@ -4,7 +4,7 @@
     matcher-combinators.test
     [status-im.common.alert-banner.events :as events]))
 
-(deftest add-alert-banner
+(deftest add-alert-banner-test
   (testing "Alert banner is added"
     (is (match? {:db                {:alert-banners
                                      {:alert {:text "Alert"
@@ -14,7 +14,7 @@
                                          [{:text "Alert"
                                            :type :alert}])))))
 
-(deftest remove-alert-banner
+(deftest remove-alert-banner-test
   (testing "Alert banner is removed"
     (is (match? {:db                {}
                  :hide-alert-banner [nil nil]}
@@ -31,7 +31,7 @@
                                                            :type :alert}}}}
                                             [:error])))))
 
-(deftest remove-all-alert-banners
+(deftest remove-all-alert-banners-test
   (testing "All Alert banners are removed"
     (is (match? {:db                {}
                  :hide-alert-banner [nil nil]}

--- a/src/status_im/common/router_test.cljs
+++ b/src/status_im/common/router_test.cljs
@@ -10,7 +10,7 @@
 (def chat-name-url "Test%20group%20chat")
 (def chat-name "Test group chat")
 
-(deftest parse-uris
+(deftest parse-uris-test
   (are [uri expected] (= (cond-> (router/match-uri uri)
                            (< (count expected) 3)
                            (assoc :query-params nil))
@@ -126,7 +126,7 @@
 
 (def error {:error :invalid-group-chat-data})
 
-(deftest match-group-chat-query
+(deftest match-group-chat-query-test
   (are [query-params expected] (= (router/match-group-chat {} query-params)
                                   expected)
    nil                                             error

--- a/src/status_im/common/universal_links_test.cljs
+++ b/src/status_im/common/universal_links_test.cljs
@@ -25,7 +25,7 @@
                             [:router/handle-uri :uri])
                     "https://status.app/u#statuse2e"))))))
 
-(deftest url-event-listener
+(deftest url-event-listener-test
   (testing "the url is not nil"
     (testing "it dispatches the url"
       (let [actual (atom nil)]
@@ -39,7 +39,7 @@
           (links/url-event-listener #js {})
           (is (match? nil @actual)))))))
 
-(deftest generate-profile-url
+(deftest generate-profile-url-test
   (testing "user has ens name"
     (testing "it calls the ens rpc method with ens name as param"
       (let [db  {:profile/profile {:ens-name? true :public-key pubkey}}
@@ -70,7 +70,7 @@
          "wakuext_shareUserURLWithData" (-> rst :json-rpc/call first :method)
          pubkey                         (-> rst :json-rpc/call first :params first))))))
 
-(deftest save-profile-url
+(deftest save-profile-url-test
   (testing "given a contact public key and profile url"
     (testing "it updates the contact in db"
       (let [url "url"

--- a/src/status_im/common/validation/general_test.cljs
+++ b/src/status_im/common/validation/general_test.cljs
@@ -3,7 +3,7 @@
     [cljs.test :refer-macros [deftest testing is]]
     [status-im.common.validation.general :refer [valid-compressed-key?]]))
 
-(deftest test-valid-compressed-key
+(deftest valid-compressed-key-test
   (testing "valid"
     (is (valid-compressed-key?
          "zQ3shWj4WaBdf2zYKCkXe6PHxDxNTzZyid1i75879Ue9cX9gA")))
@@ -32,4 +32,3 @@
   (testing "contains l"
     (is (not (valid-compressed-key?
               "zQ3shWj4WaBdf2zYKCkXe6PHxDxNTzZyid1i75879Ue9cX9gl")))))
-

--- a/src/status_im/contexts/chat/events_test.cljs
+++ b/src/status_im/contexts/chat/events_test.cljs
@@ -49,7 +49,7 @@
       (let [actual (chat/close-and-remove-chat cofx chat-id)]
         (is (= nil (get-in actual [:db :chats-home-list chat-id])))))))
 
-(deftest multi-user-chat?
+(deftest multi-user-chat?-test
   (let [chat-id "1"]
     (testing "it returns true if it's a group chat"
       (let [cofx {:db {:chats {chat-id {:group-chat true}}}}]
@@ -61,7 +61,7 @@
       (let [cofx {:db {:chats {chat-id {}}}}]
         (is (not (chat/multi-user-chat? cofx chat-id)))))))
 
-(deftest group-chat?
+(deftest group-chat?-test
   (let [chat-id "1"]
     (testing "it returns true if it's a group chat"
       (let [cofx {:db {:chats {chat-id {:group-chat true}}}}]
@@ -82,7 +82,7 @@
                      "opened" {}
                      "1-1"    {}}})
 
-(deftest navigate-to-chat
+(deftest navigate-to-chat-test
   (let [chat-id "test_chat"
         db      {:pagination-info {chat-id {:all-loaded? true}}}]
     (testing "Pagination info should be reset on navigation"

--- a/src/status_im/contexts/chat/messenger/composer/link_preview/events_test.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/link_preview/events_test.cljs
@@ -18,7 +18,7 @@
     (update-in effects [:json-rpc/call 0] dissoc :on-success :on-error)
     effects))
 
-(deftest unfurl-urls
+(deftest unfurl-urls-test
   (testing "clear up state when text is empty"
     (let [cofx {:db {:chat/link-previews {:unfurled   {}
                                           :cache      {}

--- a/src/status_im/contexts/chat/messenger/messages/delete_message/events_test.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/delete_message/events_test.cljs
@@ -7,7 +7,7 @@
 (def mid "message-id")
 (def cid "chat-id")
 
-(deftest delete
+(deftest delete-test
   (with-redefs [datetime/timestamp (constantly 1)]
     (let [db      {:messages {cid {mid {:id mid :whisper-timestamp 1}}}}
           message {:message-id mid :chat-id cid}]
@@ -57,7 +57,7 @@
         (testing "return nil if message not in db"
           (is (= (delete-message/delete {:db {:messages []}} message 1000) nil)))))))
 
-(deftest undo-delete
+(deftest undo-delete-test
   (let [db      {:messages {cid {mid {:id mid :whisper-timestamp 1}}}}
         message {:message-id mid :chat-id cid}]
     (testing "undo delete"
@@ -84,7 +84,7 @@
       (testing "return nil if message not in db"
         (is (= (delete-message/undo {:db {:messages []}} message) nil))))))
 
-(deftest delete-and-send
+(deftest delete-and-send-test
   (let [db      {:messages {cid {mid {:id mid :deleted? true :deleted-undoable-till 0}}}}
         message {:message-id mid :chat-id cid}]
     (testing "delete and send"

--- a/src/status_im/contexts/chat/messenger/messages/delete_message_for_me/events_test.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/delete_message_for_me/events_test.cljs
@@ -8,7 +8,7 @@
 (def mid "message-id")
 (def cid "chat-id")
 
-(deftest delete-for-me
+(deftest delete-for-me-test
   (with-redefs [datetime/timestamp (constantly 1)]
     (let [db      {:messages {cid {mid {:id mid :whisper-timestamp 1}}}}
           message {:message-id mid :chat-id cid}]
@@ -60,7 +60,7 @@
           (is (= (delete-message-for-me/delete {:db {:messages []}} message 1000)
                  nil)))))))
 
-(deftest undo-delete-for-me
+(deftest undo-delete-for-me-test
   (let [db      {:messages {cid {mid {:id mid :whisper-timestamp 1}}}}
         message {:message-id mid :chat-id cid}]
     (testing "undo delete for me"
@@ -93,7 +93,7 @@
         (is (= (delete-message-for-me/undo {:db {:messages []}} message)
                nil))))))
 
-(deftest delete-for-me-and-sync
+(deftest delete-for-me-and-sync-test
   (let [db      {:messages {cid {mid {:id mid :deleted-for-me? true :deleted-for-me-undoable-till 0}}}}
         message {:message-id mid :chat-id cid}]
     (testing "delete for me and sync"

--- a/src/status_im/contexts/chat/messenger/messages/list/events_test.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/events_test.cljs
@@ -4,7 +4,7 @@
     [status-im.contexts.chat.messenger.messages.list.events :as s]
     [taoensso.tufte :as tufte :refer-macros [defnp profile]]))
 
-(deftest message-stream-tests
+(deftest message-stream-tests-test
   (testing "building the list"
     (let [m1 {:from              "1"
               :clock-value       1
@@ -87,7 +87,7 @@
 (tufte/add-basic-println-handler! {:format-pstats-opts {:columns      [:n :mean :min :max :clock :sum]
                                                         :format-id-fn name}})
 
-(deftest ^:benchmark benchmark-list
+(deftest ^:benchmark benchmark-list-test
   (let [messages   (sort-by
                     :timestamp
                     (mapv (fn [i]
@@ -132,7 +132,7 @@
                    :whisper-timestamp 1000
                    :timestamp         1000}))))))
 
-(deftest message-list
+(deftest message-list-test
   (let [current-messages [{:clock-value       109
                            :message-id        "109"
                            :timestamp         9

--- a/src/status_im/contexts/chat/messenger/messages/resolver/message_resolver_test.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/resolver/message_resolver_test.cljs
@@ -27,7 +27,7 @@
       :destination "https://foo.bar"}
      {:literal " , no worries"}]}])
 
-(t/deftest test-resolve-message
+(t/deftest resolve-message-test
   (with-redefs [rf/sub sub]
     (t/testing ""
       (let [text (resolver/resolve-message parsed-text)]

--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -7,7 +7,7 @@
 
 (def community-id "community-id")
 
-(deftest fetch-community
+(deftest fetch-community-test
   (testing "with community id"
     (testing "update fetching indicator in db"
       (is (match?
@@ -26,7 +26,7 @@
            nil
            (events/fetch-community {} [{}]))))))
 
-(deftest community-failed-to-fetch
+(deftest community-failed-to-fetch-test
   (testing "given a community id"
     (testing "remove community id from fetching indicator in db"
       (is (match?
@@ -36,7 +36,7 @@
                                                      [community-id])
                    [:db :communities/fetching-communities community-id]))))))
 
-(deftest community-fetched
+(deftest community-fetched-test
   (with-redefs [link-preview.events/community-link (fn [id] (str "community-link+" id))]
     (testing "given a community"
       (let [cofx {:db {:communities/fetching-communities {community-id true}}}
@@ -82,7 +82,7 @@
              nil
              (events/community-fetched {} [community-id nil])))))))
 
-(deftest spectate-community
+(deftest spectate-community-test
   (testing "given a joined community"
     (testing "do nothing"
       (is (match?
@@ -112,13 +112,13 @@
                              :params [community-id]}]}
            (events/spectate-community {:db {:communities {community-id {}}}} [community-id]))))))
 
-(deftest spectate-community-failed
+(deftest spectate-community-failed-test
   (testing "mark community spectating false"
     (is (match?
          {:db {:communities {community-id {:spectating false}}}}
          (events/spectate-community-failed {} [community-id])))))
 
-(deftest spectate-community-success
+(deftest spectate-community-success-test
   (testing "given communities"
     (testing "mark first community spectating false"
       (is (match?
@@ -144,7 +144,7 @@
            nil
            (events/spectate-community-success {} []))))))
 
-(deftest get-revealed-accounts
+(deftest get-revealed-accounts-test
   (let [community {:id community-id}]
     (testing "given a unjoined community"
       (is (match?
@@ -169,7 +169,7 @@
                      :params [community-id "profile-public-key"]}
                     (-> effects :json-rpc/call first (select-keys [:method :params]))))))))
 
-(deftest handle-community
+(deftest handle-community-test
   (let [community {:id community-id :clock 2}]
     (testing "given a unjoined community"
       (let [effects (events/handle-community {} [community])]

--- a/src/status_im/contexts/wallet/add_account/create_account/events_test.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/events_test.cljs
@@ -6,7 +6,7 @@
     [status-im.contexts.wallet.add-account.create-account.events :as events]
     [utils.security.core :as security]))
 
-(deftest confirm-account-origin
+(deftest confirm-account-origin-test
   (let [db          {:wallet {:ui {:create-account {}}}}
         props       ["key-uid"]
         expected-db {:wallet {:ui {:create-account {:selected-keypair-uid "key-uid"}}}}
@@ -14,7 +14,7 @@
         result-db   (:db effects)]
     (is (match? result-db expected-db))))
 
-(deftest store-seed-phrase
+(deftest store-seed-phrase-test
   (let [db          {}
         props       [{:seed-phrase "test-secret" :random-phrase "random-test"}]
         expected-db {:wallet {:ui {:create-account {:new-keypair {:seed-phrase   "test-secret"
@@ -23,7 +23,7 @@
         result-db   (:db effects)]
     (is (match? result-db expected-db))))
 
-(deftest store-account-generated
+(deftest store-account-generated-test
   (let [db              {:wallet {:ui {:create-account
                                        {:new-keypair {:seed-phrase   "test-secret"
                                                       :random-phrase "random-test"}}}}}
@@ -55,7 +55,7 @@
     (is (= (unmask-mnemonic result-db) (unmask-mnemonic expected-db)))))
 
 
-(deftest generate-account-for-keypair
+(deftest generate-account-for-keypair-test
   (let [db               {:wallet {:ui {:create-account {:new-keypair {:seed-phrase "test-secret"}}}}}
         props            [{:keypair-name "test-keypair"}]
         expected-effects [[:effects.wallet/create-account-from-mnemonic
@@ -67,7 +67,7 @@
          {:fx expected-effects}))
     (is (some? (get-in effects [:fx 0 1 :on-success])))))
 
-(deftest clear-create-account-data
+(deftest clear-create-account-data-test
   (let [db          {:wallet {:ui {:create-account {:new-keypair "test-keypair"}}}}
         expected-db {:wallet {:ui {:create-account {}}}}
         effects     (events/clear-create-account-data {:db db})]

--- a/src/status_im/contexts/wallet/collectible/utils_test.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils_test.cljs
@@ -7,7 +7,7 @@
 (def token-id "0xT")
 (def contract-address "0xC")
 
-(deftest test-network->chain-id
+(deftest network->chain-id-test
   (testing "get-opensea-collectible-url mainnet"
     (is (= (utils/get-opensea-collectible-url {:chain-id         constants/ethereum-mainnet-chain-id
                                                :contract-address contract-address
@@ -66,5 +66,3 @@
                                                :test-networks-enabled? true
                                                :is-goerli-enabled?     true})
            "https://testnets.opensea.io/assets/optimism-goerli/0xC/0xT"))))
-
-

--- a/src/status_im/contexts/wallet/common/utils/networks_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils/networks_test.cljs
@@ -4,7 +4,7 @@
     [status-im.constants :as constants]
     [status-im.contexts.wallet.common.utils.networks :as utils]))
 
-(deftest test-network->chain-id
+(deftest network->chain-id-test
   (testing "network->chain-id function"
     (is (= (utils/network->chain-id {:network :mainnet :testnet-enabled? false :goerli-enabled? false})
            constants/ethereum-mainnet-chain-id))
@@ -21,15 +21,6 @@
     (is (= (utils/network->chain-id {:network :arbitrum :testnet-enabled? true :goerli-enabled? false})
            constants/arbitrum-sepolia-chain-id))))
 
-(deftest test-network-preference-prefix->network-names
-  (testing "network-preference-prefix->network-names function"
-    (is (= (utils/network-preference-prefix->network-names "eth")
-           (seq [:mainnet])))
-    (is (= (utils/network-preference-prefix->network-names "eth:oeth")
-           (seq [:mainnet :optimism])))
-    (is (= (utils/network-preference-prefix->network-names "eth:oeth:arb1")
-           (seq [:mainnet :optimism :arbitrum])))))
-
 (deftest short-names->network-preference-prefix-test
   (are [expected short-names]
    (= expected (utils/short-names->network-preference-prefix short-names))
@@ -44,7 +35,7 @@
    (seq [:mainnet :optimism])           "eth:oeth"
    (seq [:mainnet :optimism :arbitrum]) "eth:oeth:arb1"))
 
-(deftest test-network-ids->formatted-text
+(deftest network-ids->formatted-text-test
   (testing "Empty network-ids should return an empty string"
     (is (= "" (utils/network-ids->formatted-text []))))
 

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -4,12 +4,12 @@
     [status-im.contexts.wallet.common.utils :as utils]
     [utils.money :as money]))
 
-(deftest test-get-first-name
+(deftest get-first-name-test
   (testing "get-first-name function"
     (is (= (utils/get-first-name "John Doe") "John"))
     (is (= (utils/get-first-name "Jane Smith xyz") "Jane"))))
 
-(deftest test-prettify-balance
+(deftest prettify-balance-test
   (testing "prettify-balance function"
     (is (= (utils/prettify-balance "$" 100) "$100.00"))
     (is (= (utils/prettify-balance "$" 0.5) "$0.50"))
@@ -17,25 +17,25 @@
     (is (= (utils/prettify-balance "$" nil) "$0.00"))
     (is (= (utils/prettify-balance "$" "invalid input") "$0.00"))))
 
-(deftest test-get-derivation-path
+(deftest get-derivation-path-test
   (testing "get-derivation-path function"
     (is (= (utils/get-derivation-path 5) "m/44'/60'/0'/0/5"))
     (is (= (utils/get-derivation-path 0) "m/44'/60'/0'/0/0"))
     (is (= (utils/get-derivation-path 123) "m/44'/60'/0'/0/123"))))
 
-(deftest test-format-derivation-path
+(deftest format-derivation-path-test
   (testing "format-derivation-path function"
     (is (= (utils/format-derivation-path "m/44'/60'/0'/0/5") "m / 44' / 60' / 0' / 0 / 5"))
     (is (= (utils/format-derivation-path "m/44'/60'/0'/0/0") "m / 44' / 60' / 0' / 0 / 0"))
     (is (= (utils/format-derivation-path "m/44'/60'/0'/0/123") "m / 44' / 60' / 0' / 0 / 123"))))
 
-(deftest test-get-formatted-derivation-path
+(deftest get-formatted-derivation-path-test
   (testing "get-formatted-derivation-path function"
     (is (= (utils/get-formatted-derivation-path 5) "m / 44' / 60' / 0' / 0 / 5"))
     (is (= (utils/get-formatted-derivation-path 0) "m / 44' / 60' / 0' / 0 / 0"))
     (is (= (utils/get-formatted-derivation-path 123) "m / 44' / 60' / 0' / 0 / 123"))))
 
-(deftest test-total-raw-balance-in-all-chains
+(deftest total-raw-balance-in-all-chains-test
   (testing "total-raw-balance-in-all-chains function"
     (let [balances-per-chain {1     {:raw-balance (money/bignumber 100)}
                               10    {:raw-balance (money/bignumber 200)}
@@ -43,13 +43,13 @@
       (is (money/equal-to (utils/total-raw-balance-in-all-chains balances-per-chain)
                           (money/bignumber 600))))))
 
-(deftest test-extract-exponent
+(deftest extract-exponent-test
   (testing "extract-exponent function"
     (is (= (utils/extract-exponent "123.456") nil))
     (is (= (utils/extract-exponent "2.5e-2") "2"))
     (is (= (utils/extract-exponent "4.567e-10") "10"))))
 
-(deftest test-calc-max-crypto-decimals
+(deftest calc-max-crypto-decimals-test
   (testing "calc-max-crypto-decimals function"
     (is (= (utils/calc-max-crypto-decimals 0.00323) 2))
     (is (= (utils/calc-max-crypto-decimals 0.00123) 3))
@@ -57,7 +57,7 @@
     (is (= (utils/calc-max-crypto-decimals 2.23e-6) 5))
     (is (= (utils/calc-max-crypto-decimals 1.13e-6) 6))))
 
-(deftest test-get-standard-crypto-format
+(deftest get-standard-crypto-format-test
   (testing "get-standard-crypto-format function"
     (let [market-values-per-currency {:usd {:price 100}}
           token-units                (money/bignumber 0.005)]
@@ -70,7 +70,7 @@
                                                token-units)
              "<2")))))
 
-(deftest test-calculate-total-token-balance
+(deftest calculate-total-token-balance-test
   (testing "calculate-total-token-balance function"
     (let [token {:balances-per-chain {1     {:raw-balance (money/bignumber 100)}
                                       10    {:raw-balance (money/bignumber 200)}
@@ -78,7 +78,7 @@
                  :decimals           2}]
       (is (money/equal-to (utils/calculate-total-token-balance token) 6.0)))))
 
-(deftest test-get-account-by-address
+(deftest get-account-by-address-test
   (testing "get-account-by-address function"
     (let [accounts        [{:address "0x123"}
                            {:address "0x456"}
@@ -92,7 +92,7 @@
           address-to-find "0x999"]
       (is (= (utils/get-account-by-address accounts address-to-find) nil)))))
 
-(deftest test-get-wallet-qr
+(deftest get-wallet-qr-test
   (testing "Test get-wallet-qr function"
     (let [wallet-multichain  {:wallet-type       :multichain
                               :selected-networks [:ethereum :optimism]
@@ -107,7 +107,7 @@
       (is (= (utils/get-wallet-qr wallet-singlechain)
              "x000")))))
 
-(deftest test-prettify-percentage-change
+(deftest prettify-percentage-change-test
   (testing "prettify-percentage-change function"
     (is (= (utils/prettify-percentage-change nil) "0.00"))
     (is (= (utils/prettify-percentage-change "") "0.00"))

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -9,7 +9,7 @@
 
 (def address "0x2f88d65f3cb52605a54a833ae118fb1363acccd2")
 
-(deftest scan-address-success
+(deftest scan-address-success-test
   (let [db {}]
     (testing "scan-address-success"
       (let [expected-db {:wallet {:ui {:scanned-address address}}}
@@ -17,7 +17,7 @@
             result-db   (:db effects)]
         (is (match? result-db expected-db))))))
 
-(deftest clean-scanned-address
+(deftest clean-scanned-address-test
   (let [db {:wallet {:ui {:scanned-address address}}}]
     (testing "clean-scanned-address"
       (let [expected-db {:wallet {:ui {:send            nil
@@ -26,7 +26,7 @@
             result-db   (:db effects)]
         (is (match? result-db expected-db))))))
 
-(deftest store-collectibles
+(deftest store-collectibles-test
   (testing "flush-collectibles"
     (let [collectible-1 {:collectible-data {:image-url "https://..." :animation-url "https://..."}
                          :ownership        [{:address "0x1"
@@ -51,7 +51,7 @@
 
       (is (match? result-db expected-db)))))
 
-(deftest clear-stored-collectibles
+(deftest clear-stored-collectibles-test
   (let [db {:wallet {:accounts {"0x1" {:collectibles [{:id 1} {:id 2}]}
                                 "0x2" {"some other stuff" "with any value"
                                        :collectibles      [{:id 3}]}
@@ -65,7 +65,7 @@
 
         (is (match? result-db expected-db))))))
 
-(deftest store-last-collectible-details
+(deftest store-last-collectible-details-test
   (testing "store-last-collectible-details"
     (let [db               {:wallet {}}
           last-collectible {:description "Pandaria"
@@ -77,7 +77,7 @@
           result-db        (:db effects)]
       (is (match? result-db expected-db)))))
 
-(deftest reset-selected-networks
+(deftest reset-selected-networks-test
   (testing "reset-selected-networks"
     (let [db          {:wallet {}}
           expected-db {:wallet db/defaults}
@@ -85,7 +85,7 @@
           result-db   (:db effects)]
       (is (match? result-db expected-db)))))
 
-(deftest update-selected-networks
+(deftest update-selected-networks-test
   (testing "update-selected-networks"
     (let [db           {:wallet {:ui {:network-filter {:selected-networks
                                                        #{constants/optimism-network-name}

--- a/src/status_im/contexts/wallet/send/utils_test.cljs
+++ b/src/status_im/contexts/wallet/send/utils_test.cljs
@@ -4,7 +4,7 @@
             [utils.map :as map]
             [utils.money :as money]))
 
-(deftest test-amount-in-hex
+(deftest amount-in-hex-test
   (testing "Test amount-in-hex function"
     (let [amount  1
           decimal 18]
@@ -16,7 +16,7 @@
    :hashes {:5   ["0x5"]
             :420 ["0x12" "0x11"]}})
 
-(deftest test-map-multitransaction-by-ids
+(deftest map-multitransaction-by-ids-test
   (testing "test map-multitransaction-by-ids formats to right data structure"
     (let [{:keys [id hashes]} multichain-transacation]
       (is (= (utils/map-multitransaction-by-ids id hashes)
@@ -30,7 +30,7 @@
                       :id       61
                       :chain-id :420}})))))
 
-(deftest test-network-amounts-by-chain
+(deftest network-amounts-by-chain-test
   (testing "Correctly calculates network amounts for transaction with native token"
     (let [route          [{:amount-in "0xde0b6b3a7640000"
                            :to        {:chain-id 1}}
@@ -82,7 +82,7 @@
       (doseq [[chain-id exp-value] expected]
         (is (money/equal-to (get result chain-id) exp-value))))))
 
-(deftest test-network-values-for-ui
+(deftest network-values-for-ui-test
   (testing "Sanitizes values correctly for display"
     (let [amounts  {1     (money/bignumber "0")
                     10    (money/bignumber "2.5")
@@ -95,7 +95,7 @@
         (is #(or (= (get result chain-id) exp-value)
                  (money/equal-to (get result chain-id) exp-value)))))))
 
-(deftest test-calculate-gas-fee
+(deftest calculate-gas-fee-test
   (testing "EIP-1559 transaction without L1 fee"
     (let [data            {:gas-amount "23487"
                            :gas-fees   {:max-fee-per-gas-medium "2.259274911"
@@ -125,7 +125,7 @@
       (is (money/equal-to (utils/calculate-gas-fee data)
                           expected-result)))))
 
-(deftest test-calculate-full-route-gas-fee
+(deftest calculate-full-route-gas-fee-test
   (testing "Route with a single EIP-1559 transaction, no L1 fees"
     (let [route           [{:gas-amount "23487"
                             :gas-fees   {:max-fee-per-gas-medium "2.259274911"
@@ -166,7 +166,7 @@
       (is (money/equal-to (utils/calculate-full-route-gas-fee route)
                           expected-result)))))
 
-(deftest test-token-available-networks-for-suggested-routes
+(deftest token-available-networks-for-suggested-routes-test
   (testing "Excludes disabled chain-ids correctly"
     (let [balances-per-chain {1     {:chain-id 1 :balance 100}
                               10    {:chain-id 10 :balance 200}
@@ -209,7 +209,7 @@
                                                                    :disabled-chain-ids
                                                                    disabled-chain-ids}))))))
 
-(deftest test-reset-loading-network-amounts-to-zero
+(deftest reset-loading-network-amounts-to-zero-test
   (testing "Correctly resets loading network amounts to zero and changes type to default"
     (let [network-amounts [{:chain-id 1 :total-amount (money/bignumber "100") :type :loading}
                            {:chain-id 10 :total-amount (money/bignumber "200") :type :default}]
@@ -267,7 +267,7 @@
                                result)]
       (is (every? identity comparisons)))))
 
-(deftest test-network-amounts
+(deftest network-amounts-test
   (testing "Handles disabled and receiver networks correctly when receiver? is true"
     (let [network-values     {10 (money/bignumber "200")}
           disabled-chain-ids [1]
@@ -435,7 +435,7 @@
                                                      :receiver?          receiver?})]
       (is (every? identity (map #(map/deep-compare %1 %2) expected result))))))
 
-(deftest test-loading-network-amounts
+(deftest loading-network-amounts-test
   (testing "Assigns :loading type to valid networks except for disabled ones"
     (let [valid-networks     [1 10 42161]
           disabled-chain-ids [42161]
@@ -598,7 +598,7 @@
                                   result)]
       (is (every? identity comparisons)))))
 
-(deftest test-network-links
+(deftest network-links-test
   (testing "Calculates position differences correctly"
     (let [route                [{:from {:chain-id 1} :to {:chain-id 42161}}
                                 {:from {:chain-id 10} :to {:chain-id 1}}

--- a/src/status_im/subs/messages_test.cljs
+++ b/src/status_im/subs/messages_test.cljs
@@ -27,11 +27,11 @@
     :timestamp-str "14:00"
     :content-type constants/content-type-album}])
 
-(deftest albumize-messages
+(deftest albumize-messages-test
   (testing "Finding albums in the messages list"
     (is (= (messages/albumize-messages messages-state) messages-albumized-state))))
 
-(deftest intersperse-datemarks
+(deftest intersperse-datemarks-test
   (testing "it mantains the order even when timestamps are across days"
     (let [message-1           {:datemark          "Dec 31, 1999"
                                :whisper-timestamp 946641600000} ; 1999}

--- a/src/tests/contract_test/profile_test.cljs
+++ b/src/tests/contract_test/profile_test.cljs
@@ -12,7 +12,7 @@
 
 (use-fixtures :each (h/fixture-session))
 
-(deftest profile-set-bio-contract
+(deftest profile-set-bio-contract-test
   (h/test-async :contract/wakuext_setBio
     (fn []
       (-> (contract-utils/call-rpc "wakuext_setBio" "new bio")

--- a/src/tests/contract_test/wallet_test.cljs
+++ b/src/tests/contract_test/wallet_test.cljs
@@ -34,7 +34,7 @@
   (let [default-account (contract-utils/get-default-account accounts)]
     (is (= (:emoji default-account) test-emoji))))
 
-(deftest accounts-save-accounts-contract
+(deftest accounts-save-accounts-contract-test
   (h/test-async :contract/accounts-save-account
     (fn []
       (promesa/let [test-emoji      (emoji-picker.utils/random-emoji)
@@ -56,7 +56,7 @@
   (is (some #(= constants/arbitrum-sepolia-chain-id (get-in % [:Test :chainId])) response))
   (is (some #(= constants/optimism-sepolia-chain-id (get-in % [:Test :chainId])) response)))
 
-(deftest accounts-get-chains-contract
+(deftest accounts-get-chains-contract-test
   (h/test-async :contract/wallet_get-ethereum-chains
     (fn []
       (promesa/let [response (contract-utils/call-rpc "wallet_getEthereumChains")]

--- a/src/tests/integration_test/standard_auth_test.cljs
+++ b/src/tests/integration_test/standard_auth_test.cljs
@@ -24,7 +24,7 @@
   (rf/reg-fx :keychain/get-user-password
    (fn [[_ on-success]] (on-success))))
 
-(deftest standard-auth-biometric-authorize-success
+(deftest standard-auth-biometric-authorize-success-test
   (testing "calling success callback when completing biometric authentication"
     (h/log-headline :standard-auth-authorize-success)
     (rf-test/run-test-async
@@ -43,7 +43,7 @@
    (fn [_ [{:keys [on-cancel]}]] (on-cancel)))
   (rf/reg-event-fx :show-bottom-sheet identity))
 
-(deftest standard-auth-biometric-authorize-cancel
+(deftest standard-auth-biometric-authorize-cancel-test
   (testing "falling back to password authorization when biometrics canceled"
     (h/log-headline :standard-auth-authorize-cancel)
     (rf-test/run-test-async
@@ -60,7 +60,7 @@
    (fn [_ [{:keys [on-fail]}]] (on-fail (ex-info "error" {} expected-error-cause))))
   (rf/reg-event-fx :biometric/show-message identity))
 
-(deftest standard-auth-biometric-authorize-fail
+(deftest standard-auth-biometric-authorize-fail-test
   (testing "showing biometric error message when authorization failed"
     (h/log-headline :standard-auth-authorize-fail)
     (rf-test/run-test-async
@@ -84,7 +84,7 @@
    (fn [{:keys [on-fail]}] (on-fail)))
   (rf/reg-event-fx :show-bottom-sheet identity))
 
-(deftest standard-auth-password-authorize-fallback
+(deftest standard-auth-password-authorize-fallback-test
   (testing "falling back to password when biometrics is not available"
     (h/log-headline :standard-auth-password-authorize-fallback)
     (rf-test/run-test-async

--- a/src/utils/address_test.cljs
+++ b/src/utils/address_test.cljs
@@ -3,7 +3,7 @@
     [cljs.test :refer [deftest is testing]]
     [utils.address]))
 
-(deftest get-shortened-compressed-key
+(deftest get-shortened-compressed-key-test
   (testing "Ensure the function correctly abbreviates a valid public key"
     (is (= "zQ3...sgt5N"
            (utils.address/get-shortened-compressed-key
@@ -20,7 +20,7 @@
     (is (nil? (utils.address/get-shortened-compressed-key "1234")))))
 
 
-(deftest test-get-abbreviated-profile-url
+(deftest get-abbreviated-profile-url-test
   (testing "Ensure the function correctly generates an abbreviated profile URL for a valid public key"
     (is (= "status.app/u/abcde...mrdYpzeFUa"
            (utils.address/get-abbreviated-profile-url

--- a/src/utils/ens/stateofus_test.cljs
+++ b/src/utils/ens/stateofus_test.cljs
@@ -3,13 +3,13 @@
     [cljs.test :refer-macros [deftest is]]
     [utils.ens.stateofus :as stateofus]))
 
-(deftest valid-username?
+(deftest valid-username?-test
   (is (false? (stateofus/valid-username? nil)))
   (is (true? (stateofus/valid-username? "andrey")))
   (is (false? (stateofus/valid-username? "Andrey")))
   (is (true? (stateofus/valid-username? "andrey12"))))
 
-(deftest username-with-domain
+(deftest username-with-domain-test
   (is (nil? (stateofus/username-with-domain nil)))
   (is (= "andrey.stateofus.eth" (stateofus/username-with-domain "andrey")))
   (is (= "andrey.eth" (stateofus/username-with-domain "andrey.eth")))

--- a/src/utils/ethereum/chain_test.cljs
+++ b/src/utils/ethereum/chain_test.cljs
@@ -13,11 +13,11 @@
                                        {:chain-id 42161}
                                        {:chain-id 10}]}}})
 
-(deftest chain-id->chain-keyword
+(deftest chain-id->chain-keyword-test
   (is (= (chain/chain-id->chain-keyword 1) :mainnet))
   (is (= (chain/chain-id->chain-keyword 5) :goerli))
   (is (= (chain/chain-id->chain-keyword 5777) :custom)))
 
-(deftest chain-ids
+(deftest chain-ids-test
   (is (= (chain/chain-ids (chain-ids-db false)) [1 42161 10]))
   (is (= (chain/chain-ids (chain-ids-db true)) [3 4 5])))

--- a/src/utils/ethereum/eip/eip55_test.cljs
+++ b/src/utils/ethereum/eip/eip55_test.cljs
@@ -3,7 +3,7 @@
     [cljs.test :refer-macros [deftest is]]
     [utils.ethereum.eip.eip55 :as eip55]))
 
-(deftest valid-address-checksum?
+(deftest valid-address-checksum?-test
   (is (true? (eip55/valid-address-checksum? "0x52908400098527886E0F7030069857D2E4169EE7")))
   (is (true? (eip55/valid-address-checksum? "0x8617E340B3D01FA5F11F306F4090FD50E238070D")))
   (is (true? (eip55/valid-address-checksum? "0xde709f2102306220921060314715629080e2fb77")))

--- a/src/utils/ethereum/eip/eip681_test.cljs
+++ b/src/utils/ethereum/eip/eip681_test.cljs
@@ -4,7 +4,7 @@
     [utils.ethereum.eip.eip681 :as eip681]
     [utils.money :as money]))
 
-(deftest parse-uri
+(deftest parse-uri-test
   (is (= nil (eip681/parse-uri nil)))
   (is (= nil (eip681/parse-uri 5)))
   (is (= nil (eip681/parse-uri "random")))
@@ -118,7 +118,7 @@
               :symbol :STT
               :decimals 18}}})
 
-(deftest generate-uri
+(deftest generate-uri-test
   (is (= nil (eip681/generate-uri nil nil)))
   (is (= "ethereum:0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7"
          (eip681/generate-uri "0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7" nil)))
@@ -148,7 +148,7 @@
                           :function-arguments {:address "0x8e23ee67d1332ad560396262c48ffbb01f93d052"
                                                :uint256 1}}))))
 
-(deftest round-trip
+(deftest round-trip-test
   (let [uri "ethereum:0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7@3?value=1&gas=100"
         {:keys [address] :as params} (eip681/parse-uri uri)]
     (is (= uri (eip681/generate-uri address (dissoc params :address)))))

--- a/src/utils/image_server_test.cljs
+++ b/src/utils/image_server_test.cljs
@@ -4,7 +4,7 @@
     [quo.foundations.colors :as colors]
     [utils.image-server :as sut]))
 
-(t/deftest get-account-image-uri
+(t/deftest get-account-image-uri-test
   (with-redefs
     [sut/current-theme-index identity
      sut/timestamp           (constantly "timestamp")]
@@ -23,7 +23,7 @@
                                   :ring-width               2})
       "https://localhost:port/accountImages?publicKey=public-key&keyUid=key-uid&imageName=image-name&size=0&theme=:dark&clock=timestamp&indicatorColor=rgba(9%2C16%2C28%2C0.08)&indicatorSize=4&indicatorBorder=0&indicatorCenterToEdge=12&addRing=1&ringWidth=4"))))
 
-(t/deftest get-account-initials-uri
+(t/deftest get-account-initials-uri-test
   (with-redefs
     [sut/current-theme-index identity
      colors/resolve-color    str

--- a/src/utils/money_test.cljs
+++ b/src/utils/money_test.cljs
@@ -3,7 +3,7 @@
     [cljs.test :refer-macros [deftest testing is are]]
     [utils.money :as money]))
 
-(deftest wei->ether
+(deftest wei->ether-test
   (testing "Numeric input, 15 significant digits"
     (is (= (str (money/wei->ether 111122223333444000))
            "0.111122223333444")))
@@ -11,19 +11,19 @@
     (is (= (str (money/wei->ether "111122223333441239"))
            "0.111122223333441239"))))
 
-(deftest valid?
+(deftest valid?-test
   (is (not (true? (money/valid? nil))))
   (is (true? (money/valid? (money/bignumber 0))))
   (is (true? (money/valid? (money/bignumber 1))))
   (is (not (true? (money/valid? (money/bignumber -1))))))
 
-(deftest normalize
+(deftest normalize-test
   (is (= nil (money/normalize nil)))
   (is (= "1" (money/normalize "  1 ")))
   (is (= "1.1" (money/normalize "1.1")))
   (is (= "1.1" (money/normalize "1,1"))))
 
-(deftest format-amount
+(deftest format-amount-test
   (are [amount expected]
    (= expected (money/format-amount amount))
    nil       nil

--- a/src/utils/number_test.cljs
+++ b/src/utils/number_test.cljs
@@ -3,7 +3,7 @@
     [cljs.test :refer [deftest is testing]]
     [utils.number]))
 
-(deftest parse-int
+(deftest parse-int-test
   (testing "defaults to zero"
     (is (= 0 (utils.number/parse-int nil))))
 

--- a/src/utils/security/security_html_test.cljs
+++ b/src/utils/security/security_html_test.cljs
@@ -3,11 +3,11 @@
     [cljs.test :refer-macros [deftest is testing]]
     [utils.security.security-html :as s]))
 
-(deftest with-doctype
+(deftest with-doctype-test
   (is (s/is-html? "<!doctype html>"))
   (is (s/is-html? "\n\n<!doctype html><html>")))
 
-(deftest body-html-tags
+(deftest body-html-tags-test
   (testing "detect HTML if it has <html>, <body> or <x-*>"
     (is (s/is-html? "<html>"))
     (is (s/is-html? "<html></html>"))
@@ -16,12 +16,12 @@
     (is (s/is-html? "<html><body class=\"no-js\"></html>"))
     (is (s/is-html? "<x-unicorn>"))))
 
-(deftest html-standard-tags
+(deftest html-standard-tags-test
   (testing "detect HTML if it contains any of the standard HTML tags"
     (is (s/is-html? "<p>foo</p>"))
     (is (s/is-html? "<a href=\"#\">foo</a>"))))
 
-(deftest not-matching-xml
+(deftest not-matching-xml-test
   (is (not (s/is-html? "<cake>foo</cake>")))
   (is (not (s/is-html? "<any>rocks</any>")))
   (is (not (s/is-html? "<htmly>not</htmly>")))

--- a/src/utils/security/security_test.cljs
+++ b/src/utils/security/security_test.cljs
@@ -7,7 +7,7 @@
 (def rtlo-link "‮http://google.com")
 (def rtlo-link-text "blah blah ‮  some other blah blah http://google.com blah bash")
 
-(deftest safe-link-test-happy-path
+(deftest safe-link-test-happy-path-test
   (testing "an http link"
     (is (security/safe-link? "http://test.com")))
   (testing "an https link"
@@ -15,7 +15,7 @@
   (testing "a link without a a protocol"
     (is (security/safe-link? "test.com"))))
 
-(deftest safe-link-test-exceptions
+(deftest safe-link-test-exceptions-test
   (testing "a javascript link"
     (is (not (security/safe-link? "javascript://anything"))))
   (testing "a javascript link mixed cases"
@@ -27,7 +27,7 @@
   (testing "rtlo links"
     (is (not (security/safe-link? rtlo-link)))))
 
-(deftest safe-link-text-test-exceptions
+(deftest safe-link-text-test-exceptions-test
   (testing "rtlo links"
     (is (not (security/safe-link-text? rtlo-link-text)))))
 

--- a/src/utils/url_test.cljs
+++ b/src/utils/url_test.cljs
@@ -3,7 +3,7 @@
     [cljs.test :refer-macros [deftest is testing]]
     [utils.url :as url]))
 
-(deftest url-sanitize-check
+(deftest url-sanitize-check-test
   (testing
     "https://storage.googleapis.com/ck-kitty-image/0x06012c8cf97bead5deae237070f9587f8e7a266d/818934.svg"
     (testing "it returns true"
@@ -59,7 +59,7 @@
         (url/url-sanitized?
          "https://www.etheremon.com/assets/images/mons'><script>\\\\x3Bjavascript:alert(1)</script>origin/025.png"))))))
 
-(deftest url-host-check
+(deftest url-host-check-test
   (testing "Extract host/domain from URL"
     (testing "Valid URL with endpoint"
       (is (= "status.im" (url/url-host "https://status.im/testing"))))

--- a/src/utils/vector_test.cljs
+++ b/src/utils/vector_test.cljs
@@ -3,7 +3,7 @@
     [cljs.test :refer-macros [deftest is testing]]
     [utils.vector :as vector]))
 
-(deftest test-insert-element-at
+(deftest insert-element-at-test
   (testing "Inserting into an empty vector"
     (is (= [42] (vector/insert-element-at [] 42 0))))
 


### PR DESCRIPTION
### Summary

A quick win :) This PR adds a new linter to verify all test names are consistent with one common convention we already follow, for the most part, which is:

> Test vars (test names) should be suffixed with `-test`.

My motivation was that I was going to make again another comment about this in a PR review, but then I realized it wouldn't take much longer to just lint this problem once and for all.

There's no strong reason for following this convention, although it's quite common in Clojure, but in any case, these are the reasons I can think of and remember:

- Naming consistency. Sometimes tests start with `test-`, others end with `test` and others don't prefix/suffix at all. While fixing lint errors in this PR I saw a few namespaces that had all 3 conventions in the same file.
- The suffix removes potential conflicts with core Clojure functions.
- The suffix mostly eliminates potential conflicts with other vars in the test namespace. Example: you can declare a function `delete` and have a test named `delete-test`.
- For someone using Emacs `imenu` feature, it helps differentiate which vars are tests and which are just local functions supporting the tests.

#### Areas that may be impacted

None.

### Steps to test

For a dev, just open any test namespace and try to give it an "invalid" name and the linter error should be displayed. If it doesn't, you may need to remove the `.clj-kondo/cache` directory and even restart your editor (I had to). `make lint` should work as expected, this potential problem is just for the live editor preview of errors.

status: ready
