### PR TITLE
[#19766] feat: save an address by scanning it's QR code

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -35,9 +35,8 @@
 (defn- address-input
   [{:keys [input-value on-change-text paste-into-input clear-input]}]
   (let [empty-input?    (string/blank? input-value)
-        on-scan-result  (rn/use-callback #(on-change-text %))
         on-scan-address (rn/use-callback #(rf/dispatch [:open-modal :screen/wallet.scan-address
-                                                        {:on-result on-scan-result}]))]
+                                                        {:on-result on-change-text}]))]
     [rn/view {:style style/input-container}
      [quo/input
       {:accessibility-label :add-address-to-save

--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -6,7 +6,6 @@
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [status-im.common.floating-button-page.view :as floating-button-page]
-    [status-im.common.not-implemented :as not-implemented]
     [status-im.contexts.settings.wallet.saved-addresses.add-address-to-save.style :as style]
     [status-im.contexts.wallet.common.validation :as validation]
     [utils.i18n :as i18n]
@@ -35,7 +34,10 @@
 
 (defn- address-input
   [{:keys [input-value on-change-text paste-into-input clear-input]}]
-  (let [empty-input? (string/blank? input-value)]
+  (let [empty-input?    (string/blank? input-value)
+        on-scan-result  (rn/use-callback #(on-change-text %))
+        on-scan-address (rn/use-callback #(rf/dispatch [:open-modal :screen/wallet.scan-address
+                                                        {:on-result on-scan-result}]))]
     [rn/view {:style style/input-container}
      [quo/input
       {:accessibility-label :add-address-to-save
@@ -55,7 +57,7 @@
        :value               input-value}]
      [quo/button
       {:type            :outline
-       :on-press        not-implemented/alert
+       :on-press        on-scan-address
        :container-style style/scan-button
        :background      :blur
        :size            40


### PR DESCRIPTION
fixes #19766

### Summary

Save an address by scanning an address QR code

#### Areas that maybe impacted

- Save address by scanning QR code

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open profile setting
- Open Wallet setting
- Click on Saved adresses
- Click on +
- Click on Scan icon 

### Result

https://github.com/status-im/status-mobile/assets/71308738/171f3978-e4d0-4aeb-993f-9edcd6f40ce9


status: ready
