### PR TITLE
feat(wallet): sync saved addresses

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
@@ -23,15 +23,29 @@
 
 (rf/reg-event-fx :wallet/save-address save-address)
 
+(defn- update-saved-addresses
+  [saved-addresses-db new-saved-addresses]
+  (reduce
+   (fn [acc {:keys [address removed? test?] :as saved-address}]
+     (let [db-key (if test? :test :prod)]
+       (if removed?
+         (update acc db-key dissoc address)
+         (assoc-in acc [db-key address] saved-address))))
+   (or saved-addresses-db
+       {:test {}
+        :prod {}})
+   new-saved-addresses))
+
+(defn reconcile-saved-addresses
+  [{:keys [db]} [saved-addresses]]
+  {:db (update-in db [:wallet :saved-addresses] update-saved-addresses saved-addresses)})
+
+(rf/reg-event-fx :wallet/reconcile-saved-addresses reconcile-saved-addresses)
+
 (defn get-saved-addresses-success
-  [{:keys [db]} [raw-saved-addresses]]
-  (let [saved-addresses (reduce
-                         (fn [result {:keys [address test?] :as saved-address}]
-                           (assoc-in result [(if test? :test :prod) address] saved-address))
-                         {:test {}
-                          :prod {}}
-                         (data-store/rpc->saved-addresses raw-saved-addresses))]
-    {:db (assoc-in db [:wallet :saved-addresses] saved-addresses)}))
+  [_ [raw-saved-addresses]]
+  (let [saved-addresses (data-store/rpc->saved-addresses raw-saved-addresses)]
+    {:fx [[:dispatch [:wallet/reconcile-saved-addresses saved-addresses]]]}))
 
 (rf/reg-event-fx :wallet/get-saved-addresses-success get-saved-addresses-success)
 

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
@@ -2,7 +2,8 @@
   (:require
     [cljs.test :refer-macros [deftest is testing]]
     matcher-combinators.test
-    [status-im.contexts.settings.wallet.saved-addresses.events :as events]))
+    [status-im.contexts.settings.wallet.saved-addresses.events :as events]
+    [status-im.contexts.wallet.data-store :as data-store]))
 
 (deftest get-saved-addresses-test
   (testing "get saved addresses - dispatches RPC call"
@@ -15,7 +16,7 @@
                           :on-error   [:wallet/saved-addresses-rpc-error :get-saved-addresses]}]]]]
       (is (match? expected-fx result-fx)))))
 
-(def saved-address-1
+(def saved-address-rpc-1
   {:isTest           false
    :address          "0x1"
    :mixedcaseAddress "0x1"
@@ -26,21 +27,45 @@
    :colorId          "purple"
    :removed          false})
 
+(def saved-address-1
+  {:test?                     true
+   :address                   "0x1"
+   :mixedcase-address         "0x1"
+   :chain-short-names         "eth:oeth:"
+   :network-preferences-names `(:mainnet :optimism)
+   :name                      "Bob"
+   :created-at                1716826714
+   :ens                       ""
+   :ens?                      false
+   :customization-color       :blue
+   :removed?                  false})
+
 (def saved-address-2
-  {:isTest           true
-   :address          "0x2"
-   :mixedcaseAddress "0x2"
-   :chainShortNames  "eth:arb1:oeth:"
-   :name             "Bob"
-   :createdAt        1716826714
-   :ens              ""
-   :colorId          "blue"
-   :removed          false})
+  {:test?                     false
+   :address                   "0x2"
+   :mixedcase-address         "0x2"
+   :chain-short-names         "eth:arb1:oeth:"
+   :network-preferences-names `(:mainnet :arbitrum :optimism)
+   :name                      "Alicia Keys"
+   :created-at                1716826806
+   :ens                       "alicia.eth"
+   :ens?                      true
+   :customization-color       :purple
+   :removed?                  false})
 
 (deftest get-saved-addresses-success-test
+  (let [cofx                {:db {}}
+        raw-saved-addresses [saved-address-rpc-1]
+        effects             (events/get-saved-addresses-success cofx [raw-saved-addresses])
+        saved-addresses     (data-store/rpc->saved-addresses raw-saved-addresses)
+        result-fx           (:fx effects)
+        expected-fx         [[:dispatch [:wallet/reconcile-saved-addresses saved-addresses]]]]
+    (is (match? expected-fx result-fx))))
+
+(deftest reconcile-saved-addresses-test
   (testing "no saved addresses"
     (let [cofx        {:db {}}
-          effects     (events/get-saved-addresses-success cofx nil)
+          effects     (events/reconcile-saved-addresses cofx nil)
           result-db   (:db effects)
           expected-db {:wallet {:saved-addresses {:test {}
                                                   :prod {}}}}]
@@ -48,15 +73,15 @@
 
   (testing "one test saved address"
     (let [cofx        {:db {}}
-          effects     (events/get-saved-addresses-success cofx [[saved-address-2]])
+          effects     (events/reconcile-saved-addresses cofx [[saved-address-1]])
           result-db   (:db effects)
           expected-db {:wallet {:saved-addresses
-                                {:test {"0x2" {:test?                     true
-                                               :address                   "0x2"
-                                               :mixedcase-address         "0x2"
-                                               :chain-short-names         "eth:arb1:oeth:"
+                                {:test {"0x1" {:test?                     true
+                                               :address                   "0x1"
+                                               :mixedcase-address         "0x1"
+                                               :chain-short-names         "eth:oeth:"
                                                :ens?                      false
-                                               :network-preferences-names `(:mainnet :arbitrum :optimism)
+                                               :network-preferences-names `(:mainnet :optimism)
                                                :name                      "Bob"
                                                :created-at                1716826714
                                                :ens                       ""
@@ -67,29 +92,73 @@
 
   (testing "two saved addresses (test and prod)"
     (let [cofx        {:db {}}
-          effects     (events/get-saved-addresses-success cofx [[saved-address-1 saved-address-2]])
+          effects     (events/reconcile-saved-addresses cofx [[saved-address-1 saved-address-2]])
           result-db   (:db effects)
           expected-db {:wallet {:saved-addresses
-                                {:test {"0x2" {:test?                     true
-                                               :address                   "0x2"
-                                               :mixedcase-address         "0x2"
-                                               :chain-short-names         "eth:arb1:oeth:"
-                                               :network-preferences-names `(:mainnet :arbitrum :optimism)
+                                {:test {"0x1" {:test?                     true
+                                               :address                   "0x1"
+                                               :mixedcase-address         "0x1"
+                                               :chain-short-names         "eth:oeth:"
                                                :ens?                      false
+                                               :network-preferences-names `(:mainnet :optimism)
                                                :name                      "Bob"
                                                :created-at                1716826714
                                                :ens                       ""
                                                :customization-color       :blue
                                                :removed?                  false}}
-                                 :prod {"0x1" {:test?                     false
-                                               :address                   "0x1"
-                                               :mixedcase-address         "0x1"
+                                 :prod {"0x2" {:test?                     false
+                                               :address                   "0x2"
+                                               :mixedcase-address         "0x2"
                                                :chain-short-names         "eth:arb1:oeth:"
                                                :network-preferences-names `(:mainnet :arbitrum :optimism)
-                                               :ens?                      false
-                                               :name                      "Amy"
+                                               :ens?                      true
+                                               :name                      "Alicia Keys"
                                                :created-at                1716826806
-                                               :ens                       ""
+                                               :ens                       "alicia.eth"
+                                               :customization-color       :purple
+                                               :removed?                  false}}}}}]
+      (is (match? expected-db result-db))))
+
+  (testing "remove a test saved addresses"
+    (let [cofx        {:db {:wallet {:saved-addresses
+                                     {:test {"0x1" {:test?                     true
+                                                    :address                   "0x1"
+                                                    :mixedcase-address         "0x1"
+                                                    :chain-short-names         "eth:oeth:"
+                                                    :ens?                      false
+                                                    :network-preferences-names `(:mainnet :optimism)
+                                                    :name                      "Bob"
+                                                    :created-at                1716826714
+                                                    :ens                       ""
+                                                    :customization-color       :blue
+                                                    :removed?                  false}}
+                                      :prod {"0x2" {:test?                     false
+                                                    :address                   "0x2"
+                                                    :mixedcase-address         "0x2"
+                                                    :chain-short-names         "eth:arb1:oeth:"
+                                                    :network-preferences-names `(:mainnet :arbitrum
+                                                                                          :optimism)
+                                                    :ens?                      true
+                                                    :name                      "Alicia Keys"
+                                                    :created-at                1716826806
+                                                    :ens                       "alicia.eth"
+                                                    :customization-color       :purple
+                                                    :removed?                  false}}}}}}
+          effects     (events/reconcile-saved-addresses cofx
+                                                        [[(assoc saved-address-1 :removed? true)
+                                                          saved-address-2]])
+          result-db   (:db effects)
+          expected-db {:wallet {:saved-addresses
+                                {:test {}
+                                 :prod {"0x2" {:test?                     false
+                                               :address                   "0x2"
+                                               :mixedcase-address         "0x2"
+                                               :chain-short-names         "eth:arb1:oeth:"
+                                               :network-preferences-names `(:mainnet :arbitrum :optimism)
+                                               :ens?                      true
+                                               :name                      "Alicia Keys"
+                                               :created-at                1716826806
+                                               :ens                       "alicia.eth"
                                                :customization-color       :purple
                                                :removed?                  false}}}}}]
       (is (match? expected-db result-db)))))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
@@ -210,7 +210,10 @@
           expected-fx            [[:json-rpc/call
                                    [{:method     "wakuext_deleteSavedAddress"
                                      :params     [address test-networks-enabled?]
-                                     :on-success [:wallet/delete-saved-address-success toast-message]
+                                     :on-success [:wallet/delete-saved-address-success
+                                                  {:address                address
+                                                   :test-networks-enabled? test-networks-enabled?
+                                                   :toast-message          toast-message}]
                                      :on-error   [:wallet/delete-saved-address-failed]}]]]]
       (is (match? expected-fx result-fx)))))
 

--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -109,7 +109,7 @@
         :on-press            open-show-address-qr
         :accessibility-label :show-address-qr-code}
        {:icon                :i/edit
-        :label               (i18n/label :t/edit-account)
+        :label               (i18n/label :t/edit-details)
         :blur?               true
         :on-press            open-edit-saved-address
         :accessibility-label :edit-saved-address}

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -154,7 +154,7 @@
                         :colorId          :customization-color
                         :mixedcaseAddress :mixedcase-address
                         :removed          :removed?})
-      (update :customization-color keyword)
+      (update :customization-color (comp keyword string/lower-case))
       add-keys-to-saved-address))
 
 (defn rpc->saved-addresses

--- a/translations/en.json
+++ b/translations/en.json
@@ -2507,6 +2507,7 @@
     "disconnect-dapp-success": "{{dapp}} disconnected from {{account}}",
     "disconnect-dapp-fail": "Failed to disconnect {{dapp}} from {{account}}",
     "edit-account": "Edit account",
+    "edit-details": "Edit details",
     "share-account": "Share account",
     "remove-account": "Remove account",
     "select-another-account": "Select another account",


### PR DESCRIPTION
fixes #20545

### Summary

This PR adds syncing saved addresses across paired devices whenever a new saved address is added or an existing one is edited or removed.

#### Review notes:

This PR introduces a reconcile event to handle the saved addresses from the RPC response and the messenger signal.

### Platforms

- Android
- iOS

### Steps to test

##### Prerequisites: A user/profile with two or more synced/paired devices

- Open Status in one of your synced/paired device
- Navigate to `Profile > Wallet > Saved addresses`
- Add a new saved address and verify it's updated in other paired devices
- Edit an existing saved address and verify  it's updated in other paired devices
- Remove a saved address and verify it's updated in other paired devices

status: Ready


