### PR TITLE
fix: create password for small screen

### DIFF
--- a/src/status_im/common/floating_button_page/floating_container/style.cljs
+++ b/src/status_im/common/floating_button_page/floating_container/style.cljs
@@ -14,11 +14,12 @@
 
 (defn blur-inner-container
   [{:keys [theme shell-overlay? padding-vertical padding-horizontal background-color]}]
-  {:background-color   (or background-color (colors/theme-colors
-                         colors/white-70-blur
-                         (if shell-overlay?
-                           colors/neutral-80-opa-80-blur
-                           colors/neutral-95-opa-70-blur)
-                         theme))
+  {:background-color   (or background-color
+                           (colors/theme-colors
+                            colors/white-70-blur
+                            (if shell-overlay?
+                              colors/neutral-80-opa-80-blur
+                              colors/neutral-95-opa-70-blur)
+                            theme))
    :padding-vertical   (or padding-vertical 12)
    :padding-horizontal (or padding-horizontal 20)})

--- a/src/status_im/common/floating_button_page/floating_container/style.cljs
+++ b/src/status_im/common/floating_button_page/floating_container/style.cljs
@@ -3,21 +3,22 @@
             [react-native.safe-area :as safe-area]))
 
 (defn content-container
-  [blur? keyboard-shown?]
+  [blur? keyboard-shown? {:keys [padding-vertical padding-horizontal]}]
   (let [margin-bottom (if keyboard-shown? 0 (safe-area/get-bottom))]
     (cond-> {:margin-top         :auto
              :overflow           :hidden
              :margin-bottom      margin-bottom
-             :padding-vertical   12
-             :padding-horizontal 20}
+             :padding-vertical   (or padding-vertical 12)
+             :padding-horizontal (or padding-horizontal 20)}
       blur? (dissoc :padding-vertical :padding-horizontal))))
 
 (defn blur-inner-container
-  [theme shell-overlay?]
-  {:background-color   (colors/theme-colors colors/white-70-blur
-                                            (if shell-overlay?
-                                              colors/neutral-80-opa-80-blur
-                                              colors/neutral-95-opa-70-blur)
-                                            theme)
-   :padding-vertical   12
-   :padding-horizontal 20})
+  [{:keys [theme shell-overlay? padding-vertical padding-horizontal]}]
+  {:background-color   (colors/theme-colors
+                        colors/white-70-blur
+                        (if shell-overlay?
+                          colors/neutral-80-opa-80-blur
+                          colors/neutral-95-opa-70-blur)
+                        theme)
+   :padding-vertical   (or padding-vertical 12)
+   :padding-horizontal (or padding-horizontal 20)})

--- a/src/status_im/common/floating_button_page/floating_container/style.cljs
+++ b/src/status_im/common/floating_button_page/floating_container/style.cljs
@@ -13,12 +13,12 @@
       blur? (dissoc :padding-vertical :padding-horizontal))))
 
 (defn blur-inner-container
-  [{:keys [theme shell-overlay? padding-vertical padding-horizontal]}]
-  {:background-color   (colors/theme-colors
-                        colors/white-70-blur
-                        (if shell-overlay?
-                          colors/neutral-80-opa-80-blur
-                          colors/neutral-95-opa-70-blur)
-                        theme)
+  [{:keys [theme shell-overlay? padding-vertical padding-horizontal background-color]}]
+  {:background-color   (or background-color (colors/theme-colors
+                         colors/white-70-blur
+                         (if shell-overlay?
+                           colors/neutral-80-opa-80-blur
+                           colors/neutral-95-opa-70-blur)
+                         theme))
    :padding-vertical   (or padding-vertical 12)
    :padding-horizontal (or padding-horizontal 20)})

--- a/src/status_im/common/floating_button_page/floating_container/view.cljs
+++ b/src/status_im/common/floating_button_page/floating_container/view.cljs
@@ -13,10 +13,11 @@
          {:blur-amount   20
           :blur-type     :transparent
           :overlay-color :transparent})
-     [rn/view {:style (style/blur-inner-container (assoc
-                                                   blur-options
-                                                   :theme theme
-                                                   :shell-overlay? shell-overlay?))}
+     [rn/view
+      {:style (style/blur-inner-container (assoc
+                                           blur-options
+                                           :theme          theme
+                                           :shell-overlay? shell-overlay?))}
       child]]))
 
 (defn view

--- a/src/status_im/common/floating_button_page/floating_container/view.cljs
+++ b/src/status_im/common/floating_button_page/floating_container/view.cljs
@@ -10,9 +10,9 @@
   (let [theme (quo.theme/use-theme)]
     [quo/blur
      (or blur-options
-     {:blur-amount   20
-      :blur-type     :transparent
-      :overlay-color :transparent} )
+         {:blur-amount   20
+          :blur-type     :transparent
+          :overlay-color :transparent} )
      [rn/view {:style (style/blur-inner-container theme shell-overlay?)}
       child]]))
 

--- a/src/status_im/common/floating_button_page/floating_container/view.cljs
+++ b/src/status_im/common/floating_button_page/floating_container/view.cljs
@@ -6,20 +6,21 @@
     [status-im.common.floating-button-page.floating-container.style :as style]))
 
 (defn- blur-container
-  [child shell-overlay?]
+  [shell-overlay? blur-options child]
   (let [theme (quo.theme/use-theme)]
     [quo/blur
+     (or blur-options
      {:blur-amount   20
       :blur-type     :transparent
-      :overlay-color :transparent}
+      :overlay-color :transparent} )
      [rn/view {:style (style/blur-inner-container theme shell-overlay?)}
       child]]))
 
 (defn view
-  [{:keys [on-layout keyboard-shown? blur? shell-overlay?]} child]
+  [{:keys [on-layout keyboard-shown? blur? shell-overlay? blur-options]} child]
   [rn/view
    {:style     (style/content-container blur? keyboard-shown?)
     :on-layout on-layout}
    (if blur?
-     [blur-container child shell-overlay?]
+     [blur-container shell-overlay? blur-options child]
      child)])

--- a/src/status_im/common/floating_button_page/floating_container/view.cljs
+++ b/src/status_im/common/floating_button_page/floating_container/view.cljs
@@ -12,14 +12,17 @@
      (or blur-options
          {:blur-amount   20
           :blur-type     :transparent
-          :overlay-color :transparent} )
-     [rn/view {:style (style/blur-inner-container theme shell-overlay?)}
+          :overlay-color :transparent})
+     [rn/view {:style (style/blur-inner-container (assoc
+                                                   blur-options
+                                                   :theme theme
+                                                   :shell-overlay? shell-overlay?))}
       child]]))
 
 (defn view
   [{:keys [on-layout keyboard-shown? blur? shell-overlay? blur-options]} child]
   [rn/view
-   {:style     (style/content-container blur? keyboard-shown?)
+   {:style     (style/content-container blur? keyboard-shown? blur-options)
     :on-layout on-layout}
    (if blur?
      [blur-container shell-overlay? blur-options child]

--- a/src/status_im/common/floating_button_page/style.cljs
+++ b/src/status_im/common/floating_button_page/style.cljs
@@ -13,3 +13,5 @@
    :bottom   0
    :left     0
    :right    0})
+
+(def scroll-view-container {:flex 1})

--- a/src/status_im/common/floating_button_page/style.cljs
+++ b/src/status_im/common/floating_button_page/style.cljs
@@ -14,4 +14,12 @@
    :left     0
    :right    0})
 
+(defn content-keyboard-avoiding-view
+  [{:keys [top bottom]}]
+  {:position :absolute
+   :top      top
+   :left     0
+   :right    0
+   :bottom   bottom})
+
 (def scroll-view-container {:flex 1})

--- a/src/status_im/common/floating_button_page/view.cljs
+++ b/src/status_im/common/floating_button_page/view.cljs
@@ -108,7 +108,7 @@
            :on-scroll                            set-content-y-scroll
            :scroll-event-throttle                64
            :content-container-style              {:flex-grow      1
-                                                  :padding-bottom (when @keyboard-did-show?
+                                                  :padding-bottom (when keyboard-shown?
                                                                     @footer-container-height)}
            :always-bounce-vertical               @keyboard-did-show?
            :automatically-adjust-keyboard-insets true

--- a/src/status_im/common/floating_button_page/view.cljs
+++ b/src/status_im/common/floating_button_page/view.cljs
@@ -86,13 +86,14 @@
                                                       (oops/oget event "nativeEvent.contentOffset.y")))]
     (let [keyboard-shown?          (if platform/ios? @keyboard-will-show? @keyboard-did-show?)
           footer-container-padding (+ footer-container-padding (rf/sub [:alert-banners/top-margin]))
-          show-background?         (show-background {:window-height            window-height
-                                                     :footer-container-height  @footer-container-height
-                                                     :keyboard-height          @keyboard-height
-                                                     :content-scroll-y         @content-scroll-y
-                                                     :content-container-height @content-container-height
-                                                     :header-height            @header-height
-                                                     :keyboard-shown?          keyboard-shown?})]
+          show-background?         (show-background
+                                    {:window-height            window-height
+                                     :footer-container-height  @footer-container-height
+                                     :keyboard-height          @keyboard-height
+                                     :content-scroll-y         @content-scroll-y
+                                     :content-container-height @content-container-height
+                                     :header-height            @header-height
+                                     :keyboard-shown?          keyboard-shown?})]
       [:<>
        (when gradient-cover?
          [quo/gradient-cover {:customization-color customization-color}])

--- a/src/status_im/contexts/onboarding/create_password/style.cljs
+++ b/src/status_im/contexts/onboarding/create_password/style.cljs
@@ -30,4 +30,8 @@
 
 (def disclaimer-container
   {:padding-horizontal 20
+   :padding-top        12
    :margin-vertical    4})
+
+(def footer-container {:padding-bottom 12})
+(def footer-button-container {:margin-top 20 :padding-horizontal 20})

--- a/src/status_im/contexts/onboarding/create_password/style.cljs
+++ b/src/status_im/contexts/onboarding/create_password/style.cljs
@@ -18,12 +18,21 @@
    :justify-content   :space-between
    :margin-horizontal 20})
 
+(defn password-form-container
+  [min-height]
+  {:min-height min-height
+   :flex       1})
+
 (def top-part
   {:margin-horizontal 20
+   :flex              0
    :margin-top        12})
 
+(def middle-part
+  {:flex 1})
+
 (def bottom-part
-  {:flex            1
+  {:flex            0
    :margin-top      12
    :justify-content :flex-end})
 

--- a/src/status_im/contexts/onboarding/create_password/style.cljs
+++ b/src/status_im/contexts/onboarding/create_password/style.cljs
@@ -16,22 +16,11 @@
    :justify-content    :space-between
    :padding-horizontal 20})
 
-(defn container
-  [keyboard-shown footer-height]
-  {:flex-grow      (if keyboard-shown 0 1)
-   :padding-bottom (when-not keyboard-shown (+ footer-height 36))})
-
-(def form-container {:flex 1 :justify-content :space-between})
-
-(def top-part
-  {:padding-horizontal 20
-   :flex               0
-   :margin-vertical    12})
-
-(def disclaimer-container
-  {:padding-horizontal 20
+(def form-container
+  {:justify-content    :space-between
    :padding-top        12
-   :margin-vertical    4})
+   :padding-horizontal 20})
 
+(def disclaimer-container {:padding-horizontal 20})
 (def footer-container {:padding-bottom 12})
 (def footer-button-container {:margin-top 20 :padding-horizontal 20})

--- a/src/status_im/contexts/onboarding/create_password/style.cljs
+++ b/src/status_im/contexts/onboarding/create_password/style.cljs
@@ -2,8 +2,6 @@
   (:require
     [quo.foundations.colors :as colors]))
 
-(def flex-fill {:flex 1})
-
 (def heading {:margin-bottom 20})
 (def heading-subtitle {:color colors/white})
 (def heading-title (assoc heading-subtitle :margin-bottom 8))
@@ -14,32 +12,22 @@
 (def space-between-inputs {:height 16})
 
 (def password-tips
-  {:flex-direction    :row
-   :justify-content   :space-between
-   :margin-horizontal 20})
+  {:flex-direction     :row
+   :justify-content    :space-between
+   :padding-horizontal 20})
 
-(defn password-form-container
-  [min-height]
-  {:min-height min-height
-   :flex       1})
+(defn container
+  [keyboard-shown footer-height]
+  {:flex-grow      (if keyboard-shown 0 1)
+   :padding-bottom (when-not keyboard-shown (+ footer-height 36))})
+
+(def form-container {:flex 1 :justify-content :space-between})
 
 (def top-part
-  {:margin-horizontal 20
-   :flex              0
-   :margin-top        12})
-
-(def middle-part
-  {:flex 1})
-
-(def bottom-part
-  {:flex            0
-   :margin-top      12
-   :justify-content :flex-end})
+  {:padding-horizontal 20
+   :flex               0
+   :margin-vertical    12})
 
 (def disclaimer-container
-  {:margin-horizontal 20
-   :margin-vertical   4})
-
-(def button-container
-  {:margin-horizontal 20
-   :margin-vertical   12})
+  {:padding-horizontal 20
+   :margin-vertical    4})

--- a/src/status_im/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im/contexts/onboarding/create_password/view.cljs
@@ -212,15 +212,31 @@
                                 keyboard-shown?
                                 (+ safe-area-bottom footer-height))
       :blur-options
-      {:blur-amount      34
-       :blur-type        :transparent
-       :overlay-color    :transparent
-       :background-color (if platform/android? colors/neutral-100 colors/neutral-80-opa-1-blur)}
+      {:blur-amount        34
+       :blur-type          :transparent
+       :overlay-color      :transparent
+       :background-color   (if platform/android? colors/neutral-100 colors/neutral-80-opa-1-blur)
+       :padding-vertical   0
+       :padding-horizontal 0}
       :footer-container-padding 0
       :footer
-      [rn/view {:on-layout on-footer-layout-change}
+      [rn/view
+       {:on-layout on-footer-layout-change
+        :style     style/footer-container}
+       (when same-passwords?
+         [rn/view {:style style/disclaimer-container}
+          [quo/disclaimer
+           {:blur?     true
+            :on-change (partial set-accepts-disclaimer? not)
+            :checked?  accepts-disclaimer?}
+           (i18n/label :t/password-creation-disclaimer)]])
+       (when (and (= focused-input :password) (not same-passwords?))
+         [help
+          {:validations       password-validations
+           :password-strength password-strength}])
        [quo/button
-        {:disabled?           (not meet-requirements?)
+        {:container-style     style/footer-button-container
+         :disabled?           (not meet-requirements?)
          :customization-color user-color
          :on-press            #(rf/dispatch
                                 [:onboarding/password-set
@@ -247,16 +263,4 @@
                                         (set-show-password-validation? true)))
          :on-blur-repeat-password   #(if empty-password?
                                        (set-show-password-validation? false)
-                                       (set-show-password-validation? true))}]]
-      [rn/view
-       (when same-passwords?
-         [rn/view {:style style/disclaimer-container}
-          [quo/disclaimer
-           {:blur?     true
-            :on-change (partial set-accepts-disclaimer? not)
-            :checked?  accepts-disclaimer?}
-           (i18n/label :t/password-creation-disclaimer)]])
-       (when (and (= focused-input :password) (not same-passwords?))
-         [help
-          {:validations       password-validations
-           :password-strength password-strength}])]]]))
+                                       (set-show-password-validation? true))}]]]]))

--- a/src/status_im/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im/contexts/onboarding/create_password/view.cljs
@@ -201,13 +201,16 @@
         {:keys [keyboard-will-show? keyboard-shown]}    (hooks/use-keyboard)
         keyboard-shown?                                 (if platform/ios?
                                                           keyboard-will-show?
-                                                          keyboard-shown)]
+                                                          keyboard-shown)
+        safe-area-bottom                                (safe-area/get-bottom)]
 
     [floating-button/view
      {:header [page-nav]
       :keyboard-should-persist-taps :handled
       :content-avoid-keyboard? true
-      :content-container-style (style/container keyboard-shown? footer-height)
+      :content-container-style (style/container
+                                keyboard-shown?
+                                (+ safe-area-bottom footer-height))
       :blur-options
       {:blur-amount      34
        :blur-type        :transparent

--- a/src/status_im/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im/contexts/onboarding/create_password/view.cljs
@@ -1,10 +1,8 @@
 (ns status-im.contexts.onboarding.create-password.view
   (:require
-    [oops.core :as oops]
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
     [react-native.core :as rn]
-    [react-native.hooks :as hooks]
     [react-native.platform :as platform]
     [react-native.safe-area :as safe-area]
     [status-im.common.floating-button-page.view :as floating-button]
@@ -14,10 +12,6 @@
     [utils.re-frame :as rf]
     [utils.security.core :as security]
     [utils.string :as utils.string]))
-
-(defn- get-height-from-layout
-  [laytout-event]
-  (oops/oget laytout-event :nativeEvent :layout :height))
 
 (defn header
   []
@@ -176,10 +170,6 @@
         [focused-input set-focused-input]               (rn/use-state nil)
         [show-password-validation?
          set-show-password-validation?]                 (rn/use-state false)
-        [footer-height set-footer-height]               (rn/use-state 0)
-        on-footer-layout-change                         (comp set-footer-height
-                                                              get-height-from-layout)
-
         {user-color :color}                             (rf/sub [:onboarding/profile])
 
 
@@ -197,20 +187,12 @@
                                                                same-passwords?
                                                                accepts-disclaimer?)
                                                          [password repeat-password
-                                                          accepts-disclaimer?])
-        {:keys [keyboard-will-show? keyboard-shown]}    (hooks/use-keyboard)
-        keyboard-shown?                                 (if platform/ios?
-                                                          keyboard-will-show?
-                                                          keyboard-shown)
-        safe-area-bottom                                (safe-area/get-bottom)]
+                                                          accepts-disclaimer?])]
 
     [floating-button/view
      {:header [page-nav]
       :keyboard-should-persist-taps :handled
       :content-avoid-keyboard? true
-      :content-container-style (style/container
-                                keyboard-shown?
-                                (+ safe-area-bottom footer-height))
       :blur-options
       {:blur-amount        34
        :blur-radius        20
@@ -222,8 +204,7 @@
       :footer-container-padding 0
       :footer
       [rn/view
-       {:on-layout on-footer-layout-change
-        :style     style/footer-container}
+       {:style style/footer-container}
        (when same-passwords?
          [rn/view {:style style/disclaimer-container}
           [quo/disclaimer
@@ -245,23 +226,22 @@
         (i18n/label :t/password-creation-confirm)]]}
 
      [rn/view {:style style/form-container}
-      [rn/view {:style style/top-part}
-       [header]
-       [password-inputs
-        {:password-long-enough?     password-long-enough?
-         :passwords-match?          same-passwords?
-         :empty-password?           empty-password?
-         :show-password-validation? show-password-validation?
-         :on-input-focus            #(set-focused-input :password)
-         :on-change-password        (fn [new-value]
-                                      (set-password new-value)
-                                      (when same-password-length?
-                                        (set-show-password-validation? true)))
+      [header]
+      [password-inputs
+       {:password-long-enough?     password-long-enough?
+        :passwords-match?          same-passwords?
+        :empty-password?           empty-password?
+        :show-password-validation? show-password-validation?
+        :on-input-focus            #(set-focused-input :password)
+        :on-change-password        (fn [new-value]
+                                     (set-password new-value)
+                                     (when same-password-length?
+                                       (set-show-password-validation? true)))
 
-         :on-change-repeat-password (fn [new-value]
-                                      (set-repeat-password new-value)
-                                      (when same-password-length?
-                                        (set-show-password-validation? true)))
-         :on-blur-repeat-password   #(if empty-password?
-                                       (set-show-password-validation? false)
-                                       (set-show-password-validation? true))}]]]]))
+        :on-change-repeat-password (fn [new-value]
+                                     (set-repeat-password new-value)
+                                     (when same-password-length?
+                                       (set-show-password-validation? true)))
+        :on-blur-repeat-password   #(if empty-password?
+                                      (set-show-password-validation? false)
+                                      (set-show-password-validation? true))}]]]))

--- a/src/status_im/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im/contexts/onboarding/create_password/view.cljs
@@ -198,12 +198,16 @@
                                                                accepts-disclaimer?)
                                                          [password repeat-password
                                                           accepts-disclaimer?])
-        {:keys [keyboard-shown]}                        (hooks/use-keyboard)]
+        {:keys [keyboard-will-show? keyboard-shown]}    (hooks/use-keyboard)
+        keyboard-shown?                                 (if platform/ios?
+                                                          keyboard-will-show?
+                                                          keyboard-shown)]
 
     [floating-button/view
      {:header [page-nav]
+      :keyboard-should-persist-taps :handled
       :content-avoid-keyboard? true
-      :content-container-style (style/container keyboard-shown footer-height)
+      :content-container-style (style/container keyboard-shown? footer-height)
       :blur-options
       {:blur-amount      34
        :blur-type        :transparent

--- a/src/status_im/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im/contexts/onboarding/create_password/view.cljs
@@ -1,11 +1,10 @@
 (ns status-im.contexts.onboarding.create-password.view
   (:require
-    [oops.core :refer [ocall]]
+    [oops.core :as oops]
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
-    [reagent.core :as reagent]
     [status-im.constants :as constants]
     [status-im.contexts.onboarding.create-password.style :as style]
     [utils.i18n :as i18n]
@@ -94,7 +93,7 @@
     [quo/tips {:completed? symbols?}
      (i18n/label :t/password-creation-tips-4)]]])
 
-(defn password-validations
+(defn validate-password
   [password]
   (let [validations (juxt utils.string/has-lower-case?
                           utils.string/has-upper-case?
@@ -111,68 +110,112 @@
        (filter true?)
        count))
 
+(defn- get-height-from-layout
+  [laytout-event]
+  (oops/oget laytout-event :nativeEvent :layout :height))
+
+(defn- use-password-checks
+  [password]
+  (rn/use-memo
+   (fn []
+     (let [{:keys [long-enough?]
+            :as   validations} (validate-password password)]
+       {:password-long-enough? long-enough?
+        :password-validations  validations
+        :password-strength     (calc-password-strength validations)
+        :empty-password?       (empty? password)}))
+   [password]))
+
+(defn- use-repeat-password-checks
+  [password repeat-password]
+  (rn/use-memo
+   (fn []
+     {:same-password-length? (and (seq password) (= (count password) (count repeat-password)))
+      :same-passwords?       (and (seq password) (= password repeat-password))})
+   [password repeat-password]))
+
 (defn password-form
   []
-  (let [password                  (reagent/atom "")
-        repeat-password           (reagent/atom "")
-        accepts-disclaimer?       (reagent/atom false)
-        focused-input             (reagent/atom nil)
-        show-password-validation? (reagent/atom false)
-        same-password-length?     #(and (seq @password)
-                                        (= (count @password) (count @repeat-password)))]
-    (fn []
-      (let [{user-color :color} (rf/sub [:onboarding/profile])
-            {:keys [long-enough?]
-             :as   validations} (password-validations @password)
-            password-strength   (calc-password-strength validations)
-            empty-password?     (empty? @password)
-            same-passwords?     (and (not empty-password?) (= @password @repeat-password))
-            meet-requirements?  (and (not empty-password?)
-                                     (utils.string/at-least-n-chars? @password 10)
-                                     same-passwords?
-                                     @accepts-disclaimer?)]
-        [:<>
-         [rn/view {:style style/top-part}
-          [header]
-          [password-inputs
-           {:password-long-enough?     long-enough?
-            :passwords-match?          same-passwords?
-            :empty-password?           empty-password?
-            :show-password-validation? @show-password-validation?
-            :on-input-focus            #(reset! focused-input :password)
-            :on-change-password        (fn [new-value]
-                                         (reset! password new-value)
-                                         (when (same-password-length?)
-                                           (reset! show-password-validation? true)))
-            :on-change-repeat-password (fn [new-value]
-                                         (reset! repeat-password new-value)
-                                         (when (same-password-length?)
-                                           (reset! show-password-validation? true)))
-            :on-blur-repeat-password   #(if empty-password?
-                                          (reset! show-password-validation? false)
-                                          (reset! show-password-validation? true))}]]
+  (let [[password set-password]                         (rn/use-state "")
+        [repeat-password set-repeat-password]           (rn/use-state "")
+        [accepts-disclaimer? set-accepts-disclaimer?]   (rn/use-state false)
+        [focused-input set-focused-input]               (rn/use-state nil)
+        [show-password-validation?
+         set-show-password-validation?]                 (rn/use-state false)
 
-         [rn/view {:style style/bottom-part}
-          (when same-passwords?
-            [rn/view {:style style/disclaimer-container}
-             [quo/disclaimer
-              {:blur?     true
-               :on-change #(swap! accepts-disclaimer? not)
-               :checked?  @accepts-disclaimer?}
-              (i18n/label :t/password-creation-disclaimer)]])
-          (when (and (= @focused-input :password) (not same-passwords?))
-            [help
-             {:validations       validations
-              :password-strength password-strength}])
+        {user-color :color}                             (rf/sub [:onboarding/profile])
 
-          [rn/view {:style style/button-container}
-           [quo/button
-            {:disabled?           (not meet-requirements?)
-             :customization-color user-color
-             :on-press            #(rf/dispatch
-                                    [:onboarding/password-set
-                                     (security/mask-data @password)])}
-            (i18n/label :t/password-creation-confirm)]]]]))))
+
+        {:keys [password-long-enough?
+                password-validations password-strength
+                empty-password?]}                       (use-password-checks password)
+
+        {:keys [same-password-length? same-passwords?]} (use-repeat-password-checks password
+                                                                                    repeat-password)
+
+        meet-requirements?                              (rn/use-memo
+                                                         #(and (not empty-password?)
+                                                               (utils.string/at-least-n-chars? password
+                                                                                               10)
+                                                               same-passwords?
+                                                               accepts-disclaimer?)
+                                                         [password repeat-password
+                                                          accepts-disclaimer?])
+
+        [top-part-height set-top-part-height]           (rn/use-state 0)
+        [bottom-part-height set-bottom-part-height]     (rn/use-state 0)
+        on-top-part-layout                              (comp set-top-part-height
+                                                              get-height-from-layout)
+        on-bottom-part-layout                           (comp set-bottom-part-height
+                                                              get-height-from-layout)]
+
+    [rn/view
+     {:style (style/password-form-container (+ top-part-height bottom-part-height))}
+     [rn/view {:style style/top-part :on-layout on-top-part-layout}
+      [header]
+      [password-inputs
+       {:password-long-enough?     password-long-enough?
+        :passwords-match?          same-passwords?
+        :empty-password?           empty-password?
+        :show-password-validation? show-password-validation?
+        :on-input-focus            #(set-focused-input :password)
+        :on-change-password        (fn [new-value]
+                                     (set-password new-value)
+                                     (when same-password-length?
+                                       (set-show-password-validation? true)))
+
+        :on-change-repeat-password (fn [new-value]
+                                     (set-repeat-password new-value)
+                                     (when same-password-length?
+                                       (set-show-password-validation? true)))
+        :on-blur-repeat-password   #(if empty-password?
+                                      (set-show-password-validation? false)
+                                      (set-show-password-validation? true))}]]
+
+     ;; empty view shrink when keyboard shown
+     [rn/view {:style style/middle-part}]
+
+     [rn/view {:style style/bottom-part :on-layout on-bottom-part-layout}
+      (when same-passwords?
+        [rn/view {:style style/disclaimer-container}
+         [quo/disclaimer
+          {:blur?     true
+           :on-change (partial set-accepts-disclaimer? not)
+           :checked?  accepts-disclaimer?}
+          (i18n/label :t/password-creation-disclaimer)]])
+      (when (and (= focused-input :password) (not same-passwords?))
+        [help
+         {:validations       password-validations
+          :password-strength password-strength}])
+
+      [rn/view {:style style/button-container}
+       [quo/button
+        {:disabled?           (not meet-requirements?)
+         :customization-color user-color
+         :on-press            #(rf/dispatch
+                                [:onboarding/password-set
+                                 (security/mask-data password)])}
+        (i18n/label :t/password-creation-confirm)]]]]))
 
 (defn create-password-doc
   []
@@ -185,36 +228,40 @@
 
 (defn create-password
   []
-  (reagent/with-let [keyboard-shown?      (reagent/atom false)
-                     {:keys [top bottom]} (safe-area/get-insets)
-                     will-show-listener   (ocall rn/keyboard
-                                                 "addListener"
-                                                 "keyboardWillShow"
-                                                 #(reset! keyboard-shown? true))
-                     will-hide-listener   (ocall rn/keyboard
-                                                 "addListener"
-                                                 "keyboardWillHide"
-                                                 #(reset! keyboard-shown? false))
-                     on-press-info        (fn []
-                                            (rn/dismiss-keyboard!)
-                                            (rf/dispatch [:show-bottom-sheet
-                                                          {:content create-password-doc
-                                                           :shell?  true}]))]
-    [:<>
-     [rn/touchable-without-feedback
-      {:on-press   rn/dismiss-keyboard!
-       :accessible false}
-      [rn/view {:style style/flex-fill}
-       [rn/keyboard-avoiding-view {:style style/flex-fill}
-        [quo/page-nav
-         {:margin-top top
-          :background :blur
-          :icon-name  :i/arrow-left
-          :on-press   #(rf/dispatch [:navigate-back])
-          :right-side [{:icon-name :i/info
-                        :on-press  on-press-info}]}]
-        [password-form]
-        [rn/view {:style {:height (if-not @keyboard-shown? bottom 0)}}]]]]]
-    (finally
-     (ocall will-show-listener "remove")
-     (ocall will-hide-listener "remove"))))
+  (let [[keyboard-shown? set-keyboard-shown?] (rn/use-state false)
+        {:keys [top bottom]}                  (safe-area/get-insets)
+        on-press-info                         (fn []
+                                                (rn/dismiss-keyboard!)
+                                                (rf/dispatch [:show-bottom-sheet
+                                                              {:content create-password-doc
+                                                               :shell?  true}]))]
+
+    (rn/use-mount
+     (fn []
+       (let [will-show-listener (oops/ocall rn/keyboard
+                                            "addListener"
+                                            "keyboardWillShow"
+                                            #(set-keyboard-shown? true))
+             will-hide-listener (oops/ocall rn/keyboard
+                                            "addListener"
+                                            "keyboardWillHide"
+                                            #(set-keyboard-shown? false))]
+         (fn []
+           (oops/ocall will-show-listener "remove")
+           (oops/ocall will-hide-listener "remove")))))
+
+    [rn/touchable-without-feedback
+     {:on-press   rn/dismiss-keyboard!
+      :accessible false}
+     [rn/keyboard-avoiding-view {:style style/flex-fill}
+      [quo/page-nav
+       {:margin-top top
+        :background :blur
+        :icon-name  :i/arrow-left
+        :on-press   #(rf/dispatch [:navigate-back])
+        :right-side [{:icon-name :i/info
+                      :on-press  on-press-info}]}]
+      [rn/scroll-view
+       {:content-container-style style/flex-fill}
+       [password-form]]
+      [rn/view {:style {:height (if-not keyboard-shown? bottom 0)}}]]]))

--- a/src/status_im/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im/contexts/onboarding/create_password/view.cljs
@@ -213,6 +213,7 @@
                                 (+ safe-area-bottom footer-height))
       :blur-options
       {:blur-amount        34
+       :blur-radius        20
        :blur-type          :transparent
        :overlay-color      :transparent
        :background-color   (if platform/android? colors/neutral-100 colors/neutral-80-opa-1-blur)


### PR DESCRIPTION
-------

fixes #17184

### Summary

- create-password now uses `floating-button-page` 
- update `react-native.hooks/use-keyboard` to also return `:keyboard-will-show?`
- update `floating-button-page`
  - add `blur-options` for custom blur effects
  - add `content-avoid-keyboard?` to wrap scroll-view in `rn/keyboard-avoiding-view`
    - so that scroll view's height is also affected by keyboard
  - set scroll view `:automatically-adjust-keyboard-insets` to `true` so that it can do keyboard aware scroll (only on iOS)


### Testing notes
I only tested this on `iPhone SE (3rd generation)` and 13 pro simulator 

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
create password view


status: ready <!-- Can be ready or wip -->