### PR TITLE
chore(perf)_: Use optimized endpoint to get communities with images

### DIFF
--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -137,7 +137,7 @@
 
 (rf/reg-event-fx :community/fetch
  (fn [_]
-   {:json-rpc/call [{:method     "wakuext_communities"
+   {:json-rpc/call [{:method     "wakuext_serializedCommunities"
                      :params     []
                      :on-success #(rf/dispatch [:community/fetch-success %])
                      :on-error   #(log/error "failed to fetch communities" %)}

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.180.30",
-    "commit-sha1": "b665d68d0cff7cd4521ac8791fcf6eac29b23cd9",
-    "src-sha256": "1bpj3x2bmrh7whhx9sb2wgwc4q8knm4c3rzvimp0s84fsvna5ynq"
+    "version": "v0.180.31",
+    "commit-sha1": "e0673ad1ffec65e3bd96a46b5054fc2d36071cc4",
+    "src-sha256": "15y3fl0q8kqxbsqj9snyg7spaqj09xid9rfza7l5zpk8p0ajqnmk"
 }


### PR DESCRIPTION
- Fixes https://github.com/status-im/status-mobile/issues/20284

### Summary

This PR adapts the client code to use the new optimized endpoint to get communities with images pointing to the media server. This PR depends on the status-go PR https://github.com/status-im/status-go/pull/5336.

#### Areas that may be impacted

Any place in the app showing community images (banner, logo, thumbnail).

### Working screenshots

<img src="https://github.com/status-im/status-mobile/assets/46027/4214af3e-aed9-4a35-86c9-7182c767e937" width="250" />

<img src="https://github.com/status-im/status-mobile/assets/46027/30e32205-3899-452e-bd2c-f97db00d8cc2" width="250" />

<img src="https://github.com/status-im/status-mobile/assets/46027/c3a6be20-db9f-48a8-a327-f2cabc34c7e8" width="250" />

<img src="https://github.com/status-im/status-mobile/assets/46027/7a794312-d1f7-420d-8bb9-fc3eaf5289ba" width="250" />

<img src="https://github.com/status-im/status-mobile/assets/46027/b1cd355c-fbaf-41ae-88e3-bad45e573bee" width="250" />

### Steps to test

Double-check places that can show community images. We expect no changes from the user's perspective. We also changed the code to transparently adapt to the new endpoint response, which greatly reduces the chance of regressions.

status: ready
