### PR TITLE
Show proper error when bio metric fails

### DIFF
--- a/src/react_native/biometrics.cljs
+++ b/src/react_native/biometrics.cljs
@@ -8,6 +8,8 @@
 
 (def ^:private ^:const android-not-available-error-message "Biometric hardware unavailable")
 (def ^:private ^:const android-not-enrolled-error-message "No fingerprints enrolled.")
+(def ^:private ^:const android-too-many-attempts-error-message
+  "Too many attempts. Use screen lock instead.")
 (def ^:private ^:const ios-not-enrolled-error-message "No identities are enrolled")
 
 (defn get-supported-type
@@ -39,8 +41,9 @@
   [message]
   (let [cause (if platform/android?
                 (condp = message
-                  android-not-enrolled-error-message  :biometrics/not-enrolled-error
-                  android-not-available-error-message :biometrics/not-available-error
+                  android-not-enrolled-error-message      :biometrics/not-enrolled-error
+                  android-not-available-error-message     :biometrics/not-available-error
+                  android-too-many-attempts-error-message :biometric/too-many-attempts
                   :biometrics/unknown-error)
 
                 (condp #(string/includes? %2 %1) message

--- a/src/status_im/common/biometric/events.cljs
+++ b/src/status_im/common/biometric/events.cljs
@@ -13,10 +13,14 @@
 
 (defn show-message
   [_ [code]]
-  (let [content (if (#{:biometrics/not-enrolled-error
-                       :biometrics/not-available-error}
-                     code)
+  (let [content (case code
+                  (:biometrics/not-enrolled-error
+                   :biometrics/not-available-error)
                   (i18n/label :t/grant-face-id-permissions)
+
+                  :biometric/too-many-attempts
+                  (i18n/label :t/biometric-too-many-attempts)
+
                   (i18n/label :t/biometric-auth-error {:code code}))]
     {:fx [[:effects.utils/show-popup
            {:title   (i18n/label :t/biometric-auth-login-error-title)

--- a/translations/en.json
+++ b/translations/en.json
@@ -91,6 +91,7 @@
     "biometric-enable-button": "Enable {{bio-type-label}}",
     "biometric-fingerprint": "Fingerprint",
     "biometric-faceid": "Face ID",
+    "biometric-too-many-attempts": "Too many attempts. Enter the password manually or try again after some time",
     "biometric-touchid": "Touch ID",
     "blank-keycard-text": "You can proceed with your keycard once you've generated your keys and name",
     "blank-keycard-title": "Looks like you’ve tapped \na blank keycard",


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20007

leftover from https://github.com/status-im/status-mobile/pull/19989#issuecomment-2106255606

### Testing

PR is manually tested and safe to merge. I only added request-manual-qa to make sure error message gets double checked. `Too many attempts. Enter the password manually or try again after some time`

UPD: Adding skip-manual-qa and merging. We can always update msg if it needs to.

status: ready