### PR TITLE
feat(wallet): Add network preferences for saved address

### DIFF
--- a/src/status_im/contexts/profile/settings/list_items.cljs
+++ b/src/status_im/contexts/profile/settings/list_items.cljs
@@ -35,7 +35,7 @@
      :blur?       true
      :action      :arrow}
     {:title       (i18n/label :t/wallet)
-     :on-press    #(rf/dispatch [:navigate-to-within-stack [:screen/settings.wallet :screen/settings]])
+     :on-press    #(rf/dispatch [:navigate-to-within-stack [:screen/settings.wallet :settings]])
      :image-props :i/wallet
      :image       :icon
      :blur?       true

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
@@ -56,9 +56,7 @@
                                                :mixedcase-address         "0x2"
                                                :chain-short-names         "eth:arb1:oeth:"
                                                :has-ens?                  false
-                                               :network-preferences-names #{:arbitrum
-                                                                            :optimism
-                                                                            :mainnet}
+                                               :network-preferences-names `(:mainnet :arbitrum :optimism)
                                                :name                      "Bob"
                                                :created-at                1716826714
                                                :ens                       ""
@@ -76,9 +74,7 @@
                                                :address                   "0x2"
                                                :mixedcase-address         "0x2"
                                                :chain-short-names         "eth:arb1:oeth:"
-                                               :network-preferences-names #{:arbitrum
-                                                                            :optimism
-                                                                            :mainnet}
+                                               :network-preferences-names `(:mainnet :arbitrum :optimism)
                                                :has-ens?                  false
                                                :name                      "Bob"
                                                :created-at                1716826714
@@ -89,9 +85,7 @@
                                                :address                   "0x1"
                                                :mixedcase-address         "0x1"
                                                :chain-short-names         "eth:arb1:oeth:"
-                                               :network-preferences-names #{:arbitrum
-                                                                            :optimism
-                                                                            :mainnet}
+                                               :network-preferences-names `(:mainnet :arbitrum :optimism)
                                                :has-ens?                  false
                                                :name                      "Amy"
                                                :created-at                1716826806

--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -71,7 +71,7 @@
                                         :address address-without-prefix
                                         :customization-color address-color
                                         :chain-short-names chain-short-names}]))
-                       [address selected-networks address-label
+                       [address-without-prefix chain-short-names address-label
                         address-color])]
     [quo/overlay {:type :shell}
      [floating-button-page/view

--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -7,9 +7,10 @@
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [status-im.common.floating-button-page.view :as floating-button-page]
-    [status-im.common.not-implemented :as not-implemented]
-    [status-im.constants :as constants]
     [status-im.contexts.settings.wallet.saved-addresses.save-address.style :as style]
+    [status-im.contexts.wallet.common.utils :as utils]
+    [status-im.contexts.wallet.common.utils.networks :as network-utils]
+    [status-im.contexts.wallet.sheets.network-preferences.view :as network-preferences]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -17,29 +18,61 @@
   []
   (rf/dispatch [:navigate-back]))
 
-(defn- extract-address
-  [address]
-  (re-find constants/regx-address-contains address))
+(defn- network-preferences-sheet
+  [{:keys [address color selected-networks set-selected-networks]}]
+  (fn []
+    [network-preferences/view
+     {:title             (i18n/label :t/add-network-preferences)
+      :description       (i18n/label :t/saved-address-network-preference-selection-description)
+      :button-label      (i18n/label :t/add-preferences)
+      :blur?             true
+      :selected-networks (set selected-networks)
+      :account           {:address address
+                          :color   color}
+      :on-save           (fn [chain-ids]
+                           (set-selected-networks (map network-utils/id->network chain-ids))
+                           (rf/dispatch [:hide-bottom-sheet]))}]))
 
 (defn view
   []
-  (let [{:keys [address]}                 (rf/sub [:wallet/saved-address])
+  (let [{:keys [address]} (rf/sub [:wallet/saved-address])
+        [network-prefixes address-without-prefix] (utils/split-prefix-and-address address)
         [address-label set-address-label] (rn/use-state "")
         [address-color set-address-color] (rn/use-state (rand-nth colors/account-colors))
-        placeholder                       (i18n/label :t/address-name)
-        on-press-save                     (rn/use-callback
-                                           (fn []
-                                             (let [address-without-prefix (extract-address address)]
-                                               (rf/dispatch [:wallet/save-address
-                                                             {:on-success
-                                                              [:wallet/add-saved-address-success
-                                                               (i18n/label :t/address-saved)]
-                                                              :on-error
-                                                              [:wallet/add-saved-address-failed]
-                                                              :name address-label
-                                                              :address address-without-prefix
-                                                              :customization-color address-color}])))
-                                           [address address-label address-color])]
+        [selected-networks set-selected-networks]
+        (rn/use-state (network-utils/network-preference-prefix->network-names network-prefixes))
+        chain-short-names (rn/use-memo
+                           #(network-utils/network-names->network-preference-prefix
+                             selected-networks)
+                           [selected-networks])
+        placeholder (i18n/label :t/address-name)
+        open-network-preferences (rn/use-callback
+                                  (fn []
+                                    (rf/dispatch
+                                     [:show-bottom-sheet
+                                      {:theme   :dark
+                                       :shell?  true
+                                       :content (network-preferences-sheet
+                                                 {:address address-without-prefix
+                                                  :color address-color
+                                                  :selected-networks selected-networks
+                                                  :set-selected-networks
+                                                  set-selected-networks})}]))
+                                  [address selected-networks address-color])
+        on-press-save (rn/use-callback
+                       (fn []
+                         (rf/dispatch [:wallet/save-address
+                                       {:on-success
+                                        [:wallet/add-saved-address-success
+                                         (i18n/label :t/address-saved)]
+                                        :on-error
+                                        [:wallet/add-saved-address-failed]
+                                        :name address-label
+                                        :address address-without-prefix
+                                        :customization-color address-color
+                                        :chain-short-names chain-short-names}]))
+                       [address selected-networks address-label
+                        address-color])]
     [quo/overlay {:type :shell}
      [floating-button-page/view
       {:footer-container-padding 0
@@ -106,8 +139,8 @@
                           (fn []
                             [quo/address-text
                              {:full-address? true
-                              :address       address
+                              :address       (str chain-short-names address-without-prefix)
                               :format        :long}])
-                          [address])
-        :on-press        not-implemented/alert
+                          [selected-networks address])
+        :on-press        open-network-preferences
         :container-style style/data-item}]]]))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/share_address/style.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/share_address/style.cljs
@@ -1,4 +1,4 @@
-(ns status-im.contexts.settings.wallet.saved-addresses.sheets.share-address.style)
+(ns status-im.contexts.settings.wallet.saved-addresses.share-address.style)
 
 (def screen-container
   {:flex 1})

--- a/src/status_im/contexts/settings/wallet/saved_addresses/share_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/share_address/view.cljs
@@ -1,9 +1,9 @@
-(ns status-im.contexts.settings.wallet.saved-addresses.sheets.share-address.view
+(ns status-im.contexts.settings.wallet.saved-addresses.share-address.view
   (:require
     [quo.core :as quo]
     [react-native.core :as rn]
     [react-native.platform :as platform]
-    [status-im.contexts.settings.wallet.saved-addresses.sheets.share-address.style :as style]
+    [status-im.contexts.settings.wallet.saved-addresses.share-address.style :as style]
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.sheets.network-preferences.view :as network-preferences]
@@ -33,16 +33,20 @@
                              :isNewTask true})}]))
 
 (defn- open-preferences
-  [selected-networks set-selected-networks]
+  [{:keys [address color selected-networks set-selected-networks]}]
   (let [on-save       (fn [chain-ids]
                         (rf/dispatch [:hide-bottom-sheet])
                         (set-selected-networks (map network-utils/id->network chain-ids)))
         sheet-content (fn []
                         [network-preferences/view
-                         {:blur?             true
+                         {:description       (i18n/label
+                                              :t/saved-address-network-preference-selection-description)
+                          :button-label      (i18n/label :t/display)
+                          :blur?             true
                           :selected-networks (set selected-networks)
-                          :on-save           on-save
-                          :button-label      (i18n/label :t/display)}])]
+                          :account           {:address address
+                                              :color   color}
+                          :on-save           on-save}])]
     (rf/dispatch [:show-bottom-sheet
                   {:theme   :dark
                    :shell?  true
@@ -54,10 +58,13 @@
                 network-preferences-names]}       (rf/sub [:get-screen-params])
         [wallet-type set-wallet-type]             (rn/use-state :legacy)
         [selected-networks set-selected-networks] (rn/use-state network-preferences-names)
-        on-settings-press                         (rn/use-callback #(open-preferences
-                                                                     selected-networks
-                                                                     set-selected-networks)
-                                                                   [selected-networks])
+        on-settings-press                         (rn/use-callback
+                                                   #(open-preferences
+                                                     {:selected-networks     selected-networks
+                                                      :set-selected-networks set-selected-networks
+                                                      :address               address
+                                                      :color                 customization-color})
+                                                   [address customization-color selected-networks])
         on-legacy-press                           (rn/use-callback #(set-wallet-type :legacy))
         on-multichain-press                       (rn/use-callback #(set-wallet-type :multichain))
         share-title                               (str name " " (i18n/label :t/address))

--- a/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
@@ -8,11 +8,11 @@
 
 (defn open-saved-addresses-settings-modal
   []
-  (rf/dispatch [:navigate-to-within-stack [:screen/settings.saved-addresses :screen/settings]]))
+  (rf/dispatch [:navigate-to-within-stack [:screen/settings.saved-addresses :settings]]))
 
 (defn open-keypairs-and-accounts-settings-modal
   []
-  (rf/dispatch [:navigate-to-within-stack [:screen/settings.keypairs-and-accounts :screen/settings]]))
+  (rf/dispatch [:navigate-to-within-stack [:screen/settings.keypairs-and-accounts :settings]]))
 
 (defn basic-settings-options
   []
@@ -38,7 +38,7 @@
 
 (defn open-network-settings-modal
   []
-  (rf/dispatch [:navigate-to-within-stack [:screen/settings.network-settings :screen/settings]]))
+  (rf/dispatch [:navigate-to-within-stack [:screen/settings.network-settings :settings]]))
 
 (defn advanced-settings-options
   []

--- a/src/status_im/contexts/wallet/common/utils/networks.cljs
+++ b/src/status_im/contexts/wallet/common/utils/networks.cljs
@@ -114,7 +114,17 @@
   [prefix]
   (as-> prefix $
     (string/split $ ":")
-    (map short-name->network $)))
+    (map short-name->network $)
+    (remove nil? $)))
+
+(defn network-names->network-preference-prefix
+  [network-names]
+  (if (empty? network-names)
+    ""
+    (->> network-names
+         (map network->short-name)
+         (remove nil?)
+         short-names->network-preference-prefix)))
 
 (defn network-ids->formatted-text
   [network-ids]

--- a/src/status_im/contexts/wallet/common/utils/networks_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils/networks_test.cljs
@@ -33,7 +33,18 @@
    (= expected (utils/network-preference-prefix->network-names short-names))
    (seq [:mainnet])                     "eth"
    (seq [:mainnet :optimism])           "eth:oeth"
-   (seq [:mainnet :optimism :arbitrum]) "eth:oeth:arb1"))
+   (seq [:mainnet :optimism :arbitrum]) "eth:oeth:arb1"
+   (seq [:mainnet :arbitrum])           "eth:sol:arb1"))
+
+(deftest network-names->network-preference-prefix-test
+  (are [expected network-names]
+   (= expected (utils/network-names->network-preference-prefix network-names))
+   "eth:"           [:mainnet]
+   "eth:oeth:"      [:mainnet :optimism]
+   "eth:oeth:arb1:" [:mainnet :optimism :arbitrum]
+   "eth:arb1:"      [:mainnet :polygon :arbitrum]
+   ""               []
+   ""               nil))
 
 (deftest network-ids->formatted-text-test
   (testing "Empty network-ids should return an empty string"

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -138,18 +138,11 @@
   (let [renamed-data (sort-and-rename-keypairs keypairs)]
     (cske/transform-keys csk/->kebab-case-keyword renamed-data)))
 
-(defn- network-short-names->full-names
-  [short-names-string]
-  (->> (string/split short-names-string constants/chain-id-separator)
-       (map network-utils/short-name->network)
-       (remove nil?)
-       set))
-
 (defn- add-keys-to-saved-address
   [saved-address]
   (-> saved-address
       (assoc :network-preferences-names
-             (network-short-names->full-names (:chain-short-names saved-address)))
+             (network-utils/network-preference-prefix->network-names (:chain-short-names saved-address)))
       (assoc :has-ens? (not (string/blank? (:ens saved-address))))))
 
 (defn rpc->saved-address

--- a/src/status_im/contexts/wallet/sheets/network_preferences/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/network_preferences/view.cljs
@@ -12,7 +12,7 @@
             [utils.re-frame :as rf]))
 
 (defn view
-  [{:keys [title first-section-label second-section-label selected-networks
+  [{:keys [first-section-label second-section-label selected-networks
            receiver-preferred-networks account watch-only?]}]
   (let [state                               (reagent/atom :default)
         {:keys [color address
@@ -38,7 +38,7 @@
                                                 initial-network-preferences-names
                                                 @network-preferences-names-state))]
     (fn [{:keys [on-save on-change blur? button-label first-section-warning-label
-                 second-section-warning-label]}]
+                 second-section-warning-label title description]}]
       (let [theme                            (quo.theme/use-theme)
             network-details                  (rf/sub [:wallet/network-details])
             first-section-networks           (filter (fn [network]
@@ -71,9 +71,10 @@
          [quo/drawer-top
           {:title       (or title (i18n/label :t/network-preferences))
            :description (when-not receiver?
-                          (if watch-only?
-                            (i18n/label :t/network-preferences-desc-1)
-                            (i18n/label :t/network-preferences-desc-2)))
+                          (or description
+                              (if watch-only?
+                                (i18n/label :t/network-preferences-desc-1)
+                                (i18n/label :t/network-preferences-desc-2))))
            :blur?       blur?}]
          (when-not receiver?
            [quo/data-item

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -68,7 +68,7 @@
     [status-im.contexts.settings.wallet.saved-addresses.add-address-to-save.view :as
      wallet-add-address-to-save]
     [status-im.contexts.settings.wallet.saved-addresses.save-address.view :as wallet-save-address]
-    [status-im.contexts.settings.wallet.saved-addresses.sheets.share-address.view :as
+    [status-im.contexts.settings.wallet.saved-addresses.share-address.view :as
      share-saved-address]
     [status-im.contexts.settings.wallet.saved-addresses.view :as saved-addresses-settings]
     [status-im.contexts.settings.wallet.wallet-options.view :as wallet-options]

--- a/translations/en.json
+++ b/translations/en.json
@@ -2692,5 +2692,8 @@
     "check-your-account-balance-and-activity": "Check your account balance and activity",
     "request-txns-and-message-signing": "Request transactions and message signing",
     "wallet-connect-qr-expired": "WalletConnect QR has expired",
-    "wallet-connect-version-not-supported": "WalletConnect version {{version}} is not supported"
+    "wallet-connect-version-not-supported": "WalletConnect version {{version}} is not supported",
+    "add-network-preferences": "Add network preferences",
+    "saved-address-network-preference-selection-description": "Only change if you know which networks the address owner is happy to to receive funds on",
+    "add-preferences": "Add preferences"
 }


### PR DESCRIPTION
fixes #16995


### Summary

This PR:
- adds a feature to add network preferences for saved addresses while saving
- updates the network preferences in "Share save address" to show the address and color of the saved address

https://github.com/status-im/status-mobile/assets/19339952/68cf4526-ad37-43cd-848f-c2b5a352fff9



### Testing notes

Testing will be done once Saved Address epic is done

### Platforms

- Android
- iOS

status: ready
