### PR TITLE
chore_: update max attemps

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.180.30",
-    "commit-sha1": "b665d68d0cff7cd4521ac8791fcf6eac29b23cd9",
-    "src-sha256": "1bpj3x2bmrh7whhx9sb2wgwc4q8knm4c3rzvimp0s84fsvna5ynq"
+    "version": "9473df1b30567912af9f97c4a0b76c3ef7674e0e",
+    "commit-sha1": "9473df1b30567912af9f97c4a0b76c3ef7674e0e",
+    "src-sha256": "0l8gigi79m6m6p9i6xcgbf1gcmr4g1y90j96a5bk8k6kc0x3n1fa"
 }


### PR DESCRIPTION
### Summary

Changes: Set the max delivery attempts from 6 to 3. 
Status-go PR: https://github.com/status-im/status-go/pull/5382
Risk: low
How to test: the changes should not affect user experience, sanity check e2e test is not broken.

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

| Figma (if available) | iOS (if available)    | Android (if available)
| --- | --- | --- |
| Please embed Image/Video here of the before and after.  | Please embed Image/Video here of the before and after.  | Please embed Image/Video here of the before and after. |

status: ready <!-- Can be ready or wip -->
