### PR TITLE
chore(communities): Hide non-implemented tabs in Discover communities

### DIFF
--- a/src/status_im/contexts/communities/discover/view.cljs
+++ b/src/status_im/contexts/communities/discover/view.cljs
@@ -8,6 +8,7 @@
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
     [status-im.common.scroll-page.view :as scroll-page]
+    [status-im.config :as config]
     [status-im.contexts.communities.actions.community-options.view :as options]
     [status-im.contexts.communities.discover.style :as style]
     [status-im.feature-flags :as ff]
@@ -76,12 +77,14 @@
      :data           [{:id                  :all
                        :label               (i18n/label :t/all)
                        :accessibility-label :all-communities-tab}
-                      {:id                  :open
-                       :label               (i18n/label :t/open)
-                       :accessibility-label :open-communities-tab}
-                      {:id                  :gated
-                       :label               (i18n/label :t/gated)
-                       :accessibility-label :gated-communities-tab}]}]])
+                      (when config/show-not-implemented-features?
+                        {:id                  :open
+                         :label               (i18n/label :t/open)
+                         :accessibility-label :open-communities-tab})
+                      (when config/show-not-implemented-features?
+                        {:id                  :gated
+                         :label               (i18n/label :t/gated)
+                         :accessibility-label :gated-communities-tab})]}]])
 
 (defn loading-community-item
   [_ _ _ {:keys [width]}]


### PR DESCRIPTION
Fixes: https://github.com/status-im/status-mobile/issues/20682

### Summary

Tabs `Open` and `Gated` in `Discover communities` screen were never implemented in the code, they are dummies. This PR hides them under the flag `config/show-not-implemented-features?`, which is disabled for users.

To avoid regressions and be quicker, I opted to not remove the `All` tab even though is the only one shown now, as that would require me to check non-trivial code due to the fact that the tabs can be sticky as the user scrolls.

#### Platforms

- Android
- iOS

### Areas that may be impacted

None

### Steps to test

Open the Discover communities section and check if only the `All` tab is shown.

status: ready