### PR TITLE
Fix integration tests for MacOS

### DIFF
--- a/nix/status-go/library/default.nix
+++ b/nix/status-go/library/default.nix
@@ -22,11 +22,14 @@ buildGoPackage {
   '';
 
   # Build the Go library
+  # ld flags and netgo tag are necessary for integration tests to work on MacOS
+  # https://github.com/status-im/status-mobile/issues/20135
   buildPhase = ''
     runHook preBuild
     go build \
       -buildmode='c-archive' \
-      -tags='gowaku_skip_migrations gowaku_no_rln' \
+      -ldflags '-w -s -extldflags "-lresolv"' \
+      -tags='gowaku_skip_migrations gowaku_no_rln netgo' \
       -o "$out/libstatus.a" \
       $NIX_BUILD_TOP/main.go
     runHook postBuild

--- a/nix/status-go/library/default.nix
+++ b/nix/status-go/library/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, meta, source, buildGoPackage }:
+{ lib, stdenv, meta, source, buildGoPackage }:
 
 buildGoPackage {
   pname = source.repo;
@@ -28,8 +28,8 @@ buildGoPackage {
     runHook preBuild
     go build \
       -buildmode='c-archive' \
-      -ldflags '-w -s -extldflags "-lresolv"' \
-      -tags='gowaku_skip_migrations gowaku_no_rln netgo' \
+      ${lib.optionalString stdenv.isDarwin "-ldflags=-extldflags=-lresolv"} \
+      -tags='gowaku_skip_migrations gowaku_no_rln ${lib.optionalString stdenv.isDarwin "netgo"}' \
       -o "$out/libstatus.a" \
       $NIX_BUILD_TOP/main.go
     runHook postBuild

--- a/nix/status-go/library/default.nix
+++ b/nix/status-go/library/default.nix
@@ -1,9 +1,6 @@
-{ stdenv, meta, source, buildGo119Package, buildGo120Package }:
-let
-  # https://github.com/status-im/status-mobile/issues/19802
-  # only for Darwin to fix Integration Tests failing with missing symbols on go 1.20
-  buildGoPackageIntegrationTest = if stdenv.isDarwin then buildGo119Package else buildGo120Package;
-in buildGoPackageIntegrationTest {
+{ stdenv, meta, source, buildGoPackage }:
+
+buildGoPackage {
   pname = source.repo;
   version = "${source.cleanVersion}-${source.shortRev}";
 


### PR DESCRIPTION
## Summary

With go 1.20 its necessary to pass `lresolv` flag when building c-archives and `netgo` for networking on MacOS.
This was the primary reason why integration tests were failing.
ref 
-> https://github.com/golang/go/issues/58416
-> https://github.com/golang/go/issues/58159

This PR adds those flags to the derivation which builds status-go-library for integration tests and fixes the missing symbol crash.

## Review notes
- `make test-contract` should now work on MacOS

## Testing notes
- not needed as this change only impacts integration tests.

## Platforms
- macOS

status: ready

fixes: https://github.com/status-im/status-mobile/issues/20135
