### PR TITLE
chore(wallet): refactor keypairs data in app-db

### DIFF
--- a/src/status_im/contexts/settings/wallet/data_store.cljs
+++ b/src/status_im/contexts/settings/wallet/data_store.cljs
@@ -53,7 +53,7 @@
              {}
              keypairs))
 
-(defn map-addresses-to-key-uids
+(defn get-keypair-key-uids-set-from-addresses
   [db addresses]
   (reduce (fn [key-uid-set address]
             (if-let [account-key-uid (get-in db [:wallet :accounts address :key-uid])]

--- a/src/status_im/contexts/settings/wallet/data_store.cljs
+++ b/src/status_im/contexts/settings/wallet/data_store.cljs
@@ -1,24 +1,5 @@
 (ns status-im.contexts.settings.wallet.data-store)
 
-(defn extract-keypair-name
-  [db key-uids-set]
-  (when (= (count key-uids-set) 1)
-    (let [key-uid  (first key-uids-set)
-          keypairs (get-in db [:wallet :keypairs])]
-      (->> (filter #(= (:key-uid %) key-uid) keypairs)
-           first
-           :name))))
-
-(defn update-keypair
-  [keypairs key-uid update-fn]
-  (mapcat (fn [keypair]
-            (if (= (keypair :key-uid) key-uid)
-              (if-let [updated (update-fn keypair)]
-                [updated]
-                [])
-              [keypair]))
-   keypairs))
-
 (defn make-accounts-fully-operable
   "Updates accounts to be fully operable based on specified key-uids and an optional operable condition.
 
@@ -32,10 +13,10 @@
   - A new map with accounts updated to be fully operable where the conditions are met."
   [{:keys [accounts key-uids-set operable-condition]}]
   (reduce-kv
-   (fn [acc k account]
-     (if (and (contains? key-uids-set (:key-uid account))
+   (fn [acc k {:keys [key-uid] :as account}]
+     (if (and (contains? key-uids-set key-uid)
               (or (nil? operable-condition)
-                  (= (keyword (:operable account)) operable-condition)))
+                  (= (:operable account) operable-condition)))
        (assoc acc k (assoc account :operable :fully))
        (assoc acc k account)))
    {}
@@ -44,7 +25,7 @@
 (defn- make-keypairs-accounts-fully-operable
   [accounts operable-condition]
   (map (fn [account]
-         (if (or (nil? operable-condition) (= (keyword (:operable account)) operable-condition))
+         (if (or (nil? operable-condition) (= (:operable account) operable-condition))
            (assoc account :operable :fully)
            account))
        accounts))
@@ -53,27 +34,30 @@
   "Updates keypairs' accounts to be fully operable based on specified key-uids and an optional operable condition.
 
   Parameters:
-  - :keypairs (seq): A sequence of keypair maps.
+  - :keypairs (map): A map of keypair key-uid to keypair details.
   - :key-uids-set (set): A set of key-uids that need to be checked and updated.
   - :operable-condition (keyword, optional): The condition that the keypair's accounts' operability must meet to be updated.
     If nil or not provided, the function will update all keypairs' accounts.
 
   Returns:
-  - A new sequence with keypairs updated to be fully operable where the conditions are met."
+  - A new map with keypairs updated to be fully operable where the conditions are met."
   [{:keys [keypairs key-uids-set operable-condition]}]
-  (map (fn [keypair]
-         (if (contains? key-uids-set (:key-uid keypair))
-           (-> keypair
-               (update :accounts #(make-keypairs-accounts-fully-operable % operable-condition))
-               (assoc :lowest-operability :fully))
-           keypair))
-       keypairs))
+  (reduce-kv (fn [acc k keypair]
+               (if (contains? key-uids-set k)
+                 (assoc acc
+                        k
+                        (-> keypair
+                            (update :accounts make-keypairs-accounts-fully-operable operable-condition)
+                            (assoc :lowest-operability :fully)))
+                 (assoc acc k keypair)))
+             {}
+             keypairs))
 
 (defn map-addresses-to-key-uids
   [db addresses]
   (reduce (fn [key-uid-set address]
-            (if-let [account (get-in db [:wallet :accounts address])]
-              (conj key-uid-set (:key-uid account))
+            (if-let [account-key-uid (get-in db [:wallet :accounts address :key-uid])]
+              (conj key-uid-set account-key-uid)
               key-uid-set))
           #{}
           addresses))

--- a/src/status_im/contexts/settings/wallet/events.cljs
+++ b/src/status_im/contexts/settings/wallet/events.cljs
@@ -230,7 +230,7 @@
 
 (defn make-partially-operable-accounts-fully-operable-success
   [{:keys [db]} [addresses]]
-  (let [key-uids-to-update (data-store/map-addresses-to-key-uids db addresses)]
+  (let [key-uids-to-update (data-store/get-keypair-key-uids-set-from-addresses db addresses)]
     {:db (-> db
              (update-in [:wallet :accounts]
                         #(data-store/make-accounts-fully-operable {:accounts           %

--- a/src/status_im/contexts/settings/wallet/events.cljs
+++ b/src/status_im/contexts/settings/wallet/events.cljs
@@ -10,9 +10,7 @@
 (rf/reg-event-fx
  :wallet/rename-keypair-success
  (fn [{:keys [db]} [key-uid name]]
-   {:db (update-in db
-                   [:wallet :keypairs]
-                   #(data-store/update-keypair % key-uid (fn [keypair] (assoc keypair :name name))))
+   {:db (update-in db [:wallet :keypairs key-uid] assoc :name name)
     :fx [[:dispatch [:navigate-back]]
          [:dispatch
           [:toasts/upsert
@@ -49,9 +47,7 @@
 
 (rf/reg-event-fx :wallet/remove-keypair-success
  (fn [{:keys [db]} [key-uid]]
-   {:db (update-in db
-                   [:wallet :keypairs]
-                   #(data-store/update-keypair % key-uid (fn [_] nil)))
+   {:db (update-in db [:wallet :keypairs] dissoc key-uid)
     :fx [[:dispatch [:hide-bottom-sheet]]
          [:dispatch
           [:toasts/upsert
@@ -71,8 +67,11 @@
 
 (defn make-keypairs-accounts-fully-operable
   [{:keys [db]} [key-uids-to-update]]
-  (let [key-uids-set (set key-uids-to-update)
-        keypair-name (data-store/extract-keypair-name db key-uids-set)]
+  (let [key-uids-set              (set key-uids-to-update)
+        single-keypair-to-update? (= (count key-uids-to-update) 1)
+        keypair-name              (when single-keypair-to-update?
+                                    (let [key-uid (first key-uids-set)]
+                                      (get-in db [:wallet :keypairs key-uid :name])))]
     {:db (->
            db
            (update-in [:wallet :accounts]
@@ -85,7 +84,7 @@
            [:toasts/upsert
             {:type  :positive
              :theme :dark
-             :text  (if (= (count key-uids-to-update) 1)
+             :text  (if single-keypair-to-update?
                       (i18n/label :t/key-pair-imported-successfully {:name keypair-name})
                       (i18n/label :t/key-pairs-successfully-imported
                                   {:count (count key-uids-to-update)}))}]]]}))

--- a/src/status_im/contexts/settings/wallet/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/events_test.cljs
@@ -29,7 +29,7 @@
                                           :keypair-name new-keypair-name}])))))))
 
 (deftest get-keypair-export-connection-test
-  (let [cofx         {:db (mock-db [] {})}
+  (let [cofx         {:db (mock-db {} {})}
         sha3-pwd     "test-password"
         user-key-uid "test-key-uid"
         callback     (fn [connect-string] (println "callback" connect-string))]
@@ -57,23 +57,23 @@
                     (sut/remove-keypair cofx [mock-key-uid])))))))
 
 (deftest make-keypairs-accounts-fully-operable-test
-  (let [db                 (mock-db [{:key-uid            mock-key-uid
-                                      :lowest-operability :no
-                                      :accounts           [{:key-uid mock-key-uid :operable "no"}]}]
-                                    {"0x1" {:key-uid mock-key-uid :operable "no"}})
+  (let [db                 (mock-db {mock-key-uid {:key-uid            mock-key-uid
+                                                   :lowest-operability :no
+                                                   :accounts           [{:key-uid  mock-key-uid
+                                                                         :operable :no}]}}
+                                    {"0x1" {:key-uid mock-key-uid :operable :no}})
         key-uids-to-update [mock-key-uid]]
     (testing "make-keypairs-accounts-fully-operable"
       (let [effects         (sut/make-keypairs-accounts-fully-operable {:db db} [key-uids-to-update])
             result-db       (:db effects)
-            updated-keypair (some #(when (= (:key-uid %) mock-key-uid) %)
-                                  (get-in result-db [:wallet :keypairs]))
+            updated-keypair (get-in result-db [:wallet :keypairs mock-key-uid])
             updated-account (get-in result-db [:wallet :accounts "0x1"])]
-        (is (= (keyword (-> updated-keypair :accounts first :operable)) :fully))
-        (is (= (keyword (:operable updated-account)) :fully))
+        (is (= (-> updated-keypair :accounts first :operable) :fully))
+        (is (= (:operable updated-account) :fully))
         (is (= (:lowest-operability updated-keypair) :fully))))))
 
 (deftest connection-string-for-import-keypair-test
-  (let [cofx              {:db (mock-db [] {})}
+  (let [cofx              {:db (mock-db {} {})}
         sha3-pwd          "test-password"
         user-key-uid      "test-key-uid"
         connection-string "test-connection-string"]

--- a/src/status_im/contexts/settings/wallet/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/events_test.cljs
@@ -1,104 +1,100 @@
 (ns status-im.contexts.settings.wallet.events-test
   (:require
-    [cljs.test :refer-macros [deftest is testing]]
+    [cljs.test :refer-macros [deftest is]]
     matcher-combinators.test
     [native-module.core :as native-module]
     [status-im.contexts.settings.wallet.events :as sut]
     [utils.security.core :as security]))
 
-(def mock-key-uid "key-1")
-(defn mock-db
-  [keypairs accounts]
-  {:wallet          {:keypairs keypairs
-                     :accounts accounts}
-   :profile/profile {:key-uid "test-key-uid"}})
+(def test-profile {:key-uid "test-key-uid"})
+(def test-keypair-key-uid "key-1")
 
 (deftest rename-keypair-test
   (let [new-keypair-name "key pair new"
-        cofx             {:db {}}]
-    (testing "rename-keypair"
-      (let [expected {:fx [[:json-rpc/call
-                            [{:method     "accounts_updateKeypairName"
-                              :params     [mock-key-uid new-keypair-name]
-                              :on-success [:wallet/rename-keypair-success mock-key-uid
-                                           new-keypair-name]
-                              :on-error   fn?}]]]}]
-        (is (match? expected
-                    (sut/rename-keypair cofx
-                                        [{:key-uid      mock-key-uid
-                                          :keypair-name new-keypair-name}])))))))
+        cofx             {:db {}}
+        expected         {:fx [[:json-rpc/call
+                                [{:method     "accounts_updateKeypairName"
+                                  :params     [test-keypair-key-uid new-keypair-name]
+                                  :on-success [:wallet/rename-keypair-success test-keypair-key-uid
+                                               new-keypair-name]
+                                  :on-error   fn?}]]]}]
+    (is (match? expected
+                (sut/rename-keypair cofx
+                                    [{:key-uid      test-keypair-key-uid
+                                      :keypair-name new-keypair-name}])))))
 
 (deftest get-keypair-export-connection-test
-  (let [cofx         {:db (mock-db {} {})}
+  (let [cofx         {:db {:profile/profile test-profile}}
         sha3-pwd     "test-password"
         user-key-uid "test-key-uid"
-        callback     (fn [connect-string] (println "callback" connect-string))]
-    (testing "get-keypair-export-connection"
-      (let [expected {:fx [[:effects.syncing/export-keypairs-keystores
+        callback     (fn [connect-string] (println "callback" connect-string))
+        expected     {:fx [[:effects.syncing/export-keypairs-keystores
                             {:key-uid         user-key-uid
                              :sha3-pwd        sha3-pwd
-                             :keypair-key-uid mock-key-uid
+                             :keypair-key-uid test-keypair-key-uid
                              :on-success      fn?
                              :on-fail         fn?}]]}]
-        (is (match? expected
-                    (sut/get-keypair-export-connection
-                     cofx
-                     [{:sha3-pwd sha3-pwd :keypair-key-uid mock-key-uid :callback callback}])))))))
+    (is (match?
+         expected
+         (sut/get-keypair-export-connection
+          cofx
+          [{:sha3-pwd sha3-pwd :keypair-key-uid test-keypair-key-uid :callback callback}])))))
 
 (deftest remove-keypair-test
-  (let [cofx {:db {}}]
-    (testing "remove-keypair"
-      (let [expected {:fx [[:json-rpc/call
-                            [{:method     "accounts_deleteKeypair"
-                              :params     [mock-key-uid]
-                              :on-success [:wallet/remove-keypair-success mock-key-uid]
-                              :on-error   fn?}]]]}]
-        (is (match? expected
-                    (sut/remove-keypair cofx [mock-key-uid])))))))
+  (let [cofx     {:db {}}
+        expected {:fx [[:json-rpc/call
+                        [{:method     "accounts_deleteKeypair"
+                          :params     [test-keypair-key-uid]
+                          :on-success [:wallet/remove-keypair-success test-keypair-key-uid]
+                          :on-error   fn?}]]]}]
+    (is (match? expected
+                (sut/remove-keypair cofx [test-keypair-key-uid])))))
 
 (deftest make-keypairs-accounts-fully-operable-test
-  (let [db                 (mock-db {mock-key-uid {:key-uid            mock-key-uid
-                                                   :lowest-operability :no
-                                                   :accounts           [{:key-uid  mock-key-uid
-                                                                         :operable :no}]}}
-                                    {"0x1" {:key-uid mock-key-uid :operable :no}})
-        key-uids-to-update [mock-key-uid]]
-    (testing "make-keypairs-accounts-fully-operable"
-      (let [effects         (sut/make-keypairs-accounts-fully-operable {:db db} [key-uids-to-update])
-            result-db       (:db effects)
-            updated-keypair (get-in result-db [:wallet :keypairs mock-key-uid])
-            updated-account (get-in result-db [:wallet :accounts "0x1"])]
-        (is (= (-> updated-keypair :accounts first :operable) :fully))
-        (is (= (:operable updated-account) :fully))
-        (is (= (:lowest-operability updated-keypair) :fully))))))
+  (let [db                 {:wallet          {:keypairs {test-keypair-key-uid {:key-uid
+                                                                               test-keypair-key-uid
+                                                                               :lowest-operability :no
+                                                                               :accounts
+                                                                               [{:key-uid
+                                                                                 test-keypair-key-uid
+                                                                                 :operable :no}]}}
+                                              :accounts {"0x1" {:key-uid  test-keypair-key-uid
+                                                                :operable :no}}}
+                            :profile/profile test-profile}
+        key-uids-to-update [test-keypair-key-uid]
+        effects            (sut/make-keypairs-accounts-fully-operable {:db db} [key-uids-to-update])
+        result-db          (:db effects)
+        updated-keypair    (get-in result-db [:wallet :keypairs test-keypair-key-uid])
+        updated-account    (get-in result-db [:wallet :accounts "0x1"])]
+    (is (= (-> updated-keypair :accounts first :operable) :fully))
+    (is (= (:operable updated-account) :fully))
+    (is (= (:lowest-operability updated-keypair) :fully))))
 
 (deftest connection-string-for-import-keypair-test
-  (let [cofx              {:db (mock-db {} {})}
+  (let [cofx              {:db {:profile/profile test-profile}}
         sha3-pwd          "test-password"
         user-key-uid      "test-key-uid"
-        connection-string "test-connection-string"]
-    (testing "connection-string-for-import-keypair"
-      (let [expected {:fx [[:effects.syncing/import-keypairs-keystores
-                            {:key-uid           user-key-uid
-                             :sha3-pwd          sha3-pwd
-                             :keypairs-key-uids [mock-key-uid]
-                             :connection-string connection-string
-                             :on-success        fn?
-                             :on-fail           fn?}]]}]
-        (is (match? expected
-                    (sut/connection-string-for-import-keypair cofx
-                                                              [{:sha3-pwd sha3-pwd
-                                                                :keypairs-key-uids [mock-key-uid]
-                                                                :connection-string
-                                                                connection-string}])))))))
+        connection-string "test-connection-string"
+        expected          {:fx [[:effects.syncing/import-keypairs-keystores
+                                 {:key-uid           user-key-uid
+                                  :sha3-pwd          sha3-pwd
+                                  :keypairs-key-uids [test-keypair-key-uid]
+                                  :connection-string connection-string
+                                  :on-success        fn?
+                                  :on-fail           fn?}]]}]
+    (is (match? expected
+                (sut/connection-string-for-import-keypair cofx
+                                                          [{:sha3-pwd sha3-pwd
+                                                            :keypairs-key-uids [test-keypair-key-uid]
+                                                            :connection-string
+                                                            connection-string}])))))
 
 (deftest success-keypair-qr-scan-test
   (let [connection-string "valid-connection-string"
-        keypairs-key-uids ["keypair-uid"]]
-    (testing "success-keypair-qr-scan"
-      (let [effects (sut/success-keypair-qr-scan nil [connection-string keypairs-key-uids])
-            fx      (:fx effects)]
-        (is (some? fx))))))
+        keypairs-key-uids [test-keypair-key-uid]
+        effects           (sut/success-keypair-qr-scan nil [connection-string keypairs-key-uids])
+        fx                (:fx effects)]
+    (is (some? fx))))
 
 (deftest wallet-validate-seed-phrase-test
   (let [cofx               {:db {}}

--- a/src/status_im/contexts/wallet/account/tabs/about/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/about/view.cljs
@@ -71,16 +71,14 @@
         {keypair-name :name
          keypair-type :type}                      (rf/sub [:wallet/current-viewing-account-keypair])
         networks                                  (rf/sub [:wallet/network-preference-details])
-        origin-type                               (rn/use-memo
-                                                   #(case keypair-type
-                                                      :seed
-                                                      :recovery-phrase
+        origin-type                               (case keypair-type
+                                                    :seed
+                                                    :recovery-phrase
 
-                                                      :key
-                                                      :private-key
+                                                    :key
+                                                    :private-key
 
-                                                      :default-keypair)
-                                                   [keypair-type])]
+                                                    :default-keypair)]
     [rn/scroll-view
      {:style                   style/about-tab
       :content-container-style {:padding-bottom (+ constants/floating-shell-button-height 8)}}

--- a/src/status_im/contexts/wallet/account/tabs/about/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/about/view.cljs
@@ -70,7 +70,17 @@
         {:keys [address path watch-only?]}        (rf/sub [:wallet/current-viewing-account])
         {keypair-name :name
          keypair-type :type}                      (rf/sub [:wallet/current-viewing-account-keypair])
-        networks                                  (rf/sub [:wallet/network-preference-details])]
+        networks                                  (rf/sub [:wallet/network-preference-details])
+        origin-type                               (rn/use-memo
+                                                   #(case keypair-type
+                                                      :seed
+                                                      :recovery-phrase
+
+                                                      :key
+                                                      :private-key
+
+                                                      :default-keypair)
+                                                   [keypair-type])]
     [rn/scroll-view
      {:style                   style/about-tab
       :content-container-style {:padding-bottom (+ constants/floating-shell-button-height 8)}}
@@ -89,7 +99,7 @@
        :on-press        #(rf/dispatch [:show-bottom-sheet {:content about-options}])}]
      (when (not watch-only?)
        [quo/account-origin
-        {:type                (if (= keypair-type "seed") :recovery-phrase :default-keypair)
+        {:type                origin-type
          :stored              :on-device
          :profile-picture     (profile.utils/photo profile)
          :customization-color customization-color

--- a/src/status_im/contexts/wallet/add_account/create_account/select_keypair/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/select_keypair/view.cljs
@@ -73,7 +73,7 @@
   []
   (let [compressed-key                          (rf/sub [:profile/compressed-key])
         customization-color                     (rf/sub [:profile/customization-color])
-        keypairs                                (rf/sub [:wallet/keypairs])
+        keypairs                                (rf/sub [:wallet/keypairs-list])
         selected-keypair                        (rf/sub [:wallet/selected-keypair-uid])
         profile-picture                         (rf/sub [:profile/image])
         [selected-key-uid set-selected-key-uid] (rn/use-state selected-keypair)]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -529,10 +529,9 @@
  :wallet/process-keypair-from-backup
  (fn [{:keys [db]} [{:keys [backedUpKeypair]}]]
    (let [{:keys [key-uid accounts]} backedUpKeypair
-         keypairs-db                (get-in db [:wallet :keypairs])
-         updated-keypairs           (-> (filter #(not= (:key-uid %) key-uid) keypairs-db)
-                                        (conj backedUpKeypair)
-                                        data-store/rpc->keypairs)
+         updated-keypairs           (assoc-in db
+                                     [:wallet :keypairs key-uid]
+                                     (data-store/rpc->keypair backedUpKeypair))
          accounts-fx                (mapv (fn [{:keys [chat] :as account}]
                                             ;; We exclude the chat account from the profile keypair
                                             ;; for fetching the assets

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -345,7 +345,7 @@
                                 (= operable :no) :missing-keypair
                                 watch-only?      :watch-only
                                 :else            :empty)
-                 keypair      (first (filter #(= key-uid (:key-uid %)) keypairs))]
+                 keypair      (get keypairs key-uid)]
              (assoc account
                     :customization-color color
                     :type                (cond

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -600,18 +600,6 @@
              (assoc :network-preferences-names #{}))]
         (rf/sub [sub-name])))))
 
-(def keypairs
-  [{:key-uid "abc"}])
-
-(h/deftest-sub :wallet/keypairs
-  [sub-name]
-  (testing "returns all keypairs"
-    (swap! rf-db/app-db
-      #(assoc-in % [:wallet :keypairs] keypairs))
-    (is
-     (= keypairs
-        (rf/sub [sub-name])))))
-
 (def chat-account
   {:path     "m/43'/60'/1581'/0'/0"
    :emoji    ""
@@ -654,19 +642,42 @@
    :operable :no
    :removed  false})
 
-(def default-keypair-accounts
-  {:key-uid            "abc"
+(def profile-key-pair-key-uid "abc")
+(def seed-phrase-key-pair-key-uid "def")
+
+(def profile-keypair
+  {:key-uid            profile-key-pair-key-uid
    :name               "My Profile"
-   :type               "profile"
+   :type               :profile
    :lowest-operability :fully
    :accounts           []})
 
-(def seed-phrase-keypair-accounts
-  {:key-uid            "def"
+(def seed-phrase-keypair
+  {:key-uid            seed-phrase-key-pair-key-uid
    :name               "My Key Pair"
-   :type               "seed"
+   :type               :seed
    :lowest-operability :no
    :accounts           []})
+
+(h/deftest-sub :wallet/keypairs
+  [sub-name]
+  (testing "returns keypairs map"
+    (swap! rf-db/app-db #(assoc-in %
+                          [:wallet :keypairs]
+                          {profile-key-pair-key-uid profile-keypair}))
+    (is (match? {profile-key-pair-key-uid profile-keypair} (rf/sub [sub-name])))))
+
+(h/deftest-sub :wallet/keypairs-list
+  [sub-name]
+  (testing "returns all keypairs"
+    (swap! rf-db/app-db #(assoc-in %
+                          [:wallet :keypairs]
+                          {profile-key-pair-key-uid     profile-keypair
+                           seed-phrase-key-pair-key-uid seed-phrase-keypair}))
+    (let [result   (rf/sub [sub-name])
+          expected (list profile-keypair seed-phrase-keypair)]
+      (is (match? 2 (count result)))
+      (is (match? expected result)))))
 
 (h/deftest-sub :wallet/settings-keypairs-accounts
   [sub-name]
@@ -676,12 +687,14 @@
         (-> db
             (assoc-in
              [:wallet :keypairs]
-             [(assoc default-keypair-accounts
-                     :accounts
-                     [operable-wallet-account])
-              (assoc seed-phrase-keypair-accounts
-                     :accounts
-                     [inoperable-wallet-account])])
+             {profile-key-pair-key-uid     (update profile-keypair
+                                                   :accounts
+                                                   conj
+                                                   operable-wallet-account)
+              seed-phrase-key-pair-key-uid (update seed-phrase-keypair
+                                                   :accounts
+                                                   conj
+                                                   inoperable-wallet-account)})
             (assoc-in
              [:wallet :accounts]
              {(:address operable-wallet-account)   operable-wallet-account
@@ -689,15 +702,15 @@
 
     (is
      (match?
-      {:missing  [{:name     (:name seed-phrase-keypair-accounts)
-                   :key-uid  (:key-uid seed-phrase-keypair-accounts)
-                   :type     (keyword (:type seed-phrase-keypair-accounts))
+      {:missing  [{:name     (:name seed-phrase-keypair)
+                   :key-uid  (:key-uid seed-phrase-keypair)
+                   :type     (:type seed-phrase-keypair)
                    :accounts [{:customization-color (:color inoperable-wallet-account)
                                :emoji               (:emoji inoperable-wallet-account)
                                :type                :default}]}]
-       :operable [{:name     (:name default-keypair-accounts)
-                   :key-uid  (:key-uid default-keypair-accounts)
-                   :type     (keyword (:type default-keypair-accounts))
+       :operable [{:name     (:name profile-keypair)
+                   :key-uid  (:key-uid profile-keypair)
+                   :type     (:type profile-keypair)
                    :accounts [{:account-props {:customization-color (:color operable-wallet-account)
                                                :size                32
                                                :emoji               (:emoji operable-wallet-account)
@@ -715,9 +728,10 @@
         (-> db
             (assoc-in
              [:wallet :keypairs]
-             [(assoc default-keypair-accounts
-                     :accounts
-                     [operable-wallet-account])])
+             {profile-key-pair-key-uid (update profile-keypair
+                                               :accounts
+                                               conj
+                                               operable-wallet-account)})
             (assoc-in
              [:wallet :accounts]
              {(:address operable-wallet-account) operable-wallet-account}))))
@@ -732,9 +746,9 @@
           size-option     20]
       (is
        (match? {:missing  []
-                :operable [{:name     (:name default-keypair-accounts)
-                            :key-uid  (:key-uid default-keypair-accounts)
-                            :type     (keyword (:type default-keypair-accounts))
+                :operable [{:name     (:name profile-keypair)
+                            :key-uid  (:key-uid profile-keypair)
+                            :type     (:type profile-keypair)
                             :accounts [{:account-props {:customization-color color
                                                         :size                size-option
                                                         :emoji               emoji
@@ -754,10 +768,11 @@
         (-> db
             (assoc-in
              [:wallet :keypairs]
-             [(assoc default-keypair-accounts
-                     :accounts
-                     [operable-wallet-account
-                      chat-account])])
+             {profile-key-pair-key-uid (update profile-keypair
+                                               :accounts
+                                               conj
+                                               operable-wallet-account
+                                               chat-account)})
             (assoc-in
              [:wallet :accounts]
              {(:address operable-wallet-account) operable-wallet-account
@@ -765,9 +780,9 @@
     (is
      (match?
       {:missing  []
-       :operable [{:name     (:name default-keypair-accounts)
-                   :key-uid  (:key-uid default-keypair-accounts)
-                   :type     (keyword (:type default-keypair-accounts))
+       :operable [{:name     (:name profile-keypair)
+                   :key-uid  (:key-uid profile-keypair)
+                   :type     (:type profile-keypair)
                    :accounts [{:account-props {:customization-color (:color operable-wallet-account)
                                                :size                32
                                                :emoji               (:emoji operable-wallet-account)

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -662,22 +662,19 @@
 (h/deftest-sub :wallet/keypairs
   [sub-name]
   (testing "returns keypairs map"
-    (swap! rf-db/app-db #(assoc-in %
-                          [:wallet :keypairs]
-                          {profile-key-pair-key-uid profile-keypair}))
+    (swap! rf-db/app-db assoc-in [:wallet :keypairs] {profile-key-pair-key-uid profile-keypair})
     (is (match? {profile-key-pair-key-uid profile-keypair} (rf/sub [sub-name])))))
 
 (h/deftest-sub :wallet/keypairs-list
   [sub-name]
-  (testing "returns all keypairs"
-    (swap! rf-db/app-db #(assoc-in %
-                          [:wallet :keypairs]
-                          {profile-key-pair-key-uid     profile-keypair
-                           seed-phrase-key-pair-key-uid seed-phrase-keypair}))
-    (let [result   (rf/sub [sub-name])
-          expected (list profile-keypair seed-phrase-keypair)]
-      (is (match? 2 (count result)))
-      (is (match? expected result)))))
+  (swap! rf-db/app-db assoc-in
+    [:wallet :keypairs]
+    {profile-key-pair-key-uid     profile-keypair
+     seed-phrase-key-pair-key-uid seed-phrase-keypair})
+  (let [result   (rf/sub [sub-name])
+        expected (list profile-keypair seed-phrase-keypair)]
+    (is (= 2 (count result)))
+    (is (match? expected result))))
 
 (h/deftest-sub :wallet/settings-keypairs-accounts
   [sub-name]


### PR DESCRIPTION
fixes #20456

### Summary

This PR refactors the keypairs data in app-db to save them by indexed by key-uid which will help to fetch, update, and delete easily instead of using `filter` and `some` every time we need to perform those operations.

| Before | After  | 
| --- | --- | 
| <img width="230" src="https://github.com/status-im/status-mobile/assets/19339952/d954ffa9-0dd5-46ff-8d71-0fea254f399c">  | <img width="655" src="https://github.com/status-im/status-mobile/assets/19339952/184f8ad5-71ca-4fd7-aac9-925811428dbb"> | 

### Testing notes

The following areas are where we display the key pair data to the user

- Create new account flow - Adding new key pair, selecting key pair
- `About` tab in the account screen

A quick testing on the wallet is appreciated

### Platforms

- Android
- iOS

#### Areas that may be impacted

##### Functional

- wallet / transactions
- account recovery
- new account


status: ready
