### PR TITLE
Added possibility to edit networks list when routes not found

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -82,8 +82,12 @@
                                              :token-networks-ids token-networks-ids
                                              :tx-type            tx-type
                                              :receiver?          true})
-                                           (send-utils/reset-loading-network-amounts-to-zero
-                                            receiver-network-values))
+                                           (->
+                                             (send-utils/reset-loading-network-amounts-to-zero
+                                              receiver-network-values)
+                                             vec
+                                             (conj {:type :edit})))
+
            network-links                 (when routes-available?
                                            (send-utils/network-links chosen-route
                                                                      sender-network-values


### PR DESCRIPTION

fixes #...

### Summary

There was a bug: if you have assets only on one network and you disabled it on the recipient side, you had no way to turn it back. Now it is fixed and there is an ability to edit networks even if routes aren't found. This is in sync with Figma designs.
 **Before:**

https://github.com/status-im/status-mobile/assets/5786310/935697e3-35b9-488b-853b-9b6a1c2c600e

**Now:**
https://github.com/status-im/status-mobile/assets/5786310/26b4f318-2dbc-45f5-a7a7-514cc6d180b8


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

### Steps to test

- Open Status
- Go to send flow, input amount and wait for the routes to load
- Disable receiver networks that participate in the generated route

status: ready 
