### PR TITLE
fixed overlapping last message by the composer when there is a pinned…

### DIFF
--- a/src/status_im/contexts/chat/group_details/view.cljs
+++ b/src/status_im/contexts/chat/group_details/view.cljs
@@ -50,7 +50,7 @@
            item])))))
 
 (defn add-manage-members
-  [{:keys [scroll-enabled? on-scroll]}]
+  [{:keys [on-scroll]}]
   (let [theme                      (quo.theme/use-theme)
         selected-participants      (rf/sub [:group-chat/selected-participants])
         deselected-members         (rf/sub [:group-chat/deselected-members])
@@ -74,7 +74,6 @@
       (i18n/label (if admin? :t/manage-members :t/add-members))]
      [gesture/section-list
       {:key-fn                         :title
-       :scroll-enabled                 @scroll-enabled?
        :on-scroll                      on-scroll
        :sticky-section-headers-enabled false
        :sections                       (rf/sub [:contacts/grouped-by-first-letter])

--- a/src/status_im/contexts/chat/messenger/messages/drawers/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/drawers/view.cljs
@@ -97,7 +97,7 @@
   [{:keys [outgoing content pinned-by outgoing-status deleted? deleted-for-me? content-type
            bridge-message]
     :as   message-data}
-   {:keys [able-to-send-message? community? can-delete-message-for-everyone?
+   {:keys [able-to-send-message? community? community-member? can-delete-message-for-everyone?
            message-pin-enabled group-chat group-admin?]}]
   (concat
    (when (and outgoing
@@ -131,7 +131,8 @@
        :id                  :copy}])
    ;; pinning images are temporarily disabled
    (when (and message-pin-enabled
-              (not= content-type constants/content-type-image))
+              (not= content-type constants/content-type-image)
+              (or community-member? (not community?)))
      [{:type                :main
        :on-press            #(pin-message message-data)
        :label               (i18n/label (if pinned-by

--- a/src/status_im/contexts/chat/messenger/messages/list/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/style.cljs
@@ -5,6 +5,8 @@
     [react-native.reanimated :as reanimated]
     [status-im.contexts.chat.messenger.messages.constants :as messages.constants]))
 
+(def permission-context-height 46)
+
 (defn keyboard-avoiding-container
   [theme]
   {:flex             1
@@ -73,3 +75,8 @@
   (reanimated/apply-animations-to-style
    {:top top}
    {:row-gap 16}))
+
+(defn permission-context-sheet
+  [margin-bottom?]
+  {:flex          3 ;; Pushes composer to bottom
+   :margin-bottom (when margin-bottom? permission-context-height)})

--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -404,8 +404,7 @@
         messages                             (rf/sub [:chats/raw-chat-messages-stream chat-id])
         margin-bottom?                       (and community-channel? (not able-to-send-message?))
         recording?                           (rf/sub [:chats/recording?])]
-    [rn/view
-     {:style (style/permission-context-sheet margin-bottom?)}
+    [rn/view {:style (style/permission-context-sheet margin-bottom?)}
      [rn/view {:style {:flex-shrink 1}} ;; Keeps flat list on top
       [reanimated/flat-list
        {:key-fn                            list-key-fn

--- a/src/status_im/contexts/chat/messenger/messages/list/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/list/view.cljs
@@ -400,16 +400,19 @@
         {:keys [keyboard-shown]}             (hooks/use-keyboard)
         {window-height :height}              (rn/get-window)
         context                              (rf/sub [:chats/current-chat-message-list-view-context])
+        able-to-send-message?                (:able-to-send-message? context)
         messages                             (rf/sub [:chats/raw-chat-messages-stream chat-id])
+        margin-bottom?                       (and community-channel? (not able-to-send-message?))
         recording?                           (rf/sub [:chats/recording?])]
-    [rn/view {:style {:flex 3}} ;; Pushes composer to bottom
+    [rn/view
+     {:style (style/permission-context-sheet margin-bottom?)}
      [rn/view {:style {:flex-shrink 1}} ;; Keeps flat list on top
       [reanimated/flat-list
        {:key-fn                            list-key-fn
         :ref                               list-ref
         :bounces                           false
         :header                            [:<>
-                                            [list-header insets (:able-to-send-message? context)]
+                                            [list-header insets able-to-send-message?]
                                             (when (= (:chat-type chat) constants/private-group-chat-type)
                                               [list-group-chat-header chat])]
         :footer                            [list-footer

--- a/src/status_im/subs/chats.cljs
+++ b/src/status_im/subs/chats.cljs
@@ -228,6 +228,7 @@
          community? (some? current-community)
          group-admin? (contains? admins current-public-key)
          community-admin? (get current-community :admin false)
+         community-member? (get current-community :is-member? false)
 
          message-pin-enabled
          (cond public?          false
@@ -247,6 +248,7 @@
       :chat-id                          chat-id
       :in-pinned-view?                  (boolean in-pinned-view?)
       :able-to-send-message?            able-to-send-message?
+      :community-member?                community-member?
       :message-pin-enabled              message-pin-enabled
       :can-delete-message-for-everyone? can-delete-message-for-everyone?})))
 


### PR DESCRIPTION
fixes 
https://github.com/status-im/status-mobile/issues/20513 

### Summary
This pr adds margin-bottom when the user is not allowed to post a message in a community channel because they are not a member. The margin-bottom is the height of the permission bottom sheet that is shown when the user is no longer a community member

A note to @status-im/mobile-qa, this pr also fixes a bug explained in this comment https://github.com/status-im/status-mobile/pull/20606#issuecomment-2245086356. Its a small simple fix I bundled up in this pr

### Before and after screenshots comparison
<img src="https://github.com/status-im/status-mobile/assets/28704507/88125159-1483-4655-95c7-05998c4a2c15" width="325">

<img src="https://github.com/status-im/status-mobile/assets/28704507/a87e2b57-332e-4c68-a206-f783aad0dacb" width="325">



status: ready 

