### PR TITLE
fix_:still return the image when handleAccountInitialsImpl is unable to get public key

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.182.36",
-    "commit-sha1": "8458cafef9f876c11a58dc9ede14fc58a5a0f968",
-    "src-sha256": "0nkb0zpqgpklh8mlrgcglh5v32qlfly9hd7ia3a1icx5kdp2q2wp"
+    "version": "v0.182.37",
+    "commit-sha1": "4a43b2b2bebe45df2100d1a5c5034105d93e50b8",
+    "src-sha256": "0f5mm7lx6s2qcy9xpa9v7piqb60yazi6p677fy105yz7hg731cw6"
 }


### PR DESCRIPTION
fixes #20512

before the fix:
![image](https://github.com/status-im/status-mobile/assets/12406719/edaf30d3-9f64-44d4-aac8-24e38fabd511)

after the fix:
![image](https://github.com/status-im/status-mobile/assets/12406719/5cbdf25e-73e3-4376-b4bf-3c0bd01ada38)

### Testing notes
- install 1.20.x PR build and generate an account use keycard
- install this PR(2.x) build and see if the avatar is blank, it should not be blank. NOTE: we can't generate the ring because we don't have the public key before login. pls see the detail [description](https://github.com/status-im/status-go/pull/5409#issue-2369438648) 

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
