### PR TITLE
[#20543] fix: incorrect black background behind floating button

### DIFF
--- a/src/status_im/common/floating_button_page/floating_container/view.cljs
+++ b/src/status_im/common/floating_button_page/floating_container/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.common.floating-button-page.floating-container.view
   (:require
     [quo.core :as quo]
+    [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [status-im.common.floating-button-page.floating-container.style :as style]))
@@ -9,9 +10,10 @@
   [child]
   (let [theme (quo.theme/use-theme)]
     [quo/blur
-     {:blur-amount 12
-      :blur-radius 12
-      :blur-type   theme}
+     {:blur-amount        52
+      :blur-radius        20
+      :blur-type          :transparent
+      :blur-overlay-color (colors/theme-colors colors/white-70-blur colors/neutral-95-opa-70-blur theme)}
      [rn/view {:style style/blur-inner-container}
       child]]))
 


### PR DESCRIPTION
fixes #20543

### Summary

Incorrect black background behind floating button

it should be like 
https://www.figma.com/design/HKncH4wnDwZDAhc4AryK8Y/Wallet-for-Mobile?node-id=2548-423720&t=aei7xqJHWUAv5eWM-1

#### Areas that maybe impacted
- add and edit save addresses 

### Steps to test

- Login to app
- Go to Profile -> Wallet -> Saved addresses
- Tap on +
- Add an address (e.g. 0x4B0897b0513fdc7C541B6d9D7E929C4e5364d2dB)
- Tap Continue

### Result
#### Before
<img src="https://github.com/status-im/status-mobile/assets/71308738/64b2fdf6-e820-4866-910d-2235ed55003d" width="390px"/>

#### After 
<img src="https://github.com/status-im/status-mobile/assets/71308738/8d1ab9ca-4a3f-4435-91ed-eecadb7602a6" width="390px"/>


status: ready

