### PR TITLE
chore: bump status-go version

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.179.27",
-    "commit-sha1": "9e5386955c4ae271ae8794a561fd953c0407f8e7",
-    "src-sha256": "13aw37bj3xsl0glqlk7ir9kxrdkw0qn5c0fly8qac73z81y6xj0g"
+    "version": "e2d262adf407b6f9380f486e21f63e0515097435",
+    "commit-sha1": "e2d262adf407b6f9380f486e21f63e0515097435",
+    "src-sha256": "1pfgj7r27s4chyknfvb2smw7q78mk8qf8qf659f730449faj6svb"
 }


### PR DESCRIPTION
This version includes:
- new go-libp2p and go-libp2p-pubsub versions
- additional logging for store requests
