### PR TITLE
[#20405] feat: make partially operable key pair to be fully operable

### DIFF
--- a/src/status_im/common/standard_authentication/events.cljs
+++ b/src/status_im/common/standard_authentication/events.cljs
@@ -66,9 +66,12 @@
 (defn- bottom-sheet-password-view
   [{:keys [on-press-biometric on-auth-success auth-button-icon-left auth-button-label]}]
   (fn []
-    (let [handle-password-success (fn [password]
-                                    (rf/dispatch [:standard-auth/reset-login-password])
-                                    (-> password security/hash-masked-password on-auth-success))]
+    (let [handle-password-success
+          (fn [password]
+            (let [sha3-pwd (security/hash-masked-password password)]
+              (rf/dispatch [:standard-auth/reset-login-password])
+              (rf/dispatch [:wallet/make-partially-operable-accounts-fully-operable sha3-pwd])
+              (on-auth-success sha3-pwd)))]
       [enter-password/view
        {:on-enter-password   handle-password-success
         :on-press-biometrics on-press-biometric

--- a/src/status_im/contexts/settings/wallet/data_store.cljs
+++ b/src/status_im/contexts/settings/wallet/data_store.cljs
@@ -23,8 +23,7 @@
   [accounts key-uids-set]
   (reduce-kv
    (fn [acc k account]
-     (if (and (contains? key-uids-set (:key-uid account))
-              (= (keyword (:operable account)) :no))
+     (if (contains? key-uids-set (:key-uid account))
        (assoc acc k (assoc account :operable :fully))
        (assoc acc k account)))
    {}
@@ -45,3 +44,12 @@
                (assoc :lowest-operability :fully))
            keypair))
        keypairs))
+
+(defn map-addresses-to-key-uids
+  [db addresses]
+  (reduce (fn [key-uid-set address]
+            (if-let [account (get-in db [:wallet :accounts address])]
+              (conj key-uid-set (:key-uid account))
+              key-uid-set))
+          #{}
+          addresses))

--- a/src/status_im/contexts/settings/wallet/data_store.cljs
+++ b/src/status_im/contexts/settings/wallet/data_store.cljs
@@ -20,27 +20,51 @@
    keypairs))
 
 (defn make-accounts-fully-operable
-  [accounts key-uids-set]
+  "Updates accounts to be fully operable based on specified key-uids and an optional operable condition.
+
+  Parameters:
+  - :accounts (map): A map of account addresses to account details.
+  - :key-uids-set (set): A set of key-uids that need to be checked and updated.
+  - :operable-condition (keyword, optional): The condition that the account's operability must meet to be updated.
+    If nil or not provided, the function will update all accounts.
+
+  Returns:
+  - A new map with accounts updated to be fully operable where the conditions are met."
+  [{:keys [accounts key-uids-set operable-condition]}]
   (reduce-kv
    (fn [acc k account]
-     (if (contains? key-uids-set (:key-uid account))
+     (if (and (contains? key-uids-set (:key-uid account))
+              (or (nil? operable-condition)
+                  (= (keyword (:operable account)) operable-condition)))
        (assoc acc k (assoc account :operable :fully))
        (assoc acc k account)))
    {}
    accounts))
 
 (defn- make-keypairs-accounts-fully-operable
-  [accounts]
+  [accounts operable-condition]
   (map (fn [account]
-         (assoc account :operable :fully))
+         (if (or (nil? operable-condition) (= (keyword (:operable account)) operable-condition))
+           (assoc account :operable :fully)
+           account))
        accounts))
 
 (defn make-keypairs-fully-operable
-  [keypairs key-uids-set]
+  "Updates keypairs' accounts to be fully operable based on specified key-uids and an optional operable condition.
+
+  Parameters:
+  - :keypairs (seq): A sequence of keypair maps.
+  - :key-uids-set (set): A set of key-uids that need to be checked and updated.
+  - :operable-condition (keyword, optional): The condition that the keypair's accounts' operability must meet to be updated.
+    If nil or not provided, the function will update all keypairs' accounts.
+
+  Returns:
+  - A new sequence with keypairs updated to be fully operable where the conditions are met."
+  [{:keys [keypairs key-uids-set operable-condition]}]
   (map (fn [keypair]
          (if (contains? key-uids-set (:key-uid keypair))
            (-> keypair
-               (update :accounts make-keypairs-accounts-fully-operable)
+               (update :accounts #(make-keypairs-accounts-fully-operable % operable-condition))
                (assoc :lowest-operability :fully))
            keypair))
        keypairs))

--- a/src/status_im/contexts/settings/wallet/events.cljs
+++ b/src/status_im/contexts/settings/wallet/events.cljs
@@ -73,9 +73,14 @@
   [{:keys [db]} [key-uids-to-update]]
   (let [key-uids-set (set key-uids-to-update)
         keypair-name (data-store/extract-keypair-name db key-uids-set)]
-    {:db (-> db
-             (update-in [:wallet :accounts] #(data-store/make-accounts-fully-operable % key-uids-set))
-             (update-in [:wallet :keypairs] #(data-store/make-keypairs-fully-operable % key-uids-set)))
+    {:db (->
+           db
+           (update-in [:wallet :accounts]
+                      #(data-store/make-accounts-fully-operable {:accounts     %
+                                                                 :key-uids-set key-uids-set}))
+           (update-in [:wallet :keypairs]
+                      #(data-store/make-keypairs-fully-operable {:keypairs     %
+                                                                 :key-uids-set key-uids-set})))
      :fx [[:dispatch
            [:toasts/upsert
             {:type  :positive
@@ -226,26 +231,33 @@
 
 (defn make-partially-operable-accounts-fully-operable-success
   [{:keys [db]} [addresses]]
-  (let [key-uids-to-update (data-store/map-addresses-to-key-uids db addresses)
-        key-uids-set       (set key-uids-to-update)]
+  (let [key-uids-to-update (data-store/map-addresses-to-key-uids db addresses)]
     {:db (-> db
-             (update-in [:wallet :accounts] #(data-store/make-accounts-fully-operable % key-uids-set))
+             (update-in [:wallet :accounts]
+                        #(data-store/make-accounts-fully-operable {:accounts           %
+                                                                   :key-uids-set       key-uids-to-update
+                                                                   :operable-condition :partially}))
              (update-in [:wallet :keypairs]
-                        #(data-store/make-keypairs-fully-operable % key-uids-set)))}))
+                        #(data-store/make-keypairs-fully-operable {:keypairs           %
+                                                                   :key-uids-set       key-uids-to-update
+                                                                   :operable-condition :partially})))}))
 
 (rf/reg-event-fx :wallet/make-partially-operable-accounts-fully-operable-success
  make-partially-operable-accounts-fully-operable-success)
 
 (defn make-partially-operable-accounts-fully-operable
-  [_ [password]]
+  [_ [{:keys [password on-success on-error]}]]
   {:fx [[:json-rpc/call
          [{:method     "accounts_makePartiallyOperableAccoutsFullyOperable"
            :params     [(security/safe-unmask-data password)]
            :on-success (fn [addresses]
                          (when addresses
                            (rf/dispatch [:wallet/make-partially-operable-accounts-fully-operable-success
-                                         addresses])))
-           :on-error   #(log/error "failed to make partially accounts fully operable" %)}]]]})
+                                         addresses]))
+                         (on-success))
+           :on-error   (fn [error]
+                         (log/error "failed to make partially accounts fully operable" {:error error})
+                         (on-error error))}]]]})
 
 (rf/reg-event-fx :wallet/make-partially-operable-accounts-fully-operable
  make-partially-operable-accounts-fully-operable)

--- a/src/status_im/contexts/settings/wallet/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/events_test.cljs
@@ -129,3 +129,16 @@
                 (sut/make-seed-phrase-keypair-fully-operable
                  cofx
                  [mnemonic-masked password-masked on-success on-error])))))
+
+(deftest make-partly-operable-accounts-fully-operable-test
+  (let [cofx            {:db {}}
+        password-masked (security/mask-data "password")
+        expected        {:fx [[:json-rpc/call
+                               [{:method     "accounts_makePartiallyOperableAccoutsFullyOperable"
+                                 :params     [(security/safe-unmask-data password-masked)]
+                                 :on-success fn?
+                                 :on-error   fn?}]]]}]
+    (is (match? expected
+                (sut/make-partially-operable-accounts-fully-operable
+                 cofx
+                 [password-masked])))))

--- a/src/status_im/contexts/settings/wallet/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/events_test.cljs
@@ -133,6 +133,8 @@
 (deftest make-partly-operable-accounts-fully-operable-test
   (let [cofx            {:db {}}
         password-masked (security/mask-data "password")
+        on-success      #(prn "success")
+        on-error        #(prn "error")
         expected        {:fx [[:json-rpc/call
                                [{:method     "accounts_makePartiallyOperableAccoutsFullyOperable"
                                  :params     [(security/safe-unmask-data password-masked)]
@@ -141,4 +143,6 @@
     (is (match? expected
                 (sut/make-partially-operable-accounts-fully-operable
                  cofx
-                 [password-masked])))))
+                 [{:password   password-masked
+                   :on-success on-success
+                   :on-error   on-error}])))))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -622,4 +622,6 @@
  :wallet/has-partially-operable-accounts?
  :<- [:wallet/accounts]
  (fn [accounts]
-   (pos? (count (filter #(= :partially (:operable %)) accounts)))))
+   (->> accounts
+        (some #(= :partially (:operable %)))
+        boolean)))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -617,3 +617,9 @@
                                   currency-symbol
                                   fee-in-fiat)]
      fee-formatted)))
+
+(rf/reg-sub
+ :wallet/has-partially-operable-accounts?
+ :<- [:wallet/accounts]
+ (fn [accounts]
+   (pos? (count (filter #(= :partially (:operable %)) accounts)))))

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -912,3 +912,17 @@
                           :market-values-per-currency {:usd {:price 10000}}}
           result         (rf/sub [sub-name token-for-fees])]
       (is (match? result "$1.00")))))
+
+(h/deftest-sub :wallet/has-partially-operable-accounts?
+  [sub-name]
+  (testing "returns false if there are no partially operable accounts"
+    (swap! rf-db/app-db
+      #(assoc-in % [:wallet :accounts] accounts))
+    (is (false? (rf/sub [sub-name]))))
+
+  (testing "returns true if there are partially operable accounts"
+    (swap! rf-db/app-db
+      #(assoc-in %
+        [:wallet :accounts]
+        (update accounts "0x2" assoc :operable :partially)))
+    (is (true? (rf/sub [sub-name])))))


### PR DESCRIPTION
fixes #20405

### Summary

Making `:partially` operable accounts to be `:fully` operable after password authentication (standard authentication)

### Areas that maybe impacted

- Standard authentication (bottom sheet that request user password), for example when you try to sync devices.

### Testing notes

to have `:partially` operable accounts you should :

1. Create a new wallet account for default key pair
2. Backup your account (Legacy Setting -> Sync Settings -> Backup settings -> Perform backup (in footer section))
3. Remove and restore you account with seed phrases. 

Also there is no UI difference between `fully` and `partially` operable accounts

### Steps to test

- Trigger password authentication in any flow like syncing device, after you entered password it should make accounts fully operable 

### Result


https://github.com/status-im/status-mobile/assets/71308738/14001fdb-7e87-402f-87c2-48f58ee38a0d



status: ready
