### PR TITLE
fix(navigation)_: Incorrect status bar color

### DIFF
--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -224,7 +224,8 @@
 ;;;; Bottom sheet
 
 (rf/reg-fx :show-bottom-sheet
- (fn [] (show-overlay "bottom-sheet")))
+ (fn [options]
+   (show-overlay "bottom-sheet" options)))
 
 (rf/reg-fx :hide-bottom-sheet
  (fn [] (navigation/dissmiss-overlay "bottom-sheet")))

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -112,12 +112,16 @@
 (rf/defn show-bottom-sheet
   {:events [:show-bottom-sheet]}
   [{:keys [db] :as cofx} content]
-  (let [{:keys [sheets hide?]} (:bottom-sheet db)]
+  (let [theme                  (or (:theme content) (:theme db))
+        {:keys [sheets hide?]} (:bottom-sheet db)]
     (rf/merge cofx
-              {:db               (update-in db [:bottom-sheet :sheets] #(conj % content))
+              {:db               (update-in db [:bottom-sheet :sheets] conj content)
                :dismiss-keyboard nil}
-              #(when-not hide?
-                 (if (seq sheets) (hide-bottom-sheet %) {:show-bottom-sheet nil})))))
+              (fn [new-cofx]
+                (when-not hide?
+                  (if (seq sheets)
+                    (hide-bottom-sheet new-cofx)
+                    {:show-bottom-sheet {:theme theme}}))))))
 
 (rf/defn dismiss-all-overlays
   {:events [:dismiss-all-overlays]}


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/20114

### Summary

This PR is a new attempt to fix the issue. The first one was https://github.com/status-im/status-mobile/pull/20167, which we can close if this one works.

### Details

I could successfully, and always reproduce in a Pixel 7A with Android 12, there's nothing random about the bug. When any bottom sheet is opened, it calls RN's `showOverlay`, but the `theme` value passed down to decide which `statusBar` style to use is `nil` and defaults to `:light`, which is why on dark mode we see a white status bar color when the bottom sheet opens. @jo-mut also found the same problem.

The fix I'm using is to grab the user's theme from the app-db and pass that down to the `:show-bottom-sheet` *effect*, which in turn will pass the theme to `showOverlay`. You can see below a few videos with the fix and also a screenshot comparing the toasts in `develop` and in this PR. Toasts should **not be affected** by this PR.

[fixed while logged in.webm](https://github.com/status-im/status-mobile/assets/46027/935722f1-6a7b-4d6f-81a4-09241b6dd3aa)

[onboarding intro fixed.webm](https://github.com/status-im/status-mobile/assets/46027/eb8d0f9c-8c53-4033-a17b-4ba0c77d9dd7)

<table>
  <thead>
    <tr>
      <th>Toasts in develop</th>
      <th>Toasts in PR</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/31af119b-11de-4aa8-aa77-5db2c2885649" height="600" /></td>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/287069e0-77ba-4334-a5c6-a1a22aa4672c" height="600" /></td>
    </tr>
  </tbody>
</table>


### Steps to test

I can only test on Android. My reproduction steps were basically any bottom sheet on dark mode, on Android 12.

status: ready
