### PR TITLE
Disable input field on send asset page

### DIFF
--- a/src/quo/components/wallet/token_input/view.cljs
+++ b/src/quo/components/wallet/token_input/view.cljs
@@ -81,8 +81,9 @@
                                         (js->clj :keywordize-keys true)
                                         (on-selection-change))))]
     (fn [{:keys [token customization-color show-keyboard? crypto? currency value error? selection
-                 handle-on-swap]
-          :or   {show-keyboard? true}}]
+                 handle-on-swap allow-selection?]
+          :or   {show-keyboard?   true
+                 allow-selection? true}}]
       (let [theme        (quo.theme/use-theme)
             window-width (:width (rn/get-window))]
         [rn/pressable
@@ -107,7 +108,8 @@
                      :selection-color          customization-color
                      :show-soft-input-on-focus show-keyboard?
                      :on-selection-change      handle-selection-change
-                     :selection                (clj->js selection)}
+                     :selection                (clj->js selection)
+                     :editable                 allow-selection?}
               controlled-input?       (assoc :value value)
               (not controlled-input?) (assoc :default-value value-internal))]
            [token-name-text theme (if crypto? token currency)]]]

--- a/src/status_im/contexts/preview/quo/wallet/token_input.cljs
+++ b/src/status_im/contexts/preview/quo/wallet/token_input.cljs
@@ -23,6 +23,8 @@
     :options [{:key :usd}
               {:key :eur}]}
    {:key  :error?
+    :type :boolean}
+   {:key  :allow-selection?
     :type :boolean}])
 
 (defn view
@@ -33,7 +35,8 @@
                                  :networks            networks
                                  :title               title
                                  :customization-color :blue
-                                 :show-keyboard?      false})
+                                 :show-keyboard?      false
+                                 :allow-selection?    true})
         value     (reagent/atom "")
         set-value (fn [v]
                     (swap! value str v))

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -349,23 +349,24 @@
        :on-press      on-navigate-back
        :switcher-type :select-account}]
      [quo/token-input
-      {:container-style style/input-container
-       :token           token-symbol
-       :currency        fiat-currency
-       :currency-symbol currency-symbol
-       :crypto-decimals (min token-decimals 6)
-       :error?          (controlled-input/input-error input-state)
-       :networks        (seq send-enabled-networks)
-       :title           (i18n/label
-                         :t/send-limit
-                         {:limit (if crypto-currency?
-                                   (utils/make-limit-label-crypto current-limit token-symbol)
-                                   (utils/make-limit-label-fiat current-limit currency-symbol))})
-       :conversion      conversion-rate
-       :show-keyboard?  false
-       :value           input-amount
-       :on-swap         swap-between-fiat-and-crypto
-       :on-token-press  show-select-asset-sheet}]
+      {:container-style  style/input-container
+       :token            token-symbol
+       :currency         fiat-currency
+       :currency-symbol  currency-symbol
+       :crypto-decimals  (min token-decimals 6)
+       :error?           (controlled-input/input-error input-state)
+       :networks         (seq send-enabled-networks)
+       :title            (i18n/label
+                          :t/send-limit
+                          {:limit (if crypto-currency?
+                                    (utils/make-limit-label-crypto current-limit token-symbol)
+                                    (utils/make-limit-label-fiat current-limit currency-symbol))})
+       :conversion       conversion-rate
+       :show-keyboard?   false
+       :value            input-amount
+       :on-swap          swap-between-fiat-and-crypto
+       :on-token-press   show-select-asset-sheet
+       :allow-selection? false}]
      [routes/view
       {:token                                     token-by-symbol
        :input-value                               input-amount

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -170,22 +170,23 @@
            {:title       (i18n/label :t/send-from-network {:network network-name-str})
             :description (i18n/label :t/define-amount-sent-from-network {:network network-name-str})}]
           [quo/token-input
-           {:container-style style/input-container
-            :token           token-symbol
-            :currency        fiat-currency
-            :currency-symbol currency-symbol
-            :crypto-decimals (min token-decimals 6)
-            :error?          (controlled-input/input-error input-state)
-            :networks        [network-details]
-            :title           (i18n/label
-                              :t/send-limit
-                              {:limit (if crypto-currency?
-                                        (utils/make-limit-label-crypto current-limit token-symbol)
-                                        (utils/make-limit-label-fiat current-limit currency-symbol))})
-            :conversion      conversion-rate
-            :show-keyboard?  false
-            :value           (controlled-input/input-value input-state)
-            :on-swap         swap-between-fiat-and-crypto}]
+           {:container-style  style/input-container
+            :token            token-symbol
+            :currency         fiat-currency
+            :currency-symbol  currency-symbol
+            :crypto-decimals  (min token-decimals 6)
+            :error?           (controlled-input/input-error input-state)
+            :networks         [network-details]
+            :title            (i18n/label
+                               :t/send-limit
+                               {:limit (if crypto-currency?
+                                         (utils/make-limit-label-crypto current-limit token-symbol)
+                                         (utils/make-limit-label-fiat current-limit currency-symbol))})
+            :conversion       conversion-rate
+            :show-keyboard?   false
+            :value            (controlled-input/input-value input-state)
+            :on-swap          swap-between-fiat-and-crypto
+            :allow-selection? false}]
           [quo/disclaimer
            {:on-change           (fn [checked?]
                                    (set-is-amount-locked checked?))


### PR DESCRIPTION

fixes #19810 

### Summary

Input field disabled to avoid existing issues and validations related to the input field that occur when pasting and changing data with help of a cursor into the current input field.

https://github.com/status-im/status-mobile/assets/5786310/8cd98769-f2fa-4e58-8ea2-408dc162e804



#### Areas that maybe impacted
Sending assets, locking amount for specific network

##### Functional

- wallet / transactions


### Steps to test

- Go to the input assets value page.
- Focus the cursor into the input field.

**Expected result:**
The cursor should not be able to be focused. Only the app's keyboard should be able to interact with the input field

status: ready 
