### PR TITLE
fix_: reloading of contacts when selected and unselected

### DIFF
--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -50,7 +50,7 @@
            item])))))
 
 (defn add-manage-members
-  [{:keys [scroll-enabled? on-scroll]}]
+  [{:keys [on-scroll]}]
   (let [theme                      (quo.theme/use-theme)
         selected-participants      (rf/sub [:group-chat/selected-participants])
         deselected-members         (rf/sub [:group-chat/deselected-members])
@@ -71,7 +71,6 @@
       (i18n/label (if admin? :t/manage-members :t/add-members))]
      [gesture/section-list
       {:key-fn                         :title
-       :scroll-enabled                 @scroll-enabled?
        :on-scroll                      on-scroll
        :sticky-section-headers-enabled false
        :sections                       (rf/sub [:contacts/grouped-by-first-letter])


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20532

### Summary
When the user navigates to the contact screen, the contact list item is already pre-checked for the group members. The user then has the option to either add new contacts to the group or the group members.  

The contact list item initialises an `atom` that gets updated when the user selects and unselects a contact however when the screen reloads and the atom loses state to the default value and because of this, the user has to repeat the process again 

