### PR TITLE
add NSAppleMusicUsageDescription permission to play audio messages

### DIFF
--- a/ios/StatusImTests/Info.plist
+++ b/ios/StatusImTests/Info.plist
@@ -26,6 +26,8 @@
 		<string>A00000080400010301</string>
 		<string>A000000151000000</string>
 	</array>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Play audio messages</string>
 	<key>NFCReaderUsageDescription</key>
 	<string>Enable Keycard</string>
 </dict>


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20234

### Summary
This seems to be a permission required by apple store because we have the feature to play audio messages

status: ready
