### PR TITLE
[#20463] Multiple fixes on Collectibles

### DIFF
--- a/src/quo/components/profile/collectible_list_item/style.cljs
+++ b/src/quo/components/profile/collectible_list_item/style.cljs
@@ -11,7 +11,7 @@
 (defn fallback
   [{:keys [theme opacity]}]
   [{:opacity opacity}
-   {:opacity          default-opacity-for-image
+   {:opacity          1
     :background-color (colors/theme-colors colors/neutral-2_5 colors/neutral-90 theme)
     :border-style     :dashed
     :border-color     (colors/theme-colors colors/neutral-20 colors/neutral-80 theme)
@@ -60,8 +60,13 @@
    :padding-right  0
    :padding-top    4})
 
-(def card-detail-text
-  {:flex 1})
+(defn card-detail-text
+  [empty-name? theme]
+  {:flex         1
+   :margin-right 8
+   :color        (if empty-name?
+                   (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)
+                   (colors/theme-colors colors/neutral-100 colors/white theme))})
 
 (defn card-loader
   [opacity]
@@ -115,6 +120,7 @@
   [{:opacity opacity}
    {:flex           1
     :flex-direction :row
+    :column-gap     8
     :opacity        default-opacity-for-image}])
 
 (defn supported-file

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -11,38 +11,24 @@
     [react-native.core :as rn]
     [react-native.reanimated :as reanimated]
     [schema.core :as schema]
-    [utils.datetime :as datetime]
     [utils.i18n :as i18n]))
 
-(def timing-options-out 650)
-(def timing-options-in 1000)
-(def first-load-time 500)
-(def cached-load-time 200)
+(def loader-out 650)
+(def image-in 1000)
 (def error-wait-time 800)
 
 (defn on-load-end
-  [{:keys [load-time set-state loader-opacity image-opacity]}]
-  (reanimated/animate loader-opacity 0 timing-options-out)
-  (reanimated/animate image-opacity 1 timing-options-in)
-  (if (> load-time cached-load-time)
-    (js/setTimeout
-     (fn []
-       (set-state (fn [prev-state]
-                    (assoc prev-state :image-loaded? true))))
-     first-load-time)
-    (set-state (fn [prev-state]
-                 (assoc prev-state :image-loaded? true)))))
+  [{:keys [loader-opacity image-opacity]}]
+  (reanimated/animate loader-opacity 0 loader-out)
+  (reanimated/animate image-opacity 1 image-in))
 
 (defn on-load-error
-  [set-state]
-  (js/setTimeout (fn []
-                   (set-state (fn [prev-state] (assoc prev-state :image-error? true))))
-                 error-wait-time))
+  [set-error]
+  (js/setTimeout set-error error-wait-time))
 
 (defn- loading-image
   [{:keys [theme gradient-color-index loader-opacity aspect-ratio]}]
-  [reanimated/view
-   {:style (style/loading-image-with-opacity loader-opacity)}
+  [reanimated/view {:style (style/loading-image-with-opacity loader-opacity)}
    [gradients/view
     {:theme           theme
      :container-style (style/gradient-view aspect-ratio)
@@ -67,62 +53,62 @@
      :style {:color (colors/theme-colors colors/neutral-40 colors/neutral-50 theme)}}
     label]])
 
+(defn- collectible-image
+  [{:keys [aspect-ratio theme gradient-color-index supported-file? set-error native-ID
+           square? image-src on-collectible-load counter]}]
+  (let [loader-opacity (reanimated/use-shared-value (if supported-file? 1 0))
+        image-opacity  (reanimated/use-shared-value (if supported-file? 0 1))]
+    [:<>
+     [loading-image
+      {:aspect-ratio         aspect-ratio
+       :loader-opacity       loader-opacity
+       :theme                theme
+       :gradient-color-index gradient-color-index}]
+
+     [reanimated/view {:style (style/supported-file image-opacity)}
+      [rn/image
+       {:style       (style/image square? aspect-ratio theme)
+        :source      image-src
+        :native-ID   native-ID
+        :on-load-end (fn []
+                       (on-load-end {:loader-opacity loader-opacity
+                                     :image-opacity  image-opacity}))
+        :on-error    #(on-load-error set-error)
+        :on-load     on-collectible-load}]
+      (when counter
+        [counter-view counter])
+      [rn/view {:style (style/collectible-border theme)}]]]))
+
 (defn view-internal
   [{:keys [container-style square? on-press counter image-src native-ID supported-file?
-           on-collectible-load aspect-ratio]}]
-  (let [theme                     (quo.theme/use-theme)
-        loader-opacity            (reanimated/use-shared-value
-                                   (if supported-file? 1 0))
-        image-opacity             (reanimated/use-shared-value
-                                   (if supported-file? 0 1))
-        [load-time set-load-time] (rn/use-state (datetime/now))
-        [state set-state]         (rn/use-state {:image-loaded? false
-                                                 :image-error?  (or (nil? image-src)
-                                                                    (string/blank?
-                                                                     image-src))})]
+           on-collectible-load aspect-ratio gradient-color-index]}]
+  (let [theme              (quo.theme/use-theme)
+        [error? set-error] (rn/use-state (or (nil? image-src)
+                                             (string/blank? image-src)))]
     [rn/pressable
-     {:on-press            (when (and (not (:image-error? state)) supported-file?) on-press)
+     {:style               (merge container-style (style/container aspect-ratio))
       :accessibility-label :expanded-collectible
-      :style               (merge container-style
-                                  (style/container aspect-ratio))}
-     (cond
-       (not supported-file?)
+      :on-press            (when (and (not error?) supported-file?)
+                             on-press)}
+     (if (or (not supported-file?) error?)
        [fallback-view
-        {:aspect-ratio aspect-ratio
-         :label        (i18n/label :t/unsupported-file)
-         :counter      counter
-         :theme        theme
-         :on-mount     on-collectible-load}]
-
-       (:image-error? state)
-       [fallback-view
-        {:label    (i18n/label :t/cant-fetch-info)
+        {:label    (i18n/label (if-not supported-file?
+                                 :t/unsupported-file
+                                 :t/cant-fetch-info))
          :counter  counter
          :theme    theme
          :on-mount on-collectible-load}]
-
-       (not (:image-loaded? state))
-       [loading-image
+       [collectible-image
         {:aspect-ratio         aspect-ratio
-         :loader-opacity       loader-opacity
          :theme                theme
-         :gradient-color-index :gradient-5}])
-     (when supported-file?
-       [reanimated/view {:style (style/supported-file image-opacity)}
-        [rn/image
-         {:style         (style/image square? aspect-ratio theme)
-          :source        image-src
-          :native-ID     native-ID
-          :on-load-start #(set-load-time (fn [start-time] (- (datetime/now) start-time)))
-          :on-load-end   #(on-load-end {:load-time      load-time
-                                        :set-state      set-state
-                                        :loader-opacity loader-opacity
-                                        :image-opacity  image-opacity})
-          :on-error      #(on-load-error set-state)
-          :on-load       on-collectible-load}]
-        (when counter
-          [counter-view counter])
-        [rn/view {:style (style/collectible-border theme)}]])]))
+         :supported-file?      supported-file?
+         :set-error            set-error
+         :native-ID            native-ID
+         :square?              square?
+         :image-src            image-src
+         :on-collectible-load  on-collectible-load
+         :counter              counter
+         :gradient-color-index gradient-color-index}])]))
 
 (def ?schema
   [:=>
@@ -137,7 +123,8 @@
       [:square? {:optional true} [:maybe boolean?]]
       [:counter {:optional true} [:maybe string?]]
       [:on-press {:optional true} [:maybe fn?]]
-      [:on-collectible-load {:optional true} [:maybe fn?]]]]]
+      [:on-collectible-load {:optional true} [:maybe fn?]]
+      [:gradient-color-index {:optional true} [:maybe keyword?]]]]]
    :any])
 
 (def view (schema/instrument #'view-internal ?schema))

--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -81,7 +81,9 @@
 
 (defn view-internal
   [{:keys [container-style square? on-press counter image-src native-ID supported-file?
-           on-collectible-load aspect-ratio gradient-color-index]}]
+           on-collectible-load aspect-ratio gradient-color-index]
+    :or   {gradient-color-index :gradient-1
+           on-collectible-load  (fn [])}}]
   (let [theme              (quo.theme/use-theme)
         [error? set-error] (rn/use-state (or (nil? image-src)
                                              (string/blank? image-src)))]

--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -11,9 +11,7 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn- on-collectible-press
-  [{:keys [id]} aspect-ratio]
-  (rf/dispatch [:wallet/get-collectible-details id aspect-ratio]))
+(def on-collectible-press #(rf/dispatch [:wallet/navigate-to-collectible-details %]))
 
 (defn- on-collectible-long-press
   [{:keys [preview-url collectible-details id]}]

--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.wallet.collectible.events
   (:require [camel-snake-kebab.extras :as cske]
+            [clojure.string :as string]
             [react-native.platform :as platform]
             [status-im.contexts.wallet.collectible.utils :as collectible-utils]
             [taoensso.timbre :as log]
@@ -43,13 +44,6 @@
   {:db (update-in db [:wallet :accounts] update-vals #(dissoc % :collectibles))})
 
 (rf/reg-event-fx :wallet/clear-stored-collectibles clear-stored-collectibles)
-
-(defn store-last-collectible-details
-  [{:keys [db]} [collectible]]
-  {:db       (assoc-in db [:wallet :last-collectible-details] collectible)
-   :dispatch [:navigate-to :screen/wallet.collectible]})
-
-(rf/reg-event-fx :wallet/store-last-collectible-details store-last-collectible-details)
 
 (rf/reg-event-fx
  :wallet/request-new-collectibles-for-account
@@ -166,39 +160,58 @@
              [:dispatch [:wallet/flush-collectibles-fetched]])]})))
 
 (rf/reg-event-fx
- :wallet/get-collectible-details
- (fn [{:keys [db]} [collectible-id aspect-ratio]]
+ :wallet/navigate-to-collectible-details
+ (fn [{:keys [db]}
+      [{{collectible-id :id :as collectible} :collectible
+        aspect-ratio                         :aspect-ratio
+        gradient-color                       :gradient-color}]]
    (let [request-id               0
          collectible-id-converted (cske/transform-keys transforms/->PascalCaseKeyword collectible-id)
          data-type                (collectible-data-types :details)
          request-params           [request-id [collectible-id-converted] data-type]]
-     {:db (assoc-in db [:wallet :last-collectible-aspect-ratio] aspect-ratio)
+     {:db (assoc-in db
+           [:wallet :ui :collectible]
+           {:details        collectible
+            :aspect-ratio   aspect-ratio
+            :gradient-color gradient-color})
       :fx [[:json-rpc/call
             [{:method   "wallet_getCollectiblesByUniqueIDAsync"
               :params   request-params
               :on-error (fn [error]
                           (log/error "failed to request collectible"
-                                     {:event  :wallet/get-collectible-details
+                                     {:event  :wallet/navigate-to-collectible-details
                                       :error  error
-                                      :params request-params}))}]]]})))
+                                      :params request-params}))}]]
+           ;; We delay the navigation because we need re-frame to update the DB on time.
+           ;; By doing it, we skip a blink while visiting the collectible detail page.
+           [:dispatch-later
+            {:ms       1
+             :dispatch [:navigate-to :screen/wallet.collectible]}]]})))
+
+(defn- keep-not-empty-value
+  [old-value new-value]
+  (if (or (string/blank? new-value) (nil? new-value))
+    old-value
+    new-value))
+
+(def merge-skipping-empty-values (partial merge-with keep-not-empty-value))
 
 (rf/reg-event-fx
  :wallet/get-collectible-details-done
- (fn [_ [{:keys [message]}]]
-   (let [response               (cske/transform-keys transforms/->kebab-case-keyword
-                                                     (transforms/json->clj message))
-         {:keys [collectibles]} response
-         collectible            (first collectibles)]
+ (fn [{db :db} [{:keys [message]}]]
+   (let [response                      (cske/transform-keys transforms/->kebab-case-keyword
+                                                            (transforms/json->clj message))
+         {[collectible] :collectibles} response]
      (if collectible
-       {:fx [[:dispatch [:wallet/store-last-collectible-details collectible]]]}
+       {:db (update-in db [:wallet :ui :collectible :details] merge-skipping-empty-values collectible)}
        (log/error "failed to get collectible details"
                   {:event    :wallet/get-collectible-details-done
                    :response response})))))
 
 (rf/reg-event-fx
- :wallet/clear-last-collectible-details
+ :wallet/clear-collectible-details
  (fn [{:keys [db]}]
-   {:db (update-in db [:wallet] dissoc :last-collectible-details :last-collectible-aspect-ratio)}))
+   {:db (update-in db [:wallet :ui] dissoc :collectible)}))
 
 (rf/reg-event-fx :wallet/trigger-share-collectible
  (fn [_ [{:keys [title uri]}]]

--- a/src/status_im/contexts/wallet/collectible/events_test.cljs
+++ b/src/status_im/contexts/wallet/collectible/events_test.cljs
@@ -43,18 +43,6 @@
 
         (is (match? result-db expected-db))))))
 
-(deftest store-last-collectible-details-test
-  (testing "store-last-collectible-details"
-    (let [db               {:wallet {}}
-          last-collectible {:description "Pandaria"
-                            :image-url   "https://..."}
-          expected-db      {:wallet {:last-collectible-details {:description "Pandaria"
-                                                                :image-url   "https://..."}}}
-          effects          (events/store-last-collectible-details {:db db}
-                                                                  [last-collectible])
-          result-db        (:db effects)]
-      (is (match? result-db expected-db)))))
-
 (deftest request-new-collectibles-for-account-from-signal-test
   (testing "request new collectibles for account from signal"
     (let [db       {:wallet {}}

--- a/src/status_im/contexts/wallet/collectible/tabs/about/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/tabs/about/view.cljs
@@ -8,12 +8,11 @@
 (def ^:private link-card-space 28)
 
 (defn view
-  []
-  (let [window-width               (rf/sub [:dimensions/window-width])
-        item-width                 (- (/ window-width 2) link-card-space)
-        {:keys [collectible-data]} (rf/sub [:wallet/last-collectible-details])
-        link-card-container-style  (style/link-card item-width)
-        collectible-about          {:cards []}]
+  [{:keys [collectible-data]}]
+  (let [window-width              (rf/sub [:dimensions/window-width])
+        item-width                (- (/ window-width 2) link-card-space)
+        link-card-container-style (style/link-card item-width)
+        collectible-about         {:cards []}]
     [:<>
      [rn/view {:style style/title}
       [quo/text

--- a/src/status_im/contexts/wallet/collectible/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/tabs/view.cljs
@@ -5,9 +5,9 @@
             [status-im.contexts.wallet.collectible.tabs.overview.view :as overview]))
 
 (defn view
-  [{:keys [selected-tab]}]
+  [{:keys [selected-tab collectible]}]
   (case selected-tab
-    :overview [overview/view]
-    :about    [about/view]
+    :overview [overview/view collectible]
+    :about    [about/view collectible]
     :activity [activity/view]
     nil))

--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -12,7 +12,7 @@
       :balance
       js/parseInt))
 
-(def ^:const supported-collectible-types
+(def supported-collectible-types
   #{"image/jpeg"
     "image/gif"
     "image/bmp"

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -225,7 +225,9 @@
             :default-active @selected-tab
             :on-change      on-tab-change
             :data           tabs-data}]
-          [tabs/view {:selected-tab @selected-tab}]]]))))
+          [tabs/view
+           {:selected-tab @selected-tab
+            :collectible  collectible}]]]))))
 
 (defn view
   [_]

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -76,11 +76,10 @@
 (defn navigate-back-and-clear-collectible
   []
   (rf/dispatch [:navigate-back])
-  (js/setTimeout #(rf/dispatch [:wallet/clear-last-collectible-details]) 700))
+  (rf/dispatch [:wallet/clear-collectible-details]))
 
 (defn animated-header
-  [{:keys [scroll-amount title-opacity page-nav-type picture title description theme
-           id]}]
+  [{:keys [scroll-amount title-opacity page-nav-type picture title description theme id]}]
   (let [blur-amount   (header-animations/use-blur-amount scroll-amount)
         layer-opacity (header-animations/use-layer-opacity
                        scroll-amount
@@ -149,8 +148,9 @@
       (let [title-ref                      (rn/use-ref-atom nil)
             set-title-ref                  (rn/use-callback #(reset! title-ref %))
             animation-shared-element-id    (rf/sub [:animation-shared-element-id])
-            collectible-owner              (rf/sub [:wallet/last-collectible-details-owner])
-            aspect-ratio                   (rf/sub [:wallet/last-collectible-aspect-ratio])
+            collectible-owner              (rf/sub [:wallet/collectible-details-owner collectible])
+            aspect-ratio                   (rf/sub [:wallet/collectible-aspect-ratio])
+            gradient-color                 (rf/sub [:wallet/collectible-gradient-color])
             {:keys [id
                     preview-url
                     collection-data
@@ -181,35 +181,36 @@
          [rn/view
           [gradient-layer preview-uri]
           [quo/expanded-collectible
-           {:aspect-ratio        aspect-ratio
-            :image-src           preview-uri
-            :container-style     (style/preview-container)
-            :counter             (utils/collectible-owned-counter total-owned)
-            :native-ID           (when (= animation-shared-element-id token-id) :shared-element)
-            :supported-file?     (utils/supported-file? (:animation-media-type collectible-data))
-            :on-press            (fn []
-                                   (if svg?
-                                     (js/alert "Can't visualize SVG images in lightbox")
-                                     (rf/dispatch
-                                      [:lightbox/navigate-to-lightbox
-                                       token-id
-                                       {:images           [collectible-image]
-                                        :index            0
-                                        :on-options-press #(rf/dispatch [:show-bottom-sheet
-                                                                         {:content
-                                                                          (fn []
-                                                                            [options-drawer/view
-                                                                             {:name collectible-name
-                                                                              :image
-                                                                              preview-uri
-                                                                              :id id}])}])}])))
-            :on-collectible-load (fn []
-                                   ;; We need to delay the measurement because the
-                                   ;; navigation has an animation
-                                   (js/setTimeout
-                                    #(some-> @title-ref
-                                             (oops/ocall "measureInWindow" set-title-bottom))
-                                    300))}]]
+           {:aspect-ratio         aspect-ratio
+            :image-src            preview-uri
+            :container-style      (style/preview-container)
+            :gradient-color-index gradient-color
+            :counter              (utils/collectible-owned-counter total-owned)
+            :native-ID            (when (= animation-shared-element-id token-id) :shared-element)
+            :supported-file?      (utils/supported-file? (:animation-media-type collectible-data))
+            :on-press             (fn []
+                                    (if svg?
+                                      (js/alert "Can't visualize SVG images in lightbox")
+                                      (rf/dispatch
+                                       [:lightbox/navigate-to-lightbox
+                                        token-id
+                                        {:images           [collectible-image]
+                                         :index            0
+                                         :on-options-press #(rf/dispatch [:show-bottom-sheet
+                                                                          {:content
+                                                                           (fn []
+                                                                             [options-drawer/view
+                                                                              {:name collectible-name
+                                                                               :image
+                                                                               preview-uri
+                                                                               :id id}])}])}])))
+            :on-collectible-load  (fn []
+                                    ;; We need to delay the measurement because the
+                                    ;; navigation has an animation
+                                    (js/setTimeout
+                                     #(some-> @title-ref
+                                              (oops/ocall "measureInWindow" set-title-bottom))
+                                     300))}]]
          [rn/view {:style (style/background-color theme)}
           [header collectible-name collection-name collection-image set-title-ref]
           [cta-buttons
@@ -229,37 +230,39 @@
            {:selected-tab @selected-tab
             :collectible  collectible}]]]))))
 
+(defn- get-title-bottom-y-position
+  [y-element-position element-height]
+  (let [{:keys [top]} (safe-area/get-insets)
+        title-height  -56]
+    (+ y-element-position
+       element-height
+       title-height
+       (when platform/ios? (* top -2)))))
+
 (defn view
   [_]
-  (let [{:keys [top]}              (safe-area/get-insets)
-        theme                      (quo.theme/use-theme)
-        title-bottom-coord         (rn/use-ref-atom 0)
-        set-title-bottom           (rn/use-callback
-                                    (fn [_ y _ height]
-                                      (reset! title-bottom-coord
-                                        (+ y
-                                           height
-                                           -56
-                                           (when platform/ios?
-                                             (* top -2))))))
-        scroll-amount              (reanimated/use-shared-value 0)
-        title-opacity              (reanimated/use-shared-value 0)
-        collectible                (rf/sub [:wallet/last-collectible-details])
-        {:keys [preview-url
-                collection-data
-                collectible-data]} collectible
-        {preview-uri :uri}         preview-url
-        {collectible-name :name}   collectible-data
-        {collection-name :name}    collection-data]
+  (let [{:keys [top]}       (safe-area/get-insets)
+        theme               (quo.theme/use-theme)
+        title-bottom-coord  (rn/use-ref-atom 0)
+        set-title-bottom    (rn/use-callback
+                             (fn [_ y _ height]
+                               (reset! title-bottom-coord
+                                 (get-title-bottom-y-position y height))))
+        scroll-amount       (reanimated/use-shared-value 0)
+        title-opacity       (reanimated/use-shared-value 0)
+        {:keys [collection-data
+                collectible-data
+                preview-url]
+         :as   collectible} (rf/sub [:wallet/collectible-details])]
     [rn/view {:style (style/background-color theme)}
      [animated-header
       {:id            (:id collectible)
        :scroll-amount scroll-amount
        :title-opacity title-opacity
        :page-nav-type :title-description
-       :picture       preview-uri
-       :title         collectible-name
-       :description   collection-name
+       :picture       (:uri preview-url)
+       :title         (:name collectible-data)
+       :description   (:name collection-data)
        :theme         theme}]
      [reanimated/scroll-view
       {:style     (style/scroll-view top)

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -13,25 +13,34 @@
   [{:keys [preview-url collection-data collectible-data total-owned on-press on-long-press]
     :as   collectible}
    index]
-  (let [on-press-fn      (rn/use-callback #(when on-press
-                                             (on-press collectible %)))
-        on-long-press-fn (rn/use-callback #(when on-long-press
-                                             (on-long-press collectible)))]
+  (let [gradient-color   (keyword (str "gradient-" (inc (mod index 5))))
+        on-press-fn      (rn/use-callback
+                          (fn [aspect-ratio]
+                            (when (fn? on-press)
+                              (on-press {:collectible    (dissoc collectible :on-press :on-long-press)
+                                         :aspect-ratio   aspect-ratio
+                                         :gradient-color gradient-color}))))
+        on-long-press-fn (rn/use-callback
+                          (fn [aspect-ratio]
+                            (when on-long-press
+                              (on-long-press
+                               (dissoc collectible :on-press :on-long-press)
+                               aspect-ratio))))]
     [quo/collectible-list-item
      {:type                 :card
       :image-src            (:uri preview-url)
       :avatar-image-src     (:image-url collection-data)
-      :collectible-name     (:name collection-data)
+      :collectible-name     (:name collectible-data)
       :supported-file?      (utils/supported-file? (:animation-media-type collectible-data))
-      :gradient-color-index (keyword (str "gradient-" (inc (mod index 5))))
+      :gradient-color-index gradient-color
       :counter              (utils/collectible-owned-counter total-owned)
       :container-style      style/collectible-container
       :on-press             on-press-fn
       :on-long-press        on-long-press-fn}]))
 
 (defn view
-  [{:keys [collectibles filtered? on-end-reached
-           on-collectible-press current-account-address on-collectible-long-press]}]
+  [{:keys [collectibles filtered? on-end-reached on-collectible-press
+           current-account-address on-collectible-long-press]}]
   (let [theme                   (quo.theme/use-theme)
         no-results-match-query? (and filtered? (empty? collectibles))]
     (cond

--- a/src/status_im/contexts/wallet/home/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/view.cljs
@@ -17,9 +17,7 @@
                               :name  (:name collectible-data)
                               :image (:uri preview-url)}])}]))
 
-(defn- on-collectible-press
-  [{:keys [id]} aspect-ratio]
-  (rf/dispatch [:wallet/get-collectible-details id aspect-ratio]))
+(def on-collectible-press #(rf/dispatch [:wallet/navigate-to-collectible-details %]))
 
 (defn view
   [{:keys [selected-tab]}]

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -32,7 +32,7 @@
      {:collectibles         collectibles
       :filtered?            search-performed?
       :on-end-reached       #(rf/dispatch [:wallet/request-collectibles-for-current-viewing-account])
-      :on-collectible-press (fn [collectible]
+      :on-collectible-press (fn [{:keys [collectible]}]
                               (rf/dispatch [:wallet/set-collectible-to-send
                                             {:collectible    collectible
                                              :current-screen :screen/wallet.select-asset}]))}]))

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -20,8 +20,7 @@
 (defn- preview-url
   [{{collectible-image-url :image-url
      animation-url         :animation-url
-     animation-media-type  :animation-media-type} :collectible-data
-    {collection-image-url :image-url}             :collection-data}]
+     animation-media-type  :animation-media-type} :collectible-data}]
   (cond
     (svg-animation? animation-url animation-media-type)
     {:uri  animation-url
@@ -34,7 +33,7 @@
     {:uri collectible-image-url}
 
     :else
-    {:uri collection-image-url}))
+    {:uri nil}))
 
 (defn add-collectibles-preview-url
   [collectibles]
@@ -91,23 +90,29 @@
              current-account-collectibles))))
 
 (re-frame/reg-sub
- :wallet/last-collectible-details
- :<- [:wallet]
- (fn [wallet]
-   (let [last-collectible (:last-collectible-details wallet)]
-     (assoc last-collectible :preview-url (preview-url last-collectible)))))
+ :wallet/collectible
+ :<- [:wallet/ui]
+ :-> :collectible)
 
 (re-frame/reg-sub
- :wallet/last-collectible-aspect-ratio
- :<- [:wallet]
- (fn [wallet]
-   (:last-collectible-aspect-ratio wallet)))
-
-(re-frame/reg-sub
+ :wallet/collectible-details
+ :<- [:wallet/collectible]
  (fn [collectible]
+   (as-> collectible $
+     (:details $)
+     (assoc $ :preview-url (preview-url $)))))
 
 (re-frame/reg-sub
+ :wallet/collectible-aspect-ratio
+ :<- [:wallet/collectible]
  (fn [collectible]
+   (:aspect-ratio collectible 1)))
+
+(re-frame/reg-sub
+ :wallet/collectible-gradient-color
+ :<- [:wallet/collectible]
+ (fn [collectible]
+   (:gradient-color collectible :gradient-1)))
 
 (re-frame/reg-sub
  :wallet/collectible-details-owner

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -104,16 +104,10 @@
    (:last-collectible-aspect-ratio wallet)))
 
 (re-frame/reg-sub
- :wallet/last-collectible-details-chain-id
- :<- [:wallet/last-collectible-details]
  (fn [collectible]
-   (get-in collectible [:id :contract-id :chain-id])))
 
 (re-frame/reg-sub
- :wallet/last-collectible-details-traits
- :<- [:wallet/last-collectible-details]
  (fn [collectible]
-   (get-in collectible [:collectible-data :traits])))
 
 (re-frame/reg-sub
  :wallet/collectible-details-owner

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -116,10 +116,11 @@
    (get-in collectible [:collectible-data :traits])))
 
 (re-frame/reg-sub
- :wallet/last-collectible-details-owner
- :<- [:wallet/last-collectible-details]
- :<- [:wallet]
- (fn [[collectible wallet]]
-   (let [address (:address (first (:ownership collectible)))
-         account (get-in wallet [:accounts address])]
-     account)))
+ :wallet/collectible-details-owner
+ :<- [:wallet/accounts]
+ (fn [accounts [_ collectible]]
+   (let [collectible-address (-> collectible :ownership first :address)]
+     (some #(when (= (:address %) collectible-address)
+              %)
+           accounts))))
+

--- a/src/status_im/subs/wallet/collectibles_test.cljs
+++ b/src/status_im/subs/wallet/collectibles_test.cljs
@@ -26,21 +26,7 @@
    :accounts                 {"0x1" {:name  "account 1"
                                      :color "army"}}})
 
-(h/deftest-sub :wallet/last-collectible-details-chain-id
-  [sub-name]
-  (testing "correct chain-id of the last collectible should be returned"
-    (swap! rf-db/app-db assoc-in [:wallet :last-collectible-details :id :contract-id :chain-id] "1")
-    (let [result (rf/sub [sub-name])]
-      (is (= "1" result)))))
-
-(h/deftest-sub :wallet/last-collectible-details-traits
-  [sub-name]
-  (testing "correct traits of the last collectible should be returned"
-    (swap! rf-db/app-db assoc-in [:wallet :last-collectible-details :collectible-data :traits] traits)
-    (let [result (rf/sub [sub-name])]
-      (is (= traits result)))))
-
-(h/deftest-sub :wallet/last-collectible-details-owner
+(h/deftest-sub :wallet/collectible-details-owner
   [sub-name]
   (testing "correct owner of the last collectible should be returned"
     (swap! rf-db/app-db assoc-in [:wallet] collectible-owner-wallet)

--- a/src/status_im/subs/wallet/collectibles_test.cljs
+++ b/src/status_im/subs/wallet/collectibles_test.cljs
@@ -2,35 +2,25 @@
   (:require
     [cljs.test :refer [is testing]]
     [re-frame.db :as rf-db]
-    status-im.subs.root
-    status-im.subs.wallet.collectibles
+    [status-im.subs.root]
+    [status-im.subs.wallet.collectibles]
     [test-helpers.unit :as h]
     [utils.re-frame :as rf]))
 
-(def ^:private traits
-  [{:trait-type   "Background"
-    :value        "Gradient 5"
-    :display-type ""
-    :max-value    ""}
-   {:trait-type   "Skin"
-    :value        "Pale"
-    :display-type ""
-    :max-value    ""}
-   {:trait-type   "Clothes"
-    :value        "Naked"
-    :display-type ""
-    :max-value    ""}])
-
-(def ^:private collectible-owner-wallet
-  {:last-collectible-details {:ownership [{:address "0x1"}]}
-   :accounts                 {"0x1" {:name  "account 1"
-                                     :color "army"}}})
+(def collectible-owner-wallet
+  {:ui       {:collectible {:details {:ownership [{:address "0x1"}]}}}
+   :accounts {"0x1" {:address "0x1"
+                     :name    "account 1"
+                     :color   "army"}}})
 
 (h/deftest-sub :wallet/collectible-details-owner
   [sub-name]
   (testing "correct owner of the last collectible should be returned"
-    (swap! rf-db/app-db assoc-in [:wallet] collectible-owner-wallet)
-    (let [result (rf/sub [sub-name])]
-      (is (= {:name  "account 1"
-              :color "army"}
+    (swap! rf-db/app-db assoc :wallet collectible-owner-wallet)
+    (let [collectible (-> collectible-owner-wallet :ui :collectible :details)
+          result      (rf/sub [sub-name collectible])]
+      (is (= {:name                      "account 1"
+              :color                     "army"
+              :address                   "0x1"
+              :network-preferences-names #{}}
              result)))))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #20463
fixes #20229 

## Summary

This PR implements various fixes related to the collectibles.

- :white_check_mark:  #20463 - But it's important to note that it is an status-go issue, sometimes Status go returns data for the listing but not when the collectible is selected. This has been addressed client-side.

- :white_check_mark:  #20229  - This is due to Status-go no longer anwering to calls, the navigation depended on the status-go response, now this has been changed, so this issue has been solved.

### Additional fixes

- :white_check_mark: Unknown variant has been implemented and it's being used in the collectible listing:

    <img src="https://github.com/status-im/status-mobile/assets/90291778/f2a38096-ca2e-4015-918f-e068229c7529" width="350">



- :white_check_mark: We were displaying the collection name instead of the collectible name and sometimes we just displayed a blank collectible:

    Before vs Now:
    <img src="https://github.com/status-im/status-mobile/assets/90291778/4ee60560-eaa6-42ea-abfe-804d6be5eda7" 
width="350"> <img src="https://github.com/status-im/status-mobile/assets/90291778/3be297da-c502-4065-8273-efef732204a3" width="350">


- :white_check_mark: The experience of opening a collectible is now smoother:
    Before (we had a blink):

    https://github.com/status-im/status-mobile/assets/90291778/fb9a14b6-f3cb-409b-b909-30d682e37041

    Now:

    https://github.com/status-im/status-mobile/assets/90291778/330b1118-73fd-4340-b940-11c3338101f8


### Review notes
Some other refactorings/renamings to subs were made. They are being mentioned in the self-review

status: ready