### PR TITLE
feat(wallet): display saved addresses in send flow

### DIFF
--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -46,16 +46,56 @@
                                                :stack-id  :screen/wallet.select-address}])}]))
             recent-recipients))))
 
+(defn- saved-address
+  [{:keys [name address chain-short-names customization-color ens? ens]}]
+  (let [full-address           (str chain-short-names address)
+        on-press-saved-address (rn/use-callback
+                                #(rf/dispatch
+                                  [:wallet/select-send-address
+                                   {:address   full-address
+                                    :recipient full-address
+                                    :stack-id  :screen/wallet.select-address}])
+                                [full-address])]
+    [quo/saved-address
+     {:user-props      {:name                name
+                        :address             full-address
+                        :ens                 (when ens? ens)
+                        :customization-color customization-color}
+      :container-style {:margin-horizontal 8}
+      :on-press        on-press-saved-address}]))
+
+(defn- saved-addresses
+  [theme]
+  (let [group-saved-addresses (rf/sub [:wallet/grouped-saved-addresses])
+        section-header        (rn/use-callback
+                               (fn [{:keys [title index]}]
+                                 [quo/divider-label
+                                  {:tight?          true
+                                   :container-style (when (pos? index) {:margin-top 8})}
+                                  title]))
+        empty-state-component (rn/use-callback
+                               (fn []
+                                 [quo/empty-state
+                                  {:title       (i18n/label :t/no-saved-addresses)
+                                   :description (i18n/label
+                                                 :t/you-like-to-type-43-characters)
+                                   :image       (resources/get-themed-image :sweating-man
+                                                                            theme)}])
+                               [theme])]
+    [rn/section-list
+     {:key-fn                          :title
+      :shows-vertical-scroll-indicator false
+      :render-section-header-fn        section-header
+      :sections                        group-saved-addresses
+      :render-fn                       saved-address
+      :empty-component                 empty-state-component}]))
+
 (defn view
   [{:keys [selected-tab]}]
   (let [theme (quo.theme/use-theme)]
     (case selected-tab
       :tab/recent      [recent-transactions theme]
-      :tab/saved       [quo/empty-state
-                        {:title           (i18n/label :t/no-saved-addresses)
-                         :description     (i18n/label :t/you-like-to-type-43-characters)
-                         :image           (resources/get-themed-image :sweating-man theme)
-                         :container-style style/empty-container-style}]
+      :tab/saved       [saved-addresses theme]
       :tab/contacts    [quo/empty-state
                         {:title           (i18n/label :t/no-contacts)
                          :description     (i18n/label :t/no-contacts-description)

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -73,7 +73,7 @@
                                   {:tight?          true
                                    :container-style (when (pos? index) {:margin-top 8})}
                                   title]))
-        empty-state-component (rn/use-callback
+        empty-state-component (rn/use-memo
                                (fn []
                                  [quo/empty-state
                                   {:title       (i18n/label :t/no-saved-addresses)


### PR DESCRIPTION
fixes #16993

### Summary

This PR adds a feature to display saved addresses in the send flow

<img width="300" src="https://github.com/status-im/status-mobile/assets/19339952/ea050dd2-9640-4ad7-81f2-c65452b8d99e" />

### Testing notes

Testing will be performed once the saved address EPIC is done

### Platforms

- Android
- iOS


### Steps to test

##### Prerequisites: Add new saved addresses from Wallet Settings

- Open Status
- Navigate to the wallet tab
- Tap on any of the account cards and navigate to Send flow
- Tap on `Saved` Tab
- Verify the saved addresses shown in the tab

status: ready 
