### PR TITLE
android: build split apks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,15 +215,13 @@ build-fdroid: ##@build Build release for F-Droid
 build-android: export BUILD_ENV ?= prod
 build-android: export BUILD_TYPE ?= nightly
 build-android: export ORG_GRADLE_PROJECT_versionCode ?= $(TMP_BUILD_NUMBER)
-build-android: export ANDROID_ABI_SPLIT ?= false
-build-android: export ANDROID_ABI_INCLUDE ?= armeabi-v7a;arm64-v8a;x86
 build-android: ##@build Build unsigned Android APK
 	@scripts/build-android.sh
 
 release-android: export TARGET := keytool
 release-android: export KEYSTORE_PATH ?= $(HOME)/.gradle/status-im.keystore
 release-android: keystore build-android ##@build Build signed Android APK
-	@scripts/sign-android.sh result/app-release-unsigned.apk
+	@scripts/sign-android.sh result/app-arm64-v8a-release-unsigned.apk
 
 release-ios: export TARGET := ios
 release-ios: export IOS_STATUS_GO_TARGETS := ios/arm64

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -211,7 +211,7 @@ android {
             reset()
             enable getEnvOrConfig('ANDROID_ABI_SPLIT').toBoolean()
             include getEnvOrConfig('ANDROID_ABI_INCLUDE').split(";")
-            universalApk true
+            universalApk false
         }
     }
     signingConfigs {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -38,10 +38,10 @@ KEYSTORE_PASSWORD=password
 KEYSTORE_ALIAS=status
 KEYSTORE_KEY_PASSWORD=password
 
-# By default we build a mostly universal APK
-ANDROID_ABI_SPLIT=false
-# Some platforms are excluded though
-ANDROID_ABI_INCLUDE=armeabi-v7a;arm64-v8a;x86;x86_64
+# Splitting by CPU Architecture produces smaller APKs.
+ANDROID_ABI_SPLIT=true
+# By default its better to only build apk for most recent devices.
+ANDROID_ABI_INCLUDE=arm64-v8a
 
 org.gradle.jvmargs=-Xmx8704M -XX:+UseParallelGC
 

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -72,11 +72,7 @@ pipeline {
         stage('Upload') {
           steps { script {
             def urls = apks.collect { s5cmd.upload(it) }
-            if (urls.size() > 1) { /* Return only the universal APK. */
-              env.PKG_URL = urls.find { it.contains('universal') }
-            } else { /* If no universal is available pick first. */
-              env.PKG_URL = urls.first()
-            }
+            env.PKG_URL = urls.first()
             jenkins.setBuildDesc(APK: env.PKG_URL)
           } }
         }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 import groovy.json.JsonBuilder
 

--- a/ci/Jenkinsfile.e2e-nightly
+++ b/ci/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.1'
+library 'status-jenkins-lib@v1.9.3'
 
 pipeline {
   agent {

--- a/nix/mobile/android/build.nix
+++ b/nix/mobile/android/build.nix
@@ -18,10 +18,10 @@
   buildUrl ? lib.getEnvWithDefault "ORG_GRADLE_PROJECT_buildUrl" null,
   statusGoSrcOverride ? lib.getEnvWithDefault "STATUS_GO_SRC_OVERRIDE" null,
   # If APKs should be split based on architectures
-  androidAbiSplit ? lib.getEnvWithDefault "ANDROID_ABI_SPLIT" "false",
+  androidAbiSplit ? lib.getEnvWithDefault "ANDROID_ABI_SPLIT" "true",
   # Android architectures to build for
   # Used to detect end-to-end builds
-  androidAbiInclude ? lib.getEnvWithDefault "ANDROID_ABI_INCLUDE" "armeabi-v7a;arm64-v8a;x86",
+  androidAbiInclude ? lib.getEnvWithDefault "ANDROID_ABI_INCLUDE" "arm64-v8a",
 }:
 
 let

--- a/scripts/run-android.sh
+++ b/scripts/run-android.sh
@@ -13,7 +13,7 @@ export BUILD_TYPE=debug
 
 # Install the APK on running emulator or android device.
 installAndLaunchApp() {
-  adb install -r ./result/app-debug.apk > "${ADB_INSTALL_LOG_FILE}" 2>&1
+  adb install -r ./result/app-arm64-v8a-debug.apk > "${ADB_INSTALL_LOG_FILE}" 2>&1
   "${GIT_ROOT}/scripts/wait-for-metro-port.sh" 2>&1
   # connected android devices need this port to be exposed for metro
   adb reverse "tcp:${RCT_METRO_PORT}" "tcp:${RCT_METRO_PORT}"


### PR DESCRIPTION
## Summary

In this PR:  
- we set `ANDROID_ABI_SPLIT` to `true`
- we set `ANDROID_ABI_INCLUDE` to `arm64-v8a` for debug & PR android builds
- release builds would still contain `armeabi-v7a;arm64-v8a` and there is no change for E2E android builds 
- we point to relevant changes in `status-jenkins-lib` which also introduces a size check for this `apk`.
The agreed threshold is 100 MB.


status: ready

