### PR TITLE
fix can't enter channel after community is fetched for the first time

### DIFF
--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -49,7 +49,7 @@
         (testing "dispatch fxs"
           (is (match?
                {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
-                     [:dispatch [:communities/update-last-opened-at community-id]]
+                     [:dispatch [:chat.ui/spectate-community community-id]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
                        {:id community-id}]]]}
@@ -60,7 +60,7 @@
         (testing "dispatch fxs, do not spectate community"
           (is (match?
                {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
-                     [:dispatch [:communities/update-last-opened-at community-id]]
+                     [:dispatch [:chat.ui/spectate-community community-id]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
                        {:id community-id}]]]}
@@ -71,7 +71,7 @@
         (testing "dispatch fxs, do not spectate community"
           (is (match?
                {:fx [[:dispatch [:communities/handle-community {:id community-id}]]
-                     [:dispatch [:communities/update-last-opened-at community-id]]
+                     [:dispatch [:chat.ui/spectate-community community-id]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
                        {:id community-id}]]]}


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20395

### Summary

We call `chat.ui/spectate-community` on the community screen opening. But when the community is opened for the first time, calling `chat.ui/spectate-community` throws the error "community not found" (because the community is not fetched yet).
So in this PR, we are also calling `chat.ui/spectate-community` in the on-success callback of fetch-community to cover this scenario.

status: ready