### PR TITLE
Disable possibility to change amounts to send via specific networks

### DIFF
--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -10,6 +10,7 @@
     [status-im.contexts.wallet.send.routes.style :as style]
     [status-im.contexts.wallet.send.utils :as send-utils]
     [status-im.contexts.wallet.sheets.network-preferences.view :as network-preferences]
+    [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
     [utils.money :as money]
     [utils.number :as number]
@@ -387,7 +388,8 @@
                                                       chain-id-to-disable
                                                       disabled-from-chain-ids
                                                       token-available-networks-for-suggested-routes))
-        :on-long-press                             (fn [chain-id amount-calculated-for-chain]
+        (when (ff/enabled? ::ff/wallet.custom-network-amounts)
+          :on-long-press)                          (fn [chain-id amount-calculated-for-chain]
                                                      (edit-amount
                                                       {:chain-id chain-id
                                                        :token-symbol token-symbol

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -25,7 +25,8 @@
    ::wallet.long-press-watch-only-asset (enabled-in-env? :FLAG_LONG_PRESS_WATCH_ONLY_ASSET_ENABLED)
    ::wallet.saved-addresses             (enabled-in-env? :WALLET_SAVED_ADDRESSES)
    ::wallet.swap                        (enabled-in-env? :FLAG_SWAP_ENABLED)
-   ::wallet.wallet-connect              (enabled-in-env? :FLAG_WALLET_CONNECT_ENABLED)})
+   ::wallet.wallet-connect              (enabled-in-env? :FLAG_WALLET_CONNECT_ENABLED)
+   ::wallet.custom-network-amounts      (enabled-in-env? :FLAG_WALLET_CUSTOM_NETWORK_AMOUNTS_ENABLED)})
 
 (defonce ^:private feature-flags-config
   (reagent/atom initial-flags))


### PR DESCRIPTION

fixes #...

### Summary

For reducing the bugs surfaces it was decided to temporarily disable the possibility to edit the amount of funds sent through the specific networks.
Before you could have edit this amount by long-pressing the route item on send screen.
In this PR long-press disabled


#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Go to send flow, enter amount to send and wait for route items to appear
- Long-press route item
- Make sure nothing happens)



status: ready <!-- Can be ready or wip -->
