### PR TITLE
fix member list in community channels

### DIFF
--- a/src/legacy/status_im/data_store/chats.cljs
+++ b/src/legacy/status_im/data_store/chats.cljs
@@ -38,10 +38,12 @@
     :always
     (update :contacts conj (:id member))))
 
+(defn community-chat-id->channel-id [chat-id] (subs chat-id constants/community-id-length))
+
 (defn decode-chat-id
   [chat-id]
   (let [community-id (subs chat-id 0 constants/community-id-length)
-        channel-id   (subs chat-id constants/community-id-length)]
+        channel-id   (community-chat-id->channel-id chat-id)]
     {:community-id community-id
      :channel-id   channel-id}))
 

--- a/src/status_im/contexts/communities/actions/channel_view_details/view.cljs
+++ b/src/status_im/contexts/communities/actions/channel_view_details/view.cljs
@@ -65,7 +65,7 @@
            :as   chat}                   (rf/sub [:chats/chat-by-id chat-id])
           pins-count                     (rf/sub [:chats/pin-messages-count chat-id])
           items                          (rf/sub [:communities/sorted-community-members-section-list
-                                                  community-id])
+                                                  community-id chat-id])
           theme                          (quo.theme/use-theme)]
       (rn/use-mount (fn []
                       (rf/dispatch [:pin-message/load-pin-messages chat-id])))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.180.31",
-    "commit-sha1": "e0673ad1ffec65e3bd96a46b5054fc2d36071cc4",
-    "src-sha256": "15y3fl0q8kqxbsqj9snyg7spaqj09xid9rfza7l5zpk8p0ajqnmk"
+    "version": "v0.181.31",
+    "commit-sha1": "6e056348e6d28f962167118612826f1ef0e47b22",
+    "src-sha256": "1qvfwk28sg93basjzy8r55qz8pk9xg0h7kxv5ykxkbfh4q17a1ns"
 }


### PR DESCRIPTION
This commit does 2 things:
1) Before any channel that had no token permissions would have a list of `members`. This was pointed out as a performance issue. This behaviour has been changed in status-go so that if a channel is not token gated, the list of members is not passed (this is consistent with our network protobufs). This should improve performance as well, in particular for users who are not core contributor of the status-community. Further optimization might be necessary, but that's a separate issue.

2) When opening a channel list for members, the code would check only the communities members and not the channel members. This commit fixes the behavior so that if a channel is token gated, the list of members is used from that channel.
