### PR TITLE
chore: remove hot reload while theme changing

### DIFF
--- a/src/legacy/status_im/events.cljs
+++ b/src/legacy/status_im/events.cljs
@@ -108,8 +108,7 @@
     (when (and (multiaccounts.model/logged-in? db)
                (= current-theme-type status-im.constants/theme-type-system))
       {:profile.settings/switch-theme-fx
-       [(get-in db [:profile/profile :appearance])
-        (:view-id db) true]})))
+       [(get-in db [:profile/profile :appearance]) (:view-id db)]})))
 
 (defn- on-biometric-auth-fail
   [{:keys [code]}]

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -83,8 +83,7 @@
                   [[:profile.settings/switch-theme-fx
                     [(or (:appearance settings)
                          constants/theme-type-dark)
-                     :shell-stack
-                     false]]
+                     :shell-stack]]
                    [:dispatch [:init-root :shell-stack]]
                    [:dispatch [:profile/show-testnet-mode-banner-if-enabled]]]))})))
 

--- a/src/status_im/contexts/profile/settings/effects.cljs
+++ b/src/status_im/contexts/profile/settings/effects.cljs
@@ -4,7 +4,6 @@
             [react-native.platform :as platform]
             [status-im.common.theme.core :as theme]
             [status-im.constants :as constants]
-            [status-im.setup.hot-reload :as hot-reload]
             [utils.re-frame :as rf]))
 
 (re-frame/reg-fx
@@ -20,7 +19,7 @@
 
 (re-frame/reg-fx
  :profile.settings/switch-theme-fx
- (fn [[theme-type view-id reload-ui?]]
+ (fn [[theme-type view-id]]
    (let [theme (if (or (= theme-type constants/theme-type-dark)
                        (and (= theme-type constants/theme-type-system)
                             (theme/device-theme-dark?)))
@@ -28,8 +27,4 @@
                  :light)]
      (theme/set-legacy-theme theme)
      (rf/dispatch [:theme/switch theme])
-     (rf/dispatch [:reload-status-nav-color view-id])
-     (when reload-ui?
-       (re-frame/dispatch [:dismiss-all-overlays])
-       (when js/goog.DEBUG
-         (hot-reload/reload))))))
+     (rf/dispatch [:reload-status-nav-color view-id]))))

--- a/src/status_im/contexts/profile/settings/events.cljs
+++ b/src/status_im/contexts/profile/settings/events.cljs
@@ -95,14 +95,14 @@
 (rf/reg-event-fx :profile.settings/change-appearance
  (fn [_ [theme]]
    {:fx [[:dispatch [:profile.settings/profile-update :appearance theme]]
-         [:profile.settings/switch-theme-fx [theme :appearance true]]]}))
+         [:profile.settings/switch-theme-fx [theme :appearance]]]}))
 
 (rf/reg-event-fx :profile.settings/switch-theme
  (fn [{:keys [db]} [theme view-id]]
    (let [theme (or theme
                    (get-in db [:profile/profile :appearance])
                    constants/theme-type-dark)]
-     {:fx [[:profile.settings/switch-theme-fx [theme view-id false]]]})))
+     {:fx [[:profile.settings/switch-theme-fx [theme view-id]]]})))
 
 (rf/reg-fx :profile.settings/get-profile-picture
  (fn [key-uid]

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -123,16 +123,6 @@
                     (hide-bottom-sheet new-cofx)
                     {:show-bottom-sheet {:theme theme}}))))))
 
-(rf/defn dismiss-all-overlays
-  {:events [:dismiss-all-overlays]}
-  [_]
-  {:dispatch-n [[:hide-popover]
-                [:hide-visibility-status-popover]
-                [:hide-bottom-sheet]
-                [:bottom-sheet-hidden]
-                [:bottom-sheet/hide-old-navigation-overlay]
-                [:toasts/close-all-toasts]]})
-
 (rf/defn set-view-id
   {:events [:set-view-id]}
   [{:keys [db]} view-id]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20563

### Summary

Sheets and overlays now will not be dismissed on theme changes.

https://github.com/status-im/status-mobile/assets/17097240/07d86de4-0737-4c60-92c7-a40b0623d5e4


### QA Testing Note:
PR removes the dismissing of overlays while changing the system theme. So overlays like the bottom sheet will remain open even after the theme is changed. Please lightly test PR to ensure those overlay themes are getting changed properly.


status: ready