### PR TITLE
Fix layout of title for select key-pairs screen

### DIFF
--- a/src/quo/components/text_combinations/standard_title/style.cljs
+++ b/src/quo/components/text_combinations/standard_title/style.cljs
@@ -2,7 +2,8 @@
   (:require [quo.foundations.colors :as colors]))
 
 (def container
-  {:flex-direction  :row
+  {:flex            1
+   :flex-direction  :row
    :justify-content :space-between})
 
 (def right-counter

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/style.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/style.cljs
@@ -1,7 +1,8 @@
 (ns status-im.contexts.settings.wallet.keypairs-and-accounts.style)
 
 (def title-container
-  {:padding-horizontal 20
+  {:flex               0
+   :padding-horizontal 20
    :margin-vertical    12})
 
 (defn page-wrapper

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/view.cljs
@@ -106,11 +106,11 @@
        :background :blur
        :icon-name  :i/arrow-left
        :on-press   navigate-back}]
-     [rn/view {:style style/title-container}
-      [quo/standard-title
-       {:title               (i18n/label :t/keypairs-and-accounts)
-        :accessibility-label :keypairs-and-accounts-header
-        :customization-color customization-color}]]
+     [quo/standard-title
+      {:title               (i18n/label :t/keypairs-and-accounts)
+       :container-style     style/title-container
+       :accessibility-label :keypairs-and-accounts-header
+       :customization-color customization-color}]
      [rn/view {:style style/settings-keypairs-container}
       (when (seq missing-keypairs)
         [quo/missing-keypairs

--- a/src/status_im/contexts/settings/wallet/network_settings/style.cljs
+++ b/src/status_im/contexts/settings/wallet/network_settings/style.cljs
@@ -2,7 +2,8 @@
   (:require [quo.foundations.colors :as colors]))
 
 (def title-container
-  {:padding-horizontal 20
+  {:flex               0
+   :padding-horizontal 20
    :padding-vertical   12})
 
 (defn page-wrapper

--- a/src/status_im/contexts/settings/wallet/network_settings/view.cljs
+++ b/src/status_im/contexts/settings/wallet/network_settings/view.cljs
@@ -114,10 +114,10 @@
        :background :blur
        :icon-name  :i/arrow-left
        :on-press   navigate-back}]
-     [rn/view {:style style/title-container}
-      [quo/standard-title
-       {:title               (i18n/label :t/network-settings)
-        :accessibility-label :network-settings-header}]]
+     [quo/standard-title
+      {:title               (i18n/label :t/network-settings)
+       :container-style     style/title-container
+       :accessibility-label :network-settings-header}]
      [rn/view {:style (style/settings-container (:bottom insets))}
       (when networks-by-name
         [rn/view {:style style/networks-container}

--- a/src/status_im/contexts/settings/wallet/saved_addresses/style.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/style.cljs
@@ -1,7 +1,8 @@
 (ns status-im.contexts.settings.wallet.saved-addresses.style)
 
 (def title-container
-  {:padding-horizontal 20
+  {:flex               0
+   :padding-horizontal 20
    :margin-top         12
    :margin-bottom      16})
 

--- a/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
@@ -78,14 +78,14 @@
        :background :blur
        :icon-name  :i/arrow-left
        :on-press   navigate-back}]
-     [rn/view {:style style/title-container}
-      [quo/standard-title
-       {:title               (i18n/label :t/saved-addresses)
-        :accessibility-label :saved-addresses-header
-        :right               :action
-        :on-press            add-address-to-save
-        :customization-color customization-color
-        :icon                :i/add}]]
+     [quo/standard-title
+      {:title               (i18n/label :t/saved-addresses)
+       :accessibility-label :saved-addresses-header
+       :right               :action
+       :on-press            add-address-to-save
+       :customization-color customization-color
+       :icon                :i/add
+       :container-style     style/title-container}]
      [rn/section-list
       {:key-fn                         :title
        :sticky-section-headers-enabled false


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #20158

### Summary

* This PR attempts to fix the layout issues described in #20158 
  * This issue was introduced when #20094 tried fixing the titles for the wallet settings screens.

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Create Account flow -- Select Key Pair Screen
- Wallet Settings Screens

### Steps to test

- Open Status mobile app
- Navigate to the wallet home screen
- Press the create a new account button
- Press the edit button on the selected key-pair

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### After Changes


https://github.com/status-im/status-mobile/assets/2845768/e0212ac4-ebb9-4eff-b525-9b45f792ca7b



status: ready <!-- Can be ready or wip -->
