### PR TITLE
The network marks are not shown on the 'send to' page for accounts #19545

### DIFF
--- a/src/quo/components/list_items/account/view.cljs
+++ b/src/quo/components/list_items/account/view.cljs
@@ -30,11 +30,7 @@
                                 (colors/theme-colors colors/neutral-50 colors/neutral-40 theme))
          :container-style     style/title-icon-container
          :accessibility-label :title-icon}])]
-    [address-text/view
-     {:networks      (:networks account-props)
-      :address       (:address account-props)
-      :full-address? (:full-address? account-props)
-      :format        :short}]]])
+    [address-text/view (assoc account-props :format :short)]]])
 
 (defn- balance-view
   [{:keys [balance-props type theme]}]

--- a/src/quo/components/list_items/account/view.cljs
+++ b/src/quo/components/list_items/account/view.cljs
@@ -31,9 +31,10 @@
          :container-style     style/title-icon-container
          :accessibility-label :title-icon}])]
     [address-text/view
-     {:networks (:networks account-props)
-      :address  (:address account-props)
-      :format   :short}]]])
+     {:networks      (:networks account-props)
+      :address       (:address account-props)
+      :full-address? (:full-address? account-props)
+      :format        :short}]]])
 
 (defn- balance-view
   [{:keys [balance-props type theme]}]

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -34,7 +34,7 @@
      {:on-press      #(on-press address network-details)
       :account-props (assoc item
                             :address       address
-                            )}]))
+                            :full-address? true)}]))
 
 (defn view
   []

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -25,7 +25,7 @@
 (defn- render-fn
   [item]
   (let [network-details     (rf/sub [:wallet/network-details])
-        network-short-names (map #(network-utils/network->short-name %)
+        network-short-names (map network-utils/network->short-name
                                  (:network-preferences-names item))
         prefix              (when (< (count network-short-names) 3)
                               (network-utils/short-names->network-preference-prefix network-short-names))

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -22,11 +22,11 @@
   (rf/dispatch [:navigate-back]))
 
 (defn- render-fn
-  [item network-details]
+  [item _ _ {:keys [network-details]}]
   (let [transformed-address (rf/sub [:wallet/account-address (:address item)
                                      (:network-preferences-names item)])]
     [quo/account-item
-     {:on-press      #(on-account-press transformed-address network-details)
+     {:on-press      #(on-account-press (:address item) network-details)
       :account-props (assoc item
                             :address       transformed-address
                             :full-address? true)}]))
@@ -49,5 +49,6 @@
       {:style                             style/accounts-list
        :content-container-style           style/accounts-list-container
        :data                              accounts
-       :render-fn                         #(render-fn % network-details)
+       :render-data                       {:network-details network-details}
+       :render-fn                         render-fn
        :shows-horizontal-scroll-indicator false}]]))

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -5,6 +5,7 @@
     [react-native.safe-area :as safe-area]
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
+    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.send.from.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -23,10 +24,17 @@
 
 (defn- render-fn
   [item]
-  (let [network-details (rf/sub [:wallet/network-details])]
+  (let [network-details     (rf/sub [:wallet/network-details])
+        network-short-names (map #(network-utils/network->short-name %)
+                                 (:network-preferences-names item))
+        prefix              (when (< (count network-short-names) 3)
+                              (network-utils/short-names->network-preference-prefix network-short-names))
+        address             (str prefix (:address item))]
     [quo/account-item
-     {:on-press      #(on-press (:address item) network-details)
-      :account-props item}]))
+     {:on-press      #(on-press address network-details)
+      :account-props (assoc item
+                            :address       address
+                            :full-address? false)}]))
 
 (defn view
   []

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -34,7 +34,7 @@
      {:on-press      #(on-press address network-details)
       :account-props (assoc item
                             :address       address
-                            :full-address? false)}]))
+                            )}]))
 
 (defn view
   []

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -9,7 +9,7 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn- on-press
+(defn- on-account-press
   [address network-details]
   (rf/dispatch [:wallet/select-from-account
                 {:address         address
@@ -25,7 +25,7 @@
   [item network-details]
   (let [transformed-address   (rf/sub [:wallet/account-address (:address item) (:network-preferences-names item)])]
     [quo/account-item
-     {:on-press      #(on-press transformed-address network-details)
+     {:on-press      #(on-account-press transformed-address network-details)
       :account-props (assoc item
                             :address       transformed-address
                             :full-address? true)}]))

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -23,7 +23,8 @@
 
 (defn- render-fn
   [item network-details]
-  (let [transformed-address   (rf/sub [:wallet/account-address (:address item) (:network-preferences-names item)])]
+  (let [transformed-address (rf/sub [:wallet/account-address (:address item)
+                                     (:network-preferences-names item)])]
     [quo/account-item
      {:on-press      #(on-account-press transformed-address network-details)
       :account-props (assoc item
@@ -32,8 +33,8 @@
 
 (defn view
   []
-  (let [accounts (rf/sub [:wallet/accounts-with-current-asset])
-        network-details     (rf/sub [:wallet/network-details])]
+  (let [accounts        (rf/sub [:wallet/accounts-with-current-asset])
+        network-details (rf/sub [:wallet/network-details])]
     [floating-button-page/view
      {:footer-container-padding 0
       :header                   [account-switcher/view

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -4,7 +4,6 @@
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [status-im.common.resources :as resources]
-    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.send.select-address.tabs.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -20,19 +19,14 @@
         :container-style style/empty-container-style}]
       (into [rn/view {:style style/my-accounts-container}]
             (map (fn [{:keys [color address] :as account}]
-                   (let [network-short-names (map network-utils/network->short-name
-                                                  (:network-preferences-names account))
-                         prefix              (when (< (count network-short-names) 3)
-                                               (network-utils/short-names->network-preference-prefix
-                                                network-short-names))
-                         address             (str prefix address)]
+                   (let [transformed-address (rf/sub [:wallet/account-address address (:network-preferences-names account)])]
                      [quo/account-item
                       {:account-props (assoc account
                                              :customization-color color
-                                             :address             address
+                                             :address             transformed-address
                                              :full-address?       true)
                        :on-press      #(rf/dispatch [:wallet/select-send-address
-                                                     {:address   address
+                                                     {:address   transformed-address
                                                       :recipient account
                                                       :stack-id  :screen/wallet.select-address}])}])))
             other-accounts))))

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -4,6 +4,7 @@
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [status-im.common.resources :as resources]
+    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.send.select-address.tabs.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -19,12 +20,21 @@
         :container-style style/empty-container-style}]
       (into [rn/view {:style style/my-accounts-container}]
             (map (fn [{:keys [color address] :as account}]
-                   [quo/account-item
-                    {:account-props (assoc account :customization-color color)
-                     :on-press      #(rf/dispatch [:wallet/select-send-address
-                                                   {:address   address
-                                                    :recipient account
-                                                    :stack-id  :screen/wallet.select-address}])}]))
+                   (let [network-short-names (map #(network-utils/network->short-name %)
+                                                  (:network-preferences-names account))
+                         prefix              (when (< (count network-short-names) 3)
+                                               (network-utils/short-names->network-preference-prefix
+                                                network-short-names))
+                         address             (str prefix address)]
+                     [quo/account-item
+                      {:account-props (assoc account
+                                             :customization-color color
+                                             :address             address
+                                             :full-address?       true)
+                       :on-press      #(rf/dispatch [:wallet/select-send-address
+                                                     {:address   address
+                                                      :recipient account
+                                                      :stack-id  :screen/wallet.select-address}])}])))
             other-accounts))))
 
 (defn- recent-transactions

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -20,7 +20,8 @@
       [rn/view {:style style/my-accounts-container}
        (for [{:keys [color address] :as account} other-accounts]
          ^{:key (str address)}
-         (let [transformed-address (rf/sub [:wallet/account-address address (:network-preferences-names account)])]
+         (let [transformed-address (rf/sub [:wallet/account-address address
+                                            (:network-preferences-names account)])]
            [quo/account-item
             {:account-props (assoc account
                                    :customization-color color

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -18,19 +18,19 @@
         :image           (resources/get-themed-image :cat-in-box theme)
         :container-style style/empty-container-style}]
       [rn/view {:style style/my-accounts-container}
-       (for [{:keys [color address] :as account} other-accounts]
-         ^{:key (str address)}
-         (let [transformed-address (rf/sub [:wallet/account-address address
-                                            (:network-preferences-names account)])]
-           [quo/account-item
-            {:account-props (assoc account
-                                   :customization-color color
-                                   :address             transformed-address
-                                   :full-address?       true)
-             :on-press      #(rf/dispatch [:wallet/select-send-address
-                                           {:address   transformed-address
-                                            :recipient account
-                                            :stack-id  :screen/wallet.select-address}])}]))])))
+       (doall (for [{:keys [color address] :as account} other-accounts]
+                ^{:key (str address)}
+                (let [transformed-address (rf/sub [:wallet/account-address address
+                                                   (:network-preferences-names account)])]
+                  [quo/account-item
+                   {:account-props (assoc account
+                                          :customization-color color
+                                          :address             transformed-address
+                                          :full-address?       true)
+                    :on-press      #(rf/dispatch [:wallet/select-send-address
+                                                  {:address   address
+                                                   :recipient account
+                                                   :stack-id  :screen/wallet.select-address}])}])))])))
 
 (defn- recent-transactions
   [theme]

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -17,19 +17,19 @@
         :description     (i18n/label :t/here-is-a-cat-in-a-box-instead)
         :image           (resources/get-themed-image :cat-in-box theme)
         :container-style style/empty-container-style}]
-      (into [rn/view {:style style/my-accounts-container}]
-            (map (fn [{:keys [color address] :as account}]
-                   (let [transformed-address (rf/sub [:wallet/account-address address (:network-preferences-names account)])]
-                     [quo/account-item
-                      {:account-props (assoc account
-                                             :customization-color color
-                                             :address             transformed-address
-                                             :full-address?       true)
-                       :on-press      #(rf/dispatch [:wallet/select-send-address
-                                                     {:address   transformed-address
-                                                      :recipient account
-                                                      :stack-id  :screen/wallet.select-address}])}])))
-            other-accounts))))
+      [rn/view {:style style/my-accounts-container}
+       (for [{:keys [color address] :as account} other-accounts]
+         ^{:key (str address)}
+         (let [transformed-address (rf/sub [:wallet/account-address address (:network-preferences-names account)])]
+           [quo/account-item
+            {:account-props (assoc account
+                                   :customization-color color
+                                   :address             transformed-address
+                                   :full-address?       true)
+             :on-press      #(rf/dispatch [:wallet/select-send-address
+                                           {:address   transformed-address
+                                            :recipient account
+                                            :stack-id  :screen/wallet.select-address}])}]))])))
 
 (defn- recent-transactions
   [theme]

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -18,19 +18,20 @@
         :image           (resources/get-themed-image :cat-in-box theme)
         :container-style style/empty-container-style}]
       [rn/view {:style style/my-accounts-container}
-       (doall (for [{:keys [color address] :as account} other-accounts]
-                ^{:key (str address)}
-                (let [transformed-address (rf/sub [:wallet/account-address address
-                                                   (:network-preferences-names account)])]
-                  [quo/account-item
-                   {:account-props (assoc account
-                                          :customization-color color
-                                          :address             transformed-address
-                                          :full-address?       true)
-                    :on-press      #(rf/dispatch [:wallet/select-send-address
-                                                  {:address   address
-                                                   :recipient account
-                                                   :stack-id  :screen/wallet.select-address}])}])))])))
+       (doall
+        (for [{:keys [color address] :as account} other-accounts]
+          ^{:key (str address)}
+          (let [transformed-address (rf/sub [:wallet/account-address address
+                                             (:network-preferences-names account)])]
+            [quo/account-item
+             {:account-props (assoc account
+                                    :customization-color color
+                                    :address             transformed-address
+                                    :full-address?       true)
+              :on-press      #(rf/dispatch [:wallet/select-send-address
+                                            {:address   address
+                                             :recipient account
+                                             :stack-id  :screen/wallet.select-address}])}])))])))
 
 (defn- recent-transactions
   [theme]

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -20,7 +20,7 @@
         :container-style style/empty-container-style}]
       (into [rn/view {:style style/my-accounts-container}]
             (map (fn [{:keys [color address] :as account}]
-                   (let [network-short-names (map #(network-utils/network->short-name %)
+                   (let [network-short-names (map network-utils/network->short-name
                                                   (:network-preferences-names account))
                          prefix              (when (< (count network-short-names) 3)
                                                (network-utils/short-names->network-preference-prefix

--- a/src/status_im/subs/wallet/networks.cljs
+++ b/src/status_im/subs/wallet/networks.cljs
@@ -1,7 +1,10 @@
 (ns status-im.subs.wallet.networks
   (:require [quo.foundations.resources :as resources]
             [re-frame.core :as re-frame]
-            [status-im.constants :as constants]))
+            [status-im.constants :as constants]
+            [status-im.contexts.wallet.common.utils.networks :as network-utils]))
+
+(def max-network-prefixes 2)
 
 (re-frame/reg-sub
  :wallet/networks
@@ -88,3 +91,13 @@
    (filter
     #(contains? selected-networks (:network-name %))
     network-details)))
+
+(re-frame/reg-sub
+ :wallet/account-address
+ (fn [_ [_ address network-preferences]]
+   (let [short-names (map network-utils/network->short-name network-preferences)
+         prefix              (when (<= (count short-names) max-network-prefixes)
+                               (network-utils/short-names->network-preference-prefix
+                                short-names))
+         transformed-address             (str prefix address)]
+     transformed-address)))

--- a/src/status_im/subs/wallet/networks.cljs
+++ b/src/status_im/subs/wallet/networks.cljs
@@ -95,9 +95,9 @@
 (re-frame/reg-sub
  :wallet/account-address
  (fn [_ [_ address network-preferences]]
-   (let [short-names (map network-utils/network->short-name network-preferences)
+   (let [short-names         (map network-utils/network->short-name network-preferences)
          prefix              (when (<= (count short-names) max-network-prefixes)
                                (network-utils/short-names->network-preference-prefix
                                 short-names))
-         transformed-address             (str prefix address)]
+         transformed-address (str prefix address)]
      transformed-address)))

--- a/src/status_im/subs/wallet/networks_test.cljs
+++ b/src/status_im/subs/wallet/networks_test.cljs
@@ -82,3 +82,12 @@
                   :chain-id         10
                   :layer            2}}
       (rf/sub [sub-name])))))
+
+(h/deftest-sub :wallet/account-address
+  [sub-name]
+  (testing "returns the address with prefixes when an address and less than 3 network preferences are passed"
+    (is 
+     (match? "eth:0x01" (rf/sub [sub-name "0x01" [:ethereum]]))))
+  (testing "returns the address without the prefixes when an address and equal or more than 3 network preferences are passed"
+    (is
+     (match? "0x01" (rf/sub [sub-name "0x01" [:ethereum :optimism :arbitrum]])))))

--- a/src/status_im/subs/wallet/networks_test.cljs
+++ b/src/status_im/subs/wallet/networks_test.cljs
@@ -85,9 +85,11 @@
 
 (h/deftest-sub :wallet/account-address
   [sub-name]
-  (testing "returns the address with prefixes when an address and less than 3 network preferences are passed"
-    (is 
+  (testing
+    "returns the address with prefixes when an address and less than 3 network preferences are passed"
+    (is
      (match? "eth:0x01" (rf/sub [sub-name "0x01" [:ethereum]]))))
-  (testing "returns the address without the prefixes when an address and equal or more than 3 network preferences are passed"
+  (testing
+    "returns the address without the prefixes when an address and equal or more than 3 network preferences are passed"
     (is
      (match? "0x01" (rf/sub [sub-name "0x01" [:ethereum :optimism :arbitrum]])))))


### PR DESCRIPTION
fixes #19545 

<img width="516" alt="Screenshot 2024-06-05 at 18 23 20" src="https://github.com/status-im/status-mobile/assets/55688834/7c20a8c5-26e5-41b0-a1a0-08959765b2cd">
<img width="516" alt="Screenshot 2024-06-05 at 18 23 25" src="https://github.com/status-im/status-mobile/assets/55688834/9f1c55ab-abf2-44a6-ab76-c5c14b4fdcb5">
