### PR TITLE
[#20638] fix: Scan missing keypair keep scanning after success attempt

### DIFF
--- a/src/status_im/common/scan_qr_code/view.cljs
+++ b/src/status_im/common/scan_qr_code/view.cljs
@@ -195,7 +195,7 @@
   true)
 
 (defn view
-  [{:keys [title subtitle validate-fn on-success-scan error-message share-button? import-keypair?]}]
+  [{:keys [title subtitle validate-fn on-success-scan error-message share-button?]}]
   (let [insets             (safe-area/get-insets)
         qr-code-succeed?   (reagent/atom false)
         qr-view-finder     (reagent/atom {})
@@ -233,9 +233,7 @@
              :set-qr-code-succeeded (fn [value]
                                       (when on-success-scan
                                         (on-success-scan value))
-                                      (if import-keypair?
-                                        (set-rescan-timeout)
-                                        (rf/dispatch [:navigate-back])))
+                                      (rf/dispatch [:navigate-back]))
              :set-rescan-timeout    set-rescan-timeout}])
          [rn/view {:style (style/root-container (:top insets))}
           [header

--- a/src/status_im/contexts/settings/wallet/events.cljs
+++ b/src/status_im/contexts/settings/wallet/events.cljs
@@ -92,7 +92,7 @@
 (rf/reg-event-fx :wallet/make-keypairs-accounts-fully-operable make-keypairs-accounts-fully-operable)
 
 (defn connection-string-for-import-keypair
-  [{:keys [db]} [{:keys [sha3-pwd keypairs-key-uids connection-string on-success]}]]
+  [{:keys [db]} [{:keys [sha3-pwd keypairs-key-uids connection-string]}]]
   (let [key-uid (get-in db [:profile/profile :key-uid])]
     {:fx [[:effects.syncing/import-keypairs-keystores
            {:key-uid           key-uid
@@ -100,7 +100,6 @@
             :keypairs-key-uids keypairs-key-uids
             :connection-string connection-string
             :on-success        (fn [key-uids]
-                                 (rf/call-continuation on-success)
                                  (rf/dispatch [:wallet/make-keypairs-accounts-fully-operable key-uids]))
             :on-fail           (fn [error]
                                  (log/error "failed to import missing key pairs with connection string"
@@ -113,7 +112,7 @@
 (rf/reg-event-fx :wallet/connection-string-for-import-keypair connection-string-for-import-keypair)
 
 (defn success-keypair-qr-scan
-  [_ [connection-string keypairs-key-uids on-import-success]]
+  [_ [connection-string keypairs-key-uids]]
   {:fx [[:dispatch
          [:standard-auth/authorize-with-password
           {:blur?             true
@@ -125,8 +124,7 @@
                                  [:wallet/connection-string-for-import-keypair
                                   {:connection-string connection-string
                                    :keypairs-key-uids keypairs-key-uids
-                                   :sha3-pwd          password
-                                   :on-success        on-import-success}]))}]]]})
+                                   :sha3-pwd          password}]))}]]]})
 
 (rf/reg-event-fx :wallet/success-keypair-qr-scan success-keypair-qr-scan)
 

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/missing_keypairs/scan_qr/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/missing_keypairs/scan_qr/view.cljs
@@ -13,14 +13,12 @@
         on-success-scan   (rn/use-callback (fn [scanned-text]
                                              (rf/dispatch [:wallet/success-keypair-qr-scan
                                                            scanned-text
-                                                           keypairs-key-uids
-                                                           [:navigate-back]])
+                                                           keypairs-key-uids])
                                              [keypairs-key-uids]))]
     [scan-qr-code/view
      {:title           (i18n/label :t/scan-key-pairs-qr-code)
       :subtitle        (i18n/label :t/find-it-in-setting)
       :share-button?   false
-      :import-keypair? true
       :validate-fn     sync-utils/valid-connection-string?
       :error-message   (i18n/label :t/invalid-key-pair-qr)
       :on-success-scan on-success-scan}]))


### PR DESCRIPTION
fixes #20638

### Summary

Scan a missing keypair keep scanning after success attempt

#### Areas that maybe impacted

- Import missing keypair by Scaning QR code

### Steps to test

- Have a paired device
- Have a missing key pair on Device B
- Open Wallet setting On Device B
- Click click on action menu (3 dot)
- Click on "Import by scanning encrypted QR"
- Scan QR code of missing key pair on Device A

### Result

https://github.com/status-im/status-mobile/assets/71308738/c7cf6d2d-5957-44aa-b962-e81407bb4dfe


status: ready
