### PR TITLE
feat: collectibles details loading

### DIFF
--- a/src/quo/components/profile/expanded_collectible/style.cljs
+++ b/src/quo/components/profile/expanded_collectible/style.cljs
@@ -1,12 +1,13 @@
 (ns quo.components.profile.expanded-collectible.style
   (:require [quo.foundations.colors :as colors]))
 
-(def container
+(defn container
+  [aspect-ratio]
   {:align-items     :center
    :justify-content :center
    :border-radius   16
    :width           "100%"
-   :aspect-ratio    1})
+   :aspect-ratio    aspect-ratio})
 
 (defn image
   [square? aspect-ratio theme]
@@ -27,14 +28,14 @@
    :border-color  (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-5 theme)})
 
 (defn fallback
-  [{:keys [theme]}]
+  [{:keys [theme]} aspect-ratio]
   {:background-color (colors/theme-colors colors/neutral-2_5 colors/neutral-90 theme)
    :border-style     :dashed
    :border-color     (colors/theme-colors colors/neutral-20 colors/neutral-80 theme)
    :border-width     1
    :border-radius    16
    :width            "100%"
-   :aspect-ratio     1
+   :aspect-ratio     aspect-ratio
    :align-items      :center
    :justify-content  :center})
 
@@ -47,10 +48,9 @@
   [theme opacity]
   [{:opacity  opacity
     :position :absolute
-    :z-index  100}
-   (fallback {:theme theme})])
+    :z-index  1}
+   (fallback {:theme theme} 1)])
 
 (defn supported-file
   [opacity]
-  {:aspect-ratio 1
-   :opacity      opacity})
+  {:opacity opacity})

--- a/src/quo/components/profile/expanded_collectible/style.cljs
+++ b/src/quo/components/profile/expanded_collectible/style.cljs
@@ -3,11 +3,11 @@
 
 (defn container
   [aspect-ratio]
-  {:align-items     :center
-   :justify-content :center
-   :border-radius   16
-   :width           "100%"
-   :aspect-ratio    aspect-ratio})
+  (cond-> {:align-items     :center
+           :justify-content :center
+           :border-radius   16}
+    aspect-ratio (assoc :width        "100%"
+                        :aspect-ratio aspect-ratio)))
 
 (defn image
   [square? aspect-ratio theme]

--- a/src/quo/components/profile/expanded_collectible/style.cljs
+++ b/src/quo/components/profile/expanded_collectible/style.cljs
@@ -28,16 +28,18 @@
    :border-color  (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-5 theme)})
 
 (defn fallback
-  [{:keys [theme]} aspect-ratio]
-  {:background-color (colors/theme-colors colors/neutral-2_5 colors/neutral-90 theme)
-   :border-style     :dashed
-   :border-color     (colors/theme-colors colors/neutral-20 colors/neutral-80 theme)
-   :border-width     1
-   :border-radius    16
-   :width            "100%"
-   :aspect-ratio     aspect-ratio
-   :align-items      :center
-   :justify-content  :center})
+  ([{:keys [theme]}]
+   (fallback {:theme theme} 1))
+  ([{:keys [theme]} aspect-ratio]
+   {:background-color (colors/theme-colors colors/neutral-2_5 colors/neutral-90 theme)
+    :border-style     :dashed
+    :border-color     (colors/theme-colors colors/neutral-20 colors/neutral-80 theme)
+    :border-width     1
+    :border-radius    16
+    :width            "100%"
+    :aspect-ratio     aspect-ratio
+    :align-items      :center
+    :justify-content  :center}))
 
 (def counter
   {:position :absolute

--- a/src/quo/components/profile/expanded_collectible/style.cljs
+++ b/src/quo/components/profile/expanded_collectible/style.cljs
@@ -4,7 +4,9 @@
 (def container
   {:align-items     :center
    :justify-content :center
-   :border-radius   16})
+   :border-radius   16
+   :width           "100%"
+   :aspect-ratio    1})
 
 (defn image
   [square? aspect-ratio theme]
@@ -40,3 +42,15 @@
   {:position :absolute
    :top      12
    :right    12})
+
+(defn loading-image-with-opacity
+  [theme opacity]
+  [{:opacity  opacity
+    :position :absolute
+    :z-index  100}
+   (fallback {:theme theme})])
+
+(defn supported-file
+  [opacity]
+  {:aspect-ratio 1
+   :opacity      opacity})

--- a/src/quo/components/profile/expanded_collectible/style.cljs
+++ b/src/quo/components/profile/expanded_collectible/style.cljs
@@ -28,9 +28,9 @@
    :border-color  (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-5 theme)})
 
 (defn fallback
-  ([{:keys [theme]}]
-   (fallback {:theme theme} 1))
-  ([{:keys [theme]} aspect-ratio]
+  ([theme]
+   (fallback theme 1))
+  ([theme aspect-ratio]
    {:background-color (colors/theme-colors colors/neutral-2_5 colors/neutral-90 theme)
     :border-style     :dashed
     :border-color     (colors/theme-colors colors/neutral-20 colors/neutral-80 theme)
@@ -47,11 +47,23 @@
    :right    12})
 
 (defn loading-image-with-opacity
-  [theme opacity]
-  [{:opacity  opacity
-    :position :absolute
-    :z-index  1}
-   (fallback {:theme theme} 1)])
+  [opacity]
+  [{:align-items     :center
+    :aspect-ratio    1
+    :border-radius   16
+    :justify-content :center
+    :opacity         opacity
+    :position        :absolute
+    :width           "100%"
+    :z-index         1}])
+
+(defn gradient-view
+  [aspect-ratio]
+  {:border-radius   16
+   :width           "100%"
+   :aspect-ratio    aspect-ratio
+   :align-items     :center
+   :justify-content :center})
 
 (defn supported-file
   [opacity]

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -12,8 +12,7 @@
     [react-native.reanimated :as reanimated]
     [schema.core :as schema]
     [utils.datetime :as datetime]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+    [utils.i18n :as i18n]))
 
 (def timing-options-out 650)
 (def timing-options-in 1000)
@@ -71,13 +70,12 @@
 
 (defn view-internal
   [{:keys [container-style square? on-press counter image-src native-ID supported-file?
-           on-collectible-load]}]
+           on-collectible-load aspect-ratio]}]
   (let [theme                     (quo.theme/use-theme)
         loader-opacity            (reanimated/use-shared-value
                                    (if supported-file? 1 0))
         image-opacity             (reanimated/use-shared-value
                                    (if supported-file? 0 1))
-        aspect-ratio              (rf/sub [:wallet/last-collectible-aspect-ratio])
         [load-time set-load-time] (rn/use-state (datetime/now))
         [state set-state]         (rn/use-state {:image-loaded? false
                                                  :image-error?  (or (nil? image-src)
@@ -133,6 +131,7 @@
    [:catn
     [:props
      [:map {:closed true}
+      [:aspect-ratio {:optional true} [:maybe number?]]
       [:image-src {:optional true} [:maybe string?]]
       [:supported-file? {:optional true} [:maybe boolean?]]
       [:container-style {:optional true} [:maybe :map]]

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -42,10 +42,10 @@
 (defn- loading-image
   [{:keys [theme gradient-color-index loader-opacity aspect-ratio]}]
   [reanimated/view
-   {:style (style/loading-image-with-opacity theme loader-opacity)}
+   {:style (style/loading-image-with-opacity loader-opacity)}
    [gradients/view
     {:theme           theme
-     :container-style (style/fallback {:theme theme} aspect-ratio)
+     :container-style (style/gradient-view aspect-ratio)
      :color-index     gradient-color-index}]])
 
 (defn- counter-view
@@ -57,7 +57,7 @@
 (defn- fallback-view
   [{:keys [label theme counter on-mount]}]
   (rn/use-mount on-mount)
-  [rn/view {:style (style/fallback {:theme theme})}
+  [rn/view {:style (style/fallback theme)}
    [counter-view counter]
    [rn/view
     [icon/icon :i/sad {:color (colors/theme-colors colors/neutral-40 colors/neutral-50 theme)}]]

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -7,10 +7,48 @@
     [quo.components.markdown.text :as text]
     [quo.components.profile.expanded-collectible.style :as style]
     [quo.foundations.colors :as colors]
+    [quo.foundations.gradients :as gradients]
     [quo.theme]
     [react-native.core :as rn]
+    [react-native.reanimated :as reanimated]
     [schema.core :as schema]
+    [utils.datetime :as datetime]
     [utils.i18n :as i18n]))
+
+(def timing-options-out 650)
+(def timing-options-in 1000)
+(def first-load-time 500)
+(def cached-load-time 200)
+(def error-wait-time 800)
+
+(defn on-load-end
+  [{:keys [load-time set-state loader-opacity image-opacity]}]
+  (reanimated/animate loader-opacity 0 timing-options-out)
+  (reanimated/animate image-opacity 1 timing-options-in)
+  (if (> load-time cached-load-time)
+    (js/setTimeout
+     (fn []
+       (set-state (fn [prev-state]
+                    (assoc prev-state :image-loaded? true))))
+     first-load-time)
+    (set-state (fn [prev-state]
+                 (assoc prev-state :image-loaded? true)))))
+
+(defn on-load-error
+  [set-state]
+  (js/setTimeout (fn []
+                   (set-state (fn [prev-state] (assoc prev-state :image-error? true))))
+                 error-wait-time))
+
+(defn- loading-image
+  [{:keys [theme gradient-color-index loader-opacity]}]
+  [reanimated/view
+   {:style (style/loading-image-with-opacity theme loader-opacity)}
+   [gradients/view
+    {:theme           theme
+     :container-style (style/fallback {:theme theme})
+     :color-index     gradient-color-index}]])
+
 
 (defn- counter-view
   [counter]
@@ -34,10 +72,15 @@
 (defn view-internal
   [{:keys [container-style square? on-press counter image-src native-ID supported-file?
            on-collectible-load]}]
-  (let [theme                          (quo.theme/use-theme)
-        [image-size set-image-size]    (rn/use-state {})
-        [image-error? set-image-error] (rn/use-state (or (nil? image-src)
-                                                         (string/blank? image-src)))]
+  (let [theme                       (quo.theme/use-theme)
+        loader-opacity              (reanimated/use-shared-value (if supported-file? 1 0))
+        image-opacity               (reanimated/use-shared-value (if supported-file? 0 1))
+        [image-size set-image-size] (rn/use-state {})
+        [load-time set-load-time]   (rn/use-state (datetime/now))
+        [state set-state]           (rn/use-state {:image-loaded? false
+                                                   :image-error?  (or (nil? image-src)
+                                                                      (string/blank? image-src))})]
+
     (rn/use-effect
      (fn []
        (promesa/let [[image-width image-height] (rn/image-get-size image-src)]
@@ -46,7 +89,7 @@
                           :aspect-ratio (/ image-width image-height)})))
      [image-src])
     [rn/pressable
-     {:on-press            (when (and (not image-error?) supported-file?) on-press)
+     {:on-press            (when (and (not (:image-error? state)) supported-file?) on-press)
       :accessibility-label :expanded-collectible
       :style               (merge container-style style/container)}
      (cond
@@ -57,21 +100,31 @@
          :theme    theme
          :on-mount on-collectible-load}]
 
-       image-error?
+       (:image-error? state)
        [fallback-view
         {:label    (i18n/label :t/cant-fetch-info)
          :counter  counter
          :theme    theme
          :on-mount on-collectible-load}]
 
-       :else
-       [rn/view
+       (not (:image-loaded? state))
+       [loading-image
+        {:loader-opacity       loader-opacity
+         :theme                theme
+         :gradient-color-index :gradient-5}])
+     (when supported-file?
+       [reanimated/view {:style (style/supported-file image-opacity)}
         [rn/image
-         {:style     (style/image square? (:aspect-ratio image-size) theme)
-          :source    image-src
-          :native-ID native-ID
-          :on-error  #(set-image-error true)
-          :on-load   on-collectible-load}]
+         {:style         (style/image square? (:aspect-ratio image-size) theme)
+          :source        image-src
+          :native-ID     native-ID
+          :on-load-start #(set-load-time (fn [start-time] (- (datetime/now) start-time)))
+          :on-load-end   #(on-load-end {:load-time      load-time
+                                        :set-state      set-state
+                                        :loader-opacity loader-opacity
+                                        :image-opacity  image-opacity})
+          :on-error      #(on-load-error set-state)
+          :on-load       on-collectible-load}]
         (when counter
           [counter-view counter])
         [rn/view {:style (style/collectible-border theme)}]])]))

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -48,7 +48,6 @@
      :container-style (style/fallback {:theme theme} aspect-ratio)
      :color-index     gradient-color-index}]])
 
-
 (defn- counter-view
   [counter]
   [collectible-counter/view
@@ -56,9 +55,9 @@
     :value           counter}])
 
 (defn- fallback-view
-  [{:keys [label theme counter on-mount aspect-ratio]}]
+  [{:keys [label theme counter on-mount]}]
   (rn/use-mount on-mount)
-  [rn/view {:style (style/fallback {:theme theme} aspect-ratio)}
+  [rn/view {:style (style/fallback {:theme theme})}
    [counter-view counter]
    [rn/view
     [icon/icon :i/sad {:color (colors/theme-colors colors/neutral-40 colors/neutral-50 theme)}]]
@@ -97,11 +96,10 @@
 
        (:image-error? state)
        [fallback-view
-        {:aspect-ratio aspect-ratio
-         :label        (i18n/label :t/cant-fetch-info)
-         :counter      counter
-         :theme        theme
-         :on-mount     on-collectible-load}]
+        {:label    (i18n/label :t/cant-fetch-info)
+         :counter  counter
+         :theme    theme
+         :on-mount on-collectible-load}]
 
        (not (:image-loaded? state))
        [loading-image

--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -12,8 +12,8 @@
     [utils.re-frame :as rf]))
 
 (defn- on-collectible-press
-  [{:keys [id]}]
-  (rf/dispatch [:wallet/get-collectible-details id]))
+  [{:keys [id]} aspect-ratio]
+  (rf/dispatch [:wallet/get-collectible-details id aspect-ratio]))
 
 (defn- on-collectible-long-press
   [{:keys [preview-url collectible-details id]}]

--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -167,12 +167,13 @@
 
 (rf/reg-event-fx
  :wallet/get-collectible-details
- (fn [_ [collectible-id]]
+ (fn [{:keys [db]} [collectible-id aspect-ratio]]
    (let [request-id               0
          collectible-id-converted (cske/transform-keys transforms/->PascalCaseKeyword collectible-id)
          data-type                (collectible-data-types :details)
          request-params           [request-id [collectible-id-converted] data-type]]
-     {:fx [[:json-rpc/call
+     {:db (assoc-in db [:wallet :last-collectible-aspect-ratio] aspect-ratio)
+      :fx [[:json-rpc/call
             [{:method   "wallet_getCollectiblesByUniqueIDAsync"
               :params   request-params
               :on-error (fn [error]
@@ -197,7 +198,7 @@
 (rf/reg-event-fx
  :wallet/clear-last-collectible-details
  (fn [{:keys [db]}]
-   {:db (update-in db [:wallet] dissoc :last-collectible-details)}))
+   {:db (update-in db [:wallet] dissoc :last-collectible-details :last-collectible-aspect-ratio)}))
 
 (rf/reg-event-fx :wallet/trigger-share-collectible
  (fn [_ [{:keys [title uri]}]]

--- a/src/status_im/contexts/wallet/collectible/style.cljs
+++ b/src/status_im/contexts/wallet/collectible/style.cljs
@@ -12,8 +12,8 @@
 
 (defn preview-container
   []
-  {:margin-horizontal 8
-   :margin-top        (+ (header-height) 12)})
+  {:padding-horizontal 8
+   :margin-top         (+ (header-height) 12)})
 
 (def header
   {:margin-horizontal 20

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -150,6 +150,7 @@
             set-title-ref                  (rn/use-callback #(reset! title-ref %))
             animation-shared-element-id    (rf/sub [:animation-shared-element-id])
             collectible-owner              (rf/sub [:wallet/last-collectible-details-owner])
+            aspect-ratio                   (rf/sub [:wallet/last-collectible-aspect-ratio])
             {:keys [id
                     preview-url
                     collection-data
@@ -180,7 +181,8 @@
          [rn/view
           [gradient-layer preview-uri]
           [quo/expanded-collectible
-           {:image-src           preview-uri
+           {:aspect-ratio        aspect-ratio
+            :image-src           preview-uri
             :container-style     (style/preview-container)
             :counter             (utils/collectible-owned-counter total-owned)
             :native-ID           (when (= animation-shared-element-id token-id) :shared-element)

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -14,7 +14,7 @@
     :as   collectible}
    index]
   (let [on-press-fn      (rn/use-callback #(when on-press
-                                             (on-press collectible)))
+                                             (on-press collectible %)))
         on-long-press-fn (rn/use-callback #(when on-long-press
                                              (on-long-press collectible)))]
     [quo/collectible-list-item

--- a/src/status_im/contexts/wallet/home/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/view.cljs
@@ -18,8 +18,8 @@
                               :image (:uri preview-url)}])}]))
 
 (defn- on-collectible-press
-  [{:keys [id]}]
-  (rf/dispatch [:wallet/get-collectible-details id]))
+  [{:keys [id]} aspect-ratio]
+  (rf/dispatch [:wallet/get-collectible-details id aspect-ratio]))
 
 (defn view
   [{:keys [selected-tab]}]

--- a/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
@@ -35,7 +35,8 @@
        :on-press      on-close
        :switcher-type :select-account}]
      [quo/expanded-collectible
-      {:image-src       preview-uri
+      {:aspect-ratio    1
+       :image-src       preview-uri
        :square?         true
        :supported-file? (utils/supported-file? (get-in collectible
                                                        [:collectible-data :animation-media-type]))

--- a/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
@@ -35,8 +35,7 @@
        :on-press      on-close
        :switcher-type :select-account}]
      [quo/expanded-collectible
-      {:aspect-ratio    1
-       :image-src       preview-uri
+      {:image-src       preview-uri
        :square?         true
        :supported-file? (utils/supported-file? (get-in collectible
                                                        [:collectible-data :animation-media-type]))

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -98,6 +98,12 @@
      (assoc last-collectible :preview-url (preview-url last-collectible)))))
 
 (re-frame/reg-sub
+ :wallet/last-collectible-aspect-ratio
+ :<- [:wallet]
+ (fn [wallet]
+   (:last-collectible-aspect-ratio wallet)))
+
+(re-frame/reg-sub
  :wallet/last-collectible-details-chain-id
  :<- [:wallet/last-collectible-details]
  (fn [collectible]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20103

### Summary
Adds a loader to the collectibles details page while the image still loads

![Simulator Screen Recording - iPhone 11 Pro - 2024-06-07 at 12 52 43](https://github.com/status-im/status-mobile/assets/45393944/b22135c8-1ea3-416d-af0d-2471c41100fa)

for non square collectibles:

![Simulator Screen Recording - iPhone 11 Pro - 2024-06-21 at 18 02 47](https://github.com/status-im/status-mobile/assets/45393944/84500bce-2a6c-44b6-8f77-e14eb697f48d)


## Review and testing notes
- Open status app
- Go to wallets
- Click on the collectibles tab, then click on any of the collectibles
- There should be a loader while the image is still been fetched

**IMPORTANT**
Builds on top of:
- #20281 which addresses the issue with rendering a fallback for when the asset can not be fetched or it is not supported

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready
