### PR TITLE
chore: statusgo changes to remove default pubsubtopic (not to merge)

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.181.31",
-    "commit-sha1": "6e056348e6d28f962167118612826f1ef0e47b22",
-    "src-sha256": "1qvfwk28sg93basjzy8r55qz8pk9xg0h7kxv5ykxkbfh4q17a1ns"
+    "version": "2470244278056f958b6b3996118d6e4c5ec336ed",
+    "commit-sha1": "2470244278056f958b6b3996118d6e4c5ec336ed",
+    "src-sha256": "0hxxfk43381x1maid6660al23x2fi88mq8f8bzngph0jrqwh6qbc"
 }


### PR DESCRIPTION
### Summary
Includes changes from https://github.com/status-im/status-go/pull/5474 which changes statusgo to only use shards and no defaultpubsubTopic. This is for dogfooding only.

#### Areas that maybe impacted

Communities and messaging.

- Test community creation and shard assignment. Try asssigning a community to shard 128 or 256(not sure if this is possible from mobile).
- Send and receive of messages should work before and after assignment of the community.
- Join community and send/receive messages.
- All messaging send and receive i.e communities, groups and 1:1 chat.

##### Functional

- 1-1 chats
- public chats
- group chats
- community chats

status: ready 

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

