### PR TITLE
[#19737] feat: edit a saved address

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
@@ -2,6 +2,7 @@
   (:require
     [status-im.contexts.wallet.data-store :as data-store]
     [taoensso.timbre :as log]
+    [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
 (defn save-address
@@ -98,6 +99,19 @@
                       :text  toast-message}]}]]})
 
 (rf/reg-event-fx :wallet/add-saved-address-success add-saved-address-success)
+
+(defn edit-saved-address-success
+  [_]
+  {:fx [[:dispatch [:wallet/get-saved-addresses]]
+        [:dispatch [:navigate-back]]
+        [:dispatch-later
+         {:ms       100
+          :dispatch [:toasts/upsert
+                     {:type  :positive
+                      :theme :dark
+                      :text  (i18n/label :t/address-edited)}]}]]})
+
+(rf/reg-event-fx :wallet/edit-saved-address-success edit-saved-address-success)
 
 (defn add-saved-address-failed
   [_ [error]]

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
@@ -161,3 +161,20 @@
                                        :text  toast-message}]}]]]
       (is (= (count result-fx) 3))
       (is (match? expected-fx result-fx)))))
+
+(deftest edit-saved-address-success-test
+  (testing "edit saved address success test - gets saved addresses, dismiss modals and dispatch toast"
+    (let [cofx          {:db {}}
+          toast-message "Address edited"
+          effects       (events/edit-saved-address-success cofx)
+          result-fx     (:fx effects)
+          expected-fx   [[:dispatch [:wallet/get-saved-addresses]]
+                         [:dispatch [:navigate-back]]
+                         [:dispatch-later
+                          {:ms       100
+                           :dispatch [:toasts/upsert
+                                      {:type  :positive
+                                       :theme :dark
+                                       :text  toast-message}]}]]]
+      (is (= (count result-fx) 3))
+      (is (match? expected-fx result-fx)))))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -36,13 +36,15 @@
 (defn view
   []
   (let [{:keys [edit?]} (rf/sub [:get-screen-params])
-        {:keys [address name customization-color ens ens?]} (rf/sub [:wallet/saved-address])
+        {:keys [address name customization-color ens ens? network-preferences-names]}
+        (rf/sub [:wallet/saved-address])
         [network-prefixes address-without-prefix] (utils/split-prefix-and-address address)
         [address-label set-address-label] (rn/use-state (or name ""))
         [address-color set-address-color] (rn/use-state (or customization-color
                                                             (rand-nth colors/account-colors)))
         [selected-networks set-selected-networks]
-        (rn/use-state (network-utils/network-preference-prefix->network-names network-prefixes))
+        (rn/use-state (or network-preferences-names
+                          (network-utils/network-preference-prefix->network-names network-prefixes)))
         chain-short-names (rn/use-memo
                            #(network-utils/network-names->network-preference-prefix
                              selected-networks)

--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -35,10 +35,12 @@
 
 (defn view
   []
-  (let [{:keys [address ens ens?]} (rf/sub [:wallet/saved-address])
+  (let [{:keys [edit?]} (rf/sub [:get-screen-params])
+        {:keys [address name customization-color ens ens?]} (rf/sub [:wallet/saved-address])
         [network-prefixes address-without-prefix] (utils/split-prefix-and-address address)
-        [address-label set-address-label] (rn/use-state "")
-        [address-color set-address-color] (rn/use-state (rand-nth colors/account-colors))
+        [address-label set-address-label] (rn/use-state (or name ""))
+        [address-color set-address-color] (rn/use-state (or customization-color
+                                                            (rand-nth colors/account-colors)))
         [selected-networks set-selected-networks]
         (rn/use-state (network-utils/network-preference-prefix->network-names network-prefixes))
         chain-short-names (rn/use-memo
@@ -70,8 +72,10 @@
                        (fn []
                          (rf/dispatch [:wallet/save-address
                                        {:on-success
-                                        [:wallet/add-saved-address-success
-                                         (i18n/label :t/address-saved)]
+                                        (if edit?
+                                          [:wallet/edit-saved-address-success]
+                                          [:wallet/add-saved-address-success
+                                           (i18n/label :t/address-saved)])
                                         :on-error
                                         [:wallet/add-saved-address-failed]
                                         :name address-label
@@ -104,9 +108,9 @@
        :header                   [quo/page-nav
                                   {:type                :no-title
                                    :background          :blur
-                                   :icon-name           :i/arrow-left
+                                   :icon-name           (if edit? :i/close :i/arrow-left)
                                    :on-press            navigate-back
-                                   :margin-top          (safe-area/get-top)
+                                   :margin-top          (when-not edit? (safe-area/get-top))
                                    :accessibility-label :save-address-page-nav}]
        :footer                   [quo/button
                                   {:accessibility-label :save-address-button

--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -5,7 +5,6 @@
     [quo.foundations.colors :as colors]
     [react-native.core :as rn]
     [react-native.platform :as platform]
-    [status-im.common.not-implemented :as not-implemented]
     [status-im.constants :as constants]
     [status-im.contexts.settings.wallet.saved-addresses.sheets.remove-address.view :as remove-address]
     [utils.i18n :as i18n]
@@ -62,6 +61,14 @@
         open-show-address-qr           (rn/use-callback
                                         #(rf/dispatch [:open-modal
                                                        :screen/settings.share-saved-address opts])
+                                        [opts])
+        open-edit-saved-address        (rn/use-callback
+                                        (fn []
+                                          (rf/dispatch [:wallet/set-address-to-save
+                                                        (assoc opts :address full-address)])
+                                          (rf/dispatch [:open-modal
+                                                        :screen/settings.edit-saved-address
+                                                        {:edit? true}]))
                                         [opts])]
     [quo/action-drawer
      [[{:icon                :i/arrow-up
@@ -102,7 +109,7 @@
        {:icon                :i/edit
         :label               (i18n/label :t/edit-account)
         :blur?               true
-        :on-press            not-implemented/alert
+        :on-press            open-edit-saved-address
         :accessibility-label :edit-saved-address}
        {:icon                :i/delete
         :label               (i18n/label :t/remove-address)

--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -64,8 +64,7 @@
                                         [opts])
         open-edit-saved-address        (rn/use-callback
                                         (fn []
-                                          (rf/dispatch [:wallet/set-address-to-save
-                                                        (assoc opts :address full-address)])
+                                          (rf/dispatch [:wallet/set-address-to-save opts])
                                           (rf/dispatch [:open-modal
                                                         :screen/settings.edit-saved-address
                                                         {:edit? true}]))

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -567,6 +567,10 @@
      :options   options/transparent-modal-screen-options
      :component wallet-save-address/view}
 
+    {:name      :screen/settings.edit-saved-address
+     :options   (assoc options/dark-screen :sheet? true)
+     :component wallet-save-address/view}
+
     {:name      :screen/settings.add-address-to-save
      :options   options/transparent-modal-screen-options
      :component wallet-add-address-to-save/view}

--- a/translations/en.json
+++ b/translations/en.json
@@ -2691,6 +2691,7 @@
     "this-address-is-already-saved": "This address is already saved",
     "this-ens-name-is-not-registered-yet": "This ENS name is not registered yet",
     "address-saved": "Address saved",
+    "address-edited": "Address edited",
     "dapp-will-be-able-to": "{{dapp-name}} will be able to:",
     "check-your-account-balance-and-activity": "Check your account balance and activity",
     "request-txns-and-message-signing": "Request transactions and message signing",


### PR DESCRIPTION
fixes #19737

### Summary

Implement the edit feature for save addresses. 

#### Areas that maybe impacted

- Save address
- Edit saved address


### Steps to test

- Open profile setting
- Open Wallet setting
- Click on Saved adresses
- Click on a saved address
- Click on Edit Account

### Result


https://github.com/status-im/status-mobile/assets/71308738/807b8cdb-49b3-4311-8937-947888ef84e6



status: ready
