### PR TITLE
chore: lightclient peer exchange

### DIFF
--- a/src/status_im/contexts/profile/config.cljs
+++ b/src/status_im/contexts/profile/config.cljs
@@ -40,7 +40,7 @@
             :verifyENSURL             config/verify-ens-url
             :verifyENSContractAddress config/verify-ens-contract-address
             :verifyTransactionChainID config/verify-transaction-chain-id
-            :wakuV2LightClient        false
+            :wakuV2LightClient        true
             :previewPrivacy           config/blank-preview?
             :testNetworksEnabled      config/test-networks-enabled?})))
 

--- a/src/status_im/contexts/syncing/events.cljs
+++ b/src/status_im/contexts/syncing/events.cljs
@@ -34,7 +34,7 @@
             :WakuV2Config {;; Temporary fix until https://github.com/status-im/status-go/issues/3024
                            ;; is resolved
                            :Nameserver  "8.8.8.8"
-                           :LightClient false}
+                           :LightClient true}
             :ShhextConfig {:VerifyTransactionURL     config/verify-transaction-url
                            :VerifyENSURL             config/verify-ens-url
                            :VerifyENSContractAddress config/verify-ens-contract-address

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.180.31",
-    "commit-sha1": "e0673ad1ffec65e3bd96a46b5054fc2d36071cc4",
-    "src-sha256": "15y3fl0q8kqxbsqj9snyg7spaqj09xid9rfza7l5zpk8p0ajqnmk"
+    "version": "a287e2cf603b0462ee3b5323fef29497ae87aaff",
+    "commit-sha1": "a287e2cf603b0462ee3b5323fef29497ae87aaff",
+    "src-sha256": "01kn3pj2xag03yxivfgvdadff9h3dhmpis5qyv9nmi2fhbf423fa"
 }


### PR DESCRIPTION
Duplicate of https://github.com/status-im/status-mobile/pull/20553 with just lightClient set to default. 

This is opened so that e2e tests can be run with lightClient.

Not to be merged.