### PR TITLE
perf_: Remove integrations with signal wakuv2.peerstats

### DIFF
--- a/src/legacy/status_im/subs/root.cljs
+++ b/src/legacy/status_im/subs/root.cljs
@@ -17,7 +17,7 @@
 (reg-root-key-sub :ui/search :ui/search)
 (reg-root-key-sub :network/type :network/type)
 (reg-root-key-sub :network-status :network-status)
-(reg-root-key-sub :peers-count :peers-count)
+(reg-root-key-sub :peer-stats/count :peer-stats/count)
 (reg-root-key-sub :peers-summary :peers-summary)
 (reg-root-key-sub :web3-node-version :web3-node-version)
 

--- a/src/legacy/status_im/ui/components/connectivity/view.cljs
+++ b/src/legacy/status_im/ui/components/connectivity/view.cljs
@@ -1,14 +1,9 @@
 (ns legacy.status-im.ui.components.connectivity.view
   (:require
-    [clojure.string :as string]
     [legacy.status-im.ui.components.animation :as animation]
     [legacy.status-im.ui.components.colors :as colors]
-    [legacy.status-im.ui.components.core :as quo]
-    [legacy.status-im.ui.components.list.item :as list.item]
-    [legacy.status-im.ui.components.react :as react]
-    [re-frame.core :as re-frame]
-    [utils.i18n :as i18n])
-  (:require-macros [legacy.status-im.utils.views :as views :refer [defview letsubs]]))
+    [legacy.status-im.ui.components.react :as react])
+  (:require-macros [legacy.status-im.utils.views :as views]))
 
 (defn easing
   [direction n]
@@ -72,112 +67,3 @@
                                           colors/white)
                       :left
                       (* 0.15 parent-width))}]]]))
-
-(defview loading-indicator
-  []
-  (letsubs [fetching?    [:mailserver/fetching?]
-            window-width [:dimensions/window-width]]
-    (when fetching?
-      [loading-indicator-anim window-width])))
-
-(defn hide-sheet-and-dispatch
-  [event]
-  (re-frame/dispatch [:bottom-sheet/hide-old])
-  (re-frame/dispatch event))
-
-(defview connectivity-sheet
-  []
-  (letsubs [{:keys [peers node mobile sync]}     [:connectivity/state]
-            current-mailserver-name              [:mailserver/current-name]
-            peers-count                          [:peers-count]
-            {:keys [syncing-on-mobile-network?]} [:profile/profile]]
-    [:<>
-     [quo/header {:title (i18n/label :t/connection-status) :border-bottom false}]
-     [quo/list-header (i18n/label :t/peer-to-peer)]
-     (if (= peers :offline)
-       [list.item/list-item
-        {:title               (i18n/label :t/not-connected-to-peers)
-         :accessibility-label "not-connected-to-peers"
-         :subtitle            (i18n/label :t/unable-to-send-messages)
-         :subtitle-max-lines  2
-         :theme               :negative
-         :icon                :main-icons/network}]
-       [list.item/list-item
-        {:title               (str (i18n/label :t/connected-to)
-                                   " " peers-count
-                                   " " (string/lower-case (i18n/label :t/peers)))
-         :accessibility-label "connected-to-n-peers"
-         :subtitle            (i18n/label :t/can-send-messages)
-         :subtitle-max-lines  2
-         :theme               :positive
-         :icon                :main-icons/network}])
-     [quo/list-header (i18n/label :t/history-nodes)]
-     (cond
-       (#{:error :offline} node)
-       [list.item/list-item
-        {:title               (i18n/label :t/not-connected-nodes)
-         :accessibility-label "not-connected-nodes"
-         :subtitle            (i18n/label :t/unable-to-fetch)
-         :theme               :negative
-         :icon                :main-icons/mailserver}]
-       (= node :disabled)
-       [list.item/list-item
-        {:title               (i18n/label :t/nodes-disabled)
-         :accessibility-label "nodes-disabled"
-         :subtitle            (i18n/label :t/unable-to-fetch)
-         :disabled            true
-         :icon                :main-icons/mailserver}]
-       (and mobile (not sync))
-       [list.item/list-item
-        {:title               (i18n/label :t/waiting-wi-fi)
-         :accessibility-label "waiting-wi-fi"
-         :subtitle            (i18n/label :t/unable-to-fetch)
-         :disabled            true
-         :icon                :main-icons/mailserver}]
-       (= node :connecting)
-       [list.item/list-item
-        {:title               (i18n/label :t/connecting)
-         :accessibility-label "connecting"
-         :subtitle            (i18n/label :t/unable-to-fetch)
-         :icon                :main-icons/mailserver}]
-       (= node :online)
-       [list.item/list-item
-        {:title               (str (i18n/label :t/connected-to) " " current-mailserver-name)
-         :accessibility-label "connected-to-mailserver"
-         :subtitle            (i18n/label :t/you-can-fetch)
-         :theme               :positive
-         :icon                :main-icons/mailserver}])
-     [list.item/list-item
-      {:title               (i18n/label :t/settings)
-       :accessibility-label "settings"
-       :theme               :accent
-       :on-press            #(hide-sheet-and-dispatch [:navigate-to :legacy-sync-settings])
-       :icon                :main-icons/settings}]
-     (when mobile
-       [:<>
-        [react/view
-         {:margin-vertical  8
-          :background-color colors/gray-lighter
-          :height           36
-          :align-items      :center
-          :justify-content  :center}
-         [react/text {:style {:color colors/gray}} (i18n/label :t/youre-on-mobile-network)]]
-        [list.item/list-item
-         {:title               (i18n/label :t/mobile-network-use-mobile)
-          :accessibility-label "mobile-network-use-mobile"
-          :accessory           :switch
-          :on-press            #(re-frame/dispatch [:mobile-network/set-syncing
-                                                    (not syncing-on-mobile-network?)])
-          :active              syncing-on-mobile-network?}]
-        [react/text {:style {:margin-horizontal 16 :margin-bottom 12 :color colors/gray}}
-         (i18n/label :t/status-mobile-descr)]])]))
-
-(defn get-icon
-  [{:keys [peers node mobile sync]}]
-  (if (or (= peers :offline)
-          (= node :offline)
-          (= node :connecting))
-    :main-icons/offline
-    (if mobile
-      (if sync :main-icons/mobile-sync :main-icons/mobile-sync-off)
-      (when (#{:error :disabled} node) :main-icons/node-offline))))

--- a/src/legacy/status_im/ui/screens/peers_stats.cljs
+++ b/src/legacy/status_im/ui/screens/peers_stats.cljs
@@ -1,17 +1,21 @@
 (ns legacy.status-im.ui.screens.peers-stats
   (:require
-    [react-native.core :as react-native.core]
+    [react-native.core :as rn]
     [utils.i18n :as i18n]
-    [utils.re-frame :as re-frame]))
+    [utils.re-frame :as rf]))
 
 (defn peers-stats
   []
-  (let [peers-count (re-frame/sub [:peers-count])]
-    [react-native.core/view
-     {:flex              1
-      :margin-horizontal 8}
-     [react-native.core/view
+  (let [peers-count (rf/sub [:peer-stats/count])]
+    (rn/use-mount
+     (fn []
+       (rf/dispatch [:peer-stats/get-count])))
+
+    [rn/view
+     {:style {:flex              1
+              :margin-horizontal 8}}
+     [rn/view
       {:style {:flex-direction  :row
                :margin-vertical 8
                :justify-content :space-between}}
-      [react-native.core/text (str (i18n/label :t/peers-count) ": " peers-count)]]]))
+      [rn/text (str (i18n/label :t/peers-count) ": " peers-count)]]]))

--- a/src/legacy/status_im/utils/logging/core.cljs
+++ b/src/legacy/status_im/utils/logging/core.cljs
@@ -128,7 +128,6 @@
                                                  :current-chat-id
                                                  :network
                                                  :network-status
-                                                 :peers-count
                                                  :peers-summary
                                                  :sync-state
                                                  :view-id

--- a/src/legacy/status_im/visibility_status_updates/core.cljs
+++ b/src/legacy/status_im/visibility_status_updates/core.cljs
@@ -130,7 +130,7 @@
              status-type]}]
           (and
            (= status-type constants/visibility-status-inactive)
-           (> (:peers-count db) 0))
+           (pos? (:peer-stats/count db)))
           ;; Disable broadcasting further updates
           (conj {:ms 1000
                  :dispatch

--- a/src/status_im/common/peer_stats/events.cljs
+++ b/src/status_im/common/peer_stats/events.cljs
@@ -1,0 +1,17 @@
+(ns status-im.common.peer-stats.events
+  (:require
+    [taoensso.timbre :as log]
+    [utils.re-frame :as rf]))
+
+(rf/reg-event-fx :peer-stats/get-count
+ (fn []
+   {:fx [[:json-rpc/call
+          [{:method     :wakuext_peers
+            :on-success [:peer-stats/get-count-success]
+            :on-error   (fn [error]
+                          (log/error "failed to fetch wakuv2 peer count"
+                                     {:error error}))}]]]}))
+
+(rf/reg-event-fx :peer-stats/get-count-success
+ (fn [{:keys [db]} [response]]
+   {:db (assoc db :peer-stats/count (count response))}))

--- a/src/status_im/contexts/profile/settings/visibility_sheet/view.cljs
+++ b/src/status_im/contexts/profile/settings/visibility_sheet/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.profile.settings.visibility-sheet.view
   (:require [quo.core :as quo]
+            [react-native.core :as rn]
             [status-im.constants :as constants]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
@@ -17,6 +18,10 @@
                                [:visibility-status-updates/visibility-status-update
                                 public-key])
         customization-color   (rf/sub [:profile/customization-color])]
+    (rn/use-mount
+     (fn []
+       (rf/dispatch [:peer-stats/get-count])))
+
     [quo/action-drawer
      [[{:icon                :i/online
         :no-icon-color?      true

--- a/src/status_im/db.cljs
+++ b/src/status_im/db.cljs
@@ -20,7 +20,7 @@
    :link-previews-whitelist            []
    :app-state                          "active"
    :wallet                             wallet/defaults
-   :peers-count                        0
+   :peer-stats/count                   0
    :node-info                          {}
    :peers-summary                      []
    :transport/message-envelopes        {}

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -9,6 +9,7 @@
     [status-im.common.json-rpc.events]
     status-im.common.log
     status-im.common.password-authentication.events
+    status-im.common.peer-stats.events
     status-im.common.shared-urls.events
     status-im.common.signals.events
     status-im.common.theme.events

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -167,12 +167,6 @@
    (get multiaccount :log-level)))
 
 (re-frame/reg-sub
- :waku/v2-flag
- :<- [:fleets/current-fleet]
- (fn [fleet]
-   (string/starts-with? (name fleet) "wakuv2")))
-
-(re-frame/reg-sub
  :dapps-address
  :<- [:profile/profile]
  (fn [acc]

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -64,7 +64,6 @@
 (reg-root-key-sub :tooltips :tooltips)
 (reg-root-key-sub :app-state :app-state)
 (reg-root-key-sub :home-items-show-number :home-items-show-number)
-(reg-root-key-sub :waku/v2-peer-stats :peer-stats)
 (reg-root-key-sub :password-authentication :password-authentication)
 (reg-root-key-sub :initials-avatar-font-file :initials-avatar-font-file)
 (reg-root-key-sub :alert-banners :alert-banners)


### PR DESCRIPTION
- Fixes https://github.com/status-im/status-mobile/issues/20176

### Summary

Removes code integrating with the signal `wakuv2.peerstats`. The response from this signal is rather large and it can sometimes happen in short bursts.

We were using it to keep track of the number of peers in real-time. This PR changes that to only fetch the peer count in two instances (synchronously inside `rn/use-mount`):

- When the user opens the legacy screen `Settings > Advanced > Peers stats`.
- When the user opens the visibility status dropdown in `Settings`, because the peers count will be used when the user chooses "Offline" (status inactive).

### Note

We don't send anymore the peers count when the user shakes the phone. We assume this value is already available in `:peers-summary` (which will be shared by the user).

status-go still publishes the signal, we just ignore it to remove the performance overhead of transforming to cljs and mutating the app-db (thus interrupting the queue from more important stuff).

### Steps to test

- Verify user can see peers count in `Settings > Advanced > Peers stats`
- Verify changing the visibility status of user Alice in the `Settings` screen leads to the desired effect to the other party seeing Alice's visibility status.

status: ready
