### PR TITLE
fix scroll to index error when switching tab on the messaging screen

### DIFF
--- a/src/status_im/contexts/chat/home/view.cljs
+++ b/src/status_im/contexts/chat/home/view.cljs
@@ -93,7 +93,8 @@
        {:selected-tab :tab/contacts
         :tab->content (empty-state-content theme)}]
       [rn/section-list
-       {:ref                               set-scroll-ref
+       {:ref                               (when (not-empty items)
+                                             set-scroll-ref)
         :key-fn                            :public-key
         :get-item-layout                   get-item-layout
         :content-inset-adjustment-behavior :never


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19845

### Summary
 Pending requests are rendered using the same section-list that renders contacts and since the pending requests are not grouped into sections unlike the contacts, before setting the scroll-ref on the section-list we should checked that the active-sections are not nil. This resolves the issues


https://github.com/status-im/status-mobile/assets/28704507/d2d8cf42-cd2c-49d7-a3f1-92d58f983e80



status: ready 
