### PR TITLE
feat: rename backupDisabledDataDir to rootDataDir

### DIFF
--- a/src/status_im/contexts/profile/config.cljs
+++ b/src/status_im/contexts/profile/config.cljs
@@ -30,7 +30,7 @@
   (let [log-enabled? (boolean (not-empty config/log-level))]
     (merge (login)
            {:deviceName               (native-module/get-installation-name)
-            :backupDisabledDataDir    (native-module/backup-disabled-data-dir)
+            :rootDataDir              (native-module/backup-disabled-data-dir)
             :rootKeystoreDir          (native-module/keystore-dir)
 
             :logLevel                 (when log-enabled? config/log-level)


### PR DESCRIPTION
-------

fixes #20397

### Summary

`BackupDisabledDataDir` is Deprecated in status-go https://github.com/status-im/status-go/blob/dbed69d1551e3fc9b29a125a36f97cc3fa8af6f3/protocol/requests/create_account.go#L30

background:

I guess this variable name is indicating that the directory won't get auto backuped by apple or google on mobile

Seems it's coming from here 
https://developer.android.com/reference/android/content/Context#getNoBackupFilesDir()
and we use it for blot db https://github.com/boltdb/bolt/blob/master/README.md?plain=1#L670

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
create account

### Steps to test
create account
upgrade app from old version to this version

status: ready <!-- Can be ready or wip -->