### PR TITLE
fix: network perf button copy

### DIFF
--- a/src/status_im/contexts/wallet/sheets/network_preferences/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/network_preferences/view.cljs
@@ -169,7 +169,7 @@
          [quo/bottom-actions
           {:actions          :one-action
            :blur?            blur?
-           :button-one-label (or button-label (i18n/label :t/update))
+           :button-one-label (or button-label (i18n/label :t/confirm))
            :button-one-props {:disabled?           (= @state :default)
                               :on-press            (fn []
                                                      (let [chain-ids (map :chain-id current-networks)]


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/20211

### Summary
This is a small PR that updates network prefernces button copy

Skipping QA as it is a small ui detail

### Demo
![Screenshot_20240530_174419_Status](https://github.com/status-im/status-mobile/assets/29354102/eef9dcf0-b086-45db-9827-cf9e79b1c37c)
