### PR TITLE
test: switch status-go to chore/keycard-login-endpoints

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "chore/keycard-login-endpoints",
-    "commit-sha1": "4c9268470660957ddc9f0580a15bc0915b0abdb2",
-    "src-sha256": "1iljn3rsr91bmvbk6jxi245h7c4pd71r475habz7iksxz667pk30"
+    "commit-sha1": "cd4f51d738da8a5294798a38e6661c76b14b7615",
+    "src-sha256": "1kdscjq4f3qpbw49w8v8iq21m6c6hys8b14gnslq269zkjb39dnj"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.180.30",
-    "commit-sha1": "b665d68d0cff7cd4521ac8791fcf6eac29b23cd9",
-    "src-sha256": "1bpj3x2bmrh7whhx9sb2wgwc4q8knm4c3rzvimp0s84fsvna5ynq"
+    "version": "chore/keycard-login-endpoints",
+    "commit-sha1": "4c9268470660957ddc9f0580a15bc0915b0abdb2",
+    "src-sha256": "1iljn3rsr91bmvbk6jxi245h7c4pd71r475habz7iksxz667pk30"
 }


### PR DESCRIPTION
### Summary

Please test the changes made to create/login/restore acocunt endpoints made in 
- https://github.com/status-im/status-go/pull/5311

I updated the `loginAccount`, `createAccount...` and `restoreAccount...` endpoints for keycard support.
Minor refactoring and improvements happened on the way.

Desktop was tested here: https://github.com/status-im/status-desktop/pull/15090

#### Areas that maybe impacted

- All onboarding flows (create, login, restore)