### PR TITLE
fix: face id toggle respect system face id permission

### DIFF
--- a/src/react_native/biometrics.cljs
+++ b/src/react_native/biometrics.cljs
@@ -41,13 +41,13 @@
   [message]
   (let [cause (if platform/android?
                 (condp = message
-                  android-not-enrolled-error-message      :biometrics/not-enrolled-error
+                  android-not-enrolled-error-message      :biometrics/fingerprints-not-enrolled-error
                   android-not-available-error-message     :biometrics/not-available-error
                   android-too-many-attempts-error-message :biometric/too-many-attempts
                   :biometrics/unknown-error)
 
                 (condp #(string/includes? %2 %1) message
-                  ios-not-enrolled-error-message :biometrics/not-enrolled-error
+                  ios-not-enrolled-error-message :biometrics/ios-not-enrolled-error
                   :biometrics/unknown-error))]
     (ex-info "Failed to authenticate with biometrics"
              {:orig-error-message message}

--- a/src/status_im/common/biometric/events.cljs
+++ b/src/status_im/common/biometric/events.cljs
@@ -14,8 +14,11 @@
 (defn show-message
   [_ [code]]
   (let [content (case code
-                  (:biometrics/not-enrolled-error
+                  (:biometrics/fingerprints-not-enrolled-error
                    :biometrics/not-available-error)
+                  (i18n/label :t/grant-fingerprints-permissions)
+
+                  :biometrics/ios-not-enrolled-error
                   (i18n/label :t/grant-face-id-permissions)
 
                   :biometric/too-many-attempts

--- a/src/status_im/common/biometric/events_test.cljs
+++ b/src/status_im/common/biometric/events_test.cljs
@@ -18,7 +18,7 @@
     (let [cofx     {:db {}}
           expected {:fx [[:effects.utils/show-popup
                           {:title   (i18n/label :t/biometric-auth-login-error-title)
-                           :content (i18n/label :t/grant-face-id-permissions)}]]}]
+                           :content (i18n/label :t/grant-fingerprints-permissions)}]]}]
       (is (match? expected
                   (sut/show-message cofx
                                     [:biometrics/not-available-error])))))

--- a/src/status_im/contexts/profile/settings/screens/password/view.cljs
+++ b/src/status_im/contexts/profile/settings/screens/password/view.cljs
@@ -30,18 +30,18 @@
         supported?     (boolean biometric-type)
         enabled?       (= auth-method constants/auth-method-biometric)
         biometric-on?  (and supported? enabled?)
-        press-handler  (if biometric-on?
-                         (fn [] (rf/dispatch [:biometric/disable]))
-                         (on-press-biometric-enable label theme))]
+        press-handler  (when supported?
+                         (if biometric-on?
+                           (fn [] (rf/dispatch [:biometric/disable]))
+                           (on-press-biometric-enable label theme)))]
     {:title        label
      :image-props  icon
      :image        :icon
      :blur?        true
      :action       :selector
-     :action-props {:disabled? (not supported?)
-                    :on-change press-handler
+     :action-props {:on-change press-handler
                     :checked?  biometric-on?}
-     :on-press     (when supported? press-handler)}))
+     :on-press     press-handler}))
 
 (defn- get-change-password-item
   []

--- a/translations/en.json
+++ b/translations/en.json
@@ -1629,6 +1629,7 @@
     "ok-save-pass": "OK, save password",
     "lock-app-with": "Lock app with",
     "grant-face-id-permissions": "To grant the required Face ID permission, please go to your system settings and make sure that Status > Face ID is selected",
+    "grant-fingerprints-permissions": "To grant the required fingerprints permission, please go to your system settings and make sure that Status > Fingerprints is selected",
     "request-feature": "Request a feature",
     "select-account-dapp": "Select the account you wish to use with Dapps",
     "apply": "Apply",


### PR DESCRIPTION
-------
In #20149
> Touch ID is shown instead of Face ID
> Error at attepmt to enable it

This only fixes the error at attempt to enable it part, it's still showing Face ID on iOS

### Summary

the code is using settings item component which do not support `disabled?`
also settings item will fallback to on-change handler when there's no on-press handler https://github.com/status-im/status-mobile/blob/ff634dd62367daf85237193d4c252c71852d3948/src/quo/components/settings/settings_item/view.cljs#L112

I checked the design and it seems there's no disabled state for this component

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
face id settingng

### Steps to test
same as the video in #20149

status: ready <!-- Can be ready or wip -->