### PR TITLE
fix:display user bio

### DIFF
--- a/src/status_im/contexts/profile/settings/header/view.cljs
+++ b/src/status_im/contexts/profile/settings/header/view.cljs
@@ -57,5 +57,6 @@
      [quo/page-top
       {:title-accessibility-label :username
        :emoji-dash                emoji-hash
-       :description               bio
+       :description               :text
+       :description-text          bio
        :title                     full-name}]]))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20290

### Summary
This pr add `description-text` whose value is the `user's bio` to the page-top component used in the profile screen. The property key `description` was in this case used as the `description-text` while it refers to the type of the description.

The issue is fixed 

### Before and after screenshots comparison

<img src="https://github.com/status-im/status-mobile/assets/28704507/aac36e52-ded5-4abc-81a6-116bf8b32662" width="325">
<img src="https://github.com/status-im/status-mobile/assets/28704507/4fe9db46-0c64-4f38-8c7a-b8a8a4e6af65" width="325">

status: ready 
