### PR TITLE
fix(wallet): saved addresses ens

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -156,7 +156,7 @@
                                                (rf/dispatch
                                                 [:wallet/set-address-to-save
                                                  {:address address
-                                                  :ens     address-or-ens
+                                                  :ens     (when ens-name? address-or-ens)
                                                   :ens?    ens-name?}])
                                                (rf/dispatch
                                                 [:open-modal :screen/settings.save-address]))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
@@ -90,7 +90,8 @@
 (defn add-saved-address-success
   [_ [toast-message]]
   {:fx [[:dispatch [:wallet/get-saved-addresses]]
-        [:dispatch [:navigate-back-to :screen/settings.saved-addresses]]
+        [:dispatch [:dismiss-modal :screen/settings.add-address-to-save]]
+        [:dispatch [:dismiss-modal :screen/settings.save-address]]
         [:dispatch-later
          {:ms       100
           :dispatch [:toasts/upsert
@@ -103,7 +104,7 @@
 (defn edit-saved-address-success
   [_]
   {:fx [[:dispatch [:wallet/get-saved-addresses]]
-        [:dispatch [:navigate-back]]
+        [:dispatch [:dismiss-modal :screen/settings.edit-saved-address]]
         [:dispatch-later
          {:ms       100
           :dispatch [:toasts/upsert

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
@@ -152,14 +152,15 @@
           effects       (events/add-saved-address-success cofx [toast-message])
           result-fx     (:fx effects)
           expected-fx   [[:dispatch [:wallet/get-saved-addresses]]
-                         [:dispatch [:navigate-back-to :screen/settings.saved-addresses]]
+                         [:dispatch [:dismiss-modal :screen/settings.add-address-to-save]]
+                         [:dispatch [:dismiss-modal :screen/settings.save-address]]
                          [:dispatch-later
                           {:ms       100
                            :dispatch [:toasts/upsert
                                       {:type  :positive
                                        :theme :dark
                                        :text  toast-message}]}]]]
-      (is (= (count result-fx) 3))
+      (is (= (count result-fx) 4))
       (is (match? expected-fx result-fx)))))
 
 (deftest edit-saved-address-success-test
@@ -169,7 +170,7 @@
           effects       (events/edit-saved-address-success cofx)
           result-fx     (:fx effects)
           expected-fx   [[:dispatch [:wallet/get-saved-addresses]]
-                         [:dispatch [:navigate-back]]
+                         [:dispatch [:dismiss-modal :screen/settings.edit-saved-address]]
                          [:dispatch-later
                           {:ms       100
                            :dispatch [:toasts/upsert

--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -81,7 +81,7 @@
                                         :on-error
                                         [:wallet/add-saved-address-failed]
                                         :name address-label
-                                        :ens ens
+                                        :ens (when ens? ens)
                                         :address address-without-prefix
                                         :customization-color address-color
                                         :chain-short-names chain-short-names}]))
@@ -93,7 +93,7 @@
                                    :subtitle-type   :default
                                    :label           :none
                                    :blur?           true
-                                   :icon-right?     true
+                                   :icon-right?     (not ens?)
                                    :right-icon      :i/advanced
                                    :card?           true
                                    :title           (i18n/label :t/address)

--- a/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
@@ -46,6 +46,8 @@
                                                         {:address address
                                                          :chain-short-names chain-short-names
                                                          :full-address full-address
+                                                         :ens? ens?
+                                                         :ens ens
                                                          :name name
                                                          :network-preferences-names
                                                          network-preferences-names


### PR DESCRIPTION
### Summary

This PR
 - fixes addresses are displayed without truncation
 - fixes network preference (advanced icon) shown for ENS
 - fixes navigation on adding a new saved address

### Testing notes

This feature is behind the feature flag and this PR does NOT update any existing features. The testing will be performed once the saved addresses EPIC is done.

### Platforms

- Android
- iOS

status: ready