### PR TITLE
fix wrong community logo position when scrolling down the channel list

### DIFF
--- a/src/quo/components/navigation/page_nav/view.cljs
+++ b/src/quo/components/navigation/page_nav/view.cljs
@@ -25,12 +25,12 @@
    :blur        :grey})
 
 (defn- page-nav-base
-  [{:keys [margin-top background on-press accessibility-label icon-name behind-overlay?]
+  [{:keys [margin-top background on-press accessibility-label icon-name behind-overlay? align-center?]
     :or   {background :white}}
    & children]
   (into [rn/view {:style (style/container margin-top)}
          (when icon-name
-           [rn/view {:style style/icon-container}
+           [rn/view (when align-center? {:style style/icon-container})
             [button/button
              {:type                (button-type background)
               :icon-only?          true

--- a/src/status_im/contexts/wallet/common/account_switcher/view.cljs
+++ b/src/status_im/contexts/wallet/common/account_switcher/view.cljs
@@ -35,6 +35,7 @@
       :on-press            on-press
       :accessibility-label accessibility-label
       :networks            networks
+      :align-center?       true
       :networks-on-press   #(rf/dispatch [:show-bottom-sheet {:content network-filter/view}])
       :right-side          [(when (and (ff/enabled? ::ff/wallet.wallet-connect)
                                        (not watch-only?))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20391

### Summary
Related to: https://github.com/status-im/status-mobile/pull/19943
For aligning networks in center we modified page-nav component and that also changed position in other screens (community-log)

### Testing
Please let me know if position is broken in any of the screen where logo/component in page-nav supposed to align in center
Ex.
![image](https://github.com/status-im/status-mobile/assets/17097240/cca75076-3696-4c25-a2c7-03911f07dfde)



status: ready