### PR TITLE
"Share all addresses" for communities

### DIFF
--- a/src/status_im/contexts/communities/actions/accounts_selection/events.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/events.cljs
@@ -17,13 +17,12 @@
 (rf/reg-event-fx :communities/initialize-permission-addresses initialize-permission-addresses)
 
 (defn do-init-permission-addresses
-  [{:keys [db]} [community-id revealed-accounts]]
+  [{:keys [db]} [community-id revealed-accounts share-future-addresses?]]
   (let [wallet-accounts     (utils/sorted-operable-non-watch-only-accounts db)
         addresses-to-reveal (if (seq revealed-accounts)
                               (set (keys revealed-accounts))
                               ;; Reveal all addresses as fallback.
                               (set (map :address wallet-accounts)))
-
         ;; When there are no revealed addresses, such as when joining a
         ;; community, use first address for airdrops.
         airdrop-address     (or (->> revealed-accounts
@@ -35,10 +34,7 @@
                                      first
                                      :address))]
     {:db (-> db
-             ;; Set to false by default while we don't persist the user's choice
-             ;; in status-go, otherwise whenever the view is mounted, the choice
-             ;; of selected addresses won't be respected.
-             (assoc-in [:communities/selected-share-all-addresses community-id] false)
+             (assoc-in [:communities/selected-share-all-addresses community-id] share-future-addresses?)
              (assoc-in [:communities/all-addresses-to-reveal community-id] addresses-to-reveal)
              (assoc-in [:communities/all-airdrop-addresses community-id] airdrop-address))
      :fx [[:dispatch
@@ -60,36 +56,44 @@
   is selecting an airdrop address, we must submit to status-go the current
   choice of addresses to share, and vice-versa. If we omit addresses to share,
   status-go will default to all available."
-  [{:keys [db]} [{:keys [community-id password on-success addresses airdrop-address]}]]
-  (let [pub-key             (get-in db [:profile/profile :public-key])
-        wallet-accounts     (utils/sorted-operable-non-watch-only-accounts db)
-        addresses-to-reveal (if (seq addresses)
-                              (set addresses)
-                              (get-in db [:communities/all-addresses-to-reveal community-id]))
-        new-airdrop-address (if (contains? addresses-to-reveal airdrop-address)
-                              airdrop-address
-                              (->> wallet-accounts
-                                   (filter #(contains? addresses-to-reveal (:address %)))
-                                   first
-                                   :address))]
+  [{:keys [db]}
+   [{:keys [community-id password on-success addresses airdrop-address share-future-addresses?]}]]
+  (let [pub-key                 (get-in db [:profile/profile :public-key])
+        wallet-accounts         (utils/sorted-operable-non-watch-only-accounts db)
+        addresses-to-reveal     (if (seq addresses)
+                                  (set addresses)
+                                  (get-in db [:communities/all-addresses-to-reveal community-id]))
+        new-airdrop-address     (if (contains? addresses-to-reveal airdrop-address)
+                                  airdrop-address
+                                  (->> wallet-accounts
+                                       (filter #(contains? addresses-to-reveal (:address %)))
+                                       first
+                                       :address))
+        share-future-addresses? (if (nil? share-future-addresses?)
+                                  (get-in db [:communities/selected-share-all-addresses community-id])
+                                  share-future-addresses?)]
     {:fx [[:effects.community/edit-shared-addresses
-           {:community-id        community-id
-            :password            password
-            :pub-key             pub-key
-            :addresses-to-reveal addresses-to-reveal
-            :airdrop-address     new-airdrop-address
-            :on-success          (fn []
-                                   (when (fn? on-success)
-                                     (on-success addresses-to-reveal new-airdrop-address))
-                                   (rf/dispatch [:communities/edit-shared-addresses-success
-                                                 community-id addresses-to-reveal airdrop-address]))
-            :on-error            [:communities/edit-shared-addresses-failure community-id]}]]}))
+           {:community-id            community-id
+            :password                password
+            :pub-key                 pub-key
+            :addresses-to-reveal     addresses-to-reveal
+            :share-future-addresses? share-future-addresses?
+            :airdrop-address         new-airdrop-address
+            :on-success              (fn []
+                                       (when (fn? on-success)
+                                         (on-success addresses-to-reveal
+                                                     new-airdrop-address
+                                                     share-future-addresses?))
+                                       (rf/dispatch [:communities/edit-shared-addresses-success
+                                                     community-id addresses-to-reveal airdrop-address]))
+            :on-error                [:communities/edit-shared-addresses-failure community-id]}]]}))
 
 (rf/reg-event-fx :communities/edit-shared-addresses edit-shared-addresses)
 
 (rf/reg-event-fx :communities/edit-shared-addresses-success
- (fn [_ [community-id addresses-to-reveal airdrop-address]]
+ (fn [_ [community-id addresses-to-reveal airdrop-address share-future-addresses?]]
    {:fx [[:dispatch [:communities/set-airdrop-address community-id airdrop-address]]
+         [:dispatch [:communities/set-share-all-addresses community-id share-future-addresses?]]
          [:dispatch [:communities/set-addresses-to-reveal community-id addresses-to-reveal]]]}))
 
 (rf/reg-event-fx :communities/edit-shared-addresses-failure

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -203,7 +203,9 @@
                                                                        :addresses-for-permissions])
                                                          (rf/dispatch [:hide-bottom-sheet]))}]))}])
               (rf/dispatch [:communities/set-share-all-addresses id flag-share-all-addresses]))
-            (rf/dispatch [:communities/set-addresses-to-reveal id addresses-to-reveal])))
+            (do
+              (rf/dispatch [:communities/set-share-all-addresses id flag-share-all-addresses])
+              (rf/dispatch [:communities/set-addresses-to-reveal id addresses-to-reveal]))))
         highest-role (rf/sub [:communities/highest-role-for-selection id])
         [unmodified-role _] (rn/use-state highest-role)]
 
@@ -261,6 +263,7 @@
         can-edit-addresses? (rf/sub [:communities/can-edit-shared-addresses? id])
 
         wallet-accounts (rf/sub [:wallet/operable-accounts-without-watched-accounts])
+        joined (rf/sub [:communities/community-joined id])
         unmodified-addresses-to-reveal (rf/sub [:communities/addresses-to-reveal id])
         [addresses-to-reveal set-addresses-to-reveal] (rn/use-state unmodified-addresses-to-reveal)
 
@@ -285,7 +288,6 @@
             (set-flag-share-all-addresses new-value)
             (when new-value
               (set-addresses-to-reveal (set (map :address wallet-accounts))))))]
-
     (rn/use-mount
      (fn []
        (when-not flag-share-all-addresses
@@ -310,6 +312,7 @@
                                  flag-share-all-addresses]
        :header                  [quo/page-setting
                                  {:checked?            flag-share-all-addresses
+                                  :disabled?           joined
                                   :customization-color color
                                   :on-change           toggle-flag-share-all-addresses
                                   :setting-text        (i18n/label

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -16,6 +16,7 @@
     [status-im.navigation.events :as navigation]
     [status-im.navigation.transitions :as transitions]
     [taoensso.timbre :as log]
+    [utils.collection :as collection-utils]
     [utils.re-frame :as rf]))
 
 (defn handle-community
@@ -372,15 +373,14 @@
     (when (and community joined (not fetching-revealed-accounts))
       {:db (assoc-in db [:communities community-id :fetching-revealed-accounts] true)
        :json-rpc/call
-       [{:method      "wakuext_getRevealedAccounts"
-         :params      [community-id (get-in db [:profile/profile :public-key])]
-         :js-response true
-         :on-success  [:communities/get-revealed-accounts-success community-id on-success]
-         :on-error    (fn [err]
-                        (log/error {:message      "failed to fetch revealed accounts"
-                                    :community-id community-id
-                                    :err          err})
-                        (rf/dispatch [:communities/get-revealed-accounts-failed community-id]))}]})))
+       [{:method     "wakuext_latestRequestToJoinForCommunity"
+         :params     [community-id]
+         :on-success [:communities/get-revealed-accounts-success community-id on-success]
+         :on-error   (fn [err]
+                       (log/error {:message      "failed to fetch revealed accounts"
+                                   :community-id community-id
+                                   :err          err})
+                       (rf/dispatch [:communities/get-revealed-accounts-failed community-id]))}]})))
 
 (rf/reg-event-fx :communities/get-revealed-accounts get-revealed-accounts)
 
@@ -399,22 +399,18 @@
      [:json-rpc/call :schema.common/rpc-call]]]])
 
 (rf/reg-event-fx :communities/get-revealed-accounts-success
- (fn [{:keys [db]} [community-id on-success revealed-accounts-js]]
+ (fn [{:keys [db]} [community-id on-success request-to-join]]
    (when-let [community (get-in db [:communities community-id])]
-     (let [revealed-accounts
-           (reduce
-            (fn [acc {:keys [address] :as revealed-account}]
-              (assoc acc address revealed-account))
-            {}
-            (data-store.communities/<-revealed-accounts-rpc revealed-accounts-js))
-
+     (let [revealed-accounts (collection-utils/index-by :address (:revealedAccounts request-to-join))
+           share-future-addresses? (:shareFutureAddresses request-to-join)
            community-with-revealed-accounts
            (-> community
                (assoc :revealed-accounts revealed-accounts)
+               (assoc :share-future-addresses? share-future-addresses?)
                (dissoc :fetching-revealed-accounts))]
        {:db (assoc-in db [:communities community-id] community-with-revealed-accounts)
         :fx [(when (vector? on-success)
-               [:dispatch (conj on-success revealed-accounts)])]}))))
+               [:dispatch (conj on-success revealed-accounts share-future-addresses?)])]}))))
 
 (rf/reg-event-fx :communities/get-revealed-accounts-failed
  (fn [{:keys [db]} [community-id]]

--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -146,8 +146,8 @@
             effects   (events/get-revealed-accounts {:db db} [community-id])]
         (is (match? (assoc-in db [:communities community-id :fetching-revealed-accounts] true)
                     (:db effects)))
-        (is (match? {:method "wakuext_getRevealedAccounts"
-                     :params [community-id "profile-public-key"]}
+        (is (match? {:method "wakuext_latestRequestToJoinForCommunity"
+                     :params [community-id]}
                     (-> effects :json-rpc/call first (select-keys [:method :params]))))))))
 
 (deftest handle-community-test

--- a/src/status_im/contexts/communities/overview/events.cljs
+++ b/src/status_im/contexts/communities/overview/events.cljs
@@ -117,13 +117,14 @@
                      {:community community-name})}]]]})))
 
 (defn request-to-join-with-signatures
-  [_ [community-id addresses-to-reveal signatures]]
+  [_ [community-id addresses-to-reveal signatures share-future-addresses?]]
   {:fx [[:json-rpc/call
          [{:method      "wakuext_requestToJoinCommunity"
-           :params      [{:communityId       community-id
-                          :signatures        signatures
-                          :addressesToReveal addresses-to-reveal
-                          :airdropAddress    (first addresses-to-reveal)}]
+           :params      [{:communityId          community-id
+                          :signatures           signatures
+                          :addressesToReveal    addresses-to-reveal
+                          :shareFutureAddresses share-future-addresses?
+                          :airdropAddress       (first addresses-to-reveal)}]
            :js-response true
            :on-success  [:communities/requested-to-join]
            :on-error    [:communities/requested-to-join-error community-id]}]]]})
@@ -153,16 +154,18 @@
 (defn request-to-join-with-addresses
   [{:keys [db]}
    [{:keys [community-id password]}]]
-  (let [pub-key             (get-in db [:profile/profile :public-key])
-        addresses-to-reveal (get-in db [:communities/all-addresses-to-reveal community-id])
-        airdrop-address     (get-in db [:communities/all-airdrop-addresses community-id])]
+  (let [pub-key                 (get-in db [:profile/profile :public-key])
+        addresses-to-reveal     (get-in db [:communities/all-addresses-to-reveal community-id])
+        share-future-addresses? (get-in db [:communities/selected-share-all-addresses community-id])
+        airdrop-address         (get-in db [:communities/all-airdrop-addresses community-id])]
     {:fx [[:effects.community/request-to-join
-           {:community-id        community-id
-            :password            password
-            :pub-key             pub-key
-            :addresses-to-reveal addresses-to-reveal
-            :airdrop-address     airdrop-address
-            :on-success          [:communities/requested-to-join]
-            :on-error            [:communities/requested-to-join-error community-id]}]]}))
+           {:community-id            community-id
+            :password                password
+            :pub-key                 pub-key
+            :addresses-to-reveal     addresses-to-reveal
+            :airdrop-address         airdrop-address
+            :share-future-addresses? share-future-addresses?
+            :on-success              [:communities/requested-to-join]
+            :on-error                [:communities/requested-to-join-error community-id]}]]}))
 
 (rf/reg-event-fx :communities/request-to-join-with-addresses request-to-join-with-addresses)

--- a/src/status_im/contexts/communities/overview/events_test.cljs
+++ b/src/status_im/contexts/communities/overview/events_test.cljs
@@ -37,19 +37,22 @@
                 (sut/sign-data cofx [community-id password sign-params])))))
 
 (deftest request-to-join-with-signatures-test
-  (let [cofx                {:db {}}
-        addresses-to-reveal [account-pub-key "0x2"]
-        signatures          ["11111" "222222"]
-        expected            {:fx [[:json-rpc/call
-                                   [{:method      "wakuext_requestToJoinCommunity"
-                                     :params      [{:communityId       community-id
-                                                    :signatures        signatures
-                                                    :addressesToReveal addresses-to-reveal
-                                                    :airdropAddress    "0x1"}]
-                                     :js-response true
-                                     :on-success  [:communities/requested-to-join]
-                                     :on-error    [:communities/requested-to-join-error
-                                                   community-id]}]]]}]
+  (let [cofx                    {:db {}}
+        addresses-to-reveal     [account-pub-key "0x2"]
+        share-future-addresses? true
+        signatures              ["11111" "222222"]
+        expected                {:fx [[:json-rpc/call
+                                       [{:method      "wakuext_requestToJoinCommunity"
+                                         :params      [{:communityId          community-id
+                                                        :signatures           signatures
+                                                        :addressesToReveal    addresses-to-reveal
+                                                        :shareFutureAddresses share-future-addresses?
+                                                        :airdropAddress       "0x1"}]
+                                         :js-response true
+                                         :on-success  [:communities/requested-to-join]
+                                         :on-error    [:communities/requested-to-join-error
+                                                       community-id]}]]]}]
     (is (match? expected
                 (sut/request-to-join-with-signatures cofx
-                                                     [community-id addresses-to-reveal signatures])))))
+                                                     [community-id addresses-to-reveal signatures
+                                                      share-future-addresses?])))))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.182.35",
-    "commit-sha1": "484b8aca1a12718c9b3940f8a398e60ee4419600",
-    "src-sha256": "1xnpx86k54lnsw93xw6la0sggd9y0nm7hn70cm0qgmq2qg8pzb3a"
+    "version": "v0.182.36",
+    "commit-sha1": "8458cafef9f876c11a58dc9ede14fc58a5a0f968",
+    "src-sha256": "0nkb0zpqgpklh8mlrgcglh5v32qlfly9hd7ia3a1icx5kdp2q2wp"
 }


### PR DESCRIPTION
"Share all future addresses" storage

Testing https://github.com/status-im/status-go/pull/5354

Fixes #18976 

## Testing notes
This is a sample testing scenario:

1. Receive a community link
2. Click on it, `Request to join`, check `Share all current and future addresses`.
3. After successful joining, logout and login again.
4. Enable `edit-account-selection` under `Feature Flags` in profile settings
5. Long tap on community you've just joined, `Edit shared addresses` -> `You're a member`
6. The `Share all current and future addresses` checkbox should remain enabled.