### PR TITLE
Fixes for screen where user locks network amounts to send

### DIFF
--- a/src/quo/components/selectors/disclaimer/view.cljs
+++ b/src/quo/components/selectors/disclaimer/view.cljs
@@ -12,7 +12,8 @@
   [{:keys [checked? blur? accessibility-label container-style on-change icon customization-color]} label]
   (let [theme (quo.theme/use-theme)]
     [rn/touchable-without-feedback
-     {:on-press            on-change
+     {:on-press            (when on-change
+                             #(on-change (not checked?)))
       :accessibility-label :disclaimer-touchable-opacity}
      [rn/view {:style (merge container-style (style/container blur? theme))}
       [selectors/view

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -237,7 +237,8 @@
               (assoc-in [:wallet :ui :send :token-not-supported-in-receiver-networks?]
                         token-not-supported-in-receiver-networks?))
       :fx [[:dispatch [:hide-bottom-sheet]]
-           [:dispatch [:wallet/clean-suggested-routes]]]})))
+           [:dispatch [:wallet/clean-suggested-routes]]
+           [:dispatch [:wallet/clean-from-locked-amounts]]]})))
 
 (rf/reg-event-fx :wallet/clean-selected-token
  (fn [{:keys [db]}]

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -369,7 +369,7 @@
        :allow-selection? false}]
      [routes/view
       {:token                                     token-by-symbol
-       :input-value                               input-amount
+       :send-amount-in-crypto                     amount-in-crypto
        :valid-input?                              valid-input?
        :token-not-supported-in-receiver-networks? token-not-supported-in-receiver-networks?
        :lock-fetch-routes?                        just-toggled-mode?

--- a/src/status_im/contexts/wallet/send/routes/style.cljs
+++ b/src/status_im/contexts/wallet/send/routes/style.cljs
@@ -47,3 +47,6 @@
 (defn keyboard-container
   [bottom]
   {:padding-bottom bottom})
+
+(def error-box
+  {:margin-horizontal 20})

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -226,31 +226,32 @@
            token-not-supported-in-receiver-networks?]}]
   [rn/view
    (map-indexed (fn [index {:keys [chain-id total-amount type]}]
-                  [rn/view
-                   {:key   (str (if receiver? "to" "from") "-" chain-id)
-                    :style {:margin-top (if (pos? index) 11 7.5)}}
-                   [quo/network-bridge
-                    {:amount        (if (= type :not-available)
-                                      (i18n/label :t/not-available)
-                                      (str total-amount " " token-symbol))
-                     :network       (network-utils/id->network chain-id)
-                     :status        (cond (and (= type :not-available)
-                                               loading-routes?
-                                               token-not-supported-in-receiver-networks?)
-                                          :loading
-                                          (= type :not-available)
-                                          :disabled
-                                          :else type)
-                     :on-press      #(when (not loading-routes?)
-                                       (cond
-                                         (= type :edit)
-                                         (open-preferences)
-                                         on-press (on-press chain-id total-amount)))
-                     :on-long-press #(when (not loading-routes?)
-                                       (cond
-                                         (= type :add)
-                                         (open-preferences)
-                                         on-long-press (on-long-press chain-id)))}]])
+                  (let [status (cond (and (= type :not-available)
+                                          loading-routes?
+                                          token-not-supported-in-receiver-networks?)
+                                     :loading
+                                     (= type :not-available)
+                                     :disabled
+                                     :else type)]
+                    [rn/view
+                     {:key   (str (if receiver? "to" "from") "-" chain-id)
+                      :style {:margin-top (if (pos? index) 11 7.5)}}
+                     [quo/network-bridge
+                      {:amount        (if (= type :not-available)
+                                        (i18n/label :t/not-available)
+                                        (str total-amount " " token-symbol))
+                       :network       (network-utils/id->network chain-id)
+                       :status        status
+                       :on-press      #(when (not loading-routes?)
+                                         (cond
+                                           (= type :edit)
+                                           (open-preferences)
+                                           on-press (on-press chain-id total-amount)))
+                       :on-long-press #(when (and (not loading-routes?) (not= status :disabled))
+                                         (cond
+                                           (= type :add)
+                                           (open-preferences)
+                                           on-long-press (on-long-press chain-id)))}]]))
                 network-values)])
 
 (defn render-network-links

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -141,10 +141,9 @@
                                                                            amount-in-crypto)
                                                               send-amount (money/bignumber
                                                                            send-amount-in-crypto)]
-                                                          (if (and (money/bignumber? amount)
-                                                                   (money/bignumber? send-amount))
-                                                            (money/greater-than amount send-amount)
-                                                            false))
+                                                          (and (money/bignumber? amount)
+                                                               (money/bignumber? send-amount)
+                                                               (money/greater-than amount send-amount)))
              swap-between-fiat-and-crypto               (fn [swap-to-crypto-currency?]
                                                           (set-crypto-currency swap-to-crypto-currency?)
                                                           (set-input-state
@@ -244,31 +243,34 @@
   [{:keys [network-values token-symbol on-press on-long-press receiver? loading-routes?
            token-not-supported-in-receiver-networks?]}]
   [rn/view
-   (map-indexed (fn [index {:keys [chain-id total-amount type]}]
-                  (let [status (cond (and (= type :not-available)
+   (map-indexed (fn [index
+                     {chain-id           :chain-id
+                      network-value-type :type
+                      total-amount       :total-amount}]
+                  (let [status (cond (and (= network-value-type :not-available)
                                           loading-routes?
                                           token-not-supported-in-receiver-networks?)
                                      :loading
-                                     (= type :not-available)
+                                     (= network-value-type :not-available)
                                      :disabled
-                                     :else type)]
+                                     :else network-value-type)]
                     [rn/view
                      {:key   (str (if receiver? "to" "from") "-" chain-id)
                       :style {:margin-top (if (pos? index) 11 7.5)}}
                      [quo/network-bridge
-                      {:amount        (if (= type :not-available)
+                      {:amount        (if (= network-value-type :not-available)
                                         (i18n/label :t/not-available)
                                         (str total-amount " " token-symbol))
                        :network       (network-utils/id->network chain-id)
                        :status        status
                        :on-press      #(when (not loading-routes?)
                                          (cond
-                                           (= type :edit)
+                                           (= network-value-type :edit)
                                            (open-preferences)
                                            on-press (on-press chain-id total-amount)))
                        :on-long-press #(when (and (not loading-routes?) (not= status :disabled))
                                          (cond
-                                           (= type :add)
+                                           (= network-value-type :add)
                                            (open-preferences)
                                            on-long-press (on-long-press chain-id total-amount)))}]]))
                 network-values)])

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -235,8 +235,10 @@
                                         (set-is-amount-locked true)
                                         (set-input-state #(controlled-input/add-character % c)))))
             :on-delete            (fn []
+                                    (set-is-amount-locked true)
                                     (set-input-state controlled-input/delete-last))
             :on-long-press-delete (fn []
+                                    (set-is-amount-locked true)
                                     (set-input-state controlled-input/delete-all))}]]))}]))
 
 (defn render-network-values

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -87,7 +87,7 @@
                                                          chain-ids]))}]))}]))
 
 (defn- edit-amount
-  [{:keys [chain-id token-symbol send-amount-in-crypto]}]
+  [{:keys [chain-id token-symbol send-amount-in-crypto init-amount]}]
   (rf/dispatch
    [:show-bottom-sheet
     {:content
@@ -106,6 +106,9 @@
              locked-amount                              (get send-from-locked-amounts chain-id)
              network-name-str                           (string/capitalize (name network-name))
              [input-state set-input-state]              (rn/use-state (cond-> controlled-input/init-state
+                                                                        init-amount
+                                                                        (controlled-input/set-input-value
+                                                                         (money/to-string init-amount))
                                                                         locked-amount
                                                                         (controlled-input/set-input-value
                                                                          locked-amount)))
@@ -267,7 +270,7 @@
                                          (cond
                                            (= type :add)
                                            (open-preferences)
-                                           on-long-press (on-long-press chain-id)))}]]))
+                                           on-long-press (on-long-press chain-id total-amount)))}]]))
                 network-values)])
 
 (defn render-network-links
@@ -380,12 +383,12 @@
                                                       chain-id-to-disable
                                                       disabled-from-chain-ids
                                                       token-available-networks-for-suggested-routes))
-
-        :on-long-press                             (fn [chain-id]
+        :on-long-press                             (fn [chain-id amount-calculated-for-chain]
                                                      (edit-amount
-                                                      {:chain-id              chain-id
-                                                       :token-symbol          token-symbol
-                                                       :send-amount-in-crypto send-amount-in-crypto}))
+                                                      {:chain-id chain-id
+                                                       :token-symbol token-symbol
+                                                       :send-amount-in-crypto send-amount-in-crypto
+                                                       :init-amount amount-calculated-for-chain}))
         :receiver?                                 false
         :theme                                     theme
         :loading-routes?                           loading-routes?

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -137,14 +137,14 @@
                                                            (.toFixed (/ input-amount
                                                                         conversion-rate)
                                                                      crypto-decimals)))
-             amount-in-crypto-bn                        (money/bignumber amount-in-crypto)
-             send-amount-in-crypto-bn                   (money/bignumber send-amount-in-crypto)
-             lock-higher-than-send-amount?              (if (and (money/bignumber? amount-in-crypto-bn)
-                                                                 (money/bignumber?
-                                                                  send-amount-in-crypto-bn))
-                                                          (money/greater-than amount-in-crypto-bn
-                                                                              send-amount-in-crypto-bn)
-                                                          false)
+             locked-greater-then-send-amount?           (let [amount      (money/bignumber
+                                                                           amount-in-crypto)
+                                                              send-amount (money/bignumber
+                                                                           send-amount-in-crypto)]
+                                                          (if (and (money/bignumber? amount)
+                                                                   (money/bignumber? send-amount))
+                                                            (money/greater-than amount send-amount)
+                                                            false))
              swap-between-fiat-and-crypto               (fn [swap-to-crypto-currency?]
                                                           (set-crypto-currency swap-to-crypto-currency?)
                                                           (set-input-state
@@ -199,7 +199,7 @@
             :value            (controlled-input/input-value input-state)
             :on-swap          swap-between-fiat-and-crypto
             :allow-selection? false}]
-          (when lock-higher-than-send-amount?
+          (when locked-greater-then-send-amount?
             [quo/information-box
              {:type  :error
               :icon  :i/info
@@ -222,7 +222,7 @@
                                :customization-color account-color
                                :disabled?           (or (controlled-input/empty-value? input-state)
                                                         (controlled-input/input-error input-state)
-                                                        lock-higher-than-send-amount?)}}]
+                                                        locked-greater-then-send-amount?)}}]
           [quo/numbered-keyboard
            {:container-style      (style/keyboard-container bottom)
             :left-action          :dot

--- a/translations/en.json
+++ b/translations/en.json
@@ -2736,5 +2736,6 @@
     "dont-auto-recalculate-network": "Don't auto recalculate {{network}}",
     "import-keypair-to-use-account": "Import key pair to use this account",
     "import-keypair-steps": "{{account-name}} was derived from your {{keypair-name}} key pair, which has not yet been imported to this device. To transact using this account, you will need to import the {{keypair-name}} key pair first.",
-    "not-now": "Not now"
+    "not-now": "Not now",
+    "value-higher-than-send-amount": "This value is higher than entered send amount"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -2737,5 +2737,5 @@
     "import-keypair-to-use-account": "Import key pair to use this account",
     "import-keypair-steps": "{{account-name}} was derived from your {{keypair-name}} key pair, which has not yet been imported to this device. To transact using this account, you will need to import the {{keypair-name}} key pair first.",
     "not-now": "Not now",
-    "value-higher-than-send-amount": "This value is higher than entered send amount"
+    "value-higher-than-send-amount": "This value is higher than entered amount to send"
 }


### PR DESCRIPTION

fixes https://github.com/status-im/status-mobile/issues/20497
fixes https://github.com/status-im/status-mobile/issues/20496
fixes https://github.com/status-im/status-mobile/issues/20498

### Summary

- long press no more active on disabled router paths
- input field in drawer has initial value
- error message shown when input field contains valuer bigger than input field on send page

https://github.com/status-im/status-mobile/assets/5786310/1f1f3ae6-5213-4e70-b2d9-02444a1a08f1


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- wallet / transactions


status: ready
