### PR TITLE
feat: statusgo filter optimizations (not to merge)

### DIFF
--- a/src/status_im/contexts/profile/config.cljs
+++ b/src/status_im/contexts/profile/config.cljs
@@ -40,7 +40,7 @@
             :verifyENSURL             config/verify-ens-url
             :verifyENSContractAddress config/verify-ens-contract-address
             :verifyTransactionChainID config/verify-transaction-chain-id
-            :wakuV2LightClient        false
+            :wakuV2LightClient        true
             :previewPrivacy           config/blank-preview?
             :testNetworksEnabled      config/test-networks-enabled?})))
 

--- a/src/status_im/contexts/syncing/events.cljs
+++ b/src/status_im/contexts/syncing/events.cljs
@@ -34,7 +34,7 @@
             :WakuV2Config {;; Temporary fix until https://github.com/status-im/status-go/issues/3024
                            ;; is resolved
                            :Nameserver  "8.8.8.8"
-                           :LightClient false}
+                           :LightClient true}
             :ShhextConfig {:VerifyTransactionURL     config/verify-transaction-url
                            :VerifyENSURL             config/verify-ens-url
                            :VerifyENSContractAddress config/verify-ens-contract-address

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.181.31",
-    "commit-sha1": "6e056348e6d28f962167118612826f1ef0e47b22",
-    "src-sha256": "1qvfwk28sg93basjzy8r55qz8pk9xg0h7kxv5ykxkbfh4q17a1ns"
+    "version": "feat/optimize-filter-subs",
+    "commit-sha1": "c67034555982c76a7595463bb6ddcfa0eb0bc562",
+    "src-sha256": "0hqvxdzp54n3asv7xfpcjsbpffh765p0lsp9fv160x8kjmmz9dba"
 }


### PR DESCRIPTION
### Summary

This PR is not to be merged, but only to be used for dogfooding.
This is based on https://github.com/status-im/status-go/pull/5440

### Affected areas
LightClient/Mode filter subscriptions.

### Testing notes

### LightClient dogfooding

To enable light-client, go to Profile --> Advanced and select "Light Client". This will require an app restart.

Dogfooding steps and things to look for in lightClient:

-  Login normally, and make sure you enable Node Management and Debug in Advanced Settings.
-  Make sure you got some peers connected in Node Management tab
-  Run tests by being part of community , 1:1 chats, private group chats etc
-  Disconnect from the internet, wait until the peer count goes to 0.
-  Connect to the internet, You should reconnect to some peers in sometime. (Note that it takes some time for peers to be connected - this needs fixing)
-  Test reception of messages on 1:1 chat, groups and community
-  Leave it running and ensure no issues in send/receive messages

`Note : Do wait for 30-60 seconds for all filter subscriptions to stabilize after logging in or starting the app, until then you may notice a latency in receiving messages.`

cc @pavloburykh  Can we get some e2e and manual testing of lightClient done for this PR?
