### PR TITLE
[#20165] feat: import a missing key pair by scanning QR code

### DIFF
--- a/src/status_im/contexts/settings/wallet/effects.cljs
+++ b/src/status_im/contexts/settings/wallet/effects.cljs
@@ -6,7 +6,7 @@
             [utils.security.core :as security]
             [utils.transforms :as transforms]))
 
-(rf/reg-fx :effects.connection-string/export-keypair
+(rf/reg-fx :effects.syncing/export-keypairs-keystores
  (fn [{:keys [key-uid sha3-pwd keypair-key-uid on-success on-fail]}]
    (let [config-map (transforms/clj->json {:senderConfig {:loggedInKeyUid   key-uid
                                                           :keystorePath     ""
@@ -23,7 +23,7 @@
                                      "generic-error: failed to get connection string")))))
          (promesa/catch on-fail)))))
 
-(rf/reg-fx :effects.connection-string/import-keypair
+(rf/reg-fx :effects.syncing/import-keypairs-keystores
  (fn [{:keys [key-uid sha3-pwd keypairs-key-uids connection-string on-success on-fail]}]
    (let [config-map (transforms/clj->json {:receiverConfig
                                            {:loggedInKeyUid   key-uid

--- a/src/status_im/contexts/settings/wallet/events.cljs
+++ b/src/status_im/contexts/settings/wallet/events.cljs
@@ -31,7 +31,7 @@
 (defn get-keypair-export-connection
   [{:keys [db]} [{:keys [sha3-pwd keypair-key-uid callback]}]]
   (let [key-uid (get-in db [:profile/profile :key-uid])]
-    {:fx [[:effects.connection-string/export-keypair
+    {:fx [[:effects.syncing/export-keypairs-keystores
            {:key-uid         key-uid
             :sha3-pwd        sha3-pwd
             :keypair-key-uid keypair-key-uid
@@ -88,7 +88,7 @@
 (defn connection-string-for-import-keypair
   [{:keys [db]} [{:keys [sha3-pwd keypairs-key-uids connection-string]}]]
   (let [key-uid (get-in db [:profile/profile :key-uid])]
-    {:fx [[:effects.connection-string/import-keypair
+    {:fx [[:effects.syncing/import-keypairs-keystores
            {:key-uid           key-uid
             :sha3-pwd          sha3-pwd
             :keypairs-key-uids keypairs-key-uids

--- a/src/status_im/contexts/settings/wallet/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/events_test.cljs
@@ -32,7 +32,7 @@
         user-key-uid "test-key-uid"
         callback     (fn [connect-string] (println "callback" connect-string))]
     (testing "get-keypair-export-connection"
-      (let [expected {:fx [[:effects.connection-string/export-keypair
+      (let [expected {:fx [[:effects.syncing/export-keypairs-keystores
                             {:key-uid         user-key-uid
                              :sha3-pwd        sha3-pwd
                              :keypair-key-uid mock-key-uid
@@ -74,7 +74,7 @@
         user-key-uid      "test-key-uid"
         connection-string "test-connection-string"]
     (testing "connection-string-for-import-keypair"
-      (let [expected {:fx [[:effects.connection-string/import-keypair
+      (let [expected {:fx [[:effects.syncing/import-keypairs-keystores
                             {:key-uid           user-key-uid
                              :sha3-pwd          sha3-pwd
                              :keypairs-key-uids [mock-key-uid]

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/actions/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/actions/view.cljs
@@ -1,44 +1,53 @@
 (ns status-im.contexts.settings.wallet.keypairs-and-accounts.actions.view
   (:require [quo.core :as quo]
+            [react-native.core :as rn]
             [status-im.contexts.settings.wallet.keypairs-and-accounts.remove.view :as remove-key-pair]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
-(defn on-rename-key-pair
-  [key-pair]
-  (rf/dispatch [:open-modal :screen/settings.rename-keypair key-pair]))
-
-(defn on-remove-key-pair
-  [key-pair]
-  (rf/dispatch [:show-bottom-sheet
-                {:theme   :dark
-                 :content (fn []
-                            [remove-key-pair/view key-pair])}]))
-
-(defn on-show-qr
-  [data]
-  (rf/dispatch [:open-modal :screen/settings.encrypted-key-pair-qr data]))
-
 (defn view
-  [props key-pair]
-  (let [has-paired-device (rf/sub [:pairing/has-paired-devices])]
+  [props keypair]
+  (let [has-paired-device (rf/sub [:pairing/has-paired-devices])
+        missing-keypair?  (rn/use-memo #(= (:stored props) :missing) [props])
+        on-scan-qr        (rn/use-callback #(rf/dispatch [:open-modal :screen/settings.scan-keypair-qr
+                                                          [(:key-uid keypair)]])
+                                           [keypair])
+        on-show-qr        (rn/use-callback #(rf/dispatch [:open-modal
+                                                          :screen/settings.encrypted-key-pair-qr
+                                                          keypair])
+                                           [keypair])
+        on-remove-keypair (rn/use-callback #(rf/dispatch
+                                             [:show-bottom-sheet
+                                              {:theme   :dark
+                                               :content (fn []
+                                                          [remove-key-pair/view keypair])}])
+                                           [keypair])
+        on-rename-keypair (rn/use-callback #(rf/dispatch [:open-modal :screen/settings.rename-keypair
+                                                          keypair])
+                                           [keypair])]
     [:<>
      [quo/drawer-top props]
      [quo/action-drawer
       [(when has-paired-device
-         [{:icon                :i/qr-code
-           :accessibility-label :show-key-pr-qr
-           :label               (i18n/label :t/show-encrypted-qr-of-key-pairs)
-           :on-press            #(on-show-qr key-pair)}])
+         (concat
+          (if-not missing-keypair?
+            [{:icon                :i/qr-code
+              :accessibility-label :show-key-pr-qr
+              :label               (i18n/label :t/show-encrypted-qr-of-key-pairs)
+              :on-press            on-show-qr}]
+            [{:icon                :i/scan
+              :accessibility-label :import-by-scan-qr
+              :label               (i18n/label :t/import-by-scanning-encrypted-qr)
+              :on-press            on-scan-qr}])))
        (when (= (:type props) :keypair)
          (concat
           [{:icon                :i/edit
             :accessibility-label :rename-key-pair
             :label               (i18n/label :t/rename-key-pair)
-            :on-press            #(on-rename-key-pair key-pair)}]
+            :on-press            on-rename-keypair}]
           [{:icon                :i/delete
             :accessibility-label :remove-key-pair
             :add-divider?        true
             :danger?             true
             :label               (i18n/label :t/remove-key-pair-and-derived-accounts)
-            :on-press            #(on-remove-key-pair key-pair)}]))]]]))
+            :on-press            on-remove-keypair}]))]]]))

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/actions/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/actions/view.cljs
@@ -8,7 +8,7 @@
 (defn view
   [props keypair]
   (let [has-paired-device (rf/sub [:pairing/has-paired-devices])
-        missing-keypair?  (rn/use-memo #(= (:stored props) :missing) [props])
+        missing-keypair?  (= (:stored props) :missing)
         on-scan-qr        (rn/use-callback #(rf/dispatch [:open-modal :screen/settings.scan-keypair-qr
                                                           [(:key-uid keypair)]])
                                            [keypair])
@@ -29,25 +29,23 @@
      [quo/drawer-top props]
      [quo/action-drawer
       [(when has-paired-device
-         (concat
-          (if-not missing-keypair?
-            [{:icon                :i/qr-code
-              :accessibility-label :show-key-pr-qr
-              :label               (i18n/label :t/show-encrypted-qr-of-key-pairs)
-              :on-press            on-show-qr}]
-            [{:icon                :i/scan
-              :accessibility-label :import-by-scan-qr
-              :label               (i18n/label :t/import-by-scanning-encrypted-qr)
-              :on-press            on-scan-qr}])))
+         (if-not missing-keypair?
+           [{:icon                :i/qr-code
+             :accessibility-label :show-key-pr-qr
+             :label               (i18n/label :t/show-encrypted-qr-of-key-pairs)
+             :on-press            on-show-qr}]
+           [{:icon                :i/scan
+             :accessibility-label :import-by-scan-qr
+             :label               (i18n/label :t/import-by-scanning-encrypted-qr)
+             :on-press            on-scan-qr}]))
        (when (= (:type props) :keypair)
-         (concat
-          [{:icon                :i/edit
-            :accessibility-label :rename-key-pair
-            :label               (i18n/label :t/rename-key-pair)
-            :on-press            on-rename-keypair}]
-          [{:icon                :i/delete
-            :accessibility-label :remove-key-pair
-            :add-divider?        true
-            :danger?             true
-            :label               (i18n/label :t/remove-key-pair-and-derived-accounts)
-            :on-press            on-remove-keypair}]))]]]))
+         [{:icon                :i/edit
+           :accessibility-label :rename-key-pair
+           :label               (i18n/label :t/rename-key-pair)
+           :on-press            on-rename-keypair}
+          {:icon                :i/delete
+           :accessibility-label :remove-key-pair
+           :add-divider?        true
+           :danger?             true
+           :label               (i18n/label :t/remove-key-pair-and-derived-accounts)
+           :on-press            on-remove-keypair}])]]]))

--- a/translations/en.json
+++ b/translations/en.json
@@ -2537,6 +2537,7 @@
     "import-using-phrase": "Import using recovery phrase",
     "import-from-keycard": "Import from Keycard",
     "import-private-key": "Import private key",
+    "import-by-scanning-encrypted-qr": "Import by scanning encrypted QR",
     "backup-recovery-phrase": "Backup recovery phrase",
     "backup-recovery-phrase-description": "Save in a secure place that only you control, these 12 words give access to all of your funds.",
     "how-to-backup": "How to backup your recovery phrase",


### PR DESCRIPTION
fixes #20165

### Summary

Implement the UI and UX flow inside the wallet settings for scanning a missing key pair's QR code.

#### Areas that maybe impacted

- Import a missing key pair by scan encrypted QR

#### Test note

To have a missing key pair on Device B, after you pair devices you can add new keypair on Device A and the on device B logout/login again. you will see missing keypair on device B

### Steps to test

- Have a paired device
- Have a missing key pair on Device B
- Open Wallet setting On Device B
- Click click on action menu (3 dot)
- Click on "Import by scanning encrypted QR"
- Scan QR code of missing key pair on Device A


### Result


https://github.com/status-im/status-mobile/assets/71308738/979e85d5-49c2-45a5-805d-a83945f36849



status: ready

