### PR TITLE
fix fail to open database error message when user enters the wrong password

### DIFF
--- a/src/status_im/common/standard_authentication/password_input/view.cljs
+++ b/src/status_im/common/standard_authentication/password_input/view.cljs
@@ -16,8 +16,7 @@
   [error]
   (if (and (some? error)
            (or (= error "file is not a database")
-               (string/starts-with? error "failed to set ")
-               (string/starts-with? error "Failed")))
+               (string/starts-with? (string/lower-case error) "failed")))
     (i18n/label :t/oops-wrong-password)
     error))
 


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20597

### Summary
When the user enters the wrong password this is the full error message returned `failed to open database: failed to set `journal_mode` pragma: file is not a database`. I did not see the message startwith either `failed to set ` or `Failed` or `file is not a database` but these are the cases that have been handled by the `get-error-message` function. 

Am not sure if getting rid of all these cases and only handling the situation with `(string/starts-with? error "failed to open database")` would do be appropriate maybe the api returns differents messages sometimes. So adding an extra option statement resolves the issue

### Before and after screenshots comparison
<img src="https://github.com/status-im/status-mobile/assets/28704507/8dfc00d6-9dda-4987-b0a8-b318c66e1591" width="325">
<img src="https://github.com/status-im/status-mobile/assets/28704507/6bfed146-ffbb-49ab-80cb-647eb7a60581" width="325">

status: ready

