### PR TITLE
bug_: fix resend type for private group messages

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.24",
-    "commit-sha1": "701b27632438a8328506cba23943bbdeb8b15b0c",
-    "src-sha256": "1jp3r6pb3q3jzjdlx8yl4js63q4av36n0wx9akb0pnarm7mwpfpb"
+    "version": "v0.179.25",
+    "commit-sha1": "0061c563f2d50679d812c5dc2978a96c49a93314",
+    "src-sha256": "0glzz5af873ym4qfbya14l38mjc8brkinpc7i57bywzsgydjqdp2"
 }


### PR DESCRIPTION
Group chat messages were not sent through datasync anymore, https://github.com/status-im/status-go/pull/5258 is the corresponding PR. They were just mislabeled with a different retry mechanism.

One thing to note that might need further investigation:

1) I disabled WIFI, phone was offline
2) I sent a message in a private group chat.
3) The message was sent without datasync, and it was retried 4 times in short notice
4) after going online, the message was never retried


3) Should probably not happen, since we were offline and we should not retry messages when offline.
after 4) the message should be sent.
it might be an issue only because we exclude those messages (i.e private group chats), but requires further investigation. From qa it looks like community messages are retried correctly.

Fixes: #20247 
Might fix https://github.com/status-im/status-mobile/issues/20261