### PR TITLE
deps: bump react-native-linear-gradient library

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,5 @@
 PODS:
   - boost (1.83.0)
-  - BVLinearGradient (2.8.0):
-    - React-Core
   - CryptoSwift (1.5.1)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.73.5)
@@ -1161,6 +1159,10 @@ PODS:
     - TOCropViewController
   - RNKeychain (8.1.2):
     - React-Core
+  - RNLinearGradient (3.0.0-alpha.1):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core
   - RNPermissions (4.1.5):
     - React-Core
   - RNReanimated (3.6.1):
@@ -1188,7 +1190,6 @@ PODS:
 
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
-  - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
@@ -1269,6 +1270,7 @@ DEPENDENCIES:
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNImageCropPicker (from `../node_modules/react-native-image-crop-picker`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
+  - RNLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNShare (from `../node_modules/react-native-share`)
@@ -1294,8 +1296,6 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   boost:
     :podspec: "../node_modules/react-native/third-party-podspecs/boost.podspec"
-  BVLinearGradient:
-    :path: "../node_modules/react-native-linear-gradient"
   DoubleConversion:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   FBLazyVector:
@@ -1451,6 +1451,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-image-crop-picker"
   RNKeychain:
     :path: "../node_modules/react-native-keychain"
+  RNLinearGradient:
+    :path: "../node_modules/react-native-linear-gradient"
   RNPermissions:
     :path: "../node_modules/react-native-permissions"
   RNReanimated:
@@ -1478,13 +1480,12 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
-  BVLinearGradient: 612a04ff38e8480291f3379ee5b5a2c571f03fe0
   CryptoSwift: c4f2debceb38bf44c80659afe009f71e23e4a082
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: 56e0e498dbb513b96c40bac6284729ba4e62672d
   FBReactNativeSpec: 146c741a3f40361f6bc13a4ba284678cbedb5881
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: 530710e7949eb12c82670bd09e946becf50a3c2a
   hermes-engine: 1d1835b2cc54c381909d94d1b3c8e0a2f1a94a0e
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   Keycard: ac6df4d91525c3c82635ac24d4ddd9a80aca5fc8
@@ -1561,6 +1562,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 15c6ef51acba34c49ff03003806cf5dd6098f383
   RNImageCropPicker: 486e2f7e2b0461ce24321f751410dce1b3b49e6d
   RNKeychain: a65256b6ca6ba6976132cc4124b238a5b13b3d9c
+  RNLinearGradient: ccaaebce083b54180da61d992e7fa56abfe000d6
   RNPermissions: 08e619529cced22695f4b6d0efcc0a233e278903
   RNReanimated: dee37576492f1a375017515f5c77e66e5eec696b
   RNShare: 859ff710211285676b0bcedd156c12437ea1d564

--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -8,10 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* StatusImTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* StatusImTests.m */; };
-		0BF51D8C7FBD6A668E6E1FC0 /* libPods-Status-StatusIm.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 45C29909A975E0654116557F /* libPods-Status-StatusIm.a */; };
-		131972279C6DBF736235F9F9 /* libPods-Status-StatusIm-StatusImTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D9DF8AC0F6547107DE1A25D /* libPods-Status-StatusIm-StatusImTests.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		231CD38186B86957CFCF645E /* libPods-Status-StatusIm.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DA19658BCC29789EBB3DE79 /* libPods-Status-StatusIm.a */; };
 		25DC9C9DC25846BD8D084888 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B9A886A2CB448B1ABA0EB62 /* libc++.tbd */; };
 		3870E1E692E24133A80B07DE /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 693A62DB37BC4CD5A30E5C96 /* Inter-SemiBold.otf */; };
 		393D26E3080B443A998F4A2F /* Inter-Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = B07176ACDAA1422E8F0A3D6B /* Inter-Italic.otf */; };
@@ -41,11 +40,13 @@
 		65F6941925780A4F00A45E76 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F6941825780A4F00A45E76 /* Bridge.swift */; };
 		65F6941A25780A4F00A45E76 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F6941825780A4F00A45E76 /* Bridge.swift */; };
 		65F6941B25780A4F00A45E76 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F6941825780A4F00A45E76 /* Bridge.swift */; };
+		67A3DF2242D5B6C35A4C6A33 /* libPods-Status-StatusIm-StatusImTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A7B7F8B9749AB74BB0697B49 /* libPods-Status-StatusIm-StatusImTests.a */; };
 		70ADBB5ECF934DCF8A0E4919 /* Inter-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 1426DF592BA248FC81D955CB /* Inter-Regular.otf */; };
 		715D8132290BE850006F5C88 /* UbuntuMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 715D8131290BE850006F5C88 /* UbuntuMono-Regular.ttf */; };
 		715D8133290BE850006F5C88 /* UbuntuMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 715D8131290BE850006F5C88 /* UbuntuMono-Regular.ttf */; };
 		74B758FC20D7C00B003343C3 /* launch-image-universal.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 74B758FB20D7C00B003343C3 /* launch-image-universal.storyboard */; };
 		8391E8E0E93C41A98AAA6631 /* Inter-SemiBoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = A4F2BBE8D4DD4140A6CCAC39 /* Inter-SemiBoldItalic.otf */; };
+		A1B6E23C86E6A40AFE74E925 /* libPods-Status-StatusImPR.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E9723BBA39FC5B087C3D475 /* libPods-Status-StatusImPR.a */; };
 		B24FC7FD1DE7195700D694FF /* Social.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B24FC7FC1DE7195700D694FF /* Social.framework */; };
 		B24FC7FF1DE7195F00D694FF /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B24FC7FE1DE7195F00D694FF /* MessageUI.framework */; };
 		B2F2D1BC1D9D531B00B7B453 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B2F2D1BB1D9D531B00B7B453 /* Images.xcassets */; };
@@ -60,7 +61,6 @@
 		D1786306E0184916B11F4C37 /* Inter-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = B2A38FC3D3954DE7B2B171F8 /* Inter-Medium.otf */; };
 		D84616FB563A48EBB1678699 /* Inter-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = CD4A2C27D6D5473184DC1F7E /* Inter-Bold.otf */; };
 		D99C50E5E18942A39C8DDF61 /* Inter-BoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = B321D25F4493470980039457 /* Inter-BoldItalic.otf */; };
-		DE2F1721F9D5702C7CEC5594 /* libPods-Status-StatusImPR.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B17DF204648B8189F8ABD0A7 /* libPods-Status-StatusImPR.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,23 +108,23 @@
 		00E356EE1AD99517003FC87E /* StatusImTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StatusImTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* StatusImTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StatusImTests.m; sourceTree = "<group>"; };
+		0E9723BBA39FC5B087C3D475 /* libPods-Status-StatusImPR.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Status-StatusImPR.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07F961A680F5B00A75B9A /* StatusIm.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StatusIm.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = StatusIm/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = StatusIm/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = StatusIm/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = StatusIm/main.m; sourceTree = "<group>"; };
 		1426DF592BA248FC81D955CB /* Inter-Regular.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-Regular.otf"; path = "../resources/fonts/Inter-Regular.otf"; sourceTree = "<group>"; };
-		1B74FBFCB9B8E34B63250A52 /* Pods-Status-StatusIm-StatusImTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusIm-StatusImTests.release.xcconfig"; path = "Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests.release.xcconfig"; sourceTree = "<group>"; };
-		232FE8EAB57384181B0DB836 /* Pods-Status-StatusIm.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusIm.release.xcconfig"; path = "Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm.release.xcconfig"; sourceTree = "<group>"; };
-		2D9DF8AC0F6547107DE1A25D /* libPods-Status-StatusIm-StatusImTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Status-StatusIm-StatusImTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2F18074BFB7862090B68D75F /* Pods-Status-StatusImPR.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusImPR.debug.xcconfig"; path = "Target Support Files/Pods-Status-StatusImPR/Pods-Status-StatusImPR.debug.xcconfig"; sourceTree = "<group>"; };
 		3A2626CE245C3F2200D5F94B /* Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dummy.swift; sourceTree = "<group>"; };
 		3A6406FB24A3ADF90046ED37 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3A8F8EA924A4D31600BF206D /* GameKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameKit.framework; path = System/Library/Frameworks/GameKit.framework; sourceTree = SDKROOT; };
 		3AAD2ADC24A3A60E0075D594 /* Status PR.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Status PR.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AB1C3AD245C043900098F67 /* StatusIm-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StatusIm-Bridging-Header.h"; sourceTree = "<group>"; };
-		45C29909A975E0654116557F /* libPods-Status-StatusIm.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Status-StatusIm.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C16DE0B1F89508700AA10DB /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		4E586E1B0E544F64AA9F5BD1 /* libz.tbd */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		5D2EA2A248267BA083152C22 /* Pods-Status-StatusIm.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusIm.release.xcconfig"; path = "Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm.release.xcconfig"; sourceTree = "<group>"; };
+		5DA19658BCC29789EBB3DE79 /* libPods-Status-StatusIm.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Status-StatusIm.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		65F693BD2578002500A45E76 /* CoreNFC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreNFC.framework; path = System/Library/Frameworks/CoreNFC.framework; sourceTree = SDKROOT; };
 		65F693BF2578003600A45E76 /* CoreNFC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreNFC.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/iOSSupport/System/Library/Frameworks/CoreNFC.framework; sourceTree = DEVELOPER_DIR; };
 		65F6941725780A4E00A45E76 /* StatusImTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StatusImTests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -132,16 +132,14 @@
 		693A62DB37BC4CD5A30E5C96 /* Inter-SemiBold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-SemiBold.otf"; path = "../resources/fonts/Inter-SemiBold.otf"; sourceTree = "<group>"; };
 		715D8131290BE850006F5C88 /* UbuntuMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "UbuntuMono-Regular.ttf"; path = "../resources/fonts/UbuntuMono-Regular.ttf"; sourceTree = "<group>"; };
 		74B758FB20D7C00B003343C3 /* launch-image-universal.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "launch-image-universal.storyboard"; sourceTree = "<group>"; };
-		7A393286DD0E844D050D0B89 /* Pods-Status-StatusImPR.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusImPR.release.xcconfig"; path = "Target Support Files/Pods-Status-StatusImPR/Pods-Status-StatusImPR.release.xcconfig"; sourceTree = "<group>"; };
-		7BF7B2DB23EE09E5229629DA /* Pods-Status-StatusImPR.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusImPR.debug.xcconfig"; path = "Target Support Files/Pods-Status-StatusImPR/Pods-Status-StatusImPR.debug.xcconfig"; sourceTree = "<group>"; };
 		8B9A886A2CB448B1ABA0EB62 /* libc++.tbd */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		922C4CA61F4D5F8B0033C753 /* StatusIm.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = StatusIm.entitlements; path = StatusIm/StatusIm.entitlements; sourceTree = "<group>"; };
 		9C76AF5A418D4D65A4CAD1D9 /* InterStatus-Regular.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterStatus-Regular.otf"; path = "../resources/fonts/InterStatus-Regular.otf"; sourceTree = "<group>"; };
 		9EC0135C1E06FB1900155B5C /* RCTWKWebView.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWKWebView.xcodeproj; path = "../node_modules/react-native-wkwebview-reborn/ios/RCTWKWebView.xcodeproj"; sourceTree = "<group>"; };
-		A0B5AD061DF0F6CC98603A99 /* Pods-Status-StatusIm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusIm.debug.xcconfig"; path = "Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm.debug.xcconfig"; sourceTree = "<group>"; };
 		A4F2BBE8D4DD4140A6CCAC39 /* Inter-SemiBoldItalic.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-SemiBoldItalic.otf"; path = "../resources/fonts/Inter-SemiBoldItalic.otf"; sourceTree = "<group>"; };
+		A7B7F8B9749AB74BB0697B49 /* libPods-Status-StatusIm-StatusImTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Status-StatusIm-StatusImTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B064AF9CEF590E7140F5193F /* Pods-Status-StatusIm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusIm.debug.xcconfig"; path = "Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm.debug.xcconfig"; sourceTree = "<group>"; };
 		B07176ACDAA1422E8F0A3D6B /* Inter-Italic.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-Italic.otf"; path = "../resources/fonts/Inter-Italic.otf"; sourceTree = "<group>"; };
-		B17DF204648B8189F8ABD0A7 /* libPods-Status-StatusImPR.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Status-StatusImPR.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B24FC7FC1DE7195700D694FF /* Social.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Social.framework; path = System/Library/Frameworks/Social.framework; sourceTree = SDKROOT; };
 		B24FC7FE1DE7195F00D694FF /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		B2A38FC3D3954DE7B2B171F8 /* Inter-Medium.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-Medium.otf"; path = "../resources/fonts/Inter-Medium.otf"; sourceTree = "<group>"; };
@@ -153,7 +151,9 @@
 		C6B1215047604CD59A4C74D6 /* Inter-MediumItalic.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-MediumItalic.otf"; path = "../resources/fonts/Inter-MediumItalic.otf"; sourceTree = "<group>"; };
 		CD4A2C27D6D5473184DC1F7E /* Inter-Bold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-Bold.otf"; path = "../resources/fonts/Inter-Bold.otf"; sourceTree = "<group>"; };
 		CE4E31B21D8695250033ED64 /* Statusgo.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Statusgo.xcframework; path = "../modules/react-native-status/ios/RCTStatus/Statusgo.xcframework"; sourceTree = "<group>"; };
-		D40C4023C7D5B793AEF98426 /* Pods-Status-StatusIm-StatusImTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusIm-StatusImTests.debug.xcconfig"; path = "Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D1249D8E109F0F96FFE2CA6C /* Pods-Status-StatusImPR.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusImPR.release.xcconfig"; path = "Target Support Files/Pods-Status-StatusImPR/Pods-Status-StatusImPR.release.xcconfig"; sourceTree = "<group>"; };
+		E089B0F56B6F6715D444A841 /* Pods-Status-StatusIm-StatusImTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusIm-StatusImTests.debug.xcconfig"; path = "Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests.debug.xcconfig"; sourceTree = "<group>"; };
+		EAAD01A6F886D961CE1A9541 /* Pods-Status-StatusIm-StatusImTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusIm-StatusImTests.release.xcconfig"; path = "Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,7 +161,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				131972279C6DBF736235F9F9 /* libPods-Status-StatusIm-StatusImTests.a in Frameworks */,
+				67A3DF2242D5B6C35A4C6A33 /* libPods-Status-StatusIm-StatusImTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -174,7 +174,7 @@
 				CE4E31B31D8695250033ED64 /* Statusgo.xcframework in Frameworks */,
 				25DC9C9DC25846BD8D084888 /* libc++.tbd in Frameworks */,
 				BA68A2377A20496EA737000D /* libz.tbd in Frameworks */,
-				0BF51D8C7FBD6A668E6E1FC0 /* libPods-Status-StatusIm.a in Frameworks */,
+				231CD38186B86957CFCF645E /* libPods-Status-StatusIm.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -188,7 +188,7 @@
 				3AAD2AC224A3A60E0075D594 /* Statusgo.xcframework in Frameworks */,
 				3AAD2AC524A3A60E0075D594 /* libc++.tbd in Frameworks */,
 				3AAD2AC624A3A60E0075D594 /* libz.tbd in Frameworks */,
-				DE2F1721F9D5702C7CEC5594 /* libPods-Status-StatusImPR.a in Frameworks */,
+				A1B6E23C86E6A40AFE74E925 /* libPods-Status-StatusImPR.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -314,9 +314,9 @@
 				CE4E31B21D8695250033ED64 /* Statusgo.xcframework */,
 				8B9A886A2CB448B1ABA0EB62 /* libc++.tbd */,
 				4E586E1B0E544F64AA9F5BD1 /* libz.tbd */,
-				45C29909A975E0654116557F /* libPods-Status-StatusIm.a */,
-				2D9DF8AC0F6547107DE1A25D /* libPods-Status-StatusIm-StatusImTests.a */,
-				B17DF204648B8189F8ABD0A7 /* libPods-Status-StatusImPR.a */,
+				5DA19658BCC29789EBB3DE79 /* libPods-Status-StatusIm.a */,
+				A7B7F8B9749AB74BB0697B49 /* libPods-Status-StatusIm-StatusImTests.a */,
+				0E9723BBA39FC5B087C3D475 /* libPods-Status-StatusImPR.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -324,12 +324,12 @@
 		D0D5C8D06825D33BA2D2121E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				A0B5AD061DF0F6CC98603A99 /* Pods-Status-StatusIm.debug.xcconfig */,
-				232FE8EAB57384181B0DB836 /* Pods-Status-StatusIm.release.xcconfig */,
-				D40C4023C7D5B793AEF98426 /* Pods-Status-StatusIm-StatusImTests.debug.xcconfig */,
-				1B74FBFCB9B8E34B63250A52 /* Pods-Status-StatusIm-StatusImTests.release.xcconfig */,
-				7BF7B2DB23EE09E5229629DA /* Pods-Status-StatusImPR.debug.xcconfig */,
-				7A393286DD0E844D050D0B89 /* Pods-Status-StatusImPR.release.xcconfig */,
+				B064AF9CEF590E7140F5193F /* Pods-Status-StatusIm.debug.xcconfig */,
+				5D2EA2A248267BA083152C22 /* Pods-Status-StatusIm.release.xcconfig */,
+				E089B0F56B6F6715D444A841 /* Pods-Status-StatusIm-StatusImTests.debug.xcconfig */,
+				EAAD01A6F886D961CE1A9541 /* Pods-Status-StatusIm-StatusImTests.release.xcconfig */,
+				2F18074BFB7862090B68D75F /* Pods-Status-StatusImPR.debug.xcconfig */,
+				D1249D8E109F0F96FFE2CA6C /* Pods-Status-StatusImPR.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -341,12 +341,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "StatusImTests" */;
 			buildPhases = (
-				5937040F3338CDF93E777A93 /* [CP] Check Pods Manifest.lock */,
+				9B331412309D5F5632348AEE /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				7AD665439C08CFEF5EF84F6A /* [CP] Embed Pods Frameworks */,
-				02C1A8CA208E38DA07BAC311 /* [CP] Copy Pods Resources */,
+				7545D1B37CABFA574D6D6C31 /* [CP] Embed Pods Frameworks */,
+				A3AD03105488DA5BC8E8C199 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -362,15 +362,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "StatusIm" */;
 			buildPhases = (
-				1DFD6BF757E89B72F40FCEE9 /* [CP] Check Pods Manifest.lock */,
+				236F25332B0D1B4DCC0E041E /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				20B6B6891D92C42700CC5C6A /* Embed Frameworks */,
 				E3914A731DF919ED00EBB515 /* Run Script */,
-				50F2A2E15670F86233743A5C /* [CP] Embed Pods Frameworks */,
-				1B623A051F855FC5B09A0480 /* [CP] Copy Pods Resources */,
+				37D91248C8178FEAC1661AE0 /* [CP] Embed Pods Frameworks */,
+				BC5CED24C6D00996607C4942 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -385,15 +385,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3AAD2AD924A3A60E0075D594 /* Build configuration list for PBXNativeTarget "StatusImPR" */;
 			buildPhases = (
-				EB421F3ED78A38D285D771D2 /* [CP] Check Pods Manifest.lock */,
+				D0B7F25508F9BD7C6B30AF36 /* [CP] Check Pods Manifest.lock */,
 				3AAD2ABB24A3A60E0075D594 /* Sources */,
 				3AAD2ABF24A3A60E0075D594 /* Frameworks */,
 				3AAD2AC924A3A60E0075D594 /* Resources */,
 				3AAD2AD524A3A60E0075D594 /* Bundle React Native code and images */,
 				3AAD2AD624A3A60E0075D594 /* Embed Frameworks */,
 				3AAD2AD724A3A60E0075D594 /* Run Script */,
-				F4561A2D3C9E6C4B66F4C4F5 /* [CP] Embed Pods Frameworks */,
-				6FA1467F7B916ED92FA688E0 /* [CP] Copy Pods Resources */,
+				5C9736BD9798020B8F31802B /* [CP] Embed Pods Frameworks */,
+				B76C3637DC2DDBB6E8472904 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -547,55 +547,7 @@
 			shellPath = "/usr/bin/env sh";
 			shellScript = "set -o errexit\nexport NODE_BINARY=\"${NODE_BINARY:-node}\"\nexport NODE_ARGS=\"${NODE_ARGS:- --max-old-space-size=16384 }\"\n\n\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n";
 		};
-		02C1A8CA208E38DA07BAC311 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNPermissions/RNPermissionsPrivacyInfo.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNPermissionsPrivacyInfo.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		1B623A051F855FC5B09A0480 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNPermissions/RNPermissionsPrivacyInfo.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNPermissionsPrivacyInfo.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		1DFD6BF757E89B72F40FCEE9 /* [CP] Check Pods Manifest.lock */ = {
+		236F25332B0D1B4DCC0E041E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -615,6 +567,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		37D91248C8178FEAC1661AE0 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3AAD2AD524A3A60E0075D594 /* Bundle React Native code and images */ = {
@@ -645,13 +615,13 @@
 			shellPath = "/usr/bin/env sh";
 			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ../logs/set_xcode_version.log 2>&1\n";
 		};
-		50F2A2E15670F86233743A5C /* [CP] Embed Pods Frameworks */ = {
+		5C9736BD9798020B8F31802B /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Status-StatusImPR/Pods-Status-StatusImPR-frameworks.sh",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -660,10 +630,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusImPR/Pods-Status-StatusImPR-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5937040F3338CDF93E777A93 /* [CP] Check Pods Manifest.lock */ = {
+		7545D1B37CABFA574D6D6C31 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9B331412309D5F5632348AEE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -685,7 +673,31 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6FA1467F7B916ED92FA688E0 /* [CP] Copy Pods Resources */ = {
+		A3AD03105488DA5BC8E8C199 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNPermissions/RNPermissionsPrivacyInfo.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNPermissionsPrivacyInfo.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B76C3637DC2DDBB6E8472904 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -709,39 +721,31 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusImPR/Pods-Status-StatusImPR-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		7AD665439C08CFEF5EF84F6A /* [CP] Embed Pods Frameworks */ = {
+		BC5CED24C6D00996607C4942 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
+				"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNPermissions/RNPermissionsPrivacyInfo.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNPermissionsPrivacyInfo.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusIm/Pods-Status-StatusIm-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E3914A731DF919ED00EBB515 /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 8;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-			shellPath = "/usr/bin/env sh";
-			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ../logs/set_xcode_version.log 2>&1\n";
-		};
-		EB421F3ED78A38D285D771D2 /* [CP] Check Pods Manifest.lock */ = {
+		D0B7F25508F9BD7C6B30AF36 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -763,23 +767,19 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F4561A2D3C9E6C4B66F4C4F5 /* [CP] Embed Pods Frameworks */ = {
+		E3914A731DF919ED00EBB515 /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Status-StatusImPR/Pods-Status-StatusImPR-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			name = "Run Script";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Status-StatusImPR/Pods-Status-StatusImPR-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = "/usr/bin/env sh";
+			shellScript = "\"${PROJECT_DIR}/scripts/set_xcode_version.sh\" > ../logs/set_xcode_version.log 2>&1\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -828,7 +828,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D40C4023C7D5B793AEF98426 /* Pods-Status-StatusIm-StatusImTests.debug.xcconfig */;
+			baseConfigurationReference = E089B0F56B6F6715D444A841 /* Pods-Status-StatusIm-StatusImTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_ID_SUFFIX = .debug;
@@ -865,7 +865,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1B74FBFCB9B8E34B63250A52 /* Pods-Status-StatusIm-StatusImTests.release.xcconfig */;
+			baseConfigurationReference = EAAD01A6F886D961CE1A9541 /* Pods-Status-StatusIm-StatusImTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_ID_SUFFIX = "";
@@ -898,7 +898,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A0B5AD061DF0F6CC98603A99 /* Pods-Status-StatusIm.debug.xcconfig */;
+			baseConfigurationReference = B064AF9CEF590E7140F5193F /* Pods-Status-StatusIm.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon$(BUNDLE_ID_SUFFIX)";
 				BUNDLE_ID_SUFFIX = .debug;
@@ -980,7 +980,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 232FE8EAB57384181B0DB836 /* Pods-Status-StatusIm.release.xcconfig */;
+			baseConfigurationReference = 5D2EA2A248267BA083152C22 /* Pods-Status-StatusIm.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon$(BUNDLE_ID_SUFFIX)";
 				BUNDLE_ID_SUFFIX = "";
@@ -1055,7 +1055,7 @@
 		};
 		3AAD2ADA24A3A60E0075D594 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7BF7B2DB23EE09E5229629DA /* Pods-Status-StatusImPR.debug.xcconfig */;
+			baseConfigurationReference = 2F18074BFB7862090B68D75F /* Pods-Status-StatusImPR.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon$(BUNDLE_ID_SUFFIX)";
 				BUNDLE_ID_SUFFIX = .debug;
@@ -1135,7 +1135,7 @@
 		};
 		3AAD2ADB24A3A60E0075D594 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7A393286DD0E844D050D0B89 /* Pods-Status-StatusImPR.release.xcconfig */;
+			baseConfigurationReference = D1249D8E109F0F96FFE2CA6C /* Pods-Status-StatusImPR.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIconPR$(BUNDLE_ID_SUFFIX)";
 				BUNDLE_ID_SUFFIX = "";

--- a/nix/deps/gradle/deps.json
+++ b/nix/deps/gradle/deps.json
@@ -8461,6 +8461,10 @@
         "sha1": "fcfa9f6e411771b8be9bee29e9d318867d3e1bc3",
         "sha256": "sha256-ZMFGqsSRjMPiHhMij1/kF4VZM7GBN0zML4me8eFWsm0="
       },
+      "commons-logging-1.3.2-api.jar": {
+        "sha1": "0cf1bbd995c6ad9a2bf03efa94b4753409afd1d0",
+        "sha256": "sha256-FULIR7cLw1ucpucmKT9wm/5cy26alI+5KjeG/6lWE40="
+      },
       "commons-logging-1.3.2.jar": {
         "sha1": "3dc966156ef19d23c839715165435e582fafa753",
         "sha256": "sha256-a4WEJPUYAV8yv80Rg6Nz9Kgn1y0Ca2Ax2gyRzw6PNIk="
@@ -10951,16 +10955,16 @@
   },
 
   {
-    "path": "com/google/auto/value/auto-value-annotations/1.10.4",
+    "path": "com/google/auto/value/auto-value-annotations/1.11.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "auto-value-annotations-1.10.4.pom": {
-        "sha1": "1625b4e3671cc5ef044f7e0ed98c15bbfeba13bb",
-        "sha256": "sha256-c6W4UV+F+IxAiff/SkPNF5Wkgf2rk/qQULE8+hqNJfc="
+      "auto-value-annotations-1.11.0.pom": {
+        "sha1": "a6b3d6cd083f5e03aad810d4bc2b08755cf91753",
+        "sha256": "sha256-KuwW406j4BFiGgMi9PNvj5v5iLtURitVcJduieoHsSI="
       },
-      "auto-value-annotations-1.10.4.jar": {
-        "sha1": "9679de8286eb0a151db6538ba297a8951c4a1224",
-        "sha256": "sha256-4cRea+ra75eXyw2a/VpFYhrQYc2GMgEvhVgoU6OIeCU="
+      "auto-value-annotations-1.11.0.jar": {
+        "sha1": "f0d047931d07cfbc6fa4079854f181ff62891d6f",
+        "sha256": "sha256-WgVc5CVTM7M0bhqHA9pb+P8ElTIob9zTFxLWJKvhEd0="
       }
     }
   },
@@ -10999,12 +11003,12 @@
   },
 
   {
-    "path": "com/google/auto/value/auto-value-parent/1.10.4",
+    "path": "com/google/auto/value/auto-value-parent/1.11.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "auto-value-parent-1.10.4.pom": {
-        "sha1": "08d4397fc90a6bd37db513aee267d40b7639db13",
-        "sha256": "sha256-vsOhnk3ci2QGZyMzzFBbngy2s1WLskIxSGm7bh1ojTA="
+      "auto-value-parent-1.11.0.pom": {
+        "sha1": "4d1249846df8ae67b8ad313bc9a6174516fa49b3",
+        "sha256": "sha256-Wg0dcYVS6KRdzOASjRtrliP6lxqCzSRXUyM7pyCMsp0="
       }
     }
   },
@@ -11151,12 +11155,12 @@
   },
 
   {
-    "path": "com/google/code/gson/gson-parent/2.10.1",
+    "path": "com/google/code/gson/gson-parent/2.11.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "gson-parent-2.10.1.pom": {
-        "sha1": "67ea6db077285dc50a9b0a627763764f0ef4a770",
-        "sha256": "sha256-QkjgiCQmxhUYI4XWCGw+8yYudplXGJ4pMGKAuFSCuDM="
+      "gson-parent-2.11.0.pom": {
+        "sha1": "b32d3bc5c89c852efe4c176df6c3fdeccbe150ef",
+        "sha256": "sha256-issfO3Km8CaRasBzW62aqwKT1Sftt7NlMn3vE6k2e3o="
       }
     }
   },
@@ -11282,16 +11286,24 @@
   },
 
   {
-    "path": "com/google/code/gson/gson/2.10.1",
+    "path": "com/google/code/gson/gson/2.11.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "gson-2.10.1.pom": {
-        "sha1": "ce159faf33c1e665e1f3a785a5d678a2b20151bc",
-        "sha256": "sha256-0rEVY09cCF20ucn/wmWOieIx/b++IkISGhzZXU2Ujdc="
+      "gson-2.11.0.pom": {
+        "sha1": "55796dd7cc329027df79e96c4e6631e3c02c93c5",
+        "sha256": "sha256-wOVHvqmYiI5uJcWIapDnYicryItSdTQ90sBd7Wyi42A="
       },
-      "gson-2.10.1.jar": {
-        "sha1": "b3add478d4382b78ea20b1671390a858002feb6c",
-        "sha256": "sha256-QkHBSncnw0/uplB+yAExij1KkPBw5FJWgQefuU7kxZM="
+      "gson-2.11.0.buildinfo": {
+        "sha1": "4d1c42ee3c07943d8e07fab98bf0491877b4c0c6",
+        "sha256": "sha256-d6O/J0uIwA+ieS0kkb+yLkeL3OUzOMUcMBHW7nDr0pI="
+      },
+      "gson-2.11.0.buildinfo.asc": {
+        "sha1": "ba50162dd390a51e11a706d62ef9a5d120138337",
+        "sha256": "sha256-blLhhVcT0w8htC6V6rrqU+CZ3egMLBv5AgE76D+zGIY="
+      },
+      "gson-2.11.0.jar": {
+        "sha1": "527175ca6d81050b53bdd4c457a6d6e017626b0e",
+        "sha256": "sha256-V5KNblpu3rKr03cKj5W6RNzkXzsjt6ncKzCcWBVSp4s="
       }
     }
   },
@@ -11507,16 +11519,31 @@
   },
 
   {
-    "path": "com/google/errorprone/error_prone_annotations/2.27.1",
+    "path": "com/google/errorprone/error_prone_annotations/2.27.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "error_prone_annotations-2.27.1.pom": {
-        "sha1": "432107569fdae073842841c566ea1eea3b2f0a96",
-        "sha256": "sha256-TCN6vSm6OvOcp0TLSkHyRbX/oEXQNskkSvKrPKvKhTc="
+      "error_prone_annotations-2.27.0.pom": {
+        "sha1": "85103026aa50b0e4efafee8f486e3ecd9ebfde31",
+        "sha256": "sha256-TKWjXWEjXhZUmsNG0eNFUc3w/ifoSqV+A8vrJV6k5do="
       },
-      "error_prone_annotations-2.27.1.jar": {
-        "sha1": "a87dac4f79a6e5b1e55c629f16c754c53cbd50ec",
-        "sha256": "sha256-pIlbXbAkNhTZDOKixvgwYkkJwB4xWH2Ow+z1Hl5+dQY="
+      "error_prone_annotations-2.27.0.jar": {
+        "sha1": "91b2c29d8a6148b5e2e4930f070d4840e2e48e34",
+        "sha256": "sha256-JMkjNyxY410LnxagKJKbua7cd1IYZ8J08r0HNd9bofU="
+      }
+    }
+  },
+
+  {
+    "path": "com/google/errorprone/error_prone_annotations/2.28.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_annotations-2.28.0.pom": {
+        "sha1": "6ab92cea437b733e5ef832e575cbf50fa8aebfad",
+        "sha256": "sha256-DOkJ8TpWgUhHbl7iAPOA+Yx1ugiXGq8V2ylet3WY7zo="
+      },
+      "error_prone_annotations-2.28.0.jar": {
+        "sha1": "59fc00087ce372de42e394d2c789295dff2d19f0",
+        "sha256": "sha256-8/yKOgpAIHBqNzsA5/V8JRLdJtH4PSjH04do+GgrIx4="
       }
     }
   },
@@ -11643,12 +11670,23 @@
   },
 
   {
-    "path": "com/google/errorprone/error_prone_parent/2.27.1",
+    "path": "com/google/errorprone/error_prone_parent/2.27.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "error_prone_parent-2.27.1.pom": {
-        "sha1": "b00504c9994e0c16dc77d661b19421f1ffd179b4",
-        "sha256": "sha256-APlKPmg8fOr5lQFP/EB/INNycrFQ0mEbNVdLjOcYIjY="
+      "error_prone_parent-2.27.0.pom": {
+        "sha1": "336f77abf2668b10cae4ab136ea0c8258875de00",
+        "sha256": "sha256-+oGCnQSVWd9pJ/nJpv1rvQn4tQ5tRzaucsgwC2w9dlQ="
+      }
+    }
+  },
+
+  {
+    "path": "com/google/errorprone/error_prone_parent/2.28.0",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "error_prone_parent-2.28.0.pom": {
+        "sha1": "5f307de93ba6c82a0ca99404c1ab927f68c7038a",
+        "sha256": "sha256-rM79u1QWzvX80t3DfbTx/LNKIZPMGlXf5ZcKExs+doM="
       }
     }
   },
@@ -11842,27 +11880,27 @@
   },
 
   {
-    "path": "com/google/guava/guava-parent/33.2.0-jre",
+    "path": "com/google/guava/guava-parent/33.2.1-jre",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "guava-parent-33.2.0-jre.pom": {
-        "sha1": "f5bfac48964350d7ad36aa378acff0ed379f816b",
-        "sha256": "sha256-Ng5j7DRbu9j6pK3YluMlAt//9U6DQJhFyzPB+tN7WYU="
+      "guava-parent-33.2.1-jre.pom": {
+        "sha1": "fc55955fab23e86fad230acc81bf570deb5660bd",
+        "sha256": "sha256-kJX22O43ZZUCB1EHhYMMwigOeBBnkV+pnP4XQNSGXBQ="
       }
     }
   },
 
   {
-    "path": "com/google/guava/guava-testlib/33.2.0-jre",
+    "path": "com/google/guava/guava-testlib/33.2.1-jre",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "guava-testlib-33.2.0-jre.pom": {
-        "sha1": "1d0c542e891776dcb545a86de861afb18bc79540",
-        "sha256": "sha256-HQFL2lY+v0p64DOKef0JPulhIctiQz0g61uejCvIroo="
+      "guava-testlib-33.2.1-jre.pom": {
+        "sha1": "3b95376190925f23c89d9f2f990f2eb0bab9d2b2",
+        "sha256": "sha256-ZAiayFTlu6dVYLw9PB/dPqQ1cpFXJvYMgjcsq/qnTuQ="
       },
-      "guava-testlib-33.2.0-jre.jar": {
-        "sha1": "4678a8fd0e7fba71a4283154fd4979f51ba294d5",
-        "sha256": "sha256-HK2mwu+stz+eoRk7sMeKr/qT2DjtAGrIBtDXoeYMQlo="
+      "guava-testlib-33.2.1-jre.jar": {
+        "sha1": "ba7d569795211c283c4576d17528534a618a5d59",
+        "sha256": "sha256-XsFBByZYQk9AzTC5FGf1zmPA5he5Hskn33JW79/S2Eo="
       }
     }
   },
@@ -12048,20 +12086,20 @@
   },
 
   {
-    "path": "com/google/guava/guava/33.2.0-jre",
+    "path": "com/google/guava/guava/33.2.1-jre",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "guava-33.2.0-jre.pom": {
-        "sha1": "e78e6bc096ac140596ce47c2cd6e90f12a417779",
-        "sha256": "sha256-7YMRSBtY5QTb/BtfR3C/B13BL2yshV3X1/NqUNTEGRA="
+      "guava-33.2.1-jre.pom": {
+        "sha1": "5f72123f1bb7d99af8b4a67745fb8309b73a6294",
+        "sha256": "sha256-QoF73BwMjHN9a0Ec+vSoR2nn0nHoebAW/QhQJIoG2rU="
       },
-      "guava-33.2.0-jre.jar": {
-        "sha1": "e264781dadc4967e5292f3c4d05f1d153631f7b4",
-        "sha256": "sha256-mfSR6GJizjjROzWB1A93rNtGlqlQVEfDFUR0wxkpCN0="
+      "guava-33.2.1-jre.jar": {
+        "sha1": "818e780da2c66c63bbb6480fef1f3855eeafa3e4",
+        "sha256": "sha256-RSstl4e302b6jPXtmhxAQEVC0F7/p6WY2gO7u7dtnzE="
       },
-      "guava-33.2.0-jre.module": {
-        "sha1": "5ee9e7ff047a61986890f7ea80a2695c7239169c",
-        "sha256": "sha256-eSlFEwC6UJb1M6LiPOqpManfGBIy21emmK1+PB4TD/g="
+      "guava-33.2.1-jre.module": {
+        "sha1": "35b3a43a28bf269178f01d7097263d9ef95cac8b",
+        "sha256": "sha256-0j7aahwsC9JfijNGzd7sQ7Ufdb+Bm5MeqpgybqZEdCI="
       }
     }
   },
@@ -12234,12 +12272,12 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-bom/4.27.0-RC3",
+    "path": "com/google/protobuf/protobuf-bom/4.27.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-bom-4.27.0-RC3.pom": {
-        "sha1": "bd9f15b87d06e839222b2dadcd90272013557048",
-        "sha256": "sha256-S1fPaw/YOC7Ntmsg4yYX+nDJh3kcIsYiOw9GMFhCogI="
+      "protobuf-bom-4.27.0.pom": {
+        "sha1": "56b4bb710c104ec9486c27b0f8e032d1bc11e9ed",
+        "sha256": "sha256-kbRq1aEDFnGx0+fzkPdYkVkXnXIP9CbHMXiYCTfeDbE="
       }
     }
   },
@@ -12485,16 +12523,16 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-java/4.27.0-RC3",
+    "path": "com/google/protobuf/protobuf-java/4.27.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-java-4.27.0-RC3.pom": {
-        "sha1": "eb6c9cf9ce563effc186f0a8bbc35aa53bbcf74e",
-        "sha256": "sha256-tYj2q0siUF4fcX4dwZ/NhbsHbICJkDDlOE0fX0+lb1s="
+      "protobuf-java-4.27.0.pom": {
+        "sha1": "03ea82f584b3f703357c571b521cc84fa80b977c",
+        "sha256": "sha256-JCl1NSx41sxgr7EY6uYMHFFNZfkwdhwG2w3Rsj4lD6A="
       },
-      "protobuf-java-4.27.0-RC3.jar": {
-        "sha1": "b8abf4eca2730bf6de63f187eb1c15dd512cbe83",
-        "sha256": "sha256-BTKtECTWI2FWGsrtuXTX0WiJ52cLNuI+kyHda50zTvk="
+      "protobuf-java-4.27.0.jar": {
+        "sha1": "c60880f1aa87ae87b9d4346f0a87c511919c2c42",
+        "sha256": "sha256-kHLmD+Zs/11sDxGh3yHY8+Sym17ngrRcP8dfWfviuDk="
       }
     }
   },
@@ -12614,12 +12652,12 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-parent/4.27.0-RC3",
+    "path": "com/google/protobuf/protobuf-parent/4.27.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-parent-4.27.0-RC3.pom": {
-        "sha1": "896b7ebb6bf6d26d64bf7b92e41d5e4f6c097a8b",
-        "sha256": "sha256-i7Fdb53i0Q8PlqmPKfkl+9T/oA/VEOyse5X3QjIYhvc="
+      "protobuf-parent-4.27.0.pom": {
+        "sha1": "10de155e31cfe0f8f7999b8436ff2b016d108591",
+        "sha256": "sha256-Zft+ZHmFhOzaC6xG5HOEWol1l2vCRspXsy/01tU1U6k="
       }
     }
   },
@@ -16681,20 +16719,20 @@
   },
 
   {
-    "path": "org/checkerframework/checker-qual/3.43.0",
+    "path": "org/checkerframework/checker-qual/3.44.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "checker-qual-3.43.0.pom": {
-        "sha1": "48ad8955d64547b84ef581361c29c030e56430cb",
-        "sha256": "sha256-kxO/U7Pv2KrKJm7qi5bjB5drZcCxZRDMbwIxn7rr7UM="
+      "checker-qual-3.44.0.pom": {
+        "sha1": "fec730b84f3509af3f10d2062cae751f14ee1978",
+        "sha256": "sha256-A7MppYafkeWYICzJNzaso3h8r0kUtUQfLAkA5fts/GU="
       },
-      "checker-qual-3.43.0.jar": {
-        "sha1": "9425eee39e56b116d2b998b7c2cebcbd11a3c98b",
-        "sha256": "sha256-P7wumPBYVMPfFt+auqlVuRsVs+ysM2IyCO1kJGQO8PY="
+      "checker-qual-3.44.0.jar": {
+        "sha1": "e026b198319ea9dd3f221fab367d2099215079e5",
+        "sha256": "sha256-MO1DlgK2wtSq6iqF5Y44hVbwzHrmjtKWSbwc0MAQLNk="
       },
-      "checker-qual-3.43.0.module": {
-        "sha1": "3020cf05cf20a5f6e2137e59291be76cd1252b83",
-        "sha256": "sha256-+BYzJyRauGJVMpSMcqkwVIzZfzTWw/6GD6auxaNNebQ="
+      "checker-qual-3.44.0.module": {
+        "sha1": "d87549604f8dab86b3bdd7e6c2a1d1edc2ecd9c2",
+        "sha256": "sha256-6oWA9FjrXS7Jw0KDiLpQm8yvZSP2kfJtv0BxZ5jvoi4="
       }
     }
   },
@@ -19228,16 +19266,16 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-reflect/2.0.0-RC3",
+    "path": "org/jetbrains/kotlin/kotlin-reflect/2.0.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-reflect-2.0.0-RC3.pom": {
-        "sha1": "a7730291ea955a34868c94a9409c048c15107d94",
-        "sha256": "sha256-9aeMqntbuaejEkPzeT4Nj+3/q1d6KNW7pXlyMFkU5nU="
+      "kotlin-reflect-2.0.0.pom": {
+        "sha1": "b4563487290a5acea0a569621f441266f36001bd",
+        "sha256": "sha256-ikQrns4+Vt+fEm8xxiodKjEkir7CiLbYMLrncjcYSLA="
       },
-      "kotlin-reflect-2.0.0-RC3.jar": {
-        "sha1": "2de9acd396986f0130a7015ca18caa593915b077",
-        "sha256": "sha256-bFXdlUw7yRgPPDvM+D9PAf+ifqvMVlWdLKw2Z6FbjMo="
+      "kotlin-reflect-2.0.0.jar": {
+        "sha1": "9c3d75110945233bf77d2e1a90604b100884db94",
+        "sha256": "sha256-ERvZBpIZN/dtoXdgZBEW0EtXp6Evz5gO/nxnZ/RRefA="
       }
     }
   },
@@ -20815,28 +20853,28 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/2.0.0-RC3",
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/2.0.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-stdlib-2.0.0-RC3.pom": {
-        "sha1": "7fb5dbef4bdc345da221fecbd12ddbcf6bbe3160",
-        "sha256": "sha256-zUpUNgRDkBPpPf5Czq/zFbV0Fy6PWdc4u7Ast9mrP38="
+      "kotlin-stdlib-2.0.0.pom": {
+        "sha1": "028759a886ea2f745a324c2d58ae631692dac90f",
+        "sha256": "sha256-WQ5ia8kzl6XnXMeI8s7INbN6HuLlSDmvMNvY1bocLvI="
       },
-      "kotlin-stdlib-2.0.0-RC3-all.jar": {
+      "kotlin-stdlib-2.0.0-all.jar": {
         "sha1": "e6142a28b5fa6722cd811dd86278ad056784fa40",
         "sha256": "sha256-MOBSIrwGf/+4lqMna18ePylFC/HZRh0noZzg78eTtc0="
       },
-      "kotlin-stdlib-2.0.0-RC3-common.jar": {
+      "kotlin-stdlib-2.0.0-common.jar": {
         "sha1": "281e03983850e590dcc0d2474758f2fa8dd0e96a",
         "sha256": "sha256-EsHDu0lApPmVlUD/tc8uLl6brNtoywDEvSidFjm9HSc="
       },
-      "kotlin-stdlib-2.0.0-RC3.jar": {
-        "sha1": "37bea4f33a0d1823317f1210048928030077ec38",
-        "sha256": "sha256-B2a3hUy+BDpaysUyZ3CUvh9ua0iT54/a2SXC64Mks3Y="
+      "kotlin-stdlib-2.0.0.jar": {
+        "sha1": "b48df2c4aede9586cc931ead433bc02d6fd7879e",
+        "sha256": "sha256-JAk4xKq45z6IhwPj59P4c4P/5b1TbW1ePBANTNA3n88="
       },
-      "kotlin-stdlib-2.0.0-RC3.module": {
-        "sha1": "83a7913d9fd48986a323feb3fccc2b1049182fab",
-        "sha256": "sha256-vpppwKPQSAwqZ2ff0DPELmM87yPovzFuqKy8Osz9piE="
+      "kotlin-stdlib-2.0.0.module": {
+        "sha1": "2753eb5e4958b5462bcc3bd38458a9589cdd1fd3",
+        "sha256": "sha256-ZPluqOe5iWcxBSJB/9OiZfgnTXYeX+ncCIrEWzFxg0E="
       }
     }
   },
@@ -21116,16 +21154,16 @@
   },
 
   {
-    "path": "org/junit/junit-bom/5.11.0-M1",
+    "path": "org/junit/junit-bom/5.11.0-M2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "junit-bom-5.11.0-M1.pom": {
-        "sha1": "afec72e7b7df3cd97c3fe53164c3f5dfc6a0ff94",
-        "sha256": "sha256-tQl19cuoYgSr2j3Nbwl6+Rn+IuIe9pR43WuRn2x0DYU="
+      "junit-bom-5.11.0-M2.pom": {
+        "sha1": "6c517cddae7893aba5bf9f051c44860a4fc18211",
+        "sha256": "sha256-Sj/8Sk7c/sLLXWGZInBqlAcWF5hXGTn4VN/ac+ThfMg="
       },
-      "junit-bom-5.11.0-M1.module": {
-        "sha1": "8824de265f75444b83779557736d03b4c8fac3f7",
-        "sha256": "sha256-j2MviWXptvQGnj1YueomuaW8dqmOibQyM3d6zm2tsjc="
+      "junit-bom-5.11.0-M2.module": {
+        "sha1": "4546561225def9f7f99c7c1abc3828dec51aad2a",
+        "sha256": "sha256-hkd6vPSQ1soFmqmXPLEI0ipQb0nRpVabsyzGy/Q8LM4="
       }
     }
   },

--- a/nix/deps/gradle/deps.list
+++ b/nix/deps/gradle/deps.list
@@ -4,12 +4,10 @@ androidx.activity:activity:1.2.4
 androidx.activity:activity:1.6.0
 androidx.annotation:annotation-experimental:1.1.0
 androidx.annotation:annotation-experimental:1.3.0
-androidx.annotation:annotation-jvm:1.6.0
 androidx.annotation:annotation:1.0.0
 androidx.annotation:annotation:1.1.0
 androidx.annotation:annotation:1.2.0
 androidx.annotation:annotation:1.3.0
-androidx.annotation:annotation:1.6.0
 androidx.appcompat:appcompat-resources:1.1.0-rc01
 androidx.appcompat:appcompat-resources:1.2.0
 androidx.appcompat:appcompat-resources:1.3.1
@@ -488,7 +486,6 @@ com.facebook.fresco:nativeimagetranscoder:3.1.3
 com.facebook.fresco:soloader:3.1.3
 com.facebook.fresco:ui-common:3.1.3
 com.facebook.infer.annotation:infer-annotation:0.18.0
-com.facebook.react:hermes-android:0.73.5
 com.facebook.react:react-android:0.73.5
 com.facebook.soloader:annotation:0.10.5
 com.facebook.soloader:nativeloader:0.10.5
@@ -944,3 +941,6 @@ com.google.errorprone:error_prone_annotations:2.7.1
 com.android.tools.lint:lint-gradle:31.1.1
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0
 com.android.tools.build:gradle:3.5.4
+androidx.annotation:annotation:1.6.0
+androidx.annotation:annotation-jvm:1.6.0
+com.facebook.react:hermes-android:0.73.5

--- a/nix/deps/gradle/deps.urls
+++ b/nix/deps/gradle/deps.urls
@@ -671,11 +671,11 @@ https://repo.maven.apache.org/maven2/com/google/auto/auto-parent/7/auto-parent-7
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-annotations/1.6.2/auto-value-annotations-1.6.2.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-annotations/1.6.3/auto-value-annotations-1.6.3.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-annotations/1.7.4/auto-value-annotations-1.7.4.pom
-https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-annotations/1.10.4/auto-value-annotations-1.10.4.pom
+https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-annotations/1.11.0/auto-value-annotations-1.11.0.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-parent/1.6.2/auto-value-parent-1.6.2.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-parent/1.6.3/auto-value-parent-1.6.3.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-parent/1.7.4/auto-value-parent-1.7.4.pom
-https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-parent/1.10.4/auto-value-parent-1.10.4.pom
+https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-parent/1.11.0/auto-value-parent-1.11.0.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value/1.5.2/auto-value-1.5.2.pom
 https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.pom
 https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom
@@ -687,7 +687,7 @@ https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.8.5/gson
 https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.8.6/gson-parent-2.8.6.pom
 https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.8.9/gson-parent-2.8.9.pom
 https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.9.1/gson-parent-2.9.1.pom
-https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.10.1/gson-parent-2.10.1.pom
+https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.11.0/gson-parent-2.11.0.pom
 https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.2.4/gson-2.2.4.pom
 https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.3/gson-2.3.pom
 https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.7/gson-2.7.pom
@@ -696,7 +696,7 @@ https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.8.5/gson-2.8.5.
 https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.8.6/gson-2.8.6.pom
 https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.8.9/gson-2.8.9.pom
 https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.9.1/gson-2.9.1.pom
-https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1.pom
+https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.11.0/gson-2.11.0.pom
 https://repo.maven.apache.org/maven2/com/google/crypto/tink/tink/1.3.0-rc2/tink-1.3.0-rc2.pom
 https://repo.maven.apache.org/maven2/com/google/crypto/tink/tink/1.7.0/tink-1.7.0.pom
 https://repo.maven.apache.org/maven2/com/google/dagger/dagger/2.28.3/dagger-2.28.3.pom
@@ -711,7 +711,8 @@ https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotatio
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.9.0/error_prone_annotations-2.9.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.10.0/error_prone_annotations-2.10.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.11.0/error_prone_annotations-2.11.0.pom
-https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.27.1/error_prone_annotations-2.27.1.pom
+https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.27.0/error_prone_annotations-2.27.0.pom
+https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.28.0/error_prone_annotations-2.28.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.0.18/error_prone_parent-2.0.18.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.2.0/error_prone_parent-2.2.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.3.1/error_prone_parent-2.3.1.pom
@@ -723,7 +724,8 @@ https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.9.0/error_prone_parent-2.9.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.10.0/error_prone_parent-2.10.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.11.0/error_prone_parent-2.11.0.pom
-https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.27.1/error_prone_parent-2.27.1.pom
+https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.27.0/error_prone_parent-2.27.0.pom
+https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.28.0/error_prone_parent-2.28.0.pom
 https://repo.maven.apache.org/maven2/com/google/flatbuffers/flatbuffers-java/1.12.0/flatbuffers-java-1.12.0.pom
 https://repo.maven.apache.org/maven2/com/google/google/1/google-1.pom
 https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom
@@ -740,8 +742,8 @@ https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/30.1-jre/guav
 https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/31.0.1-android/guava-parent-31.0.1-android.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/31.0.1-jre/guava-parent-31.0.1-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/31.1-jre/guava-parent-31.1-jre.pom
-https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.2.0-jre/guava-parent-33.2.0-jre.pom
-https://repo.maven.apache.org/maven2/com/google/guava/guava-testlib/33.2.0-jre/guava-testlib-33.2.0-jre.pom
+https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.2.1-jre/guava-parent-33.2.1-jre.pom
+https://repo.maven.apache.org/maven2/com/google/guava/guava-testlib/33.2.1-jre/guava-testlib-33.2.1-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/17.0/guava-17.0.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/22.0/guava-22.0.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/23.0/guava-23.0.pom
@@ -754,7 +756,7 @@ https://repo.maven.apache.org/maven2/com/google/guava/guava/30.1-jre/guava-30.1-
 https://repo.maven.apache.org/maven2/com/google/guava/guava/31.0.1-android/guava-31.0.1-android.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/31.1-jre/guava-31.1-jre.pom
-https://repo.maven.apache.org/maven2/com/google/guava/guava/33.2.0-jre/guava-33.2.0-jre.pom
+https://repo.maven.apache.org/maven2/com/google/guava/guava/33.2.1-jre/guava-33.2.1-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/1.0/listenablefuture-1.0.pom
 https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom
 https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom
@@ -768,7 +770,7 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.13.0/pro
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.17.2/protobuf-bom-3.17.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.19.2/protobuf-bom-3.19.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.19.3/protobuf-bom-3.19.3.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/4.27.0-RC3/protobuf-bom-4.27.0-RC3.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/4.27.0/protobuf-bom-4.27.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-javalite/3.17.2/protobuf-javalite-3.17.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-javalite/3.19.2/protobuf-javalite-3.19.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java-util/3.4.0/protobuf-java-util-3.4.0.pom
@@ -785,7 +787,7 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.13.0/pr
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.17.2/protobuf-java-3.17.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.19.2/protobuf-java-3.19.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.19.3/protobuf-java-3.19.3.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/4.27.0-RC3/protobuf-java-4.27.0-RC3.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/4.27.0/protobuf-java-4.27.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-lite/3.0.1/protobuf-lite-3.0.1.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.0.0/protobuf-parent-3.0.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.4.0/protobuf-parent-3.4.0.pom
@@ -796,7 +798,7 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.13.0/
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.17.2/protobuf-parent-3.17.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.19.2/protobuf-parent-3.19.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.19.3/protobuf-parent-3.19.3.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/4.27.0-RC3/protobuf-parent-4.27.0-RC3.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/4.27.0/protobuf-parent-4.27.0.pom
 https://repo.maven.apache.org/maven2/com/google/truth/truth-parent/1.4.2/truth-parent-1.4.2.pom
 https://repo.maven.apache.org/maven2/com/google/truth/truth/1.4.2/truth-1.4.2.pom
 https://repo.maven.apache.org/maven2/com/ibm/icu/icu4j/53.1/icu4j-53.1.pom
@@ -1089,7 +1091,7 @@ https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.8.1/che
 https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.11.1/checker-qual-2.11.1.pom
 https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.5.0/checker-qual-3.5.0.pom
 https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.12.0/checker-qual-3.12.0.pom
-https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.pom
+https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.44.0/checker-qual-3.44.0.pom
 https://repo.maven.apache.org/maven2/org/codehaus/codehaus-parent/4/codehaus-parent-4.pom
 https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-xml/3.0.9/groovy-xml-3.0.9.pom
 https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-xml/3.0.10/groovy-xml-3.0.10.pom
@@ -1246,7 +1248,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.20/kotlin-reflect-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.7.22/kotlin-reflect-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.8.20-RC2/kotlin-reflect-1.8.20-RC2.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.0.0-RC3/kotlin-reflect-2.0.0-RC3.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.0.0/kotlin-reflect-2.0.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.6.20/kotlin-scripting-common-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.7.22/kotlin-scripting-common-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.8.0/kotlin-scripting-common-1.8.0.pom
@@ -1351,7 +1353,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.8.20-R
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.8.21/kotlin-stdlib-1.8.21.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.0/kotlin-stdlib-1.9.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.21/kotlin-stdlib-1.9.21.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.0.0-RC3/kotlin-stdlib-2.0.0-RC3.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.0.0/kotlin-stdlib-2.0.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/1.7.22/kotlin-tooling-core-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/1.8.0/kotlin-tooling-core-1.8.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/1.9.0/kotlin-tooling-core-1.9.0.pom
@@ -1370,7 +1372,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/trove4j/trove4j/20160824/trov
 https://repo.maven.apache.org/maven2/org/json/json/20180813/json-20180813.pom
 https://repo.maven.apache.org/maven2/org/json/json/20240303/json-20240303.pom
 https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.13.1/jsoup-1.13.1.pom
-https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.0-M1/junit-bom-5.11.0-M1.pom
+https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.0-M2/junit-bom-5.11.0-M2.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.7.7/stax-ex-1.7.7.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.8/stax-ex-1.8.pom

--- a/nix/deps/gradle/generate.sh
+++ b/nix/deps/gradle/generate.sh
@@ -56,6 +56,8 @@ com.google.errorprone:error_prone_annotations:2.7.1
 com.android.tools.lint:lint-gradle:31.1.1
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0
 com.android.tools.build:gradle:3.5.4
+androidx.annotation:annotation:1.6.0
+androidx.annotation:annotation-jvm:1.6.0
 com.facebook.react:hermes-android:0.73.5' \
         >> "${DEPS_LIST}"
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-native-image-crop-picker": "0.40.0",
     "react-native-image-resizer": "^1.2.3",
     "react-native-keychain": "8.1.2",
-    "react-native-linear-gradient": "^2.8.0",
+    "react-native-linear-gradient": "3.0.0-alpha.1",
     "react-native-lottie-splash-screen": "^1.0.1",
     "react-native-navigation": "7.39.0",
     "react-native-orientation-locker": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9345,10 +9345,10 @@ react-native-keychain@8.1.2:
   resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-8.1.2.tgz#34291ae472878e5124d081211af5ede7d810e64f"
   integrity sha512-bhHEui+yMp3Us41NMoRGtnWEJiBE0g8tw5VFpq4mpmXAx6XJYahuM6K3WN5CsUeUl83hYysSL9oFZNKSTPSvYw==
 
-react-native-linear-gradient@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.8.0.tgz#767eda0a5c5dbed852f99e4c07fb7d54a8ee3030"
-  integrity sha512-ZuvNXEB98CMEOAphV/8N9eWrIQTbzUIZD5Tb8IqFoDE8ESERISPT2hTZMvoHTSfjvaB1zge6YpWVg3rpwiTZow==
+react-native-linear-gradient@3.0.0-alpha.1:
+  version "3.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-3.0.0-alpha.1.tgz#fa1914462536f052faa211c34240be3ab1856bdd"
+  integrity sha512-vo9ks7m2VTLtbdAIMqwk944SB65+rc0U1a2R1CAQetT282DnH4rI3GKenaa+Gj2gPngF1l7Mc3Jxk9+6IZDraA==
 
 react-native-lottie-splash-screen@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
## Summary

`react-native-linear-gradient` library has to be upgraded to `3.0.0-alpha.1` for new architecture support on `Android`.

## Testing notes
Only visual elements where gradients are used would be impacted.

## Platforms
- Android
- iOS

status: ready

related issue : https://github.com/status-im/status-mobile/issues/18138
