### PR TITLE
feat(wallet): Remove non operable accounts from account switcher

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -210,12 +210,10 @@
             :always      (assoc-in [:wallet :ui :send :token-display-name]
                           (:symbol token))
             :always      (assoc-in
-                          [:wallet :ui :send
-                           :token-not-supported-in-receiver-networks?]
+                          [:wallet :ui :send :token-not-supported-in-receiver-networks?]
                           token-not-supported-in-receiver-networks?)
             token        (assoc-in [:wallet :ui :send :token] token)
-            token-symbol (assoc-in [:wallet :ui :send :token-symbol]
-                          token-symbol))
+            token-symbol (assoc-in [:wallet :ui :send :token-symbol] token-symbol))
       :fx [[:dispatch [:wallet/clean-suggested-routes]]
            [:dispatch
             [:wallet/wizard-navigate-forward
@@ -253,8 +251,7 @@
                      :collectible
                      :token-display-name
                      :amount
-                     (when (send-utils/tx-type-collectible?
-                            transaction-type)
+                     (when (send-utils/tx-type-collectible? transaction-type)
                        :tx-type))})))
 
 (rf/reg-event-fx

--- a/src/status_im/contexts/wallet/sheets/account_options/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/account_options/view.cljs
@@ -108,8 +108,9 @@
   []
   (let [options-height (reagent/atom 0)]
     (fn []
-      (let [theme                  (quo.theme/use-theme)
-            accounts               (rf/sub [:wallet/accounts-without-current-viewing-account])
+      (let [theme (quo.theme/use-theme)
+            accounts (rf/sub
+                      [:wallet/fully-or-partially-operable-accounts-without-current-viewing-account])
             show-account-selector? (pos? (count accounts))]
         [:<>
          (when show-account-selector?

--- a/src/status_im/contexts/wallet/sheets/select_account/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/select_account/view.cljs
@@ -20,7 +20,7 @@
 (defn view
   []
   (let [selected-account-address (rf/sub [:wallet/current-viewing-account-address])
-        accounts                 (rf/sub [:wallet/accounts-without-watched-accounts])]
+        accounts (rf/sub [:wallet/fully-or-partially-operable-accounts-without-watched-accounts])]
     [:<>
      [quo/drawer-top {:title (i18n/label :t/select-account)}]
      [gesture/flat-list

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -446,6 +446,22 @@
  (fn [accounts]
    (remove :watch-only? accounts)))
 
+(defn- keep-fully-or-partially-operable-accounts
+  [accounts]
+  (filter (fn fully-or-partially-operable? [{:keys [operable]}]
+            (#{:fully :partially} operable))
+          accounts))
+
+(rf/reg-sub
+ :wallet/fully-or-partially-operable-accounts-without-current-viewing-account
+ :<- [:wallet/accounts-without-current-viewing-account]
+ keep-fully-or-partially-operable-accounts)
+
+(rf/reg-sub
+ :wallet/fully-or-partially-operable-accounts-without-watched-accounts
+ :<- [:wallet/accounts-without-watched-accounts]
+ keep-fully-or-partially-operable-accounts)
+
 (rf/reg-sub
  :wallet/accounts-with-current-asset
  :<- [:wallet/accounts-without-watched-accounts]

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -464,7 +464,7 @@
 
 (rf/reg-sub
  :wallet/accounts-with-current-asset
- :<- [:wallet/accounts-without-watched-accounts]
+ :<- [:wallet/fully-or-partially-operable-accounts-without-watched-accounts]
  :<- [:wallet/wallet-send-token-symbol]
  :<- [:wallet/wallet-send-token]
  (fn [[accounts token-symbol token]]

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -15,10 +15,12 @@
 (def ^:private accounts-with-tokens
   {:0x1 {:tokens                    [{:symbol "ETH"} {:symbol "SNT"}]
          :network-preferences-names #{}
-         :customization-color       nil}
+         :customization-color       nil
+         :operable                  :fully}
    :0x2 {:tokens                    [{:symbol "SNT"}]
          :network-preferences-names #{}
-         :customization-color       nil}})
+         :customization-color       nil
+         :operable                  :partially}})
 
 (def tokens-0x1
   [{:decimals                   1
@@ -481,7 +483,8 @@
       (is (match? result
                   [{:tokens                    [{:symbol "ETH"} {:symbol "SNT"}]
                     :network-preferences-names #{}
-                    :customization-color       nil}]))))
+                    :customization-color       nil
+                    :operable                  :fully}]))))
 
   (testing "returns the accounts list with the current asset using token"
     (swap! rf-db/app-db
@@ -492,7 +495,8 @@
       (is (match? result
                   [{:tokens                    [{:symbol "ETH"} {:symbol "SNT"}]
                     :network-preferences-names #{}
-                    :customization-color       nil}]))))
+                    :customization-color       nil
+                    :operable                  :fully}]))))
 
   (testing
     "returns the full accounts list with the current asset using token-symbol if each account has the asset"


### PR DESCRIPTION
fixes #20253 

### Summary

This PR removes the non operable accounts from the account switcher

[Screencast from 2024-06-13 14-14-51.webm](https://github.com/status-im/status-mobile/assets/90291778/6191ab0d-5a58-4c8a-ae43-add1132783d7)

### Steps to test

- Open Status
- Create a new keypair and derive some new accounts
- Perform a waku backup
- Log out and remove the profile
- Log in
- The account switcher doesn't allow you to switch to the non operable accounts.

### Before and after screenshots comparison

status: ready
