### PR TITLE
chore: remove identifiers screens

### DIFF
--- a/src/status_im/contexts/onboarding/enable_notifications/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_notifications/view.cljs
@@ -1,15 +1,15 @@
 (ns status-im.contexts.onboarding.enable-notifications.view
   (:require
-    [quo.core :as quo]
-    [react-native.core :as rn]
-    [react-native.safe-area :as safe-area]
-    [status-im.common.resources :as resources]
-    [status-im.contexts.onboarding.enable-notifications.style :as style]
-    [status-im.contexts.shell.jump-to.constants :as shell.constants]
-    [status-im.contexts.shell.jump-to.utils :as shell.utils]
-    [taoensso.timbre :as log]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+   [quo.core :as quo]
+   [react-native.core :as rn]
+   [react-native.safe-area :as safe-area]
+   [status-im.common.resources :as resources]
+   [status-im.contexts.onboarding.enable-notifications.style :as style]
+   [status-im.contexts.shell.jump-to.constants :as shell.constants]
+   [status-im.contexts.shell.jump-to.utils :as shell.utils]
+   [taoensso.timbre :as log]
+   [utils.i18n :as i18n]
+   [utils.re-frame :as rf]))
 
 (defn page-title
   []
@@ -72,6 +72,7 @@
   (let [insets (safe-area/get-insets)]
     [rn/view {:style (style/page-container insets)}
      [rn/view {:style style/page-heading}
+      [quo/page-nav {:type :no-title :background :blur}]
       [page-title]]
      [enable-notifications-simple]
      [enable-notification-buttons {:insets insets}]]))

--- a/src/status_im/contexts/onboarding/enable_notifications/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_notifications/view.cljs
@@ -72,10 +72,6 @@
   (let [insets (safe-area/get-insets)]
     [rn/view {:style (style/page-container insets)}
      [rn/view {:style style/page-heading}
-      [quo/page-nav
-       {:background :blur
-        :icon-name  :i/arrow-left
-        :on-press   #(rf/dispatch [:navigate-back])}]
       [page-title]]
      [enable-notifications-simple]
      [enable-notification-buttons {:insets insets}]]))

--- a/src/status_im/contexts/onboarding/enable_notifications/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_notifications/view.cljs
@@ -1,15 +1,15 @@
 (ns status-im.contexts.onboarding.enable-notifications.view
   (:require
-   [quo.core :as quo]
-   [react-native.core :as rn]
-   [react-native.safe-area :as safe-area]
-   [status-im.common.resources :as resources]
-   [status-im.contexts.onboarding.enable-notifications.style :as style]
-   [status-im.contexts.shell.jump-to.constants :as shell.constants]
-   [status-im.contexts.shell.jump-to.utils :as shell.utils]
-   [taoensso.timbre :as log]
-   [utils.i18n :as i18n]
-   [utils.re-frame :as rf]))
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [react-native.safe-area :as safe-area]
+    [status-im.common.resources :as resources]
+    [status-im.contexts.onboarding.enable-notifications.style :as style]
+    [status-im.contexts.shell.jump-to.constants :as shell.constants]
+    [status-im.contexts.shell.jump-to.utils :as shell.utils]
+    [taoensso.timbre :as log]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (defn page-title
   []

--- a/src/status_im/contexts/onboarding/events.cljs
+++ b/src/status_im/contexts/onboarding/events.cljs
@@ -73,7 +73,7 @@
                                       :onboarding/navigated-to-enter-seed-phrase-from-screen
                                       :screen/onboarding.new-to-status)]]
                :dispatch-later [{:ms       constants/onboarding-generating-keys-animation-duration-ms
-                                 :dispatch [:onboarding/navigate-to-identifiers]}]
+                                 :dispatch [:onboarding/navigate-to-enable-notifications]}]
                :db             (-> db
                                    (dissoc :profile/login)
                                    (dissoc :auth-method)

--- a/src/status_im/contexts/onboarding/events.cljs
+++ b/src/status_im/contexts/onboarding/events.cljs
@@ -73,7 +73,7 @@
                                       :onboarding/navigated-to-enter-seed-phrase-from-screen
                                       :screen/onboarding.new-to-status)]]
                :dispatch-later [{:ms       constants/onboarding-generating-keys-animation-duration-ms
-                                 :dispatch [:onboarding/navigate-to-enable-notifications]}]
+                                 :dispatch [:init-root :screen/onboarding.enable-notifications]}]
                :db             (-> db
                                    (dissoc :profile/login)
                                    (dissoc :auth-method)

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -347,7 +347,7 @@
 
     {:name      :screen/onboarding.enable-notifications
      :options   {:theme      :dark
-                 :layout     options/onboarding-layout
+                 :layout     options/onboarding-transparent-layout
                  :animations (merge
                               transitions/new-to-status-modal-animations
                               transitions/push-animations-for-transparent-background)}
@@ -399,7 +399,7 @@
 
     {:name      :screen/onboarding.welcome
      :options   {:theme      :dark
-                 :layout     options/onboarding-layout
+                 :layout     options/onboarding-transparent-layout
                  :animations transitions/push-animations-for-transparent-background}
      :component welcome/view}
 

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -346,12 +346,11 @@
      :component enter-seed-phrase/view}
 
     {:name      :screen/onboarding.enable-notifications
-     :options   {:theme                  :dark
-                 :layout                 options/onboarding-transparent-layout
-                 :animations             (merge
-                                          transitions/new-to-status-modal-animations
-                                          transitions/push-animations-for-transparent-background)
-                 :modalPresentationStyle :overCurrentContext}
+     :options   {:theme      :dark
+                 :layout     options/onboarding-layout
+                 :animations (merge
+                              transitions/new-to-status-modal-animations
+                              transitions/push-animations-for-transparent-background)}
      :component enable-notifications/view}
 
     {:name      :screen/onboarding.identifiers
@@ -400,7 +399,7 @@
 
     {:name      :screen/onboarding.welcome
      :options   {:theme      :dark
-                 :layout     options/onboarding-transparent-layout
+                 :layout     options/onboarding-layout
                  :animations transitions/push-animations-for-transparent-background}
      :component welcome/view}
 

--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -244,8 +244,8 @@ class SignInView(BaseView):
         self.generate_keys_button.click_until_presence_of_element(self.profile_title_input)
         self.set_profile(username)
         self.set_password(password)
-        if self.enable_biometric_maybe_later_button.is_element_displayed(10):
-            self.enable_biometric_maybe_later_button.click()
+        # if self.enable_biometric_maybe_later_button.is_element_displayed(10):
+        #     self.enable_biometric_maybe_later_button.click()
         # self.next_button.click_until_absense_of_element(self.element_by_translation_id("intro-wizard-title2"))
         # if keycard:
         #     keycard_flow = self.keycard_storage_button.click()
@@ -256,7 +256,7 @@ class SignInView(BaseView):
         #     self.create_password_input.send_keys(password)
         #     self.confirm_your_password_input.send_keys(password)
         #     self.next_button.click()
-        self.identifiers_button.wait_and_click(30)
+        # self.identifiers_button.wait_and_click(30)
         if enable_notifications:
             self.enable_notifications_button.click_until_presence_of_element(self.start_button)
             if self.allow_button.is_element_displayed():
@@ -283,9 +283,9 @@ class SignInView(BaseView):
         self.continue_button.click_until_presence_of_element(self.profile_title_input)
         self.set_profile(username, set_image)
         self.set_password(password)
-        if self.enable_biometric_maybe_later_button.is_element_displayed(10):
-            self.enable_biometric_maybe_later_button.click()
-        self.identifiers_button.wait_and_click(30)
+        # if self.enable_biometric_maybe_later_button.is_element_displayed(10):
+        #     self.enable_biometric_maybe_later_button.click()
+        # self.identifiers_button.wait_and_click(30)
         if enable_notifications:
             self.enable_notifications_button.click_until_presence_of_element(self.start_button)
         else:


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20314

### Summary

In this pr we removed the identifiers screen so that the users are navigate to enable notifiactions during onbaording

https://github.com/status-im/status-mobile/assets/28704507/b40e38ac-a29d-49ba-ab58-b3a565645f02



status: ready 
