### PR TITLE
[#19734] feat: share saved address QR

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -56,6 +56,10 @@
                                             :shell?  true
                                             :content (fn []
                                                        [remove-address/view opts])}])
+                                        [opts])
+        open-show-address-qr           (rn/use-callback
+                                        #(rf/dispatch [:open-modal
+                                                       :screen/settings.share-saved-address opts])
                                         [opts])]
     [quo/action-drawer
      [[{:icon                :i/arrow-up
@@ -91,7 +95,7 @@
        {:icon                :i/qr-code
         :label               (i18n/label :t/show-address-qr)
         :blur?               true
-        :on-press            not-implemented/alert
+        :on-press            open-show-address-qr
         :accessibility-label :show-address-qr-code}
        {:icon                :i/edit
         :label               (i18n/label :t/edit-account)

--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/share_address/style.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/share_address/style.cljs
@@ -1,0 +1,10 @@
+(ns status-im.contexts.settings.wallet.saved-addresses.sheets.share-address.style)
+
+(def screen-container
+  {:flex 1})
+
+(def top-container
+  {:margin-bottom 8})
+
+(def qr-wrapper
+  {:padding-horizontal 20})

--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/share_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/share_address/view.cljs
@@ -1,0 +1,107 @@
+(ns status-im.contexts.settings.wallet.saved-addresses.sheets.share-address.view
+  (:require
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [react-native.platform :as platform]
+    [react-native.safe-area :as safe-area]
+    [status-im.constants :as constants]
+    [status-im.contexts.wallet.common.utils :as utils]
+    [status-im.contexts.wallet.common.utils.networks :as network-utils]
+    [status-im.contexts.wallet.sheets.network-preferences.view :as network-preferences]
+    [utils.i18n :as i18n]
+    [utils.image-server :as image-server]
+    [utils.re-frame :as rf]))
+
+(def qr-size 500)
+
+(defn- navigate-back
+  []
+  (rf/dispatch [:navigate-back]))
+
+(defn- share-action
+  [address share-title]
+  (rf/dispatch [:open-share
+                {:options (if platform/ios?
+                            {:activityItemSources [{:placeholderItem {:type    :text
+                                                                      :content address}
+                                                    :item            {:default {:type :text
+                                                                                :content
+                                                                                address}}
+                                                    :linkMetadata    {:title share-title}}]}
+                            {:title     share-title
+                             :subject   share-title
+                             :message   address
+                             :isNewTask true})}]))
+
+(defn- open-preferences
+  [selected-networks set-selected-networks]
+  (let [on-save       (fn [chain-ids]
+                        (rf/dispatch [:hide-bottom-sheet])
+                        (set-selected-networks (map network-utils/id->network chain-ids)))
+        sheet-content (fn []
+                        [network-preferences/view
+                         {:blur?             true
+                          :selected-networks (set selected-networks)
+                          :on-save           on-save
+                          :button-label      (i18n/label :t/display)}])]
+    (rf/dispatch [:show-bottom-sheet
+                  {:theme   :dark
+                   :shell?  true
+                   :content sheet-content}])))
+
+(defn view
+  []
+  (let [padding-top                                (:top (safe-area/get-insets))
+        {:keys [name address customization-color]} (rf/sub [:get-screen-params])
+        [wallet-type set-wallet-type]              (rn/use-state :legacy)
+        [selected-networks set-selected-networks]  (rn/use-state constants/default-network-names)
+        on-settings-press                          (rn/use-callback #(open-preferences
+                                                                      selected-networks
+                                                                      set-selected-networks)
+                                                                    [selected-networks])
+        on-legacy-press                            (rn/use-callback #(set-wallet-type :legacy))
+        on-multichain-press                        (rn/use-callback #(set-wallet-type :multichain))
+        preferred-networks                         (rf/sub [:wallet/preferred-chain-names-for-address
+                                                            address])
+        share-title                                (str name " " (i18n/label :t/address))
+        qr-url                                     (rn/use-memo #(utils/get-wallet-qr
+                                                                  {:wallet-type       wallet-type
+                                                                   :selected-networks selected-networks
+                                                                   :address           address})
+                                                                [wallet-type selected-networks address])
+        qr-media-server-uri                        (rn/use-memo
+                                                    #(image-server/get-qr-image-uri-for-any-url
+                                                      {:url         qr-url
+                                                       :port        (rf/sub [:mediaserver/port])
+                                                       :qr-size     qr-size
+                                                       :error-level :highest})
+                                                    [qr-url])]
+
+    (rn/use-mount #(set-selected-networks preferred-networks))
+
+    [quo/overlay {:type :shell}
+     [rn/view
+      {:flex        1
+       :padding-top padding-top}
+      [quo/page-nav
+       {:icon-name           :i/close
+        :on-press            navigate-back
+        :background          :blur
+        :accessibility-label :top-bar}]
+      [quo/page-top
+       {:title           (i18n/label :t/share-address)
+        :container-style {:margin-bottom 8}}]
+      [rn/view {:style {:padding-horizontal 20}}
+       [quo/share-qr-code
+        {:type                :saved-address
+         :address             wallet-type
+         :qr-image-uri        qr-media-server-uri
+         :qr-data             qr-url
+         :networks            selected-networks
+         :on-share-press      #(share-action qr-url share-title)
+         :profile-picture     nil
+         :full-name           name
+         :customization-color customization-color
+         :on-legacy-press     on-legacy-press
+         :on-multichain-press on-multichain-press
+         :on-settings-press   on-settings-press}]]]]))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
@@ -20,7 +20,7 @@
       :container-style style/empty-container-style}]))
 
 (defn- saved-address
-  [{:keys [name address chain-short-names customization-color has-ens? ens]}]
+  [{:keys [name address chain-short-names customization-color has-ens? ens network-preferences-names]}]
   (let [full-address           (str chain-short-names address)
         on-press-saved-address (rn/use-callback
                                 #(rf/dispatch
@@ -29,11 +29,12 @@
                                     :shell?  true
                                     :content (fn []
                                                [address-options/view
-                                                {:address             address
-                                                 :chain-short-names   chain-short-names
-                                                 :full-address        full-address
-                                                 :name                name
-                                                 :customization-color customization-color}])}])
+                                                {:address                   address
+                                                 :chain-short-names         chain-short-names
+                                                 :full-address              full-address
+                                                 :name                      name
+                                                 :network-preferences-names network-preferences-names
+                                                 :customization-color       customization-color}])}])
                                 [address chain-short-names full-address name customization-color])]
     [quo/saved-address
      {:blur?           true

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -66,6 +66,8 @@
     [status-im.contexts.settings.wallet.saved-addresses.add-address-to-save.view :as
      wallet-add-address-to-save]
     [status-im.contexts.settings.wallet.saved-addresses.save-address.view :as wallet-save-address]
+    [status-im.contexts.settings.wallet.saved-addresses.sheets.share-address.view :as
+     share-saved-address]
     [status-im.contexts.settings.wallet.saved-addresses.view :as saved-addresses-settings]
     [status-im.contexts.settings.wallet.wallet-options.view :as wallet-options]
     [status-im.contexts.shell.activity-center.view :as activity-center]
@@ -556,6 +558,10 @@
     {:name      :screen/settings.add-address-to-save
      :options   options/transparent-modal-screen-options
      :component wallet-add-address-to-save/view}
+
+    {:name      :screen/settings.share-saved-address
+     :options   options/transparent-screen-options
+     :component share-saved-address/view}
 
     {:name      :screen/settings-messages
      :options   options/transparent-modal-screen-options


### PR DESCRIPTION
fixes #19734

### Summary

Implement the screen to show the QR code that can be shared

#### Areas that maybe impacted

-  Share saved address QR code


### Steps to test

- Open profile setting
- Open Wallet setting 
- Click on Saved adresses
- Click on one address
- Click on Show address QR


### Result


https://github.com/status-im/status-mobile/assets/71308738/16af116e-bb81-4f81-8a21-00ea529964ce


status: ready
