### PR TITLE
No routes found error is displayed in case asset value is within max amount but not enough balance for fee #20148

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -286,7 +286,7 @@
                                                      (if (= token-symbol
                                                             (string/upper-case
                                                              constants/mainnet-short-name))
-                                                       (= available-limit amount)
+                                                       (= current-limit input-amount)
                                                        (money/equal-to (:total-balance
                                                                         owned-eth-token)
                                                                        0)))

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -277,12 +277,15 @@
         should-try-again?                           (and (not limit-insufficient?) no-routes-found?)
         current-address                             (rf/sub [:wallet/current-viewing-account-address])
         owned-eth-token                             (rf/sub [:wallet/token-by-symbol
-                                                             (string/upper-case constants/mainnet-short-name)
+                                                             (string/upper-case
+                                                              constants/mainnet-short-name)
                                                              enabled-from-chain-ids])
         not-enough-asset?                           (and
                                                      (or no-routes-found? limit-insufficient?)
                                                      (not-empty sender-network-values)
-                                                     (if (= token-symbol (string/upper-case constants/mainnet-short-name))
+                                                     (if (= token-symbol
+                                                            (string/upper-case
+                                                             constants/mainnet-short-name))
                                                        (= available-limit amount)
                                                        (money/equal-to (:total-balance
                                                                         owned-eth-token)

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -7,6 +7,7 @@
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [status-im.common.controlled-input.utils :as controlled-input]
+    [status-im.constants :as constants]
     [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im.contexts.wallet.common.asset-list.view :as asset-list]
     [status-im.contexts.wallet.common.utils :as utils]
@@ -276,12 +277,12 @@
         should-try-again?                           (and (not limit-insufficient?) no-routes-found?)
         current-address                             (rf/sub [:wallet/current-viewing-account-address])
         owned-eth-token                             (rf/sub [:wallet/token-by-symbol
-                                                             "ETH"
+                                                             (string/upper-case constants/mainnet-short-name)
                                                              enabled-from-chain-ids])
         not-enough-asset?                           (and
                                                      (or no-routes-found? limit-insufficient?)
                                                      (not-empty sender-network-values)
-                                                     (if (= token-symbol "ETH")
+                                                     (if (= token-symbol (string/upper-case constants/mainnet-short-name))
                                                        (= available-limit amount)
                                                        (money/equal-to (:total-balance
                                                                         owned-eth-token)

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -12,6 +12,7 @@
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.send.input-amount.style :as style]
     [status-im.contexts.wallet.send.routes.view :as routes]
+    [status-im.contexts.wallet.sheets.buy-token.view :as buy-token]
     [status-im.contexts.wallet.sheets.unpreferred-networks-alert.view :as unpreferred-networks-alert]
     [utils.debounce :as debounce]
     [utils.i18n :as i18n]
@@ -131,7 +132,8 @@
    {:action?         true
     :text            (i18n/label :t/not-enough-assets)
     :button-text     (i18n/label :t/buy-eth)
-    :on-button-press #(js/alert "not implemented yet")}])
+    :on-button-press #(rf/dispatch [:show-bottom-sheet
+                                    {:content buy-token/view}])}])
 
 (defn view
   ;; crypto-decimals, limit-crypto and initial-crypto-currency? args are needed

--- a/translations/en.json
+++ b/translations/en.json
@@ -2700,5 +2700,7 @@
     "wallet-connect-version-not-supported": "WalletConnect version {{version}} is not supported",
     "add-network-preferences": "Add network preferences",
     "saved-address-network-preference-selection-description": "Only change if you know which networks the address owner is happy to to receive funds on",
-    "add-preferences": "Add preferences"
+    "add-preferences": "Add preferences",
+    "buy-eth": "Buy ETH",
+    "not-enough-assets": "Not enough assets to pay gas fees"
 }


### PR DESCRIPTION
fixes #20148 


When sending a non ETH asset and there is no ETH asset in the account:
https://github.com/status-im/status-mobile/assets/55688834/273eb430-9a28-4652-be3f-3540be73102f

When sending max ETH asset:


https://github.com/status-im/status-mobile/assets/55688834/3b8ce9ab-26b9-40e8-b4a8-f15828e1921c



Please note that at the moment, we can't get the fee if there is not enough asset for the fee transaction, so I hid this part in the UI. And because of the same reason, the only way of determining when there is not enough ETH asset for the fee, when user tries to send ETH and they enter max amount, we show the `not enough asset` error. And when they try to send a different asset other than `ETH`, we check their eth amount and if it's 0, then we show the error.
<img width="391" alt="Screenshot 2024-05-30 at 14 07 54" src="https://github.com/status-im/status-mobile/assets/55688834/7a1a6408-8a89-4224-8489-11fc01ef59b2">:
