### PR TITLE
[#20571] fix: cleanup save address on mount

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -36,8 +36,10 @@
 (defn- address-input
   [{:keys [input-value on-change-text paste-into-input clear-input]}]
   (let [empty-input?    (string/blank? input-value)
-        on-scan-address (rn/use-callback #(rf/dispatch [:open-modal :screen/wallet.scan-address
-                                                        {:on-result on-change-text}]))]
+        on-scan-address (rn/use-callback (fn []
+                                           (rf/dispatch [:wallet/clean-scanned-address])
+                                           (rf/dispatch [:open-modal :screen/wallet.scan-address
+                                                         {:on-result on-change-text}])))]
     [rn/view {:style style/input-container}
      [quo/input
       {:accessibility-label :add-address-to-save
@@ -161,7 +163,9 @@
                                                (rf/dispatch
                                                 [:open-modal :screen/settings.save-address]))
                                              [address ens-name? address-or-ens])]
-    (rn/use-unmount #(rf/dispatch [:wallet/clear-address-to-save]))
+    (rn/use-mount (fn []
+                    (rf/dispatch [:wallet/clean-scanned-address])
+                    (rf/dispatch [:wallet/clear-address-to-save])))
     [quo/overlay {:type :shell}
      [floating-button-page/view
       {:footer-container-padding 0


### PR DESCRIPTION
fixes #20571

### Summary

Cleanup save address and scanned address events in mount save address screen

#### Areas that maybe impacted

- Scan address to save address
- Edit saved address


### Steps to test

- Open profile setting
- Open Wallet setting
- Click on Saved adresses
- Click on +
- Click on Scan icon

status: ready
