### PR TITLE
fix: ensure the key pair action button opens bottom-sheet inside key pairs and accounts

### DIFF
--- a/src/quo/components/wallet/keypair/view.cljs
+++ b/src/quo/components/wallet/keypair/view.cljs
@@ -102,7 +102,7 @@
                                               :container-style container-style
                                               :theme           theme))
       :on-press       #(when (= action :selector) (on-press))
-      :pointer-events :box-only}
+      :pointer-events (when (= action :selector) :box-only)}
      [rn/view {:style style/header-container}
       [avatar props]
       [rn/view


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #20609 

### Summary

* This PR attempts to fix an issue where the options / actions menu button for a key-pair, inside the key-pairs and accounts settings, does not open the key-pair action menu.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Key pairs and Accounts settings
- Selecting a key pair when creating an account

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile
- Navigate to the Settings screen
- Navigate to Wallet settings screen
- Navigate to Key pairs and Accounts settings screen
- Press on the "..." menu button on a existing key pair

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Screen capture after changes

https://github.com/status-im/status-mobile/assets/2845768/b7798322-b1ed-4dd3-b112-e2ea14f42a71

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
