### PR TITLE
Fix: navigation after transaction from settings

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -15,15 +15,19 @@
   [{:keys [name full-address chain-short-names address] :as opts}]
   (let [[_ splitted-address]           (network-utils/split-network-full-address address)
         open-send-flow                 (rn/use-callback
-                                        #(rf/dispatch [:wallet/select-send-address
-                                                       {:address        full-address
-                                                        :recipient      {:label
-                                                                         (utils/get-shortened-address
-                                                                          splitted-address)
-                                                                         :recipient-type :saved-address}
-                                                        :stack-id       :wallet-select-address
-                                                        :start-flow?    true
-                                                        :from-settings? true}])
+                                        (fn []
+                                          (rf/dispatch [:hide-bottom-sheet])
+                                          (rf/dispatch [:pop-to-root :shell-stack])
+                                          (js/setTimeout #(rf/dispatch [:wallet/select-send-address
+                                                                        {:address full-address
+                                                                         :recipient
+                                                                         {:label
+                                                                          (utils/get-shortened-address
+                                                                           splitted-address)
+                                                                          :recipient-type :saved-address}
+                                                                         :stack-id :wallet-select-address
+                                                                         :start-flow? true}])
+                                                         400))
                                         [full-address])
         open-eth-chain-explorer        (rn/use-callback
                                         #(rf/dispatch [:wallet/navigate-to-chain-explorer

--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -16,12 +16,13 @@
   (let [[_ splitted-address]           (network-utils/split-network-full-address address)
         open-send-flow                 (rn/use-callback
                                         #(rf/dispatch [:wallet/select-send-address
-                                                       {:address     full-address
-                                                        :recipient   {:label (utils/get-shortened-address
-                                                                              splitted-address)
-                                                                      :recipient-type :saved-address}
-                                                        :stack-id    :wallet-select-address
-                                                        :start-flow? true
+                                                       {:address        full-address
+                                                        :recipient      {:label
+                                                                         (utils/get-shortened-address
+                                                                          splitted-address)
+                                                                         :recipient-type :saved-address}
+                                                        :stack-id       :wallet-select-address
+                                                        :start-flow?    true
                                                         :from-settings? true}])
                                         [full-address])
         open-eth-chain-explorer        (rn/use-callback

--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -21,7 +21,8 @@
                                                                               splitted-address)
                                                                       :recipient-type :saved-address}
                                                         :stack-id    :wallet-select-address
-                                                        :start-flow? true}])
+                                                        :start-flow? true
+                                                        :from-settings? true}])
                                         [full-address])
         open-eth-chain-explorer        (rn/use-callback
                                         #(rf/dispatch [:wallet/navigate-to-chain-explorer

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -156,7 +156,7 @@
 
 (rf/reg-event-fx
  :wallet/select-send-address
- (fn [{:keys [db]} [{:keys [address recipient stack-id start-flow? from-settings?]}]]
+ (fn [{:keys [db]} [{:keys [address recipient stack-id start-flow?]}]]
    (let [[prefix to-address] (utils/split-prefix-and-address address)
          testnet-enabled?    (get-in db [:profile/profile :test-networks-enabled?])
          goerli-enabled?     (get-in db [:profile/profile :is-goerli-enabled?])
@@ -175,13 +175,9 @@
               (assoc-in [:wallet :ui :send :to-address] to-address)
               (assoc-in [:wallet :ui :send :address-prefix] prefix)
               (assoc-in [:wallet :ui :send :receiver-preferred-networks] receiver-networks)
-              (assoc-in [:wallet :ui :send :receiver-networks] receiver-networks)
-              ;(assoc-in [:wallet :ui :send :from-settings?] from-settings?)
-          )
+              (assoc-in [:wallet :ui :send :receiver-networks] receiver-networks))
       :fx [(when (and collectible-tx? one-collectible?)
              [:dispatch [:wallet/get-suggested-routes {:amount 1}]])
-           (when from-settings?
-             [:dispatch [:pop-to-root :shell-stack]])
            [:dispatch
             [:wallet/wizard-navigate-forward
              {:current-screen stack-id
@@ -507,7 +503,7 @@
 
 (rf/reg-event-fx :wallet/end-transaction-flow
  (fn [{:keys [db]}]
-   (let [address        (get-in db [:wallet :current-viewing-account-address])]
+   (let [address (get-in db [:wallet :current-viewing-account-address])]
      {:fx [[:dispatch [:wallet/navigate-to-account-within-stack address]]
            [:dispatch [:wallet/fetch-activities-for-current-account]]
            [:dispatch [:wallet/select-account-tab :activity]]

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -177,7 +177,7 @@
               (assoc-in [:wallet :ui :send :receiver-preferred-networks] receiver-networks)
               (assoc-in [:wallet :ui :send :receiver-networks] receiver-networks)
               (assoc-in [:wallet :ui :send :from-settings?] from-settings?)
-              )
+          )
       :fx [(when (and collectible-tx? one-collectible?)
              [:dispatch [:wallet/get-suggested-routes {:amount 1}]])
            [:dispatch
@@ -506,7 +506,7 @@
 
 (rf/reg-event-fx :wallet/end-transaction-flow
  (fn [{:keys [db]}]
-   (let [address (get-in db [:wallet :current-viewing-account-address])
+   (let [address        (get-in db [:wallet :current-viewing-account-address])
          from-settings? (get-in db [:wallet :ui :send :from-settings?])]
      {:fx [(when from-settings?
              [:dispatch [:pop-to-root :shell-stack]])

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -176,10 +176,12 @@
               (assoc-in [:wallet :ui :send :address-prefix] prefix)
               (assoc-in [:wallet :ui :send :receiver-preferred-networks] receiver-networks)
               (assoc-in [:wallet :ui :send :receiver-networks] receiver-networks)
-              (assoc-in [:wallet :ui :send :from-settings?] from-settings?)
+              ;(assoc-in [:wallet :ui :send :from-settings?] from-settings?)
           )
       :fx [(when (and collectible-tx? one-collectible?)
              [:dispatch [:wallet/get-suggested-routes {:amount 1}]])
+           (when from-settings?
+             [:dispatch [:pop-to-root :shell-stack]])
            [:dispatch
             [:wallet/wizard-navigate-forward
              {:current-screen stack-id
@@ -495,9 +497,8 @@
             [:wallet/end-transaction-flow]]]})))
 
 (rf/reg-event-fx :wallet/clean-up-transaction-flow
- (fn [_ [from-settings?]]
-   {:fx [(when-not from-settings?
-           [:dispatch [:dismiss-modal :screen/wallet.transaction-confirmation]])
+ (fn [_]
+   {:fx [[:dispatch [:dismiss-modal :screen/wallet.transaction-confirmation]]
          [:dispatch [:wallet/clean-scanned-address]]
          [:dispatch [:wallet/clean-local-suggestions]]
          [:dispatch [:wallet/clean-send-address]]
@@ -506,18 +507,13 @@
 
 (rf/reg-event-fx :wallet/end-transaction-flow
  (fn [{:keys [db]}]
-   (let [address        (get-in db [:wallet :current-viewing-account-address])
-         from-settings? (get-in db [:wallet :ui :send :from-settings?])]
-     {:fx [(when from-settings?
-             [:dispatch [:pop-to-root :shell-stack]])
-           (if from-settings?
-             [:dispatch-later [{:ms 600 :dispatch [:wallet/navigate-to-account address]}]]
-             [:dispatch [:wallet/navigate-to-account-within-stack address]])
+   (let [address        (get-in db [:wallet :current-viewing-account-address])]
+     {:fx [[:dispatch [:wallet/navigate-to-account-within-stack address]]
            [:dispatch [:wallet/fetch-activities-for-current-account]]
            [:dispatch [:wallet/select-account-tab :activity]]
            [:dispatch-later
             [{:ms       20
-              :dispatch [:wallet/clean-up-transaction-flow from-settings?]}]]]})))
+              :dispatch [:wallet/clean-up-transaction-flow]}]]]})))
 
 (defn- transaction-data
   [{:keys [from-address to-address token-address route data eth-transfer?]}]


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/20591

### Summary

This PR fixes navigation after completing a transaction from settings. After completing a transaction it should navigate to the activity tab of the sender's account.

### Demo

https://github.com/status-im/status-mobile/assets/29354102/b8b4fa64-29e8-4c77-a648-37008055deef

