### PR TITLE
feat(wallet): Wallet settings screen transition

### DIFF
--- a/src/status_im/contexts/profile/settings/list_items.cljs
+++ b/src/status_im/contexts/profile/settings/list_items.cljs
@@ -36,7 +36,7 @@
      :blur?       true
      :action      :arrow}
     {:title        (i18n/label :t/wallet)
-     :on-press     #(rf/dispatch [:open-modal :screen/settings.wallet])
+     :on-press     #(rf/dispatch [:navigate-to-within-stack [:screen/settings.wallet :screen/settings]])
      :image-props  :i/wallet
      :image        :icon
      :blur?        true

--- a/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
@@ -8,11 +8,11 @@
 
 (defn open-saved-addresses-settings-modal
   []
-  (rf/dispatch [:open-modal :screen/settings.saved-addresses]))
+  (rf/dispatch [:navigate-to-within-stack [:screen/settings.saved-addresses :screen/settings]]))
 
 (defn open-keypairs-and-accounts-settings-modal
   []
-  (rf/dispatch [:open-modal :screen/settings.keypairs-and-accounts]))
+  (rf/dispatch [:navigate-to-within-stack [:screen/settings.keypairs-and-accounts :screen/settings]]))
 
 (defn basic-settings-options
   []
@@ -38,7 +38,7 @@
 
 (defn open-network-settings-modal
   []
-  (rf/dispatch [:open-modal :screen/settings.network-settings]))
+  (rf/dispatch [:navigate-to-within-stack [:screen/settings.network-settings :screen/settings]]))
 
 (defn advanced-settings-options
   []


### PR DESCRIPTION
### Summary

This PR updates the navigation methods for wallet settings screens to use slide-in/slide-out transitions


https://github.com/status-im/status-mobile/assets/19339952/42ef339c-a2dc-4491-9138-57ac31e3dd6a


### Review notes

Just updated the navigation method called on each screen

### Testing notes

Testing is not required as these screens are living under feature flags

#### Platforms

- Android
- iOS

status: ready 
