### PR TITLE
Wallet: fix asset sorting

### DIFF
--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -177,7 +177,7 @@
   "This function returns token values in the props of token-value (quo) component"
   [{:keys [token color currency currency-symbol]}]
   (let [balance                           (calculate-total-token-balance token)
-        fiat-unformatted-value                        (calculate-token-fiat-value
+        fiat-unformatted-value            (calculate-token-fiat-value
                                            {:currency currency
                                             :balance  balance
                                             :token    token})
@@ -201,11 +201,11 @@
                             (neg? change-pct-24hour) :negative
                             :else                    :empty)
      :customization-color color
-     :values              {:crypto-value      crypto-value
-                           :fiat-value        fiat-value
+     :values              {:crypto-value           crypto-value
+                           :fiat-value             fiat-value
                            :fiat-unformatted-value fiat-unformatted-value
-                           :fiat-change       formatted-token-price
-                           :percentage-change percentage-change}}))
+                           :fiat-change            formatted-token-price
+                           :percentage-change      percentage-change}}))
 
 (defn get-multichain-address
   [networks address]

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -308,11 +308,9 @@
                                                     :currency        currency
                                                     :currency-symbol currency-symbol}))
         calculated-tokens (map calculate-token tokens)
-        token-priority    {"SNT" 1 "ETH" 2 "DAI" 3}]
-    (sort-by (juxt #(get-in % [:values :fiat-unformatted-value])
-                   #(get token-priority (:token %)))
-             (fn [[val1 pri1] [val2 pri2]]
-               (if (= val1 val2)
-                 (< pri1 pri2)
-                 (> val1 val2)))
+        token-priority    {"SNT" 1 "STT" 1 "ETH" 2 "DAI" 3}]
+    (sort-by (fn [token]
+               (let [fiat-value (get-in token [:values :fiat-unformatted-value])
+                     priority   (get token-priority (:token token) 999)]
+                 [(- fiat-value) priority]))
              calculated-tokens)))

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -302,10 +302,18 @@
 
 (defn calculate-and-sort-tokens
   [{:keys [tokens color currency currency-symbol]}]
-  (let [calculated-tokens (map #(calculate-token-value {:token           %
-                                                        :color           color
-                                                        :currency        currency
-                                                        :currency-symbol currency-symbol})
-                               tokens)]
-    (println "cccxxx" calculated-tokens)
-    (sort-by #(get-in % [:values :fiat-unformatted-value]) > calculated-tokens)))
+  (let [calculate-token   (fn [token]
+                            (calculate-token-value {:token           token
+                                                    :color           color
+                                                    :currency        currency
+                                                    :currency-symbol currency-symbol}))
+        calculated-tokens (map calculate-token tokens)
+        token-priority    {"SNT" 1 "ETH" 2 "DAI" 3}]
+    (sort-by (juxt #(get-in % [:values :fiat-unformatted-value])
+                   #(get token-priority (:token %)))
+             (fn [[val1 pri1] [val2 pri2]]
+               (if (= val1 val2)
+                 (< pri1 pri2)
+                 (> val1 val2)))
+             calculated-tokens)))
+

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -299,3 +299,12 @@
     (utils.string/contains-emoji? s)             :emoji
     (existing-account-names s)                   :existing-name
     (utils.string/contains-special-character? s) :special-character))
+
+(defn calculate-and-sort-tokens
+  [{:keys [tokens color currency currency-symbol]}]
+  (let [calculated-tokens (map #(calculate-token-value {:token           %
+                                                        :color           color
+                                                        :currency        currency
+                                                        :currency-symbol currency-symbol})
+                               tokens)]
+    (sort-by #(get-in % [:values :fiat-unformatted-value]) > calculated-tokens)))

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -307,4 +307,5 @@
                                                         :currency        currency
                                                         :currency-symbol currency-symbol})
                                tokens)]
+    (println "cccxxx" calculated-tokens)
     (sort-by #(get-in % [:values :fiat-unformatted-value]) > calculated-tokens)))

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -177,7 +177,7 @@
   "This function returns token values in the props of token-value (quo) component"
   [{:keys [token color currency currency-symbol]}]
   (let [balance                           (calculate-total-token-balance token)
-        fiat-value                        (calculate-token-fiat-value
+        fiat-unformatted-value                        (calculate-token-fiat-value
                                            {:currency currency
                                             :balance  balance
                                             :token    token})
@@ -191,7 +191,7 @@
         crypto-value                      (get-standard-crypto-format token balance)
         fiat-value                        (get-standard-fiat-format crypto-value
                                                                     currency-symbol
-                                                                    fiat-value)]
+                                                                    fiat-unformatted-value)]
     {:token               (:symbol token)
      :token-name          (:name token)
      :state               :default
@@ -203,6 +203,7 @@
      :customization-color color
      :values              {:crypto-value      crypto-value
                            :fiat-value        fiat-value
+                           :fiat-unformatted-value fiat-unformatted-value
                            :fiat-change       formatted-token-price
                            :percentage-change percentage-change}}))
 

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -316,4 +316,3 @@
                  (< pri1 pri2)
                  (> val1 val2)))
              calculated-tokens)))
-

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -122,60 +122,66 @@
           mock-currency        "USD"
           mock-currency-symbol "$"]
 
-      (testing "Standard case with different fiat-unformatted-values"
-        (let [mock-tokens    [{:symbol             "ETH"
-                               :name               "Ethereum"
-                               :balances-per-chain {:mock-chain 5}
-                               :decimals           18}
-                              {:symbol             "DAI"
-                               :name               "Dai"
-                               :balances-per-chain {:mock-chain 10}
-                               :decimals           18}
-                              {:symbol             "SNT"
-                               :name               "Status Network Token"
-                               :balances-per-chain {:mock-chain 1}
-                               :decimals           18}]
-              mock-input     {:tokens          mock-tokens
-                              :color           mock-color
-                              :currency        mock-currency
-                              :currency-symbol mock-currency-symbol}
-              sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
-              expected-order ["DAI" "ETH" "SNT"]]
-          (is (= expected-order sorted-tokens))))
+      (with-redefs [utils/calculate-token-value
+                    (fn [{:keys [token]}]
+                      (case (:symbol token)
+                        "ETH" {:token "ETH" :values {:fiat-unformatted-value 5}}
+                        "DAI" {:token "DAI" :values {:fiat-unformatted-value 10}}
+                        "SNT" {:token "SNT" :values {:fiat-unformatted-value 1}}))]
+        (testing "Standard case with different fiat-unformatted-values"
+          (let [mock-tokens    [{:symbol             "ETH"
+                                 :name               "Ethereum"
+                                 :balances-per-chain {:mock-chain 5}
+                                 :decimals           18}
+                                {:symbol             "DAI"
+                                 :name               "Dai"
+                                 :balances-per-chain {:mock-chain 10}
+                                 :decimals           18}
+                                {:symbol             "SNT"
+                                 :name               "Status Network Token"
+                                 :balances-per-chain {:mock-chain 1}
+                                 :decimals           18}]
+                mock-input     {:tokens          mock-tokens
+                                :color           mock-color
+                                :currency        mock-currency
+                                :currency-symbol mock-currency-symbol}
+                sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
+                expected-order ["DAI" "ETH" "SNT"]]
+            (is (= expected-order sorted-tokens))))
 
-      (testing "Case with all zero fiat-unformatted-values"
-        (let [mock-tokens    [{:symbol             "ETH"
-                               :name               "Ethereum"
-                               :balances-per-chain {:mock-chain 0}
-                               :decimals           18}
-                              {:symbol             "DAI"
-                               :name               "Dai"
-                               :balances-per-chain {:mock-chain 0}
-                               :decimals           18}
-                              {:symbol             "SNT"
-                               :name               "Status Network Token"
-                               :balances-per-chain {:mock-chain 0}
-                               :decimals           18}]
-              mock-input     {:tokens          mock-tokens
-                              :color           mock-color
-                              :currency        mock-currency
-                              :currency-symbol mock-currency-symbol}
-              sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
-              expected-order ["ETH" "DAI" "SNT"]]
-          (is (= expected-order sorted-tokens))))
+        (testing "Case with all zero fiat-unformatted-values"
+          (let [mock-tokens    [{:symbol             "ETH"
+                                 :name               "Ethereum"
+                                 :balances-per-chain {:mock-chain 0}
+                                 :decimals           18}
+                                {:symbol             "DAI"
+                                 :name               "Dai"
+                                 :balances-per-chain {:mock-chain 0}
+                                 :decimals           18}
+                                {:symbol             "SNT"
+                                 :name               "Status Network Token"
+                                 :balances-per-chain {:mock-chain 0}
+                                 :decimals           18}]
+                mock-input     {:tokens          mock-tokens
+                                :color           mock-color
+                                :currency        mock-currency
+                                :currency-symbol mock-currency-symbol}
+                sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
+                expected-order ["ETH" "DAI" "SNT"]]
+            (is (= expected-order sorted-tokens))))
 
-      (testing "Case with only one token"
-        (let [mock-tokens    [{:symbol             "ETH"
-                               :name               "Ethereum"
-                               :balances-per-chain {:mock-chain 5}
-                               :decimals           18}]
-              mock-input     {:tokens          mock-tokens
-                              :color           mock-color
-                              :currency        mock-currency
-                              :currency-symbol mock-currency-symbol}
-              sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
-              expected-order ["ETH"]]
-          (is (= expected-order sorted-tokens)))))))
+        (testing "Case with only one token"
+          (let [mock-tokens    [{:symbol             "ETH"
+                                 :name               "Ethereum"
+                                 :balances-per-chain {:mock-chain 5}
+                                 :decimals           18}]
+                mock-input     {:tokens          mock-tokens
+                                :color           mock-color
+                                :currency        mock-currency
+                                :currency-symbol mock-currency-symbol}
+                sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
+                expected-order ["ETH"]]
+            (is (= expected-order sorted-tokens))))))))
 
 
 

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -123,36 +123,82 @@
           mock-currency-symbol "$"]
 
       (testing "Standard case with different fiat-unformatted-values"
-        (let [mock-tokens     [{:token "TokenA" :values {:fiat-unformatted-value 5}}
-                               {:token "TokenB" :values {:fiat-unformatted-value 10}}
-                               {:token "TokenC" :values {:fiat-unformatted-value 1}}]
+        (let [mock-tokens     [{:symbol "ETH" :name "Ethereum" :values {:fiat-unformatted-value 5}}
+                               {:symbol "DAI" :name "Dai" :values {:fiat-unformatted-value 10}}
+                               {:symbol "SNT"
+                                :name   "Status Network Token"
+                                :values {:fiat-unformatted-value 1}}]
               mock-input      {:tokens          mock-tokens
                                :color           mock-color
                                :currency        mock-currency
                                :currency-symbol mock-currency-symbol}
-              expected-output [{:token "TokenB" :values {:fiat-unformatted-value 10}}
-                               {:token "TokenA" :values {:fiat-unformatted-value 5}}
-                               {:token "TokenC" :values {:fiat-unformatted-value 1}}]]
+              expected-output [{:token               "DAI"
+                                :token-name          "Dai"
+                                :state               :default
+                                :metrics?            true
+                                :status              :empty
+                                :customization-color "blue"
+                                :values              {:fiat-unformatted-value 10}}
+                               {:token               "ETH"
+                                :token-name          "Ethereum"
+                                :state               :default
+                                :metrics?            true
+                                :status              :empty
+                                :customization-color "blue"
+                                :values              {:fiat-unformatted-value 5}}
+                               {:token               "SNT"
+                                :token-name          "Status Network Token"
+                                :state               :default
+                                :metrics?            true
+                                :status              :empty
+                                :customization-color "blue"
+                                :values              {:fiat-unformatted-value 1}}]]
           (is (= expected-output (utils/calculate-and-sort-tokens mock-input)))))
 
       (testing "Case with all zero fiat-unformatted-values"
-        (let [mock-tokens     [{:token "TokenA" :values {:fiat-unformatted-value 0}}
-                               {:token "TokenB" :values {:fiat-unformatted-value 0}}
-                               {:token "TokenC" :values {:fiat-unformatted-value 0}}]
+        (let [mock-tokens     [{:symbol "ETH" :name "Ethereum" :values {:fiat-unformatted-value 0}}
+                               {:symbol "DAI" :name "Dai" :values {:fiat-unformatted-value 0}}
+                               {:symbol "SNT"
+                                :name   "Status Network Token"
+                                :values {:fiat-unformatted-value 0}}]
               mock-input      {:tokens          mock-tokens
                                :color           mock-color
                                :currency        mock-currency
                                :currency-symbol mock-currency-symbol}
-              expected-output [{:token "TokenA" :values {:fiat-unformatted-value 0}}
-                               {:token "TokenB" :values {:fiat-unformatted-value 0}}
-                               {:token "TokenC" :values {:fiat-unformatted-value 0}}]]
+              expected-output [{:token               "ETH"
+                                :token-name          "Ethereum"
+                                :state               :default
+                                :metrics?            true
+                                :status              :empty
+                                :customization-color "blue"
+                                :values              {:fiat-unformatted-value 0}}
+                               {:token               "DAI"
+                                :token-name          "Dai"
+                                :state               :default
+                                :metrics?            true
+                                :status              :empty
+                                :customization-color "blue"
+                                :values              {:fiat-unformatted-value 0}}
+                               {:token               "SNT"
+                                :token-name          "Status Network Token"
+                                :state               :default
+                                :metrics?            true
+                                :status              :empty
+                                :customization-color "blue"
+                                :values              {:fiat-unformatted-value 0}}]]
           (is (= expected-output (utils/calculate-and-sort-tokens mock-input)))))
 
       (testing "Case with only one token"
-        (let [mock-tokens     [{:token "TokenA" :values {:fiat-unformatted-value 5}}]
+        (let [mock-tokens     [{:symbol "ETH" :name "Ethereum" :values {:fiat-unformatted-value 5}}]
               mock-input      {:tokens          mock-tokens
                                :color           mock-color
                                :currency        mock-currency
                                :currency-symbol mock-currency-symbol}
-              expected-output [{:token "TokenA" :values {:fiat-unformatted-value 5}}]]
+              expected-output [{:token               "ETH"
+                                :token-name          "Ethereum"
+                                :state               :default
+                                :metrics?            true
+                                :status              :empty
+                                :customization-color "blue"
+                                :values              {:fiat-unformatted-value 5}}]]
           (is (= expected-output (utils/calculate-and-sort-tokens mock-input))))))))

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -167,7 +167,7 @@
                                 :currency        mock-currency
                                 :currency-symbol mock-currency-symbol}
                 sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
-                expected-order ["ETH" "DAI" "SNT"]]
+                expected-order ["SNT" "ETH" "DAI"]]
             (is (= expected-order sorted-tokens))))
 
         (testing "Case with only one token"

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -115,3 +115,44 @@
     (is (= (utils/prettify-percentage-change 1.113454) "1.11"))
     (is (= (utils/prettify-percentage-change -0.35) "0.35"))
     (is (= (utils/prettify-percentage-change -0.78234) "0.78"))))
+
+(deftest utils/calculate-and-sort-tokens-test
+  (testing "utils/calculate-and-sort-tokens function"
+    (let [mock-color           "blue"
+          mock-currency        "USD"
+          mock-currency-symbol "$"]
+
+      (testing "Standard case with different fiat-unformatted-values"
+        (let [mock-tokens     [{:token "TokenA" :values {:fiat-unformatted-value 5}}
+                               {:token "TokenB" :values {:fiat-unformatted-value 10}}
+                               {:token "TokenC" :values {:fiat-unformatted-value 1}}]
+              mock-input      {:tokens          mock-tokens
+                               :color           mock-color
+                               :currency        mock-currency
+                               :currency-symbol mock-currency-symbol}
+              expected-output [{:token "TokenB" :values {:fiat-unformatted-value 10}}
+                               {:token "TokenA" :values {:fiat-unformatted-value 5}}
+                               {:token "TokenC" :values {:fiat-unformatted-value 1}}]]
+          (is (= expected-output (utils/calculate-and-sort-tokens mock-input)))))
+
+      (testing "Case with all zero fiat-unformatted-values"
+        (let [mock-tokens     [{:token "TokenA" :values {:fiat-unformatted-value 0}}
+                               {:token "TokenB" :values {:fiat-unformatted-value 0}}
+                               {:token "TokenC" :values {:fiat-unformatted-value 0}}]
+              mock-input      {:tokens          mock-tokens
+                               :color           mock-color
+                               :currency        mock-currency
+                               :currency-symbol mock-currency-symbol}
+              expected-output [{:token "TokenA" :values {:fiat-unformatted-value 0}}
+                               {:token "TokenB" :values {:fiat-unformatted-value 0}}
+                               {:token "TokenC" :values {:fiat-unformatted-value 0}}]]
+          (is (= expected-output (utils/calculate-and-sort-tokens mock-input)))))
+
+      (testing "Case with only one token"
+        (let [mock-tokens     [{:token "TokenA" :values {:fiat-unformatted-value 5}}]
+              mock-input      {:tokens          mock-tokens
+                               :color           mock-color
+                               :currency        mock-currency
+                               :currency-symbol mock-currency-symbol}
+              expected-output [{:token "TokenA" :values {:fiat-unformatted-value 5}}]]
+          (is (= expected-output (utils/calculate-and-sort-tokens mock-input))))))))

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -147,40 +147,6 @@
                                 :currency-symbol mock-currency-symbol}
                 sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
                 expected-order ["DAI" "ETH" "SNT"]]
-            (is (= expected-order sorted-tokens))))
-
-        (testing "Case with all zero fiat-unformatted-values"
-          (let [mock-tokens    [{:symbol             "ETH"
-                                 :name               "Ethereum"
-                                 :balances-per-chain {:mock-chain 0}
-                                 :decimals           18}
-                                {:symbol             "DAI"
-                                 :name               "Dai"
-                                 :balances-per-chain {:mock-chain 0}
-                                 :decimals           18}
-                                {:symbol             "SNT"
-                                 :name               "Status Network Token"
-                                 :balances-per-chain {:mock-chain 0}
-                                 :decimals           18}]
-                mock-input     {:tokens          mock-tokens
-                                :color           mock-color
-                                :currency        mock-currency
-                                :currency-symbol mock-currency-symbol}
-                sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
-                expected-order ["SNT" "ETH" "DAI"]]
-            (is (= expected-order sorted-tokens))))
-
-        (testing "Case with only one token"
-          (let [mock-tokens    [{:symbol             "ETH"
-                                 :name               "Ethereum"
-                                 :balances-per-chain {:mock-chain 5}
-                                 :decimals           18}]
-                mock-input     {:tokens          mock-tokens
-                                :color           mock-color
-                                :currency        mock-currency
-                                :currency-symbol mock-currency-symbol}
-                sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
-                expected-order ["ETH"]]
             (is (= expected-order sorted-tokens))))))))
 
 

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -117,7 +117,7 @@
     (is (= (utils/prettify-percentage-change -0.78234) "0.78"))))
 
 (deftest calculate-and-sort-tokens-test
-  (testing "utils/calculate-and-sort-tokens function"
+  (testing "calculate-and-sort-tokens function"
     (let [mock-color           "blue"
           mock-currency        "USD"
           mock-currency-symbol "$"]

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -123,129 +123,59 @@
           mock-currency-symbol "$"]
 
       (testing "Standard case with different fiat-unformatted-values"
-        (let [mock-tokens     [{:symbol             "ETH"
-                                :name               "Ethereum"
-                                :balances-per-chain {:mock-chain 5}
-                                :decimals           18}
-                               {:symbol             "DAI"
-                                :name               "Dai"
-                                :balances-per-chain {:mock-chain 10}
-                                :decimals           18}
-                               {:symbol             "SNT"
-                                :name               "Status Network Token"
-                                :balances-per-chain {:mock-chain 1}
-                                :decimals           18}]
-              mock-input      {:tokens          mock-tokens
-                               :color           mock-color
-                               :currency        mock-currency
-                               :currency-symbol mock-currency-symbol}
-              expected-output [{:token               "DAI"
-                                :token-name          "Dai"
-                                :state               :default
-                                :metrics?            true
-                                :status              :empty
-                                :customization-color "blue"
-                                :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$10"
-                                                      :fiat-unformatted-value 10
-                                                      :fiat-change            "$0.00"
-                                                      :percentage-change      "0.00"}}
-                               {:token               "ETH"
-                                :token-name          "Ethereum"
-                                :state               :default
-                                :metrics?            true
-                                :status              :empty
-                                :customization-color "blue"
-                                :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$5"
-                                                      :fiat-unformatted-value 5
-                                                      :fiat-change            "$0.00"
-                                                      :percentage-change      "0.00"}}
-                               {:token               "SNT"
-                                :token-name          "Status Network Token"
-                                :state               :default
-                                :metrics?            true
-                                :status              :empty
-                                :customization-color "blue"
-                                :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$1"
-                                                      :fiat-unformatted-value 1
-                                                      :fiat-change            "$0.00"
-                                                      :percentage-change      "0.00"}}]]
-          (is (= expected-output (utils/calculate-and-sort-tokens mock-input)))))
+        (let [mock-tokens    [{:symbol             "ETH"
+                               :name               "Ethereum"
+                               :balances-per-chain {:mock-chain 5}
+                               :decimals           18}
+                              {:symbol             "DAI"
+                               :name               "Dai"
+                               :balances-per-chain {:mock-chain 10}
+                               :decimals           18}
+                              {:symbol             "SNT"
+                               :name               "Status Network Token"
+                               :balances-per-chain {:mock-chain 1}
+                               :decimals           18}]
+              mock-input     {:tokens          mock-tokens
+                              :color           mock-color
+                              :currency        mock-currency
+                              :currency-symbol mock-currency-symbol}
+              sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
+              expected-order ["DAI" "ETH" "SNT"]]
+          (is (= expected-order sorted-tokens))))
 
       (testing "Case with all zero fiat-unformatted-values"
-        (let [mock-tokens     [{:symbol             "ETH"
-                                :name               "Ethereum"
-                                :balances-per-chain {:mock-chain 0}
-                                :decimals           18}
-                               {:symbol             "DAI"
-                                :name               "Dai"
-                                :balances-per-chain {:mock-chain 0}
-                                :decimals           18}
-                               {:symbol             "SNT"
-                                :name               "Status Network Token"
-                                :balances-per-chain {:mock-chain 0}
-                                :decimals           18}]
-              mock-input      {:tokens          mock-tokens
-                               :color           mock-color
-                               :currency        mock-currency
-                               :currency-symbol mock-currency-symbol}
-              expected-output [{:token               "ETH"
-                                :token-name          "Ethereum"
-                                :state               :default
-                                :metrics?            true
-                                :status              :empty
-                                :customization-color "blue"
-                                :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$0"
-                                                      :fiat-unformatted-value 0
-                                                      :fiat-change            "$0.00"
-                                                      :percentage-change      "0.00"}}
-                               {:token               "DAI"
-                                :token-name          "Dai"
-                                :state               :default
-                                :metrics?            true
-                                :status              :empty
-                                :customization-color "blue"
-                                :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$0"
-                                                      :fiat-unformatted-value 0
-                                                      :fiat-change            "$0.00"
-                                                      :percentage-change      "0.00"}}
-                               {:token               "SNT"
-                                :token-name          "Status Network Token"
-                                :state               :default
-                                :metrics?            true
-                                :status              :empty
-                                :customization-color "blue"
-                                :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$0"
-                                                      :fiat-unformatted-value 0
-                                                      :fiat-change            "$0.00"
-                                                      :percentage-change      "0.00"}}]]
-          (is (= expected-output (utils/calculate-and-sort-tokens mock-input)))))
+        (let [mock-tokens    [{:symbol             "ETH"
+                               :name               "Ethereum"
+                               :balances-per-chain {:mock-chain 0}
+                               :decimals           18}
+                              {:symbol             "DAI"
+                               :name               "Dai"
+                               :balances-per-chain {:mock-chain 0}
+                               :decimals           18}
+                              {:symbol             "SNT"
+                               :name               "Status Network Token"
+                               :balances-per-chain {:mock-chain 0}
+                               :decimals           18}]
+              mock-input     {:tokens          mock-tokens
+                              :color           mock-color
+                              :currency        mock-currency
+                              :currency-symbol mock-currency-symbol}
+              sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
+              expected-order ["ETH" "DAI" "SNT"]]
+          (is (= expected-order sorted-tokens))))
 
       (testing "Case with only one token"
-        (let [mock-tokens     [{:symbol             "ETH"
-                                :name               "Ethereum"
-                                :balances-per-chain {:mock-chain 5}
-                                :decimals           18}]
-              mock-input      {:tokens          mock-tokens
-                               :color           mock-color
-                               :currency        mock-currency
-                               :currency-symbol mock-currency-symbol}
-              expected-output [{:token               "ETH"
-                                :token-name          "Ethereum"
-                                :state               :default
-                                :metrics?            true
-                                :status              :empty
-                                :customization-color "blue"
-                                :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$5"
-                                                      :fiat-unformatted-value 5
-                                                      :fiat-change            "$0.00"
-                                                      :percentage-change      "0.00"}}]]
-          (is (= expected-output (utils/calculate-and-sort-tokens mock-input))))))))
+        (let [mock-tokens    [{:symbol             "ETH"
+                               :name               "Ethereum"
+                               :balances-per-chain {:mock-chain 5}
+                               :decimals           18}]
+              mock-input     {:tokens          mock-tokens
+                              :color           mock-color
+                              :currency        mock-currency
+                              :currency-symbol mock-currency-symbol}
+              sorted-tokens  (map :token (utils/calculate-and-sort-tokens mock-input))
+              expected-order ["ETH"]]
+          (is (= expected-order sorted-tokens)))))))
+
 
 

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -138,21 +138,33 @@
                                 :metrics?            true
                                 :status              :empty
                                 :customization-color "blue"
-                                :values              {:fiat-unformatted-value 10}}
+                                :values              {:crypto-value           "mock"
+                                                      :fiat-value             "$10.00"
+                                                      :fiat-unformatted-value 10
+                                                      :fiat-change            "$0.00"
+                                                      :percentage-change      "0.00"}}
                                {:token               "ETH"
                                 :token-name          "Ethereum"
                                 :state               :default
                                 :metrics?            true
                                 :status              :empty
                                 :customization-color "blue"
-                                :values              {:fiat-unformatted-value 5}}
+                                :values              {:crypto-value           "mock"
+                                                      :fiat-value             "$5.00"
+                                                      :fiat-unformatted-value 5
+                                                      :fiat-change            "$0.00"
+                                                      :percentage-change      "0.00"}}
                                {:token               "SNT"
                                 :token-name          "Status Network Token"
                                 :state               :default
                                 :metrics?            true
                                 :status              :empty
                                 :customization-color "blue"
-                                :values              {:fiat-unformatted-value 1}}]]
+                                :values              {:crypto-value           "mock"
+                                                      :fiat-value             "$1.00"
+                                                      :fiat-unformatted-value 1
+                                                      :fiat-change            "$0.00"
+                                                      :percentage-change      "0.00"}}]]
           (is (= expected-output (utils/calculate-and-sort-tokens mock-input)))))
 
       (testing "Case with all zero fiat-unformatted-values"
@@ -171,21 +183,33 @@
                                 :metrics?            true
                                 :status              :empty
                                 :customization-color "blue"
-                                :values              {:fiat-unformatted-value 0}}
+                                :values              {:crypto-value           "mock"
+                                                      :fiat-value             "$0.00"
+                                                      :fiat-unformatted-value 0
+                                                      :fiat-change            "$0.00"
+                                                      :percentage-change      "0.00"}}
                                {:token               "DAI"
                                 :token-name          "Dai"
                                 :state               :default
                                 :metrics?            true
                                 :status              :empty
                                 :customization-color "blue"
-                                :values              {:fiat-unformatted-value 0}}
+                                :values              {:crypto-value           "mock"
+                                                      :fiat-value             "$0.00"
+                                                      :fiat-unformatted-value 0
+                                                      :fiat-change            "$0.00"
+                                                      :percentage-change      "0.00"}}
                                {:token               "SNT"
                                 :token-name          "Status Network Token"
                                 :state               :default
                                 :metrics?            true
                                 :status              :empty
                                 :customization-color "blue"
-                                :values              {:fiat-unformatted-value 0}}]]
+                                :values              {:crypto-value           "mock"
+                                                      :fiat-value             "$0.00"
+                                                      :fiat-unformatted-value 0
+                                                      :fiat-change            "$0.00"
+                                                      :percentage-change      "0.00"}}]]
           (is (= expected-output (utils/calculate-and-sort-tokens mock-input)))))
 
       (testing "Case with only one token"
@@ -200,5 +224,10 @@
                                 :metrics?            true
                                 :status              :empty
                                 :customization-color "blue"
-                                :values              {:fiat-unformatted-value 5}}]]
+                                :values              {:crypto-value           "mock"
+                                                      :fiat-value             "$5.00"
+                                                      :fiat-unformatted-value 5
+                                                      :fiat-change            "$0.00"
+                                                      :percentage-change      "0.00"}}]]
           (is (= expected-output (utils/calculate-and-sort-tokens mock-input))))))))
+

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -123,11 +123,18 @@
           mock-currency-symbol "$"]
 
       (testing "Standard case with different fiat-unformatted-values"
-        (let [mock-tokens     [{:symbol "ETH" :name "Ethereum" :values {:fiat-unformatted-value 5}}
-                               {:symbol "DAI" :name "Dai" :values {:fiat-unformatted-value 10}}
-                               {:symbol "SNT"
-                                :name   "Status Network Token"
-                                :values {:fiat-unformatted-value 1}}]
+        (let [mock-tokens     [{:symbol             "ETH"
+                                :name               "Ethereum"
+                                :balances-per-chain {:mock-chain 5}
+                                :decimals           18}
+                               {:symbol             "DAI"
+                                :name               "Dai"
+                                :balances-per-chain {:mock-chain 10}
+                                :decimals           18}
+                               {:symbol             "SNT"
+                                :name               "Status Network Token"
+                                :balances-per-chain {:mock-chain 1}
+                                :decimals           18}]
               mock-input      {:tokens          mock-tokens
                                :color           mock-color
                                :currency        mock-currency
@@ -139,7 +146,7 @@
                                 :status              :empty
                                 :customization-color "blue"
                                 :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$10.00"
+                                                      :fiat-value             "$10"
                                                       :fiat-unformatted-value 10
                                                       :fiat-change            "$0.00"
                                                       :percentage-change      "0.00"}}
@@ -150,7 +157,7 @@
                                 :status              :empty
                                 :customization-color "blue"
                                 :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$5.00"
+                                                      :fiat-value             "$5"
                                                       :fiat-unformatted-value 5
                                                       :fiat-change            "$0.00"
                                                       :percentage-change      "0.00"}}
@@ -161,18 +168,25 @@
                                 :status              :empty
                                 :customization-color "blue"
                                 :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$1.00"
+                                                      :fiat-value             "$1"
                                                       :fiat-unformatted-value 1
                                                       :fiat-change            "$0.00"
                                                       :percentage-change      "0.00"}}]]
           (is (= expected-output (utils/calculate-and-sort-tokens mock-input)))))
 
       (testing "Case with all zero fiat-unformatted-values"
-        (let [mock-tokens     [{:symbol "ETH" :name "Ethereum" :values {:fiat-unformatted-value 0}}
-                               {:symbol "DAI" :name "Dai" :values {:fiat-unformatted-value 0}}
-                               {:symbol "SNT"
-                                :name   "Status Network Token"
-                                :values {:fiat-unformatted-value 0}}]
+        (let [mock-tokens     [{:symbol             "ETH"
+                                :name               "Ethereum"
+                                :balances-per-chain {:mock-chain 0}
+                                :decimals           18}
+                               {:symbol             "DAI"
+                                :name               "Dai"
+                                :balances-per-chain {:mock-chain 0}
+                                :decimals           18}
+                               {:symbol             "SNT"
+                                :name               "Status Network Token"
+                                :balances-per-chain {:mock-chain 0}
+                                :decimals           18}]
               mock-input      {:tokens          mock-tokens
                                :color           mock-color
                                :currency        mock-currency
@@ -184,7 +198,7 @@
                                 :status              :empty
                                 :customization-color "blue"
                                 :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$0.00"
+                                                      :fiat-value             "$0"
                                                       :fiat-unformatted-value 0
                                                       :fiat-change            "$0.00"
                                                       :percentage-change      "0.00"}}
@@ -195,7 +209,7 @@
                                 :status              :empty
                                 :customization-color "blue"
                                 :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$0.00"
+                                                      :fiat-value             "$0"
                                                       :fiat-unformatted-value 0
                                                       :fiat-change            "$0.00"
                                                       :percentage-change      "0.00"}}
@@ -206,14 +220,17 @@
                                 :status              :empty
                                 :customization-color "blue"
                                 :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$0.00"
+                                                      :fiat-value             "$0"
                                                       :fiat-unformatted-value 0
                                                       :fiat-change            "$0.00"
                                                       :percentage-change      "0.00"}}]]
           (is (= expected-output (utils/calculate-and-sort-tokens mock-input)))))
 
       (testing "Case with only one token"
-        (let [mock-tokens     [{:symbol "ETH" :name "Ethereum" :values {:fiat-unformatted-value 5}}]
+        (let [mock-tokens     [{:symbol             "ETH"
+                                :name               "Ethereum"
+                                :balances-per-chain {:mock-chain 5}
+                                :decimals           18}]
               mock-input      {:tokens          mock-tokens
                                :color           mock-color
                                :currency        mock-currency
@@ -225,9 +242,10 @@
                                 :status              :empty
                                 :customization-color "blue"
                                 :values              {:crypto-value           "mock"
-                                                      :fiat-value             "$5.00"
+                                                      :fiat-value             "$5"
                                                       :fiat-unformatted-value 5
                                                       :fiat-change            "$0.00"
                                                       :percentage-change      "0.00"}}]]
           (is (= expected-output (utils/calculate-and-sort-tokens mock-input))))))))
+
 

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -116,7 +116,7 @@
     (is (= (utils/prettify-percentage-change -0.35) "0.35"))
     (is (= (utils/prettify-percentage-change -0.78234) "0.78"))))
 
-(deftest utils/calculate-and-sort-tokens-test
+(deftest calculate-and-sort-tokens-test
   (testing "utils/calculate-and-sort-tokens function"
     (let [mock-color           "blue"
           mock-currency        "USD"

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -496,12 +496,12 @@
  :<- [:profile/currency]
  :<- [:profile/currency-symbol]
  (fn [[{:keys [color]} tokens currency currency-symbol]]
-   (let [calculated-tokens (mapv #(utils/calculate-token-value {:token           %
-                                                                :color           color
-                                                                :currency        currency
-                                                                :currency-symbol currency-symbol})
-                                 tokens)]
-     (vec (sort-by #(get-in % [:values :fiat-unformatted-value]) > calculated-tokens)))))
+   (let [calculated-tokens (map #(utils/calculate-token-value {:token           %
+                                                               :color           color
+                                                               :currency        currency
+                                                               :currency-symbol currency-symbol})
+                                tokens)]
+     (sort-by #(get-in % [:values :fiat-unformatted-value]) > calculated-tokens))))
 
 
 (rf/reg-sub
@@ -527,11 +527,11 @@
    (let [balance             (utils/calculate-balance-from-tokens {:currency currency
                                                                    :tokens   aggregated-tokens})
          formatted-balance   (utils/prettify-balance currency-symbol balance)
-         token-values        (mapv #(utils/calculate-token-value {:token           %
-                                                                  :color           color
-                                                                  :currency        currency
-                                                                  :currency-symbol currency-symbol})
-                                   aggregated-tokens)
+         token-values        (map #(utils/calculate-token-value {:token           %
+                                                                 :color           color
+                                                                 :currency        currency
+                                                                 :currency-symbol currency-symbol})
+                                  aggregated-tokens)
          sorted-token-values (sort-by #(-> % :values :fiat-unformatted-value) > token-values)]
      {:balance           balance
       :formatted-balance formatted-balance

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -490,18 +490,18 @@
    (get-in ui [:account-page :active-tab])))
 
 (rf/reg-sub
-  :wallet/current-viewing-account-token-values
-  :<- [:wallet/current-viewing-account]
-  :<- [:wallet/current-viewing-account-tokens-in-selected-networks]
-  :<- [:profile/currency]
-  :<- [:profile/currency-symbol]
-  (fn [[{:keys [color]} tokens currency currency-symbol]]
-    (let [calculated-tokens (mapv #(utils/calculate-token-value {:token           %
-                                                                 :color           color
-                                                                 :currency        currency
-                                                                 :currency-symbol currency-symbol})
-                                  tokens)]
-      (vec (sort-by #(get-in % [:values :fiat-unformatted-value]) > calculated-tokens)))))
+ :wallet/current-viewing-account-token-values
+ :<- [:wallet/current-viewing-account]
+ :<- [:wallet/current-viewing-account-tokens-in-selected-networks]
+ :<- [:profile/currency]
+ :<- [:profile/currency-symbol]
+ (fn [[{:keys [color]} tokens currency currency-symbol]]
+   (let [calculated-tokens (mapv #(utils/calculate-token-value {:token           %
+                                                                :color           color
+                                                                :currency        currency
+                                                                :currency-symbol currency-symbol})
+                                 tokens)]
+     (vec (sort-by #(get-in % [:values :fiat-unformatted-value]) > calculated-tokens)))))
 
 
 (rf/reg-sub
@@ -518,24 +518,24 @@
    (utils/filter-tokens-in-chains aggregated-tokens chain-ids)))
 
 (rf/reg-sub
-  :wallet/aggregated-token-values-and-balance
-  :<- [:wallet/aggregated-tokens-in-selected-networks]
-  :<- [:profile/customization-color]
-  :<- [:profile/currency]
-  :<- [:profile/currency-symbol]
-  (fn [[aggregated-tokens color currency currency-symbol]]
-    (let [balance           (utils/calculate-balance-from-tokens {:currency currency
-                                                                  :tokens   aggregated-tokens})
-          formatted-balance (utils/prettify-balance currency-symbol balance)
-          token-values      (mapv #(utils/calculate-token-value {:token           %
-                                                                 :color           color
-                                                                 :currency        currency
-                                                                 :currency-symbol currency-symbol})
-                                  aggregated-tokens)
-          sorted-token-values (sort-by #(-> % :values :fiat-unformatted-value) > token-values)]
-      {:balance           balance
-       :formatted-balance formatted-balance
-       :tokens            sorted-token-values})))
+ :wallet/aggregated-token-values-and-balance
+ :<- [:wallet/aggregated-tokens-in-selected-networks]
+ :<- [:profile/customization-color]
+ :<- [:profile/currency]
+ :<- [:profile/currency-symbol]
+ (fn [[aggregated-tokens color currency currency-symbol]]
+   (let [balance             (utils/calculate-balance-from-tokens {:currency currency
+                                                                   :tokens   aggregated-tokens})
+         formatted-balance   (utils/prettify-balance currency-symbol balance)
+         token-values        (mapv #(utils/calculate-token-value {:token           %
+                                                                  :color           color
+                                                                  :currency        currency
+                                                                  :currency-symbol currency-symbol})
+                                   aggregated-tokens)
+         sorted-token-values (sort-by #(-> % :values :fiat-unformatted-value) > token-values)]
+     {:balance           balance
+      :formatted-balance formatted-balance
+      :tokens            sorted-token-values})))
 
 
 (rf/reg-sub


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/19954

### Summary
This PR implements sorting for the assets to be in descending order of the fiat value.

### Demo

Note: the testing account I have seems not to have balances anymore so I used hardcoded fiat-values to test the functionality.

Before:
<img src="https://github.com/status-im/status-mobile/assets/29354102/56b09ab5-5f0f-4bbd-85de-2a37bacf2385" width="300" height="600" />

After:
<img src="https://github.com/status-im/status-mobile/assets/29354102/f342a37d-6028-40f6-b7d8-217d633aba73" width="300" height="600" />