### PR TITLE
fix_: update message content type when an emoji message is editted

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.180.31",
-    "commit-sha1": "e0673ad1ffec65e3bd96a46b5054fc2d36071cc4",
-    "src-sha256": "15y3fl0q8kqxbsqj9snyg7spaqj09xid9rfza7l5zpk8p0ajqnmk"
+    "version": "fix/editted-emoji-msg-formatting",
+    "commit-sha1": "9bcb23b7a116cc678bd839cb1a8ef01d2eb776ad",
+    "src-sha256": "06vz09660km1xm0g6zfv7a28vf16ib46kkdiq3h3gsy0z0nyq6gw"
 }


### PR DESCRIPTION
fixes #https://github.com/status-im/status-mobile/issues/20352

### Summary

On status-go when an emoji message is sent, the contentType is `EMOJI` and when the message is editted with a text the contentType is updated to `TEXT_PLAIN` but when the message is received on mobile, the content-type is not updated to the updated contentType hence the reason why messages were still emoji styling instead of text.

On status-go we check if the message contentType is an emoji and check if the county of emojis in the message equal 0 and if true we update the message contentType to `TEXT_PLAIN`. This fixes the issue

The status-go pr https://github.com/status-im/status-go/pull/5353


### Video

https://github.com/status-im/status-mobile/assets/28704507/0eff26b4-38b8-4082-a16d-1c7f1fe24f08

In the screenshots above the message were emoji before and after being editted on desktop now they are correctly formatted as text

status: ready


