### PR TITLE
fix(profile)_: Fallback to old profile name after migration from v1

### DIFF
--- a/src/legacy/status_im/ui/screens/default_sync_period_settings/view.cljs
+++ b/src/legacy/status_im/ui/screens/default_sync_period_settings/view.cljs
@@ -13,6 +13,7 @@
    constants/one-day    (i18n/label :t/one-day)
    constants/three-days (i18n/label :t/three-days)
    constants/one-week   (i18n/label :t/one-week)
+   constants/nine-days  (i18n/label :t/nine-days)
    constants/one-month  (i18n/label :t/one-month)})
 
 (defn radio-item
@@ -34,4 +35,5 @@
      [radio-item constants/one-day default-sync-period]
      [radio-item constants/three-days default-sync-period]
      [radio-item constants/one-week default-sync-period]
+     [radio-item constants/nine-days default-sync-period]
      [radio-item constants/one-month default-sync-period]]))

--- a/src/legacy/status_im/ui/screens/sync_settings/views.cljs
+++ b/src/legacy/status_im/ui/screens/sync_settings/views.cljs
@@ -57,14 +57,21 @@
         :accessory-text      (cond
                                (= default-sync-period constants/two-mins)
                                (i18n/label :t/two-minutes)
+
                                (or
                                 (nil? default-sync-period)
                                 (= default-sync-period constants/one-day))
                                (i18n/label :t/one-day)
+
                                (= default-sync-period constants/three-days)
                                (i18n/label :t/three-days)
+
+                               (= default-sync-period constants/nine-days)
+                               (i18n/label :t/nine-days)
+
                                (= default-sync-period constants/one-week)
                                (i18n/label :t/one-week)
+
                                (= default-sync-period constants/one-month)
                                (i18n/label :t/one-month))}]
       [list.item/list-item

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -293,6 +293,7 @@
 (def ^:const two-mins (* 2 60))
 (def ^:const one-day (* 60 60 24))
 (def ^:const three-days (* one-day 3))
+(def ^:const nine-days (* one-day 9))
 (def ^:const one-week (* one-day 7))
 (def ^:const one-month (* one-day 31))
 

--- a/src/status_im/contexts/profile/utils.cljs
+++ b/src/status_im/contexts/profile/utils.cljs
@@ -13,7 +13,7 @@
                            name)]
     (if (or preferred-name (and ens-verified name))
       ens-name
-      (or display-name primary-name alias))))
+      (or display-name primary-name alias name))))
 
 (defn photo
   [{:keys [images]}]

--- a/src/status_im/contexts/profile/utils_test.cljs
+++ b/src/status_im/contexts/profile/utils_test.cljs
@@ -1,0 +1,19 @@
+(ns status-im.contexts.profile.utils-test
+  (:require
+    [cljs.test :refer [are deftest]]
+    [status-im.contexts.profile.utils :as sut]))
+
+(deftest displayed-name-test
+  (are [expected arg] (= expected (sut/displayed-name arg))
+   "Display Name"   {:display-name "Display Name"}
+   "Primary Name"   {:primary-name "Primary Name"}
+   "Alias"          {:alias "Alias"}
+   "Name"           {:name "Name"}
+   nil              {:preferred-name "  "}
+   "Preferred Name" {:preferred-name "Preferred Name"}
+   "Preferred Name" {:preferred-name "Preferred Name" :display-name "Display Name"}
+   "Preferred Name" {:preferred-name "Preferred Name" :display-name "Display Name" :name "Name"}
+   "Display Name"   {:ens-verified true :name "Name" :display-name "Display Name"}
+   "Name"           {:ens-verified true :name "Name" :display-name "  "}
+   "Name"           {:ens-verified true :name "Name"}
+   "Name"           {:name "Name"}))

--- a/src/status_im/subs/contact.cljs
+++ b/src/status_im/subs/contact.cljs
@@ -258,13 +258,14 @@
    [(re-frame/subscribe [:contacts/contact-by-identity contact-identity])
     (re-frame/subscribe [:profile/profile])])
  (fn [[{:keys [primary-name] :as contact}
-       {:keys [public-key preferred-name display-name]}]
+       {:keys [public-key preferred-name display-name name]}]
       [_ contact-identity]]
    [(if (= public-key contact-identity)
       (cond
         (not (string/blank? preferred-name)) preferred-name
         (not (string/blank? display-name))   display-name
         (not (string/blank? primary-name))   primary-name
+        (not (string/blank? name))           name
         :else                                public-key)
       (profile.utils/displayed-name contact))
     (:secondary-name contact)]))

--- a/translations/en.json
+++ b/translations/en.json
@@ -1863,6 +1863,7 @@
     "accept-and-add": "Accept and add",
     "one-day": "One day",
     "three-days": "Three days",
+    "nine-days": "Nine days",
     "one-week": "One week",
     "one-month": "One month",
     "my-profile": "My profile",


### PR DESCRIPTION
- Closes https://github.com/status-im/status-mobile/issues/20203

### Summary

This PR is a byproduct of the investigation on issue https://github.com/status-im/status-mobile/issues/20203, more specifically, to double-check if v1 users have their display names shown correctly. I preferred to fix on the client side because the profile name is already available to us, so I took that as a bug on our end.

This is the scenario to reproduce the bugs this PR is solving:

1. Alice creates an account in v1 (branch `release/1.20.x`).
2. Alice had 1 friend to chat with, Carol.
3. Alice sends and receives at least one message from Carol.
4. Alice installs the new app (latest `develop` branch suffices).
5. Alice login and try to edit her profile, but her 3-word name is not displayed in the `Settings > Edit Profile` screen, nor in the `Settings > Edit profile > Name` input field.
6. Alice also opens her chat with Carol, but her name appears as a public key instead of her 3-word name she identifies herself with.

The solution in this PR is to just fallback to Alice's 3-word name (`name` field in the profile/contact app-db instance).

### Before and after screenshots comparison

<img src="https://github.com/status-im/status-mobile/assets/46027/bb88a810-82bc-48bc-af4c-91ec8b53e973" height="400" />

<img src="https://github.com/status-im/status-mobile/assets/46027/444d9711-5132-4b98-b6f1-65f40d658418" height="400" />

<img src="https://github.com/status-im/status-mobile/assets/46027/be84a136-5213-4be1-8131-e27be65c8128" height="400" />

<br>

<img src="https://github.com/status-im/status-mobile/assets/46027/631288f7-6dc0-470d-8a68-61d8143f2f9e" height="400" />

<img src="https://github.com/status-im/status-mobile/assets/46027/633fc467-d663-4e06-9648-e88d76265c2d" height="400" />

<img src="https://github.com/status-im/status-mobile/assets/46027/9b1d7939-c626-4461-81f9-ef450a60f9b8" height="400" />

### Areas that may be impacted

- Edit profile name.
- Name displayed in chats from the perspective of the sender who migrated from v1.

### Steps to test

In order to test this PR, it's necessary to migrate from v1 to v2 using two separate builds. The v1 build can be obtained in PR https://github.com/status-im/status-mobile/pull/20123. v2 build can be any one from `develop` from today, for example.

The reproduction steps are defined above, in the PR's summary.

@status-im/mobile-qa, unless this has been done already, it would be better if you could verify in more detail the migration from v1 to v2 doesn't have other UI/UX regressions so that we can be sure we can close the parent issue https://github.com/status-im/status-mobile/issues/20203.

status: ready
