### PR TITLE
The community channel is opening very slowly #20231

### DIFF
--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -252,7 +252,9 @@
 
 (defn fetch-community
   [{:keys [db]} [{:keys [community-id update-last-opened-at?]}]]
-  (when (and community-id (not (get-in db [:communities/fetching-communities community-id])))
+  (when (and community-id
+             (not (get-in db [:communities community-id]))
+             (not (get-in db [:communities/fetching-communities community-id])))
     {:db            (assoc-in db [:communities/fetching-communities community-id] true)
      :json-rpc/call [{:method     "wakuext_fetchCommunity"
                       :params     [{:CommunityKey    community-id


### PR DESCRIPTION
partially addresses #20231

don't re-fetch community data on overview or channel opening

manual testing is not needed because it's a small local change