### PR TITLE
chore: add Xcode 15.4 to allowed versions

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -57,7 +57,7 @@ in {
   yarn = super.yarn.override { nodejs = super.nodejs-18_x; };
   openjdk = super.openjdk11_headless;
   xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
-    versions = ["15.1" "15.2" "15.3"];
+    versions = ["15.1" "15.2" "15.3" "15.4"];
   };
   go = super.go_1_21;
   clang = super.clang_15;


### PR DESCRIPTION
## Summary

This PR adds Xcode 15.4 to allowed versions in xcode-wrapper overlay.

## Review notes
`make run-ios` should work

## Testing notes
not required, since this would only impact local builds.

status: ready
