### PR TITLE
fix: use "Biometric" instead of Touch ID when no Biometric found

### DIFF
--- a/src/legacy/status_im/events.cljs
+++ b/src/legacy/status_im/events.cljs
@@ -135,7 +135,8 @@
                                  (>= (- now app-in-background-since)
                                      constants/ms-in-bg-for-require-bioauth))]
     (rf/merge cofx
-              {:db (dissoc db :app-in-background-since)}
+              {:db                                   (dissoc db :app-in-background-since)
+               :effects.biometric/get-supported-type nil}
               (mailserver/process-next-messages-request)
               (when-not new-account?
                 (universal-links/process-stored-event))

--- a/src/status_im/common/biometric/utils.cljs
+++ b/src/status_im/common/biometric/utils.cljs
@@ -11,9 +11,10 @@
 (defn get-label-by-type
   [biometric-type]
   (condp = biometric-type
-    constants/biometrics-type-android (i18n/label :t/biometric-fingerprint)
-    constants/biometrics-type-face-id (i18n/label :t/biometric-faceid)
-    (i18n/label :t/biometric-touchid)))
+    constants/biometrics-type-android  (i18n/label :t/biometric-fingerprint)
+    constants/biometrics-type-face-id  (i18n/label :t/biometric-faceid)
+    constants/biometrics-type-touch-id (i18n/label :t/biometric-touchid)
+    (i18n/label :t/biometric)))
 
 (defn get-icon-by-type
   [biometric-type]

--- a/translations/en.json
+++ b/translations/en.json
@@ -70,6 +70,7 @@
     "bio-added": "Bio added",
     "bio-is-too-long": "Bio is too long",
     "bio-updated": "Bio updated",
+    "biometric": "Biometric",
     "biometric-auth-android-sensor-desc": "Touch sensor",
     "biometric-auth-android-sensor-error-desc": "Failed",
     "biometric-auth-android-title": "Authentication Required",


### PR DESCRIPTION
-------

fixes #20149

### Summary

react native biometric returns `nil` when no biometric sensor/permission is avaliable
status fallback to "Face ID" when it's `nil`

this PR changes the fallback to "Biometric"

### Testing notes
- create profile
- disable biometric permission for status
- check password setting

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
password setting

status: ready <!-- Can be ready or wip -->