### PR TITLE
[#20179] collectibles page fixes

### DIFF
--- a/src/quo/components/profile/expanded_collectible/style.cljs
+++ b/src/quo/components/profile/expanded_collectible/style.cljs
@@ -11,9 +11,17 @@
   {:width            "100%"
    :aspect-ratio     (if square? 1 aspect-ratio)
    :border-radius    16
-   :background-color (colors/theme-colors colors/white colors/neutral-95 theme)
-   :border-width     1
-   :border-color     (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-5 theme)})
+   :background-color (colors/theme-colors colors/white colors/neutral-95 theme)})
+
+(defn collectible-border [theme]
+  {:position      :absolute
+   :top           0
+   :left          0
+   :right         0
+   :bottom        0
+   :border-radius 16
+   :border-width  1
+   :border-color  (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-5 theme)})
 
 (defn fallback
   [{:keys [theme]}]

--- a/src/quo/components/profile/expanded_collectible/style.cljs
+++ b/src/quo/components/profile/expanded_collectible/style.cljs
@@ -11,7 +11,9 @@
   {:width            "100%"
    :aspect-ratio     (if square? 1 aspect-ratio)
    :border-radius    16
-   :background-color (colors/theme-colors colors/white colors/neutral-95 theme)})
+   :background-color (colors/theme-colors colors/white colors/neutral-95 theme)
+   :border-width     1
+   :border-color     (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-5 theme)})
 
 (defn fallback
   [{:keys [theme]}]

--- a/src/quo/components/profile/expanded_collectible/style.cljs
+++ b/src/quo/components/profile/expanded_collectible/style.cljs
@@ -7,10 +7,11 @@
    :border-radius   16})
 
 (defn image
-  [square? aspect-ratio]
-  {:width         "100%"
-   :aspect-ratio  (if square? 1 aspect-ratio)
-   :border-radius 16})
+  [square? aspect-ratio theme]
+  {:width            "100%"
+   :aspect-ratio     (if square? 1 aspect-ratio)
+   :border-radius    16
+   :background-color (colors/theme-colors colors/white colors/neutral-95 theme)})
 
 (defn fallback
   [{:keys [theme]}]

--- a/src/quo/components/profile/expanded_collectible/style.cljs
+++ b/src/quo/components/profile/expanded_collectible/style.cljs
@@ -13,7 +13,8 @@
    :border-radius    16
    :background-color (colors/theme-colors colors/white colors/neutral-95 theme)})
 
-(defn collectible-border [theme]
+(defn collectible-border
+  [theme]
   {:position      :absolute
    :top           0
    :left          0

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -66,7 +66,7 @@
        (and (not image-error?) supported-file?)
        [rn/view
         [rn/image
-         {:style     (style/image square? (:aspect-ratio image-size))
+         {:style     (style/image square? (:aspect-ratio image-size) theme)
           :source    image-src
           :native-ID native-ID
           :on-error  #(set-image-error true)

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -1,17 +1,16 @@
 (ns quo.components.profile.expanded-collectible.view
   (:require
-    [promesa.core :as promesa]
-    [quo.components.counter.collectible-counter.view :as collectible-counter]
-    [quo.components.icon :as icon]
-    [quo.components.markdown.text :as text]
-    [quo.components.profile.expanded-collectible.style :as style]
-    [quo.foundations.colors :as colors]
-    [quo.theme]
-    [quo.theme]
-    [quo.theme]
-    [react-native.core :as rn]
-    [schema.core :as schema]
-    [utils.i18n :as i18n]))
+   [clojure.string :as string]
+   [promesa.core :as promesa]
+   [quo.components.counter.collectible-counter.view :as collectible-counter]
+   [quo.components.icon :as icon]
+   [quo.components.markdown.text :as text]
+   [quo.components.profile.expanded-collectible.style :as style]
+   [quo.foundations.colors :as colors]
+   [quo.theme]
+   [react-native.core :as rn]
+   [schema.core :as schema]
+   [utils.i18n :as i18n]))
 
 (defn- counter-view
   [counter]
@@ -38,7 +37,8 @@
            on-collectible-load]}]
   (let [theme                          (quo.theme/use-theme)
         [image-size set-image-size]    (rn/use-state {})
-        [image-error? set-image-error] (rn/use-state false)]
+        [image-error? set-image-error] (rn/use-state (or (nil? image-src)
+                                                         (string/blank? image-src)))]
     (rn/use-effect
      (fn []
        (promesa/let [[image-width image-height] (rn/image-get-size image-src)]

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -14,10 +14,9 @@
 
 (defn- counter-view
   [counter]
-  (when counter
-    [collectible-counter/view
-     {:container-style style/counter
-      :value           counter}]))
+  [collectible-counter/view
+   {:container-style style/counter
+    :value           counter}])
 
 (defn- fallback-view
   [{:keys [label theme counter on-mount]}]
@@ -66,14 +65,16 @@
          :on-mount on-collectible-load}]
 
        :else
-       [rn/view
-        [rn/image
-         {:style     (style/image square? (:aspect-ratio image-size) theme)
-          :source    image-src
-          :native-ID native-ID
-          :on-error  #(set-image-error true)
-          :on-load   on-collectible-load}]
-        [counter-view counter]])]))
+      [rn/view
+       [rn/image
+        {:style     (style/image square? (:aspect-ratio image-size) theme)
+         :source    image-src
+         :native-ID native-ID
+         :on-error  #(set-image-error true)
+         :on-load   on-collectible-load}]
+       (when counter
+         [counter-view counter])
+       [rn/view {:style (style/collectible-border theme)}]])]))
 
 (def ?schema
   [:=>

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -1,16 +1,16 @@
 (ns quo.components.profile.expanded-collectible.view
   (:require
-   [clojure.string :as string]
-   [promesa.core :as promesa]
-   [quo.components.counter.collectible-counter.view :as collectible-counter]
-   [quo.components.icon :as icon]
-   [quo.components.markdown.text :as text]
-   [quo.components.profile.expanded-collectible.style :as style]
-   [quo.foundations.colors :as colors]
-   [quo.theme]
-   [react-native.core :as rn]
-   [schema.core :as schema]
-   [utils.i18n :as i18n]))
+    [clojure.string :as string]
+    [promesa.core :as promesa]
+    [quo.components.counter.collectible-counter.view :as collectible-counter]
+    [quo.components.icon :as icon]
+    [quo.components.markdown.text :as text]
+    [quo.components.profile.expanded-collectible.style :as style]
+    [quo.foundations.colors :as colors]
+    [quo.theme]
+    [react-native.core :as rn]
+    [schema.core :as schema]
+    [utils.i18n :as i18n]))
 
 (defn- counter-view
   [counter]

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -65,16 +65,16 @@
          :on-mount on-collectible-load}]
 
        :else
-      [rn/view
-       [rn/image
-        {:style     (style/image square? (:aspect-ratio image-size) theme)
-         :source    image-src
-         :native-ID native-ID
-         :on-error  #(set-image-error true)
-         :on-load   on-collectible-load}]
-       (when counter
-         [counter-view counter])
-       [rn/view {:style (style/collectible-border theme)}]])]))
+       [rn/view
+        [rn/image
+         {:style     (style/image square? (:aspect-ratio image-size) theme)
+          :source    image-src
+          :native-ID native-ID
+          :on-error  #(set-image-error true)
+          :on-load   on-collectible-load}]
+        (when counter
+          [counter-view counter])
+        [rn/view {:style (style/collectible-border theme)}]])]))
 
 (def ?schema
   [:=>

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -65,7 +65,7 @@
          :theme    theme
          :on-mount on-collectible-load}]
 
-       (and (not image-error?) supported-file?)
+       :else
        [rn/view
         [rn/image
          {:style     (style/image square? (:aspect-ratio image-size) theme)

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -21,9 +21,9 @@
       :value           counter}]))
 
 (defn- fallback-view
-  [{:keys [label theme counter]}]
-  [rn/view
-   {:style (style/fallback {:theme theme})}
+  [{:keys [label theme counter on-mount]}]
+  (rn/use-mount on-mount)
+  [rn/view {:style (style/fallback {:theme theme})}
    [counter-view counter]
    [rn/view
     [icon/icon :i/sad {:color (colors/theme-colors colors/neutral-40 colors/neutral-50 theme)}]]
@@ -53,15 +53,17 @@
      (cond
        (not supported-file?)
        [fallback-view
-        {:label   (i18n/label :t/unsupported-file)
-         :counter counter
-         :theme   theme}]
+        {:label    (i18n/label :t/unsupported-file)
+         :counter  counter
+         :theme    theme
+         :on-mount on-collectible-load}]
 
        image-error?
        [fallback-view
-        {:label   (i18n/label :t/cant-fetch-info)
-         :counter counter
-         :theme   theme}]
+        {:label    (i18n/label :t/cant-fetch-info)
+         :counter  counter
+         :theme    theme
+         :on-mount on-collectible-load}]
 
        (and (not image-error?) supported-file?)
        [rn/view

--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -18,7 +18,7 @@
            {:id :collectibles :label (i18n/label :t/collectibles) :accessibility-label :collectibles-tab}
            {:id :activity :label (i18n/label :t/activity) :accessibility-label :activity-tab}]
     (not watch-only?) (conj {:id :dapps :label (i18n/label :t/dapps) :accessibility-label :dapps})
-    true              (conj {:id :about :label (i18n/label :t/about) :accessibility-label :about})))
+    :always           (conj {:id :about :label (i18n/label :t/about) :accessibility-label :about})))
 
 (defn- change-tab [id] (rf/dispatch [:wallet/select-account-tab id]))
 
@@ -42,7 +42,8 @@
        :account-name        name
        :account             (if watch-only? :watched-address :default)
        :customization-color color}]
-     (when (ff/enabled? ::ff/wallet.graph) [quo/wallet-graph {:time-frame :empty}])
+     (when (ff/enabled? ::ff/wallet.graph)
+       [quo/wallet-graph {:time-frame :empty}])
      (when (not watch-only?)
        [quo/wallet-ctas
         {:container-style style/cta-buttons

--- a/src/status_im/contexts/wallet/collectible/style.cljs
+++ b/src/status_im/contexts/wallet/collectible/style.cljs
@@ -6,10 +6,12 @@
 
 (def container {:margin-bottom 34})
 
-(defn- header-height []
+(defn- header-height
+  []
   (+ 56 (safe-area/get-top)))
 
-(defn preview-container []
+(defn preview-container
+  []
   {:margin-horizontal 8
    :margin-top        (+ (header-height) 12)})
 
@@ -44,7 +46,8 @@
   {:flex        1
    :margin-left 6})
 
-(defn animated-header []
+(defn animated-header
+  []
   {:position :absolute
    :top      0
    :left     0
@@ -82,5 +85,5 @@
 (defn background-color
   [theme]
   {:flex             1
-   :height 1500
+   :height           1500
    :background-color (colors/theme-colors colors/white colors/neutral-95 theme)})

--- a/src/status_im/contexts/wallet/collectible/style.cljs
+++ b/src/status_im/contexts/wallet/collectible/style.cljs
@@ -85,5 +85,4 @@
 (defn background-color
   [theme]
   {:flex             1
-   :height           1500
    :background-color (colors/theme-colors colors/white colors/neutral-95 theme)})

--- a/src/status_im/contexts/wallet/collectible/style.cljs
+++ b/src/status_im/contexts/wallet/collectible/style.cljs
@@ -1,15 +1,17 @@
 (ns status-im.contexts.wallet.collectible.style
   (:require [quo.foundations.colors :as colors]
             [react-native.core :as rn]
-            [react-native.platform :as platform]))
+            [react-native.platform :as platform]
+            [react-native.safe-area :as safe-area]))
 
-(def container
-  {:margin-bottom 34})
+(def container {:margin-bottom 34})
 
-(def preview-container
+(defn- header-height []
+  (+ 56 (safe-area/get-top)))
+
+(defn preview-container []
   {:margin-horizontal 8
-   :margin-top        12
-   :padding-top       100})
+   :margin-top        (+ (header-height) 12)})
 
 (def header
   {:margin-horizontal 20
@@ -42,12 +44,12 @@
   {:flex        1
    :margin-left 6})
 
-(def animated-header
+(defn animated-header []
   {:position :absolute
    :top      0
    :left     0
    :right    0
-   :height   100
+   :height   (header-height)
    :z-index  1
    :overflow :hidden})
 
@@ -80,4 +82,5 @@
 (defn background-color
   [theme]
   {:flex             1
+   :height 1500
    :background-color (colors/theme-colors colors/white colors/neutral-95 theme)})

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -76,7 +76,7 @@
 (defn navigate-back-and-clear-collectible
   []
   (rf/dispatch [:navigate-back])
-  (rf/dispatch [:wallet/clear-last-collectible-details]))
+  (js/setTimeout #(rf/dispatch [:wallet/clear-last-collectible-details]) 700))
 
 (defn animated-header
   [{:keys [scroll-amount title-opacity page-nav-type picture title description theme]}]

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -80,9 +80,9 @@
   (let [blur-amount   (header-animations/use-blur-amount scroll-amount)
         layer-opacity (header-animations/use-layer-opacity
                        scroll-amount
-                       "transparent"
+                       (colors/theme-colors colors/white-opa-0 colors/neutral-95-opa-0 theme)
                        (colors/theme-colors colors/white-opa-50 colors/neutral-95-opa-70-blur theme))]
-    [rn/view {:style style/animated-header}
+    [rn/view {:style (style/animated-header)}
      [reanimated/blur-view
       {:style         {:flex             1
                        :background-color (when platform/android?
@@ -113,8 +113,10 @@
 
 (defn on-scroll
   [e scroll-amount title-opacity title-bottom-coord]
+
   (let [scroll-y    (oops/oget e "nativeEvent.contentOffset.y")
         new-opacity (if (>= scroll-y @title-bottom-coord) 1 0)]
+    (println @title-bottom-coord scroll-y)
     (reanimated/set-shared-value scroll-amount scroll-y)
     (reanimated/set-shared-value title-opacity
                                  (reanimated/with-timing new-opacity #js {:duration 300}))))
@@ -175,7 +177,7 @@
           [gradient-layer preview-uri]
           [quo/expanded-collectible
            {:image-src           preview-uri
-            :container-style     style/preview-container
+            :container-style     (style/preview-container)
             :counter             (utils/collectible-owned-counter total-owned)
             :native-ID           (when (= animation-shared-element-id token-id) :shared-element)
             :supported-file?     (utils/supported-file? (:animation-media-type collectible-data))
@@ -199,7 +201,7 @@
                                    ;; navigation has an animation
                                    (js/setTimeout
                                     #(some-> @title-ref
-                                             (oops/ocall "measureInWindow" set-title-bottom))
+                                       (oops/ocall "measureInWindow" set-title-bottom))
                                     300))}]]
          [rn/view {:style (style/background-color theme)}
           [header collectible-name collection-name collection-image set-title-ref]
@@ -226,7 +228,8 @@
         set-title-bottom           (rn/use-callback
                                     (fn [_ y _ height]
                                       (reset! title-bottom-coord
-                                        (+ y height -100 (if platform/ios? (- top) top)))))
+                                              (+ y height -56 (when platform/ios?
+                                                                (* top -2))))))
         scroll-amount              (reanimated/use-shared-value 0)
         title-opacity              (reanimated/use-shared-value 0)
         collectible                (rf/sub [:wallet/last-collectible-details])

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -144,36 +144,36 @@
   (let [selected-tab  (reagent/atom :overview)
         on-tab-change #(reset! selected-tab %)]
     (fn [{:keys [collectible set-title-bottom theme]}]
-      (let [title-ref                   (rn/use-ref-atom nil)
-            set-title-ref               (rn/use-callback #(reset! title-ref %))
-            animation-shared-element-id (rf/sub [:animation-shared-element-id])
-            collectible-owner           (rf/sub [:wallet/last-collectible-details-owner])
+      (let [title-ref                      (rn/use-ref-atom nil)
+            set-title-ref                  (rn/use-callback #(reset! title-ref %))
+            animation-shared-element-id    (rf/sub [:animation-shared-element-id])
+            collectible-owner              (rf/sub [:wallet/last-collectible-details-owner])
             {:keys [id
                     preview-url
                     collection-data
-                    collectible-data]}  collectible
+                    collectible-data]}     collectible
             {svg?        :svg?
              preview-uri :uri
              :or         {preview-uri ""}} preview-url
-            token-id                    (:token-id id)
-            chain-id                    (get-in id [:contract-id :chain-id])
-            contract-address            (get-in id [:contract-id :address])
+            token-id                       (:token-id id)
+            chain-id                       (get-in id [:contract-id :chain-id])
+            contract-address               (get-in id [:contract-id :address])
             {collection-image :image-url
-             collection-name  :name}    collection-data
-            {collectible-name :name}    collectible-data
-            collectible-image           {:image        preview-uri
-                                         :image-width  300
-                                         ; collectibles don't have width/height
-                                         ; but we need to pass something
-                                         ; without it animation doesn't work smoothly
-                                         ; and :border-radius not  applied
-                                         :image-height 300
-                                         :id           token-id
-                                         :header       collectible-name
-                                         :description  collection-name}
-            total-owned                 (utils/total-owned-collectible
-                                         (:ownership collectible)
-                                         (:address collectible-owner))]
+             collection-name  :name}       collection-data
+            {collectible-name :name}       collectible-data
+            collectible-image              {:image        preview-uri
+                                            :image-width  300
+                                            ; collectibles don't have width/height
+                                            ; but we need to pass something
+                                            ; without it animation doesn't work smoothly
+                                            ; and :border-radius not  applied
+                                            :image-height 300
+                                            :id           token-id
+                                            :header       collectible-name
+                                            :description  collection-name}
+            total-owned                    (utils/total-owned-collectible
+                                            (:ownership collectible)
+                                            (:address collectible-owner))]
         [rn/view {:style style/container}
          [rn/view
           [gradient-layer preview-uri]

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -73,7 +73,8 @@
     :label               (i18n/label :t/about)
     :accessibility-label :about-tab}])
 
-(defn navigate-back-and-clear-collectible []
+(defn navigate-back-and-clear-collectible
+  []
   (rf/dispatch [:navigate-back])
   (rf/dispatch [:wallet/clear-last-collectible-details]))
 

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -73,7 +73,9 @@
     :label               (i18n/label :t/about)
     :accessibility-label :about-tab}])
 
-(def navigate-back #(rf/dispatch [:navigate-back]))
+(defn navigate-back-and-clear-collectible []
+  (rf/dispatch [:navigate-back])
+  (rf/dispatch [:wallet/clear-last-collectible-details]))
 
 (defn animated-header
   [{:keys [scroll-amount title-opacity page-nav-type picture title description theme]}]
@@ -100,7 +102,7 @@
          :background          :blur
          :icon-name           :i/close
          :accessibility-label :back-button
-         :on-press            navigate-back
+         :on-press            navigate-back-and-clear-collectible
          :right-side          [{:icon-name :i/options
                                 :on-press  #(rf/dispatch
                                              [:show-bottom-sheet
@@ -242,9 +244,6 @@
         {preview-uri :uri}         preview-url
         {collectible-name :name}   collectible-data
         {collection-name :name}    collection-data]
-
-    (rn/use-unmount #(rf/dispatch [:wallet/clear-last-collectible-details]))
-
     [rn/view {:style (style/background-color theme)}
      [animated-header
       {:scroll-amount scroll-amount

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -153,7 +153,8 @@
                     collection-data
                     collectible-data]}  collectible
             {svg?        :svg?
-             preview-uri :uri}          preview-url
+             preview-uri :uri
+             :or         {preview-uri ""}} preview-url
             token-id                    (:token-id id)
             chain-id                    (get-in id [:contract-id :chain-id])
             contract-address            (get-in id [:contract-id :address])

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -115,10 +115,8 @@
 
 (defn on-scroll
   [e scroll-amount title-opacity title-bottom-coord]
-
   (let [scroll-y    (oops/oget e "nativeEvent.contentOffset.y")
         new-opacity (if (>= scroll-y @title-bottom-coord) 1 0)]
-    (println @title-bottom-coord scroll-y)
     (reanimated/set-shared-value scroll-amount scroll-y)
     (reanimated/set-shared-value title-opacity
                                  (reanimated/with-timing new-opacity #js {:duration 300}))))

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -201,7 +201,7 @@
                                    ;; navigation has an animation
                                    (js/setTimeout
                                     #(some-> @title-ref
-                                       (oops/ocall "measureInWindow" set-title-bottom))
+                                             (oops/ocall "measureInWindow" set-title-bottom))
                                     300))}]]
          [rn/view {:style (style/background-color theme)}
           [header collectible-name collection-name collection-image set-title-ref]
@@ -228,8 +228,11 @@
         set-title-bottom           (rn/use-callback
                                     (fn [_ y _ height]
                                       (reset! title-bottom-coord
-                                              (+ y height -56 (when platform/ios?
-                                                                (* top -2))))))
+                                        (+ y
+                                           height
+                                           -56
+                                           (when platform/ios?
+                                             (* top -2))))))
         scroll-amount              (reanimated/use-shared-value 0)
         title-opacity              (reanimated/use-shared-value 0)
         collectible                (rf/sub [:wallet/last-collectible-details])


### PR DESCRIPTION
fixes #20179

along with other improvements

### Summary

#### Adds the new background color expected for collectibles with transparency:
  
  Before vs Now:
  [Figma Link](https://www.figma.com/design/HKncH4wnDwZDAhc4AryK8Y/Wallet-for-Mobile?node-id=13212-177685&t=03vTGa5YTuFaQ2Oh-4) (we still have issues with the shadow and the blur)
  
  <img src="https://github.com/status-im/status-mobile/assets/90291778/6ea43ecf-0bc4-484b-866e-d9a11a24bc84"
width="300"> <img src="https://github.com/status-im/status-mobile/assets/90291778/cd0001b4-8983-4546-9e8a-bd1356ff0115"
width="300">



#### Fix the header color while scrolling (looked dark for a moment) and the text animation in unsupported colletibles

Before (it was dark for a while and the text appears immediately):

[Screencast from 2024-05-30 14-36-58.webm](https://github.com/status-im/status-mobile/assets/90291778/861713ce-05a3-411a-bff4-c38039e1d085)

Now (the text appears once the title is covered by the header):

[Screencast from 2024-05-30 14-30-31.webm](https://github.com/status-im/status-mobile/assets/90291778/023c0b8d-6366-466a-8e79-ad5b7d59ad35)

(Sorry for the laggy videos)

#### The issue presented in #20179 of the missing collectible placeholder.

#### The collectible page nav component was misaligned on Android:

[Screencast from 2024-05-30 15-35-55.webm](https://github.com/status-im/status-mobile/assets/90291778/5b0bbf76-d4f9-43ad-8e1e-12544c00ee43)


## Review and testing notes

**IMPORTANT**
In develop, the PR merged:
- #19943

Has the side effect of misaligning the collectibles header, since it modifies the page-top component.

While testing, the header will look centered instead of aligned to the left:
![image](https://github.com/status-im/status-mobile/assets/90291778/b2c9c513-8293-4731-96ae-d07f750111a7)


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready
