### PR TITLE
Long tap on route to lock value sent from this network

### DIFF
--- a/src/quo/components/wallet/network_bridge/view.cljs
+++ b/src/quo/components/wallet/network_bridge/view.cljs
@@ -31,7 +31,7 @@
         :else                 (string/capitalize (name network))))
 
 (defn view-internal
-  [{:keys [network status amount container-style on-press] :as args}]
+  [{:keys [network status amount container-style on-press on-long-press] :as args}]
   (let [theme (quo.theme/use-theme)]
     (if (= status :edit)
       [network-bridge-add (assoc args :theme theme)]
@@ -39,7 +39,8 @@
        {:style               (merge (style/container network status theme) container-style)
         :accessible          true
         :accessibility-label :container
-        :on-press            on-press}
+        :on-press            on-press
+        :on-long-press       on-long-press}
        (if (= status :loading)
          [rn/view
           {:style               (style/loading-skeleton theme)

--- a/src/status_im/common/controlled_input/utils.cljs
+++ b/src/status_im/common/controlled_input/utils.cljs
@@ -127,3 +127,6 @@
   [state]
   (set-input-value state ""))
 
+(defn empty-value?
+  [state]
+  (string/blank? (:value state)))

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -269,3 +269,15 @@
     (some #(when (= token-symbol (:symbol %))
              %)
           address-tokens)))
+
+(defn make-limit-label-crypto
+  [amount currency]
+  (str amount
+       " "
+       (some-> currency
+               name
+               string/upper-case)))
+
+(defn make-limit-label-fiat
+  [amount currency-symbol]
+  (str currency-symbol amount))

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -36,8 +36,8 @@
            receiver-network-values       (get-in db [:wallet :ui :send :receiver-network-values])
            sender-network-values         (get-in db [:wallet :ui :send :sender-network-values])
            tx-type                       (get-in db [:wallet :ui :send :tx-type])
-           disabled-from-chain-ids       (or (get-in db [:wallet :ui :send :disabled-from-chain-ids]) [])
-           from-locked-amounts           (or (get-in db [:wallet :ui :send :from-locked-amounts]) {})
+           disabled-from-chain-ids       (get-in db [:wallet :ui :send :disabled-from-chain-ids] [])
+           from-locked-amounts           (get-in db [:wallet :ui :send :from-locked-amounts] {})
            token-decimals                (if collectible 0 (:decimals token))
            native-token?                 (and token (= token-display-name "ETH"))
            routes-available?             (pos? (count chosen-route))
@@ -344,10 +344,7 @@
 
 (rf/reg-event-fx :wallet/unlock-from-amount
  (fn [{:keys [db]} [chain-id]]
-   (let [new-locked-amounts (-> db
-                                (get-in [:wallet :ui :send :from-locked-amounts])
-                                (dissoc chain-id))]
-     {:db (assoc-in db [:wallet :ui :send :from-locked-amounts] new-locked-amounts)})))
+   {:db (update-in db [:wallet :ui :send :from-locked-amounts] dissoc chain-id)}))
 
 (rf/reg-event-fx :wallet/reset-network-amounts-to-zero
  (fn [{:keys [db]}]

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -400,9 +400,6 @@
                                                       receiver-networks)))
                                          network-chain-ids))
          from-locked-amount (update-vals from-locked-amounts to-hex)
-         _ (tap> {:in                 `get-suggested-routes
-                  :from-locked-amount from-locked-amount
-                  :amount-in          amount-in})
          transaction-type-param (case transaction-type
                                   :tx/collectible-erc-721  constants/send-type-erc-721-transfer
                                   :tx/collectible-erc-1155 constants/send-type-erc-1155-transfer

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -389,7 +389,7 @@
          to-token-id ""
          network-preferences (if token [] [(get-in collectible [:id :contract-id :chain-id])])
          gas-rates constants/gas-rate-medium
-         to-hex (fn [val] (send-utils/amount-in-hex val (if token token-decimal 0)))
+         to-hex (fn [v] (send-utils/amount-in-hex v (if token token-decimal 0)))
          amount-in (to-hex amount)
          from-address wallet-address
          disabled-from-chain-ids disabled-from-chain-ids

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -143,12 +143,12 @@
    {:db (update-in db [:wallet :ui :send] dissoc :amount)}))
 
 (rf/reg-event-fx :wallet/clean-disabled-from-networks
-                 (fn [{:keys [db]}]
-                   {:db (update-in db [:wallet :ui :send] dissoc :disabled-from-chain-ids)}))
+ (fn [{:keys [db]}]
+   {:db (update-in db [:wallet :ui :send] dissoc :disabled-from-chain-ids)}))
 
 (rf/reg-event-fx :wallet/clean-from-locked-amounts
-                 (fn [{:keys [db]}]
-                   {:db (update-in db [:wallet :ui :send] dissoc :from-locked-amounts)}))
+ (fn [{:keys [db]}]
+   {:db (update-in db [:wallet :ui :send] dissoc :from-locked-amounts)}))
 
 (rf/reg-event-fx
  :wallet/select-send-address
@@ -339,38 +339,38 @@
    {:db (assoc-in db [:wallet :ui :send :disabled-from-chain-ids] chain-ids)}))
 
 (rf/reg-event-fx :wallet/lock-from-amount
-                 (fn [{:keys [db]} [chain-id amount]]
-                   {:db (assoc-in db [:wallet :ui :send :from-locked-amounts chain-id] amount)}))
+ (fn [{:keys [db]} [chain-id amount]]
+   {:db (assoc-in db [:wallet :ui :send :from-locked-amounts chain-id] amount)}))
 
 (rf/reg-event-fx :wallet/unlock-from-amount
-                 (fn [{:keys [db]} [chain-id]]
-                   (let [new-locked-amounts (-> db
-                                                (get-in [:wallet :ui :send :from-locked-amounts])
-                                                (dissoc chain-id))]
-                     {:db (assoc-in db [:wallet :ui :send :from-locked-amounts] new-locked-amounts)})))
+ (fn [{:keys [db]} [chain-id]]
+   (let [new-locked-amounts (-> db
+                                (get-in [:wallet :ui :send :from-locked-amounts])
+                                (dissoc chain-id))]
+     {:db (assoc-in db [:wallet :ui :send :from-locked-amounts] new-locked-amounts)})))
 
 (rf/reg-event-fx :wallet/reset-network-amounts-to-zero
-                 (fn [{:keys [db]}]
-                   (let [sender-network-values   (get-in db [:wallet :ui :send :sender-network-values])
-                         receiver-network-values (get-in db [:wallet :ui :send :receiver-network-values])
-                         disabled-from-chain-ids (get-in db [:wallet :ui :send :disabled-from-chain-ids])
-                         sender-network-values   (send-utils/reset-network-amounts-to-zero
-                                                  {:network-amounts    sender-network-values
-                                                   :disabled-chain-ids disabled-from-chain-ids})
-                         receiver-network-values (send-utils/reset-network-amounts-to-zero
-                                                  {:network-amounts    receiver-network-values
-                                                   :disabled-chain-ids []})]
-                     {:db (-> db
-                              (assoc-in [:wallet :ui :send :sender-network-values] sender-network-values)
-                              (assoc-in [:wallet :ui :send :receiver-network-values] receiver-network-values)
-                              (update-in [:wallet :ui :send]
-                                         dissoc
-                                         :network-links
-                                         (when (empty? sender-network-values) :sender-network-values)
-                                         (when (empty? receiver-network-values) :receiver-network-values)))})))
+ (fn [{:keys [db]}]
+   (let [sender-network-values   (get-in db [:wallet :ui :send :sender-network-values])
+         receiver-network-values (get-in db [:wallet :ui :send :receiver-network-values])
+         disabled-from-chain-ids (get-in db [:wallet :ui :send :disabled-from-chain-ids])
+         sender-network-values   (send-utils/reset-network-amounts-to-zero
+                                  {:network-amounts    sender-network-values
+                                   :disabled-chain-ids disabled-from-chain-ids})
+         receiver-network-values (send-utils/reset-network-amounts-to-zero
+                                  {:network-amounts    receiver-network-values
+                                   :disabled-chain-ids []})]
+     {:db (-> db
+              (assoc-in [:wallet :ui :send :sender-network-values] sender-network-values)
+              (assoc-in [:wallet :ui :send :receiver-network-values] receiver-network-values)
+              (update-in [:wallet :ui :send]
+                         dissoc
+                         :network-links
+                         (when (empty? sender-network-values) :sender-network-values)
+                         (when (empty? receiver-network-values) :receiver-network-values)))})))
 
 (rf/reg-event-fx :wallet/get-suggested-routes
- (fn [{:keys [db now]} [{:keys [amount updated-token ]}]]
+ (fn [{:keys [db now]} [{:keys [amount updated-token]}]]
    (let [wallet-address (get-in db [:wallet :current-viewing-account-address])
          token (or updated-token (get-in db [:wallet :ui :send :token]))
          transaction-type (get-in db [:wallet :ui :send :tx-type])

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -81,6 +81,7 @@
                                                                                     :has-error false}}
                                                     :market-values-per-currency {:usd {:price 10}}}
    :wallet/wallet-send-disabled-from-chain-ids     []
+   :wallet/wallet-send-from-locked-amounts         {}
    :wallet/wallet-send-from-values-by-chain        {1 (money/bignumber "250")}
    :wallet/wallet-send-to-values-by-chain          {1 (money/bignumber "250")}
    :wallet/wallet-send-sender-network-values       nil

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -315,7 +315,6 @@
                                                                                       12))]
                                                             (number/remove-trailing-zeroes
                                                              new-value))))))]
-
     (rn/use-mount
      (fn []
        (let [dismiss-keyboard-fn   #(when (= % "active") (rn/dismiss-keyboard!))

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -135,16 +135,16 @@
                                     {:content buy-token/view}])}])
 
 (defn- fetch-routes
-  [{:keys [amount bounce-duration-ms token valid-input? ]}]
+  [{:keys [amount bounce-duration-ms token valid-input?]}]
   (tap>
-   {:in            `fetch-routes
-    :amount        amount
-    :token         token})
+   {:in     `fetch-routes
+    :amount amount
+    :token  token})
   (if valid-input?
     (debounce/debounce-and-dispatch
      [:wallet/get-suggested-routes
       {:amount        amount
-       :updated-token token }]
+       :updated-token token}]
      bounce-duration-ms)
     (rf/dispatch [:wallet/clean-suggested-routes])))
 

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -136,10 +136,6 @@
 
 (defn- fetch-routes
   [{:keys [amount bounce-duration-ms token valid-input?]}]
-  (tap>
-   {:in     `fetch-routes
-    :amount amount
-    :token  token})
   (if valid-input?
     (debounce/debounce-and-dispatch
      [:wallet/get-suggested-routes
@@ -335,8 +331,6 @@
      [current-address])
     (rn/use-effect
      (fn []
-       (tap> {:in                   `use-effect
-              :request-fetch-routes request-fetch-routes})
        (request-fetch-routes 0))
      [send-from-locked-amounts])
     [rn/view

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -394,20 +394,13 @@
                                                 (and (not should-try-again?) confirm-disabled?))
                                  :on-press  (cond
                                               should-try-again?
-                                              #(let [input-amount (controlled-input/input-value
-                                                                   input-state)
-                                                     amount       (if crypto-currency?
-                                                                    input-amount
-                                                                    (.toFixed (* token-balance
-                                                                                 conversion-rate)
-                                                                              2))]
-                                                 (rf/dispatch [:wallet/get-suggested-routes
-                                                               {:amount        amount
-                                                                :updated-token token-by-symbol}]))
+                                              #(rf/dispatch [:wallet/get-suggested-routes
+                                                             {:amount        amount-in-crypto
+                                                              :updated-token token-by-symbol}])
                                               sending-to-unpreferred-networks?
                                               #(show-unpreferred-networks-alert on-confirm)
                                               :else
-                                              #(on-confirm amount))}
+                                              #(on-confirm amount-in-crypto))}
                                 (when should-try-again?
                                   {:type :grey}))}]
      [quo/numbered-keyboard

--- a/src/status_im/contexts/wallet/send/routes/style.cljs
+++ b/src/status_im/contexts/wallet/send/routes/style.cljs
@@ -61,11 +61,11 @@
 
 (def disclaimer
   {:margin-horizontal 20
-   :margin-top 20
-   :margin-bottom 8})
+   :margin-top        20
+   :margin-bottom     8})
 
 (def input-container
-  {:margin-top 8
+  {:margin-top    8
    :margin-bottom 12})
 
 (defn keyboard-container

--- a/src/status_im/contexts/wallet/send/routes/style.cljs
+++ b/src/status_im/contexts/wallet/send/routes/style.cljs
@@ -1,5 +1,4 @@
-(ns status-im.contexts.wallet.send.routes.style
-  (:require [quo.foundations.colors :as colors]))
+(ns status-im.contexts.wallet.send.routes.style)
 
 (def routes-container
   {:padding-horizontal 20
@@ -35,29 +34,6 @@
            :top      margin-top}
     inverted?
     (assoc :transform [{:scaleY -1}])))
-
-(def empty-container
-  {:flex-grow       1
-   :align-items     :center
-   :justify-content :center})
-
-(defn warning-container
-  [color theme]
-  {:flex-direction    :row
-   :border-width      1
-   :border-color      (colors/resolve-color color theme 10)
-   :background-color  (colors/resolve-color color theme 5)
-   :margin-horizontal 20
-   :margin-top        4
-   :margin-bottom     8
-   :padding-left      12
-   :padding-vertical  11
-   :border-radius     12})
-
-(def warning-text
-  {:margin-left   8
-   :margin-right  12
-   :padding-right 12})
 
 (def disclaimer
   {:margin-horizontal 20

--- a/src/status_im/contexts/wallet/send/routes/style.cljs
+++ b/src/status_im/contexts/wallet/send/routes/style.cljs
@@ -58,3 +58,16 @@
   {:margin-left   8
    :margin-right  12
    :padding-right 12})
+
+(def disclaimer
+  {:margin-horizontal 20
+   :margin-top 20
+   :margin-bottom 8})
+
+(def input-container
+  {:margin-top 8
+   :margin-bottom 12})
+
+(defn keyboard-container
+  [bottom]
+  {:padding-bottom bottom})

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -179,7 +179,6 @@
                                      (number/remove-trailing-zeroes new-value))))))}]
           [quo/disclaimer
            {:on-change       (fn [checked?]
-                               (tap> {:checked checked?})
                                (set-is-amount-locked checked?))
             :checked?        is-amount-locked?
             :container-style style/disclaimer
@@ -292,10 +291,6 @@
 
 (defn disable-chain
   [chain-id disabled-from-chain-ids token-available-networks-for-suggested-routes]
-  #_(tap> {:in                                            `disable-chain
-           :chain-id                                      chain-id
-           :disabled-from-chain-ids                       disabled-from-chain-ids
-           :token-available-networks-for-suggested-routes token-available-networks-for-suggested-routes})
   (let [disabled-chain-ids
         (if (contains? (set
                         disabled-from-chain-ids)

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -1,14 +1,19 @@
 (ns status-im.contexts.wallet.send.routes.view
   (:require
-    [quo.core :as quo]
-    [react-native.core :as rn]
-    [status-im.contexts.wallet.common.utils.networks :as network-utils]
-    [status-im.contexts.wallet.send.routes.style :as style]
-    [status-im.contexts.wallet.send.utils :as send-utils]
-    [status-im.contexts.wallet.sheets.network-preferences.view :as network-preferences]
-    [utils.debounce :as debounce]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+   [clojure.string :as string]
+   [quo.core :as quo]
+   [react-native.core :as rn]
+   [react-native.safe-area :as safe-area]
+   [status-im.common.controlled-input.utils :as controlled-input]
+   [status-im.contexts.wallet.common.utils :as utils]
+   [status-im.contexts.wallet.common.utils.networks :as network-utils]
+   [status-im.contexts.wallet.send.routes.style :as style]
+   [status-im.contexts.wallet.send.utils :as send-utils]
+   [status-im.contexts.wallet.sheets.network-preferences.view :as network-preferences]
+   [utils.i18n :as i18n]
+   [utils.number :as number]
+   [utils.re-frame :as rf]))
+
 
 (def row-height 44)
 (def space-between-rows 11)
@@ -16,15 +21,6 @@
 (def network-link-1x-height 56)
 (def network-link-2x-height 111)
 
-(defn- fetch-routes
-  [{:keys [amount bounce-duration-ms token valid-input?]}]
-  (if valid-input?
-    (debounce/debounce-and-dispatch
-     [:wallet/get-suggested-routes
-      {:amount        amount
-       :updated-token token}]
-     bounce-duration-ms)
-    (rf/dispatch [:wallet/clean-suggested-routes])))
 
 (defn- open-preferences
   []
@@ -89,8 +85,140 @@
                                            (rf/dispatch [:wallet/update-receiver-networks
                                                          chain-ids]))}]))}]))
 
+(comment
+  (string/capitalize (name :mainnet)))
+
+(defn- make-limit-label-crypto
+  [amount currency]
+  (str amount
+       " "
+       (some-> currency
+               name
+               string/upper-case)))
+
+(defn- make-limit-label-fiat
+  [amount currency-symbol]
+  (str currency-symbol amount))
+
+(defn- edit-amount
+  [{:keys [chain-id token-symbol]}]
+  (rf/dispatch
+   [:show-bottom-sheet
+    {:content
+     (fn []
+       (let [{:keys [network-name] :as network-details} (rf/sub [:wallet/network-details-by-chain-id
+                                                                 chain-id])
+             {fiat-currency :currency}                  (rf/sub [:profile/profile])
+             {token-decimals :decimals
+              :as
+              token}                                    (rf/sub [:wallet/wallet-send-token])
+             currency                                   (rf/sub [:profile/currency])
+             currency-symbol                            (rf/sub [:profile/currency-symbol])
+             send-from-locked-amounts                   (rf/sub [:wallet/wallet-send-from-locked-amounts])
+             locked-amount                              (get send-from-locked-amounts chain-id)
+             network-name-str                           (string/capitalize (name network-name))
+             [input-state set-input-state]              (rn/use-state (cond-> controlled-input/init-state
+                                                                        locked-amount (controlled-input/set-input-value locked-amount)))
+             [crypto-currency? set-crypto-currency]     (rn/use-state true)
+             conversion-rate                            (-> token
+                                                            :market-values-per-currency
+                                                            currency
+                                                            :price)
+             {token-balance :total-balance}             (rf/sub [:wallet/token-by-symbol
+                                                                 (str token-symbol)
+                                                                 [chain-id]])
+             current-crypto-limit                       (utils/get-standard-crypto-format
+                                                         token
+                                                         token-balance)
+             current-fiat-limit                         (.toFixed (* token-balance conversion-rate) 2)
+             current-limit                              (if crypto-currency?
+                                                          current-crypto-limit
+                                                          current-fiat-limit)
+             crypto-decimals                            token-decimals
+             input-amount                               (controlled-input/input-value input-state)
+             [is-amount-locked? set-is-amount-locked] (rn/use-state (some? locked-amount))
+             bottom                                      (safe-area/get-bottom)]
+         (rn/use-effect
+          (fn []
+            (set-input-state #(controlled-input/set-upper-limit % current-limit)))
+          [current-limit])
+         [:<>
+          [quo/drawer-top
+           {:title       (i18n/label :t/send-from-network {:network network-name-str})
+            :description (i18n/label :t/define-amount-sent-from-network {:network network-name-str})}]
+          [quo/token-input
+           {:container-style style/input-container
+            :token           token-symbol
+            :currency        fiat-currency
+            :currency-symbol currency-symbol
+            :crypto-decimals (min token-decimals 6)
+            :error?          (controlled-input/input-error input-state)
+            :networks        [network-details]
+            :title           (i18n/label
+                              :t/send-limit
+                              {:limit (if crypto-currency?
+                                        (make-limit-label-crypto current-limit token-symbol)
+                                        (make-limit-label-fiat current-limit currency-symbol))})
+            :conversion      conversion-rate
+            :show-keyboard?  false
+            :value           (controlled-input/input-value input-state)
+            :on-swap         (fn [swap-to-crypto-currency?]
+                               (set-crypto-currency swap-to-crypto-currency?)
+                               (set-input-state
+                                (fn [input-state]
+                                  (controlled-input/set-input-value
+                                   input-state
+                                   (let [value     (controlled-input/input-value input-state)
+                                         new-value (if swap-to-crypto-currency?
+                                                     (.toFixed (/ value conversion-rate)
+                                                               crypto-decimals)
+                                                     (.toFixed (* value conversion-rate) 12))]
+                                     (number/remove-trailing-zeroes new-value))))))}]
+          [quo/disclaimer
+           {:on-change (fn [checked?]
+                         (tap> {:checked checked?})
+                         (set-is-amount-locked checked?))
+            :checked? is-amount-locked?
+            :container-style style/disclaimer
+            :icon      (if is-amount-locked?
+                         :i/locked
+                         :i/unlocked)}
+           (i18n/label :t/dont-auto-recalculate-network {:network network-name-str})]
+          [quo/bottom-actions
+           {:actions          :one-action
+            :button-one-label (i18n/label :t/update)
+            :button-one-props {:on-press (fn []
+                                           (if is-amount-locked?
+                                             (let [limit-in-crypto (if crypto-currency?
+                                                                     input-amount
+                                                                     (number/remove-trailing-zeroes
+                                                                      (.toFixed (/ input-amount
+                                                                                   conversion-rate)
+                                                                                crypto-decimals)))]
+                                               (rf/dispatch [:wallet/lock-from-amount chain-id limit-in-crypto]))
+                                             (rf/dispatch [:wallet/unlock-from-amount chain-id]))
+                                           (rf/dispatch [:hide-bottom-sheet]))
+                               :disabled? (or (controlled-input/empty-value? input-state)
+                                              (controlled-input/input-error input-state))}}]
+          [quo/numbered-keyboard
+           {:container-style      (style/keyboard-container bottom)
+            :left-action          :dot
+            :delete-key?          true
+            :on-press             (fn [c]
+                                    (let [new-text      (str input-amount c)
+                                          max-decimals  (if crypto-currency? crypto-decimals 2)
+                                          regex-pattern (str "^\\d*\\.?\\d{0," max-decimals "}$")
+                                          regex         (re-pattern regex-pattern)]
+                                      (when (re-matches regex new-text)
+                                        (set-is-amount-locked true)
+                                        (set-input-state #(controlled-input/add-character % c)))))
+            :on-delete            (fn []
+                                    (set-input-state controlled-input/delete-last))
+            :on-long-press-delete (fn []
+                                    (set-input-state controlled-input/delete-all))}]]))}]))
+
 (defn render-network-values
-  [{:keys [network-values token-symbol on-press receiver? loading-routes?
+  [{:keys [network-values token-symbol on-press on-long-press receiver? loading-routes?
            token-not-supported-in-receiver-networks?]}]
   [rn/view
    (map-indexed (fn [index {:keys [chain-id total-amount type]}]
@@ -98,22 +226,27 @@
                    {:key   (str (if receiver? "to" "from") "-" chain-id)
                     :style {:margin-top (if (pos? index) 11 7.5)}}
                    [quo/network-bridge
-                    {:amount   (if (= type :not-available)
-                                 (i18n/label :t/not-available)
-                                 (str total-amount " " token-symbol))
-                     :network  (network-utils/id->network chain-id)
-                     :status   (cond (and (= type :not-available)
-                                          loading-routes?
-                                          token-not-supported-in-receiver-networks?)
-                                     :loading
-                                     (= type :not-available)
-                                     :disabled
-                                     :else type)
-                     :on-press #(when (not loading-routes?)
-                                  (cond
-                                    (= type :edit)
-                                    (open-preferences)
-                                    on-press (on-press chain-id total-amount)))}]])
+                    {:amount        (if (= type :not-available)
+                                      (i18n/label :t/not-available)
+                                      (str total-amount " " token-symbol))
+                     :network       (network-utils/id->network chain-id)
+                     :status        (cond (and (= type :not-available)
+                                               loading-routes?
+                                               token-not-supported-in-receiver-networks?)
+                                          :loading
+                                          (= type :not-available)
+                                          :disabled
+                                          :else type)
+                     :on-press      #(when (not loading-routes?)
+                                       (cond
+                                         (= type :edit)
+                                         (open-preferences)
+                                         on-press (on-press chain-id total-amount)))
+                     :on-long-press #(when (not loading-routes?)
+                                       (cond
+                                         (= type :add)
+                                         (open-preferences)
+                                         on-long-press (on-long-press chain-id)))}]])
                 network-values)])
 
 (defn render-network-links
@@ -155,6 +288,10 @@
 
 (defn disable-chain
   [chain-id disabled-from-chain-ids token-available-networks-for-suggested-routes]
+  #_(tap> {:in                                            `disable-chain
+           :chain-id                                      chain-id
+           :disabled-from-chain-ids                       disabled-from-chain-ids
+           :token-available-networks-for-suggested-routes token-available-networks-for-suggested-routes})
   (let [disabled-chain-ids
         (if (contains? (set
                         disabled-from-chain-ids)
@@ -176,7 +313,7 @@
                      :text (i18n/label :t/at-least-one-network-must-be-activated)}]))))
 
 (defn view
-  [{:keys [token theme input-value value valid-input?
+  [{:keys [token theme input-value valid-input? request-fetch-routes
            lock-fetch-routes? on-press-to-network current-screen-id
            token-not-supported-in-receiver-networks?]}]
   (let [token-symbol (:symbol token)
@@ -202,19 +339,11 @@
        (when (and active-screen?
                   (> (count token-available-networks-for-suggested-routes) 0)
                   (not lock-fetch-routes?))
-         (fetch-routes
-          {:amount             value
-           :valid-input?       valid-input?
-           :bounce-duration-ms 2000
-           :token              token})))
+         (request-fetch-routes 2000)))
      [input-value valid-input?])
     (rn/use-effect
      #(when (and active-screen? (> (count token-available-networks-for-suggested-routes) 0))
-        (fetch-routes
-         {:amount             value
-          :valid-input?       valid-input?
-          :bounce-duration-ms 0
-          :token              token}))
+        (request-fetch-routes 0))
      [disabled-from-chain-ids])
     [rn/scroll-view {:content-container-style style/routes-container}
      (when show-routes?
@@ -234,6 +363,11 @@
                                                       chain-id-to-disable
                                                       disabled-from-chain-ids
                                                       token-available-networks-for-suggested-routes))
+
+        :on-long-press                             (fn [chain-id]
+                                                     (edit-amount
+                                                      {:chain-id     chain-id
+                                                       :token-symbol token-symbol}))
         :receiver?                                 false
         :theme                                     theme
         :loading-routes?                           loading-routes?
@@ -249,8 +383,5 @@
         :loading-routes?                           loading-routes?
         :theme                                     theme
         :token-not-supported-in-receiver-networks? token-not-supported-in-receiver-networks?
-        :on-save                                   #(fetch-routes
-                                                     {:amount             input-value
-                                                      :valid-input?       valid-input?
-                                                      :bounce-duration-ms 0})}]]]))
+        :on-save                                   #(request-fetch-routes 0)}]]]))
 

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -85,9 +85,6 @@
                                            (rf/dispatch [:wallet/update-receiver-networks
                                                          chain-ids]))}]))}]))
 
-(comment
-  (string/capitalize (name :mainnet)))
-
 (defn- make-limit-label-crypto
   [amount currency]
   (str amount

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -113,6 +113,7 @@
              currency-symbol                            (rf/sub [:profile/currency-symbol])
              send-from-locked-amounts                   (rf/sub
                                                          [:wallet/wallet-send-from-locked-amounts])
+             customization-color (rf/sub [:profile/customization-color])
              locked-amount                              (get send-from-locked-amounts chain-id)
              network-name-str                           (string/capitalize (name network-name))
              [input-state set-input-state]              (rn/use-state (cond-> controlled-input/init-state
@@ -181,7 +182,8 @@
             :container-style style/disclaimer
             :icon            (if is-amount-locked?
                                :i/locked
-                               :i/unlocked)}
+                               :i/unlocked)
+            :customization-color customization-color}
            (i18n/label :t/dont-auto-recalculate-network {:network network-name-str})]
           [quo/bottom-actions
            {:actions          :one-action

--- a/src/status_im/contexts/wallet/send/send_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/send_amount/view.cljs
@@ -12,5 +12,6 @@
     :button-one-label  (i18n/label :t/review-send)
     :on-navigate-back  (fn []
                          (rf/dispatch [:wallet/clean-disabled-from-networks])
+                         (rf/dispatch [:wallet/clean-from-locked-amounts])
                          (rf/dispatch [:wallet/clean-send-amount])
                          (rf/dispatch [:navigate-back]))}])

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -119,7 +119,8 @@
    network-amounts))
 
 (defn network-amounts
-  [{:keys [network-values disabled-chain-ids receiver-networks token-networks-ids tx-type receiver? from-locked-amounts]}]
+  [{:keys [network-values disabled-chain-ids receiver-networks token-networks-ids tx-type receiver?
+           from-locked-amounts]}]
   (let [disabled-set                             (set disabled-chain-ids)
         receiver-networks-set                    (set receiver-networks)
         network-values-keys                      (set (keys network-values))
@@ -161,7 +162,7 @@
                                     locked-amount
                                     amount))
                   :type         (cond
-                                  (contains? from-locked-amounts chain-id) :locked
+                                  (contains? from-locked-amounts chain-id)                :locked
                                   (contains? not-available-networks-set chain-id)         :not-available
                                   (or receiver? (not (contains? disabled-set chain-id)))  :default
                                   (and (not receiver?) (contains? disabled-set chain-id)) :disabled)}))

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -157,10 +157,7 @@
               (map
                (fn [[chain-id amount]]
                  {:chain-id     chain-id
-                  :total-amount (let [locked-amount (get from-locked-amounts chain-id)]
-                                  (if locked-amount
-                                    locked-amount
-                                    amount))
+                  :total-amount (get from-locked-amounts chain-id amount)
                   :type         (cond
                                   (contains? from-locked-amounts chain-id)                :locked
                                   (contains? not-available-networks-set chain-id)         :not-available

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -119,7 +119,7 @@
    network-amounts))
 
 (defn network-amounts
-  [{:keys [network-values disabled-chain-ids receiver-networks token-networks-ids tx-type receiver?]}]
+  [{:keys [network-values disabled-chain-ids receiver-networks token-networks-ids tx-type receiver? from-locked-amounts]}]
   (let [disabled-set                             (set disabled-chain-ids)
         receiver-networks-set                    (set receiver-networks)
         network-values-keys                      (set (keys network-values))
@@ -156,8 +156,12 @@
               (map
                (fn [[chain-id amount]]
                  {:chain-id     chain-id
-                  :total-amount amount
+                  :total-amount (let [locked-amount (get from-locked-amounts chain-id)]
+                                  (if locked-amount
+                                    locked-amount
+                                    amount))
                   :type         (cond
+                                  (contains? from-locked-amounts chain-id) :locked
                                   (contains? not-available-networks-set chain-id)         :not-available
                                   (or receiver? (not (contains? disabled-set chain-id)))  :default
                                   (and (not receiver?) (contains? disabled-set chain-id)) :disabled)}))

--- a/src/status_im/subs/wallet/networks.cljs
+++ b/src/status_im/subs/wallet/networks.cljs
@@ -83,6 +83,7 @@
  (fn [networks [_ chain-id]]
    (some #(when (= chain-id (:chain-id %)) %) networks)))
 
+
 (re-frame/reg-sub
  :wallet/selected-network-details
  :<- [:wallet/network-details]

--- a/src/status_im/subs/wallet/networks.cljs
+++ b/src/status_im/subs/wallet/networks.cljs
@@ -83,7 +83,6 @@
  (fn [networks [_ chain-id]]
    (some #(when (= chain-id (:chain-id %)) %) networks)))
 
-
 (re-frame/reg-sub
  :wallet/selected-network-details
  :<- [:wallet/network-details]

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -150,6 +150,11 @@
  :-> :disabled-from-chain-ids)
 
 (rf/reg-sub
+ :wallet/wallet-send-from-locked-amounts
+ :<- [:wallet/wallet-send]
+ :-> :from-locked-amounts)
+
+(rf/reg-sub
  :wallet/wallet-send-from-values-by-chain
  :<- [:wallet/wallet-send]
  :-> :from-values-by-chain)

--- a/translations/en.json
+++ b/translations/en.json
@@ -2704,5 +2704,8 @@
     "saved-address-network-preference-selection-description": "Only change if you know which networks the address owner is happy to to receive funds on",
     "add-preferences": "Add preferences",
     "buy-eth": "Buy ETH",
-    "not-enough-assets": "Not enough assets to pay gas fees"
+    "not-enough-assets": "Not enough assets to pay gas fees",
+    "send-from-network" : "Send from {{network}}",
+    "define-amount-sent-from-network" : "Define amount sent from {{network}} network",
+    "dont-auto-recalculate-network": "Don't auto recalculate {{network}}"
 }


### PR DESCRIPTION
fixes #16974

### Summary

Implemented long tap to edit amount of tokens sent through the specific network


https://github.com/status-im/status-mobile/assets/5786310/84a41136-8613-42ae-b217-20507a62195e


### Review notes
Implemented screen borrows heavily from `send/input_amount/view.cljs`, mostly because of `token-input` component. So there is definitely room for a refactoring but here I'd like to concentrate more on functionality. And postpone refactoring until we decide to refactor `send/input_amount/view.cljs`

### Testing notes
<!-- (Optional) -->


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- wallet / transactions


status: ready
