### PR TITLE
fix endless loading skeleton for some empty channels on IOS

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -98,9 +98,8 @@
                               window-height
                               loading-indicator-page-loading-height)]
     [rn/view {:padding-top top-spacing}
-     ;; Only use animated loading skeleton for ios
-     ;; https://github.com/status-im/status-mobile/issues/17426
-     [quo/skeleton-list (skeleton-list-props :messages parent-height platform/ios?)]]))
+     ;; Don't use animated loading skeleton https://github.com/status-im/status-mobile/issues/17426
+     [quo/skeleton-list (skeleton-list-props :messages parent-height false)]]))
 
 (defn header-height
   [{:keys [insets able-to-send-message? images reply edit link-previews? input-content-height]}]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20599

### Testing

If the issue cause is the same as what we faced in Android (https://github.com/status-im/status-mobile/issues/17426), then removing the animated loading skeleton should fix the issue. Please let me know if this is not the case.

status: ready