### PR TITLE
fix: remove non operable accounts in the selection of sharing addresses with the community

### DIFF
--- a/src/status_im/contexts/communities/actions/accounts_selection/events.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/events.cljs
@@ -18,7 +18,7 @@
 
 (defn do-init-permission-addresses
   [{:keys [db]} [community-id revealed-accounts]]
-  (let [wallet-accounts     (utils/sorted-non-watch-only-accounts db)
+  (let [wallet-accounts     (utils/sorted-operable-non-watch-only-accounts db)
         addresses-to-reveal (if (seq revealed-accounts)
                               (set (keys revealed-accounts))
                               ;; Reveal all addresses as fallback.
@@ -62,7 +62,7 @@
   status-go will default to all available."
   [{:keys [db]} [{:keys [community-id password on-success addresses airdrop-address]}]]
   (let [pub-key             (get-in db [:profile/profile :public-key])
-        wallet-accounts     (utils/sorted-non-watch-only-accounts db)
+        wallet-accounts     (utils/sorted-operable-non-watch-only-accounts db)
         addresses-to-reveal (if (seq addresses)
                               (set addresses)
                               (get-in db [:communities/all-addresses-to-reveal community-id]))

--- a/src/status_im/contexts/communities/actions/accounts_selection/events_test.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/events_test.cljs
@@ -9,17 +9,25 @@
 (def wallet-accounts
   {"0xA" {:address     "0xA"
           :watch-only? true
+          :operable?   true
           :position    2
           :color       :red
           :emoji       "🦇"}
-   "0xB" {:address  "0xB"
-          :position 0
-          :color    :blue
-          :emoji    "🐈"}
-   "0xC" {:address  "0xC"
-          :position 1
-          :color    :orange
-          :emoji    "🛏️"}})
+   "0xB" {:address   "0xB"
+          :operable? true
+          :position  0
+          :color     :blue
+          :emoji     "🐈"}
+   "0xC" {:address   "0xC"
+          :operable? true
+          :position  1
+          :color     :orange
+          :emoji     "🛏️"}
+   "0xD" {:address   "0xD"
+          :operable? false
+          :position  3
+          :color     :flamingo
+          :emoji     "🦩"}})
 
 (def permissioned-accounts
   [{:address          "0xB"

--- a/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
@@ -22,7 +22,7 @@
         airdrop-account (rf/sub [:communities/airdrop-account id])
         revealed-accounts (rf/sub [:communities/accounts-to-reveal id])
         revealed-accounts-count (count revealed-accounts)
-        wallet-accounts-count (count (rf/sub [:wallet/accounts-without-watched-accounts]))
+        wallet-accounts-count (count (rf/sub [:wallet/operable-accounts-without-watched-accounts]))
         addresses-shared-text (if (= revealed-accounts-count wallet-accounts-count)
                                 (i18n/label :t/all-addresses)
                                 (i18n/label-pluralize

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/events.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/events.cljs
@@ -120,7 +120,7 @@
 (defn set-permissioned-accounts
   [{:keys [db]} [community-id addresses-to-reveal]]
   (let [addresses-to-reveal     (set addresses-to-reveal)
-        wallet-accounts         (utils/sorted-non-watch-only-accounts db)
+        wallet-accounts         (utils/sorted-operable-non-watch-only-accounts db)
         current-airdrop-address (get-in db [:communities/all-airdrop-addresses community-id])
         new-airdrop-address     (if (contains? addresses-to-reveal current-airdrop-address)
                                   current-airdrop-address
@@ -142,7 +142,7 @@
   [{:keys [db]} [community-id new-value]]
   (let [current-addresses   (get-in db [:communities/all-addresses-to-reveal community-id])
         addresses-to-reveal (if new-value
-                              (->> (utils/sorted-non-watch-only-accounts db)
+                              (->> (utils/sorted-operable-non-watch-only-accounts db)
                                    (map :address)
                                    set)
                               current-addresses)]

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/events_test.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/events_test.cljs
@@ -33,9 +33,15 @@
     (let [cofx
           {:db {:communities/all-addresses-to-reveal {community-id #{"0xA" "0xB" "0xC"}}
                 :communities/all-airdrop-addresses   {community-id "0xB"}
-                :wallet                              {:accounts {"0xB" {:address "0xB" :position 0}
-                                                                 "0xA" {:address "0xA" :position 1}
-                                                                 "0xC" {:address "0xC" :position 2}}}}}
+                :wallet                              {:accounts {"0xB" {:address   "0xB"
+                                                                        :operable? true
+                                                                        :position  0}
+                                                                 "0xA" {:address   "0xA"
+                                                                        :operable? true
+                                                                        :position  1}
+                                                                 "0xC" {:address   "0xC"
+                                                                        :operable? true
+                                                                        :position  2}}}}}
           addresses-to-reveal ["0xA" "0xC"]]
       (is (match?
            {:db {:communities/all-addresses-to-reveal
@@ -52,9 +58,9 @@
   (testing "sets flag from false -> true will mark all addresses to be revealed"
     (let [cofx                {:db
                                {:wallet
-                                {:accounts {"0xB" {:address "0xB" :position 0}
-                                            "0xA" {:address "0xA" :position 1}
-                                            "0xC" {:address "0xC" :position 2}}}
+                                {:accounts {"0xB" {:address "0xB" :operable? true :position 0}
+                                            "0xA" {:address "0xA" :operable? true :position 1}
+                                            "0xC" {:address "0xC" :operable? true :position 2}}}
                                 :communities/all-addresses-to-reveal {community-id #{"0xA"}}
                                 :communities/selected-share-all-addresses {community-id false}}}
           addresses-to-reveal #{"0xA" "0xB" "0xC"}]

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -260,7 +260,7 @@
 
         can-edit-addresses? (rf/sub [:communities/can-edit-shared-addresses? id])
 
-        wallet-accounts (rf/sub [:wallet/accounts-without-watched-accounts])
+        wallet-accounts (rf/sub [:wallet/operable-accounts-without-watched-accounts])
         unmodified-addresses-to-reveal (rf/sub [:communities/addresses-to-reveal id])
         [addresses-to-reveal set-addresses-to-reveal] (rn/use-state unmodified-addresses-to-reveal)
 

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -154,7 +154,7 @@
 (defn update-previous-permission-addresses
   [{:keys [db]} [community-id]]
   (when community-id
-    (let [accounts                      (utils/sorted-non-watch-only-accounts db)
+    (let [accounts                      (utils/sorted-operable-non-watch-only-accounts db)
           selected-permission-addresses (get-in db
                                                 [:communities community-id
                                                  :selected-permission-addresses])
@@ -198,7 +198,7 @@
   [{:keys [db]} [community-id]]
   (let [share-all-addresses?      (get-in db [:communities community-id :share-all-addresses?])
         next-share-all-addresses? (not share-all-addresses?)
-        accounts                  (utils/sorted-non-watch-only-accounts db)
+        accounts                  (utils/sorted-operable-non-watch-only-accounts db)
         addresses                 (set (map :address accounts))]
     {:db (update-in db
                     [:communities community-id]

--- a/src/status_im/contexts/communities/overview/events.cljs
+++ b/src/status_im/contexts/communities/overview/events.cljs
@@ -51,7 +51,7 @@
 
 (rf/reg-event-fx :communities/check-permissions-to-join-community-with-all-addresses
  (fn [{:keys [db]} [community-id]]
-   (let [accounts  (utils/sorted-non-watch-only-accounts db)
+   (let [accounts  (utils/sorted-operable-non-watch-only-accounts db)
          addresses (set (map :address accounts))]
      {:db            (assoc-in db [:communities/permissions-check community-id :checking?] true)
       :json-rpc/call [{:method "wakuext_checkPermissionsToJoinCommunity"

--- a/src/status_im/contexts/communities/utils.cljs
+++ b/src/status_im/contexts/communities/utils.cljs
@@ -17,4 +17,5 @@
   (->> (get-in db [:wallet :accounts])
        (vals)
        (remove :watch-only?)
+       (filter :operable?)
        (sort-by :position)))

--- a/src/status_im/contexts/communities/utils.cljs
+++ b/src/status_im/contexts/communities/utils.cljs
@@ -12,7 +12,7 @@
      constants/community-token-permission-become-member       :t/member
      fallback-to)))
 
-(defn sorted-non-watch-only-accounts
+(defn sorted-operable-non-watch-only-accounts
   [db]
   (->> (get-in db [:wallet :accounts])
        (vals)

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -23,6 +23,7 @@
 (defn add-keys-to-account
   [account]
   (-> account
+      (assoc :operable? (not= (:operable account) :no))
       (assoc :watch-only? (= (:type account) :watch))
       (assoc :default-account? (:wallet account))))
 
@@ -67,7 +68,7 @@
                         :color                    :colorId})
       (update :prodPreferredChainIds chain-ids-set->string)
       (update :testPreferredChainIds chain-ids-set->string)
-      (dissoc :watch-only? :default-account? :tokens :collectibles)))
+      (dissoc :watch-only? :default-account? :operable? :tokens :collectibles)))
 
 (defn- rpc->balances-per-chain
   [token]

--- a/src/status_im/contexts/wallet/data_store_test.cljs
+++ b/src/status_im/contexts/wallet/data_store_test.cljs
@@ -32,6 +32,7 @@
    :watch-only?              false
    :prod-preferred-chain-ids #{1 42161}
    :created-at               1716548742000
+   :operable?                true
    :operable                 :fully
    :removed                  false})
 
@@ -171,9 +172,10 @@
                                                      {:key-uid "0x123"
                                                       :address "1x123"})
                                       "1x456" (merge account
-                                                     {:key-uid  "0x456"
-                                                      :address  "1x456"
-                                                      :operable :no})}
+                                                     {:key-uid   "0x456"
+                                                      :address   "1x456"
+                                                      :operable? false
+                                                      :operable  :no})}
         :updated-keypairs-by-id      {"0x123" {:key-uid            "0x123"
                                                :type               :seed
                                                :lowest-operability :fully
@@ -184,9 +186,10 @@
                                                :type               :key
                                                :lowest-operability :no
                                                :accounts           [(merge account
-                                                                           {:key-uid  "0x456"
-                                                                            :address  "1x456"
-                                                                            :operable :no})]}}})
+                                                                           {:key-uid   "0x456"
+                                                                            :address   "1x456"
+                                                                            :operable? false
+                                                                            :operable  :no})]}}})
       (sut/reconcile-keypairs [raw-keypair-seed-phrase
                                raw-keypair-private-key]))))
   (testing "reconcile-keypairs represents removed key pairs and accounts"

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -40,6 +40,7 @@
    :color :purple
    :wallet true
    :default-account? true
+   :operable? true
    :name "Ethereum account"
    :type :generated
    :chat false

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -146,10 +146,7 @@
 (h/deftest-event :wallet/process-account-from-signal
   [event-id dispatch]
   (let [expected-effects {:db {:wallet {:accounts {address account}}}
-                          :fx [[:dispatch [:wallet/get-wallet-token-for-account address]]
-                               [:dispatch
-                                [:wallet/request-new-collectibles-for-account-from-signal address]]
-                               [:dispatch [:wallet/check-recent-history-for-account address]]]}]
+                          :fx [[:dispatch [:wallet/fetch-assets-for-address address]]]}]
     (reset! rf-db/app-db {:wallet {:accounts {}}})
     (is (match? expected-effects (dispatch [event-id raw-account])))))
 
@@ -170,9 +167,7 @@
                                                     :type               :seed
                                                     :lowest-operability :fully
                                                     :accounts           [account]}}}}
-          :fx [[:dispatch [:wallet/get-wallet-token-for-account address]]
-               [:dispatch [:wallet/request-new-collectibles-for-account-from-signal address]]
-               [:dispatch [:wallet/check-recent-history-for-account address]]]})
+          :fx [[:dispatch [:wallet/fetch-assets-for-address address]]]})
         (dispatch [event-id
                    [{:key-uid  keypair-key-uid
                      :type     "seed"
@@ -293,6 +288,7 @@
                                 (assoc raw-account
                                        :address "1x001"
                                        :chat    true)]}]]))))))
+
 (h/deftest-event :wallet/reconcile-watch-only-accounts
   [event-id dispatch]
   (testing "event adds new watch-only accounts"
@@ -304,10 +300,7 @@
         vector? matchers/equals
         map? matchers/equals]
        {:db {:wallet {:accounts {(:address account) account}}}
-        :fx [[:dispatch [:wallet/get-wallet-token-for-account address]]
-             [:dispatch
-              [:wallet/request-new-collectibles-for-account-from-signal address]]
-             [:dispatch [:wallet/check-recent-history-for-account address]]]})
+        :fx [[:dispatch [:wallet/fetch-assets-for-address address]]]})
       (dispatch [event-id [raw-account]]))))
   (testing "event removes watch-only accounts that are marked as removed"
     (reset! rf-db/app-db {:wallet {:accounts {(:address account) account}}})
@@ -317,8 +310,7 @@
        [set? matchers/set-equals
         vector? matchers/equals
         map? matchers/equals]
-       {:db {:wallet {:accounts {}}}
-        :fx []})
+       {:db {:wallet {:accounts {}}}})
       (dispatch [event-id [(assoc raw-account :removed true)]]))))
   (testing "event updates existing watch-only accounts"
     (reset! rf-db/app-db {:wallet
@@ -329,10 +321,8 @@
        [set? matchers/set-equals
         vector? matchers/equals
         map? matchers/equals]
-       {:db {:wallet {:accounts {address (assoc account :name "Test")}}}
-        :fx []})
+       {:db {:wallet {:accounts {address (assoc account :name "Test")}}}})
       (dispatch [event-id
                  [(assoc raw-account
                          :address address
                          :name    "Test")]])))))
-(cljs.test/run-tests)

--- a/src/status_im/contexts/wallet/sheets/account_options/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/account_options/view.cljs
@@ -108,9 +108,8 @@
   []
   (let [options-height (reagent/atom 0)]
     (fn []
-      (let [theme (quo.theme/use-theme)
-            accounts (rf/sub
-                      [:wallet/fully-or-partially-operable-accounts-without-current-viewing-account])
+      (let [theme                  (quo.theme/use-theme)
+            accounts               (rf/sub [:wallet/operable-accounts-without-current-viewing-account])
             show-account-selector? (pos? (count accounts))]
         [:<>
          (when show-account-selector?

--- a/src/status_im/contexts/wallet/sheets/select_account/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/select_account/view.cljs
@@ -20,7 +20,7 @@
 (defn view
   []
   (let [selected-account-address (rf/sub [:wallet/current-viewing-account-address])
-        accounts (rf/sub [:wallet/fully-or-partially-operable-accounts-without-watched-accounts])]
+        accounts                 (rf/sub [:wallet/operable-accounts-without-watched-accounts])]
     [:<>
      [quo/drawer-top {:title (i18n/label :t/select-account)}]
      [gesture/flat-list

--- a/src/status_im/subs/community/account_selection.cljs
+++ b/src/status_im/subs/community/account_selection.cljs
@@ -53,7 +53,7 @@
 
 (re-frame/reg-sub :communities/accounts-to-reveal
  (fn [[_ community-id]]
-   [(re-frame/subscribe [:wallet/accounts-without-watched-accounts])
+   [(re-frame/subscribe [:wallet/operable-accounts-without-watched-accounts])
     (re-frame/subscribe [:communities/addresses-to-reveal community-id])])
  (fn [[accounts addresses] _]
    (filter #(contains? addresses (:address %))
@@ -61,7 +61,7 @@
 
 (re-frame/reg-sub :communities/airdrop-account
  (fn [[_ community-id]]
-   [(re-frame/subscribe [:wallet/accounts-without-watched-accounts])
+   [(re-frame/subscribe [:wallet/operable-accounts-without-watched-accounts])
     (re-frame/subscribe [:communities/airdrop-address community-id])])
  (fn [[accounts airdrop-address] _]
    (->> accounts

--- a/src/status_im/subs/community/account_selection_test.cljs
+++ b/src/status_im/subs/community/account_selection_test.cljs
@@ -24,10 +24,10 @@
 
 (h/deftest-sub :communities/airdrop-account
   [sub-name]
-  (let [airdrop-account {:address "0xA" :position 1}]
+  (let [airdrop-account {:address "0xA" :operable? true :position 1}]
     (reset! rf-db/app-db
       {:communities/all-airdrop-addresses {community-id "0xA"}
-       :wallet                            {:accounts {"0xB" {:address "0xB" :position 0}
+       :wallet                            {:accounts {"0xB" {:address "0xB" :operable? true :position 0}
                                                       "0xA" airdrop-account}}})
 
     (is (match? airdrop-account (rf/sub [sub-name community-id])))))
@@ -36,9 +36,11 @@
   [sub-name]
   (reset! rf-db/app-db
     {:communities/all-addresses-to-reveal {community-id #{"0xC" "0xB"}}
-     :wallet                              {:accounts {"0xB" {:address "0xB" :position 0}
-                                                      "0xA" {:address "0xA" :position 1}
-                                                      "0xC" {:address "0xC" :position 2}}}})
+     :wallet                              {:accounts {"0xB" {:address "0xB" :operable? true :position 0}
+                                                      "0xA" {:address "0xA" :operable? true :position 1}
+                                                      "0xC" {:address   "0xC"
+                                                             :operable? true
+                                                             :position  2}}}})
 
   (is (match? [{:address "0xB" :position 0}
                {:address "0xC" :position 2}]

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -454,25 +454,23 @@
  (fn [accounts]
    (remove :watch-only? accounts)))
 
-(defn- keep-fully-or-partially-operable-accounts
+(defn- keep-operable-accounts
   [accounts]
-  (filter (fn fully-or-partially-operable? [{:keys [operable]}]
-            (#{:fully :partially} operable))
-          accounts))
+  (filter :operable? accounts))
 
 (rf/reg-sub
- :wallet/fully-or-partially-operable-accounts-without-current-viewing-account
+ :wallet/operable-accounts-without-current-viewing-account
  :<- [:wallet/accounts-without-current-viewing-account]
- keep-fully-or-partially-operable-accounts)
+ keep-operable-accounts)
 
 (rf/reg-sub
- :wallet/fully-or-partially-operable-accounts-without-watched-accounts
+ :wallet/operable-accounts-without-watched-accounts
  :<- [:wallet/accounts-without-watched-accounts]
- keep-fully-or-partially-operable-accounts)
+ keep-operable-accounts)
 
 (rf/reg-sub
  :wallet/accounts-with-current-asset
- :<- [:wallet/fully-or-partially-operable-accounts-without-watched-accounts]
+ :<- [:wallet/operable-accounts-without-watched-accounts]
  :<- [:wallet/wallet-send-token-symbol]
  :<- [:wallet/wallet-send-token]
  (fn [[accounts token-symbol token]]

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -224,7 +224,7 @@
            (assoc-in [:wallet :accounts] accounts)
            (assoc-in [:wallet :networks] network-data)))
     (is
-     (=
+     (match?
       (list {:path                      "m/44'/60'/0'/0/0"
              :emoji                     "😃"
              :key-uid                   "0x2f5ea39"
@@ -315,30 +315,30 @@
 
     (let [result (rf/sub [sub-name])]
       (is
-       (= {:path                      "m/44'/60'/0'/0/0"
-           :emoji                     "😃"
-           :key-uid                   "0x2f5ea39"
-           :address                   "0x1"
-           :wallet                    false
-           :name                      "Account One"
-           :type                      :generated
-           :watch-only?               false
-           :operable?                 true
-           :chat                      false
-           :test-preferred-chain-ids  #{5 420 421613}
-           :color                     :blue
-           :hidden                    false
-           :prod-preferred-chain-ids  #{1 10 42161}
-           :network-preferences-names #{:mainnet :arbitrum :optimism}
-           :position                  0
-           :clock                     1698945829328
-           :created-at                1698928839000
-           :operable                  :fully
-           :mixedcase-address         "0x7bcDfc75c431"
-           :public-key                "0x04371e2d9d66b82f056bc128064"
-           :removed                   false
-           :tokens                    tokens-0x1}
-          (dissoc result :balance :formatted-balance)))
+       (match? {:path                      "m/44'/60'/0'/0/0"
+                :emoji                     "😃"
+                :key-uid                   "0x2f5ea39"
+                :address                   "0x1"
+                :wallet                    false
+                :name                      "Account One"
+                :type                      :generated
+                :watch-only?               false
+                :operable?                 true
+                :chat                      false
+                :test-preferred-chain-ids  #{5 420 421613}
+                :color                     :blue
+                :hidden                    false
+                :prod-preferred-chain-ids  #{1 10 42161}
+                :network-preferences-names #{:mainnet :arbitrum :optimism}
+                :position                  0
+                :clock                     1698945829328
+                :created-at                1698928839000
+                :operable                  :fully
+                :mixedcase-address         "0x7bcDfc75c431"
+                :public-key                "0x04371e2d9d66b82f056bc128064"
+                :removed                   false
+                :tokens                    tokens-0x1}
+               (dissoc result :balance :formatted-balance)))
 
       (is (money/equal-to (:balance result) (money/bignumber 3250)))
       (is (match? (:formatted-balance result) "$3250.00")))))
@@ -376,7 +376,7 @@
            (assoc-in [:wallet :current-viewing-account-address] "0x2")
            (assoc-in [:wallet :networks] network-data)))
     (is
-     (=
+     (match?
       (list
        {:path                      "m/44'/60'/0'/0/0"
         :emoji                     "😃"
@@ -434,7 +434,7 @@
            (assoc-in [:wallet :accounts] accounts)
            (assoc-in [:wallet :networks] network-data)))
     (is
-     (=
+     (match?
       (list
        {:path                      "m/44'/60'/0'/0/0"
         :emoji                     "😃"
@@ -592,19 +592,19 @@
            (assoc-in [:wallet :accounts] accounts)
            (assoc-in [:wallet :networks] network-data)))
     (is
-     (= [(-> accounts
-             (get "0x1")
-             (assoc :customization-color :blue)
-             (assoc :network-preferences-names #{:mainnet :arbitrum :optimism}))
-         (-> accounts
-             (get "0x2")
-             (assoc :customization-color :purple)
-             (assoc :network-preferences-names #{:mainnet :arbitrum :optimism}))
-         (-> accounts
-             (get "0x3")
-             (assoc :customization-color :magenta)
-             (assoc :network-preferences-names #{}))]
-        (rf/sub [sub-name])))))
+     (match? [(-> accounts
+                  (get "0x1")
+                  (assoc :customization-color :blue)
+                  (assoc :network-preferences-names #{:mainnet :arbitrum :optimism}))
+              (-> accounts
+                  (get "0x2")
+                  (assoc :customization-color :purple)
+                  (assoc :network-preferences-names #{:mainnet :arbitrum :optimism}))
+              (-> accounts
+                  (get "0x3")
+                  (assoc :customization-color :magenta)
+                  (assoc :network-preferences-names #{}))]
+             (rf/sub [sub-name])))))
 
 (h/deftest-sub :wallet/watch-only-accounts
   [sub-name]
@@ -614,10 +614,10 @@
            (assoc-in [:wallet :accounts] accounts)
            (assoc-in [:wallet :networks] network-data)))
     (is
-     (= [(-> accounts
-             (get "0x3")
-             (assoc :network-preferences-names #{}))]
-        (rf/sub [sub-name])))))
+     (match? [(-> accounts
+                  (get "0x3")
+                  (assoc :network-preferences-names #{}))]
+             (rf/sub [sub-name])))))
 
 (def chat-account
   {:path     "m/43'/60'/1581'/0'/0"
@@ -827,9 +827,7 @@
   (testing "returns local suggestions:"
     (swap! rf-db/app-db
       #(assoc-in % [:wallet :ui :search-address :local-suggestions] local-suggestions))
-    (is
-     (= local-suggestions
-        (rf/sub [sub-name])))))
+    (is (match? local-suggestions (rf/sub [sub-name])))))
 
 (h/deftest-sub :wallet/valid-ens-or-address?
   [sub-name]

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -16,10 +16,12 @@
   {:0x1 {:tokens                    [{:symbol "ETH"} {:symbol "SNT"}]
          :network-preferences-names #{}
          :customization-color       nil
+         :operable?                 true
          :operable                  :fully}
    :0x2 {:tokens                    [{:symbol "SNT"}]
          :network-preferences-names #{}
          :customization-color       nil
+         :operable?                 true
          :operable                  :partially}})
 
 (def tokens-0x1
@@ -106,6 +108,7 @@
           :name                     "Account One"
           :type                     :generated
           :watch-only?              false
+          :operable?                true
           :chat                     false
           :test-preferred-chain-ids #{5 420 421613}
           :color                    :blue
@@ -127,6 +130,7 @@
           :name                     "Account Two"
           :type                     :generated
           :watch-only?              false
+          :operable?                true
           :chat                     false
           :test-preferred-chain-ids #{5 420 421613}
           :color                    :purple
@@ -148,6 +152,7 @@
           :name                     "Watched Account 1"
           :type                     :watch
           :watch-only?              true
+          :operable?                true
           :chat                     false
           :test-preferred-chain-ids #{0}
           :color                    :magenta
@@ -228,6 +233,7 @@
              :name                      "Account One"
              :type                      :generated
              :watch-only?               false
+             :operable?                 true
              :chat                      false
              :test-preferred-chain-ids  #{5 420 421613}
              :color                     :blue
@@ -250,6 +256,7 @@
              :name                      "Account Two"
              :type                      :generated
              :watch-only?               false
+             :operable?                 true
              :chat                      false
              :test-preferred-chain-ids  #{5 420 421613}
              :color                     :purple
@@ -272,6 +279,7 @@
              :name                      "Watched Account 1"
              :type                      :watch
              :watch-only?               true
+             :operable?                 true
              :chat                      false
              :test-preferred-chain-ids  #{0}
              :color                     :magenta
@@ -315,6 +323,7 @@
            :name                      "Account One"
            :type                      :generated
            :watch-only?               false
+           :operable?                 true
            :chat                      false
            :test-preferred-chain-ids  #{5 420 421613}
            :color                     :blue
@@ -367,52 +376,55 @@
            (assoc-in [:wallet :current-viewing-account-address] "0x2")
            (assoc-in [:wallet :networks] network-data)))
     (is
-     (= (list
-         {:path                      "m/44'/60'/0'/0/0"
-          :emoji                     "😃"
-          :key-uid                   "0x2f5ea39"
-          :address                   "0x1"
-          :wallet                    false
-          :name                      "Account One"
-          :type                      :generated
-          :watch-only?               false
-          :chat                      false
-          :test-preferred-chain-ids  #{5 420 421613}
-          :color                     :blue
-          :hidden                    false
-          :prod-preferred-chain-ids  #{1 10 42161}
-          :network-preferences-names #{:mainnet :arbitrum :optimism}
-          :position                  0
-          :clock                     1698945829328
-          :created-at                1698928839000
-          :operable                  :fully
-          :mixedcase-address         "0x7bcDfc75c431"
-          :public-key                "0x04371e2d9d66b82f056bc128064"
-          :removed                   false
-          :tokens                    tokens-0x1}
-         {:path                      ""
-          :emoji                     "🎉"
-          :key-uid                   "0x2f5ea39"
-          :address                   "0x3"
-          :wallet                    false
-          :name                      "Watched Account 1"
-          :type                      :watch
-          :watch-only?               true
-          :chat                      false
-          :test-preferred-chain-ids  #{0}
-          :color                     :magenta
-          :hidden                    false
-          :prod-preferred-chain-ids  #{0}
-          :network-preferences-names #{}
-          :position                  2
-          :clock                     1698945829328
-          :created-at                1698928839000
-          :operable                  :fully
-          :mixedcase-address         "0x7bcDfc75c431"
-          :public-key                "0x"
-          :removed                   false
-          :tokens                    tokens-0x3})
-        (rf/sub [sub-name])))))
+     (=
+      (list
+       {:path                      "m/44'/60'/0'/0/0"
+        :emoji                     "😃"
+        :key-uid                   "0x2f5ea39"
+        :address                   "0x1"
+        :wallet                    false
+        :name                      "Account One"
+        :type                      :generated
+        :watch-only?               false
+        :operable?                 true
+        :chat                      false
+        :test-preferred-chain-ids  #{5 420 421613}
+        :color                     :blue
+        :hidden                    false
+        :prod-preferred-chain-ids  #{1 10 42161}
+        :network-preferences-names #{:mainnet :arbitrum :optimism}
+        :position                  0
+        :clock                     1698945829328
+        :created-at                1698928839000
+        :operable                  :fully
+        :mixedcase-address         "0x7bcDfc75c431"
+        :public-key                "0x04371e2d9d66b82f056bc128064"
+        :removed                   false
+        :tokens                    tokens-0x1}
+       {:path                      ""
+        :emoji                     "🎉"
+        :key-uid                   "0x2f5ea39"
+        :address                   "0x3"
+        :wallet                    false
+        :name                      "Watched Account 1"
+        :type                      :watch
+        :watch-only?               true
+        :operable?                 true
+        :chat                      false
+        :test-preferred-chain-ids  #{0}
+        :color                     :magenta
+        :hidden                    false
+        :prod-preferred-chain-ids  #{0}
+        :network-preferences-names #{}
+        :position                  2
+        :clock                     1698945829328
+        :created-at                1698928839000
+        :operable                  :fully
+        :mixedcase-address         "0x7bcDfc75c431"
+        :public-key                "0x"
+        :removed                   false
+        :tokens                    tokens-0x3})
+      (rf/sub [sub-name])))))
 
 (h/deftest-sub :wallet/accounts-without-watched-accounts
   [sub-name]
@@ -432,6 +444,7 @@
         :name                      "Account One"
         :type                      :generated
         :watch-only?               false
+        :operable?                 true
         :chat                      false
         :test-preferred-chain-ids  #{5 420 421613}
         :color                     :blue
@@ -455,6 +468,7 @@
         :name                      "Account Two"
         :type                      :generated
         :watch-only?               false
+        :operable?                 true
         :chat                      false
         :test-preferred-chain-ids  #{5 420 421613}
         :color                     :purple
@@ -484,6 +498,7 @@
                   [{:tokens                    [{:symbol "ETH"} {:symbol "SNT"}]
                     :network-preferences-names #{}
                     :customization-color       nil
+                    :operable?                 true
                     :operable                  :fully}]))))
 
   (testing "returns the accounts list with the current asset using token"
@@ -496,6 +511,7 @@
                   [{:tokens                    [{:symbol "ETH"} {:symbol "SNT"}]
                     :network-preferences-names #{}
                     :customization-color       nil
+                    :operable?                 true
                     :operable                  :fully}]))))
 
   (testing


### PR DESCRIPTION
fixes #20624

### Summary

This PR removes the non-operable accounts in the `Addresses for permission` and `Airdrop address` selections while joining a community.

https://github.com/status-im/status-mobile/assets/19339952/ed9ed655-bb38-4008-a738-f82b38367660

### Testing notes

A quick check across the app to verify the non-operable accounts are not shown is appreciated.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Login with a profile with a missing key pair
- Navigate to a community that the user does not join
- Tap on request to join
- Verify the non-operable accounts are not shown to the user for selection in `Addresses for permission` and `Airdrop address`

status: ready 
