### PR TITLE
add NSAppleMusicUsageDescription permission to play audio messages to…

### DIFF
--- a/ios/StatusIm/Info.plist
+++ b/ios/StatusIm/Info.plist
@@ -82,6 +82,8 @@
 	<string>Photos access is required to give you the ability to save images.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Photos access is required to give you the ability to send images.</string>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Play audio messages</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Inter-Bold.otf</string>

--- a/ios/StatusIm/Info.plist
+++ b/ios/StatusIm/Info.plist
@@ -83,7 +83,7 @@
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Photos access is required to give you the ability to send images.</string>
 	<key>NSAppleMusicUsageDescription</key>
-	<string>Play audio messages</string>
+	<string>Status uses Media Library to save and send Images. The Media Library module internally requires permissions to Apple Music</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Inter-Bold.otf</string>

--- a/ios/StatusImTests/Info.plist
+++ b/ios/StatusImTests/Info.plist
@@ -26,8 +26,6 @@
 		<string>A00000080400010301</string>
 		<string>A000000151000000</string>
 	</array>
-	<key>NSAppleMusicUsageDescription</key>
-	<string>Play audio messages</string>
 	<key>NFCReaderUsageDescription</key>
 	<string>Enable Keycard</string>
 </dict>


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20234

Summary
This seems to be a permission required by apple store because we have the feature to play audio messages

status: ready