### PR TITLE
fix ios wrong status bar color in dark theme

### DIFF
--- a/ios/StatusIm/Info.plist
+++ b/ios/StatusIm/Info.plist
@@ -119,8 +119,6 @@
 	<array>
 		<string>armv7</string>
 	</array>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -133,7 +131,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 	<key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
 	<array>
 		<string>A00000080400010101</string>

--- a/src/legacy/status_im/multiaccounts/logout/core.cljs
+++ b/src/legacy/status_im/multiaccounts/logout/core.cljs
@@ -28,7 +28,7 @@
   [{:keys [db] :as cofx} {:keys [auth-method logout?]}]
   (let [key-uid (get-in db [:profile/profile :key-uid])]
     (rf/merge cofx
-              {:set-root                               :progress
+              {:dispatch                               [:init-root :progress]
                :effects.shell/reset-state              nil
                :hide-popover                           nil
                ::logout                                nil

--- a/src/legacy/status_im/ui/screens/screens.cljs
+++ b/src/legacy/status_im/ui/screens/screens.cljs
@@ -53,7 +53,8 @@
   []
   [;;PROGRESS
    {:name      :progress
-    :options   {:insets {:top? true}}
+    :options   {:insets {:top? true}
+                :theme  :dark}
     :component progress/progress}
 
    ;;COMMUNITY

--- a/src/status_im/contexts/onboarding/events.cljs
+++ b/src/status_im/contexts/onboarding/events.cljs
@@ -89,7 +89,7 @@
     (merge
      {:db (assoc db :profile/profiles-overview multiaccounts)}
      (when-not (seq multiaccounts)
-       {:set-root :screen/onboarding.intro}))))
+       {:dispatch [:init-root :screen/onboarding.intro]}))))
 
 (rf/defn password-set
   {:events [:onboarding/password-set]}

--- a/src/status_im/contexts/profile/events.cljs
+++ b/src/status_im/contexts/profile/events.cljs
@@ -45,14 +45,14 @@
                   (assoc :profile/profiles-overview profiles)
                   (update :profile/login #(select-profile % key-uid)))
               db)
-        :fx [[:set-root :screen/profile.profiles]
+        :fx [[:dispatch [:init-root :screen/profile.profiles]]
              (when key-uid
                [:effects.biometric/check-if-available
                 {:key-uid    key-uid
                  :on-success (fn [auth-method]
                                (rf/dispatch [:profile.login/check-biometric-success key-uid
                                              auth-method]))}])]})
-     {:fx [[:set-root :screen/onboarding.intro]]})))
+     {:fx [[:dispatch [:init-root :screen/onboarding.intro]]]})))
 
 (rf/reg-event-fx
  :profile/update-setting-from-backup

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -74,7 +74,7 @@
 
                 (cond
                   pairing-completed?
-                  [[:set-root :screen/onboarding.syncing-results]]
+                  [[:dispatch [:init-root :screen/onboarding.syncing-results]]]
 
                   (get db :onboarding/new-account?)
                   [[:dispatch [:onboarding/finalize-setup]]]
@@ -85,7 +85,7 @@
                          constants/theme-type-dark)
                      :shell-stack
                      false]]
-                   [:set-root :shell-stack]
+                   [:dispatch [:init-root :shell-stack]]
                    [:dispatch [:profile/show-testnet-mode-banner-if-enabled]]]))})))
 
 ;; login phase 2: we want to load and show chats faster, so we split login into 2 phases
@@ -179,7 +179,7 @@
      {:db (-> db
               (assoc-in [:profile/login :password] password)
               (assoc-in [:profile/login :processing] true))
-      :fx [[:set-root :progress]
+      :fx [[:dispatch [:init-root :progress]]
            [:effects.profile/login
             [(get-in db [:profile/login :key-uid])
              (security/safe-unmask-data password)]]]})))

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -71,8 +71,8 @@
 
 (rf/defn init-root
   {:events [:init-root]}
-  [_ root-id]
-  {:set-root root-id})
+  [{:keys [db]} root-id]
+  {:set-root [root-id (:theme db)]})
 
 (rf/defn set-stack-root
   {:events [:set-stack-root]}

--- a/src/status_im/navigation/roots.cljs
+++ b/src/status_im/navigation/roots.cljs
@@ -15,7 +15,7 @@
    :shell-stack             nil})
 
 (defn roots-internal
-  []
+  [status-bar-theme]
   {:screen/onboarding.intro
    {:root
     {:stack {:id       :screen/onboarding.intro
@@ -28,7 +28,8 @@
              :children [{:component {:name    :shell-stack
                                      :id      :shell-stack
                                      :options (options/root-options
-                                               {:nav-bar-color colors/neutral-100})}}]}}}
+                                               {:nav-bar-color    colors/neutral-100
+                                                :status-bar-theme status-bar-theme})}}]}}}
    :screen/profile.profiles
    {:root
     {:stack {:id       :screen/profile.profiles
@@ -51,17 +52,18 @@
                                            :options (options/dark-root-options)}}]}}}})
 
 (defn old-roots
-  []
+  [status-bar-theme]
   {:progress
    {:root {:stack {:children [{:component {:name    :progress
                                            :id      :progress
-                                           :options (options/root-options nil)}}]
+                                           :options (options/root-options {:status-bar-theme
+                                                                           status-bar-theme})}}]
                    :options  (assoc (options/root-options nil)
                                     :topBar
                                     {:visible false})}}}})
 
 (defn roots
-  []
+  [status-bar-theme]
   (merge
-   (old-roots)
-   (roots-internal)))
+   (old-roots status-bar-theme)
+   (roots-internal status-bar-theme)))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/19720
fixes https://github.com/status-im/status-mobile/issues/20495

### Summary
https://github.com/status-im/status-mobile/issues/20495#issuecomment-2186858868

### Testing
Please make sure status-bar color is right after login (with, without banner, dark, light theme and both android and ios). Status bar will be broken on theme change, but it should be fixed as soon as app restarted.


status: ready