### PR TITLE
Move buy assets recurrent tab out of feature flag

### DIFF
--- a/src/status_im/contexts/wallet/sheets/buy_token/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/buy_token/view.cljs
@@ -3,7 +3,6 @@
             [quo.core :as quo]
             [react-native.core :as rn]
             [status-im.contexts.wallet.sheets.buy-token.style :as style]
-            [status-im.feature-flags :as ff]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
@@ -46,15 +45,14 @@
                                            (oops/oget % :nativeEvent :layout :height)))]
     [:<>
      [quo/drawer-top {:title (i18n/label :t/buy-assets)}]
-     (when (ff/enabled? ::ff/wallet.buy-recurrent-assets)
-       [quo/segmented-control
-        {:size            32
-         :container-style style/tabs
-         :default-active  initial-tab
-         :on-change       set-selected-tab
-         :data            tabs}])
+     [quo/segmented-control
+      {:size            32
+       :container-style style/tabs
+       :default-active  initial-tab
+       :on-change       set-selected-tab
+       :data            tabs}]
      [rn/flat-list
-      {:data        (if (and (ff/enabled? ::ff/wallet.buy-recurrent-assets) (= selected-tab :recurrent))
+      {:data        (if (= selected-tab :recurrent)
                       (:recurrent crypto-on-ramps)
                       (:one-time crypto-on-ramps))
        :on-layout   on-layout

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -19,7 +19,6 @@
    ::wallet.assets-modal-hide           (enabled-in-env? :FLAG_ASSETS_MODAL_HIDE)
    ::wallet.assets-modal-manage-tokens  (enabled-in-env? :FLAG_ASSETS_MODAL_MANAGE_TOKENS)
    ::wallet.bridge-token                (enabled-in-env? :FLAG_BRIDGE_TOKEN_ENABLED)
-   ::wallet.buy-recurrent-assets        (enabled-in-env? :FLAG_BUY_RECURRENT_ASSETS)
    ::wallet.contacts                    (enabled-in-env? :FLAG_CONTACTS_ENABLED)
    ::wallet.edit-derivation-path        (enabled-in-env? :FLAG_EDIT_DERIVATION_PATH)
    ::wallet.graph                       (enabled-in-env? :FLAG_GRAPH_ENABLED)


### PR DESCRIPTION
fixes #20390

### Summary
Previously, we didn’t have any recurrent purchase providers, so the recurrent tab was hidden under a feature flag. In [this status-go PR](https://github.com/status-im/status-go/pull/5276), we’re adding Mercuryo as our only recurrent option at the moment.

### Test Notes
The recurrent feature has not undergone manual QA yet.

#### Steps to test

- Open the Status app.
- Switch to the Wallet Tab.
- Open the buy assets drawer by either:
  - Long-pressing any token and selecting the buy option from the menu.
  - Navigating to an account and tapping on the buy option.
- Ensure that tapping on any one-time and recurrent purchase providers opens the relevant website in the external browser.

### Screenshots
One-time | Recurrent
-|-
<img src="https://github.com/status-im/status-mobile/assets/19279756/cfa5cd50-bbf6-40fd-a4be-39f30362093c" width=340/> | <img src="https://github.com/status-im/status-mobile/assets/19279756/accbda31-4b79-47f9-8f58-d8301871b9a6" width=340/>


status: ready <!-- Can be ready or wip -->
