### PR TITLE
[#19375] Fix remove modal for seed accounts

### DIFF
--- a/src/status_im/contexts/wallet/sheets/remove_account/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/remove_account/view.cljs
@@ -92,6 +92,6 @@
   []
   (let [{:keys [type] :as account} (rf/sub [:wallet/current-viewing-account])]
     (case type
-      :generated [recovery-phase-flow account]
-      :watch     [watched-address-flow account]
+      (:generated :seed) [recovery-phase-flow account]
+      :watch             [watched-address-flow account]
       nil)))

--- a/src/status_im/contexts/wallet/sheets/remove_account/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/remove_account/view.cljs
@@ -88,10 +88,29 @@
      :address          address
      :toast-message    (i18n/label :t/watched-account-removed)}]])
 
+(defn- private-key-address-flow
+  [{:keys [address name emoji color] :as _account}]
+  [:<>
+   [quo/drawer-top
+    {:title               (i18n/label :t/remove-account-title)
+     :type                :context-tag
+     :context-tag-type    :account
+     :account-name        name
+     :emoji               emoji
+     :customization-color color}]
+   [rn/view {:style style/desc-container}
+    [quo/text {:weight :medium}
+     (i18n/label :t/remove-private-key-address-desc)]]
+   [footer
+    {:submit-disabled? false
+     :address          address
+     :toast-message    (i18n/label :t/account-removed)}]])
+
 (defn view
   []
-  (let [{:keys [type] :as account} (rf/sub [:wallet/current-viewing-account])]
-    (case type
+  (let [{account-type :type :as account} (rf/sub [:wallet/current-viewing-account])]
+    (case account-type
       (:generated :seed) [recovery-phase-flow account]
       :watch             [watched-address-flow account]
+      :key               [private-key-address-flow account]
       nil)))

--- a/translations/en.json
+++ b/translations/en.json
@@ -2603,6 +2603,7 @@
     "remove-watched-address-desc": "The watched address will be removed from all of your synced devices.",
     "remove-account-title": "Remove account",
     "remove-account-desc": "The account will be removed from all of your synced devices. Make sure you have a backup of your key pair or recovery phrase and derivation path (if it’s not default).",
+    "remove-private-key-address-desc": "The account will be removed from all of your synced devices. Make sure you have a backup of your key pair or recovery phrase.",
     "derivation-path-copied": "Derivation path copied",
     "remove-account-confirmation": "I have taken note of the derivation path",
     "edit-receiver-networks": "Edit receiver networks",


### PR DESCRIPTION
fixes #19375 

### Summary

Just a quick fix, shows the modal to remove accounts created from an imported or new generated keypair


### Steps to test

- Create a new keypair or import a keypair
- Create acounts for it
- Remove them

status: ready