### PR TITLE
fix white screen when navigating back from a channel

### DIFF
--- a/src/status_im/contexts/chat/events.cljs
+++ b/src/status_im/contexts/chat/events.cljs
@@ -202,7 +202,8 @@
   {:events [:chat/navigate-to-chat]}
   [{db :db :as cofx} chat-id animation]
   (rf/merge cofx
-            {:dispatch [(if animation :shell/navigate-to :navigate-to) :chat chat-id animation]}
+            (when-not (:current-chat-id db)
+              {:dispatch [(if animation :shell/navigate-to :navigate-to) :chat chat-id animation]})
             (close-chat chat-id)
             (force-close-chat chat-id)
             (fn [{:keys [db]}]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20313

### Summary

This issue only happens when the user navigates to a community chat from a community tag inside a chat. The user would be navigated back to the previous chat when the they choose to navigate back but we do not persist reference to the previous chat since that is not inline with the designs hence the white screen.

This pr updates the event that  navigates the user to the new community-chat to pass the `community-id` and instead of `:navigate-back`  replaces this event to navigate back to the community-overview screen with an event to directly just launch the overview screen of the community-id

The video below show the flow without the white screen issue

https://github.com/status-im/status-mobile/assets/28704507/52a33e1d-0746-4ea9-b448-989b37fafa66

status: ready 
