### PR TITLE
fix: User can not add his existing ENS name to v.1 app

### DIFF
--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -20,12 +20,12 @@
 ;; flags stay up to date and are removed once behavior introduced is stable.
 
 (goog-define INFURA_TOKEN "800c641949d64d768a5070a1b0511938")
-(goog-define POKT_TOKEN "")
+(goog-define POKT_TOKEN "3ef2018191814b7e1009b8d9")
 (goog-define OPENSEA_API_KEY "")
 
 (def infura-key INFURA_TOKEN)
 (def pokt-key POKT_TOKEN)
-(def mainnet-rpc-url (str "https://eth-archival.gateway.pokt.network/v1/lb/" POKT_TOKEN))
+(def mainnet-rpc-url (str "https://eth-archival.rpc.grove.city/v1/" POKT_TOKEN))
 (def testnet-rpc-url (str "https://ropsten.infura.io/v3/" INFURA_TOKEN))
 (def goerli-rpc-url (str "https://goerli-archival.gateway.pokt.network/v1/lb/" POKT_TOKEN))
 (def opensea-api-key OPENSEA_API_KEY)

--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -20,7 +20,7 @@
 ;; flags stay up to date and are removed once behavior introduced is stable.
 
 (goog-define INFURA_TOKEN "800c641949d64d768a5070a1b0511938")
-(goog-define POKT_TOKEN "3ef2018191814b7e1009b8d9")
+(goog-define POKT_TOKEN "")
 (goog-define OPENSEA_API_KEY "")
 
 (def infura-key INFURA_TOKEN)

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "release/v0.108.x",
-    "commit-sha1": "b966cb14adb860ae0e3dffbb9b40c25ba854d5a3",
-    "src-sha256": "1r86hkncx3ir2n5n6l69h9xqdr9amrrbaap9knlmlacmzi9s62m2"
+    "version": "fix/ens-api-owner-of",
+    "commit-sha1": "67f82548e5b0754c2af1ed6167f2543e5cec268d",
+    "src-sha256": "1avp1l8hyk3pbcpiwkhm7kq5izd6rzcnqvjpxnz77rx7mfryygnr"
 }


### PR DESCRIPTION
relate status-go [PR](https://github.com/status-im/status-go/pull/5379)

fixes #20468

<img width="1271" alt="image" src="https://github.com/status-im/status-mobile/assets/12406719/60adfdff-f0f3-4803-8a65-6d3423e4dbce">
the screenshot shows we should be able to get the correct feedback when searching ens name now.

### Testing notes
won't fix `goerli` since it's deprecated, this PR only fixed `mainnet` when searching ens name. Not sure if we can add existing ENS name, looking forward the testing result on mainnet.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
