### PR TITLE
fix group Image can't be set up during group creation in Android

### DIFF
--- a/src/status_im/contexts/chat/group_create/events.cljs
+++ b/src/status_im/contexts/chat/group_create/events.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.chat.group-create.events
-  (:require [legacy.status-im.data-store.chats :as data-store.chats]
+  (:require [clojure.string :as string]
+            [legacy.status-im.data-store.chats :as data-store.chats]
             [oops.core :as oops]
             [re-frame.core :as rf]
             [status-im.common.avatar-picture-picker.view :as avatar-picture-picker]))
@@ -30,7 +31,7 @@
  (fn [_ [{:keys [chat-id group-name color image]}]]
    {:json-rpc/call [{:method      "chat_editChat"
                      :params      ["" chat-id group-name (name color)
-                                   {:imagePath image
+                                   {:imagePath (when image (string/replace-first image #"file://" ""))
                                     :x         0
                                     :y         0
                                     :width     avatar-picture-picker/crop-size


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19993

### Testing
- Please make sure ios is working as expected 
- 19993 also reports another issue specific to iOS, where on the group creation, the image is not visible, but on reopening chat it is. This one looks somewhat timing issue, we probably are navigating to chat on group chat creation but we are updating the image later. I will explore this issue separately.

status: ready
