### PR TITLE
fix(ci): add missing import for JsonBuilder

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,6 +1,8 @@
 #!/usr/bin/env groovy
 library 'status-jenkins-lib@v1.9.1'
 
+import groovy.json.JsonBuilder
+
 pipeline {
   agent { label 'linux' }
 


### PR DESCRIPTION
Fixes error:
```
WorkflowScript: 130: unable to resolve class JsonBuilder 
 @ line 130, column 21.
     def contentJson = new JsonBuilder(content).toPrettyString()
                       ^
```