### PR TITLE
fix(saved-addresses): grouping and sorting of saved addresses

### DIFF
--- a/src/status_im/subs/wallet/saved_addresses.cljs
+++ b/src/status_im/subs/wallet/saved_addresses.cljs
@@ -38,11 +38,11 @@
  (fn [saved-addresses]
    (->> saved-addresses
         vals
-        (sort-by :name)
-        (group-by #(string/upper-case (first (:name %))))
+        (group-by (comp string/upper-case first :name))
         (map (fn [[k v]]
                {:title k
-                :data  v})))))
+                :data  (sort-by (comp string/lower-case :name) v)}))
+        (sort-by :title))))
 
 (rf/reg-sub
  :wallet/saved-addresses-addresses
@@ -62,7 +62,7 @@
  (fn [saved-addresses [_ query]]
    (->> saved-addresses
         vals
-        (sort-by :name)
+        (sort-by (comp string/lower-case :name))
         (filter
          (fn [{:keys [name address ens chain-short-names]}]
            (let [lowercase-query (string/lower-case (string/trim query))]


### PR DESCRIPTION
fixes #20687

### Summary

This PR fixes the grouping and sorting of saved addresses.

| Before | After   | 
| --- | --- | 
| <img width="250" src="https://github.com/status-im/status-mobile/assets/19339952/ecbf2ecd-67b5-45cc-a446-c76193d02f52" /> | <img width="250" src="https://github.com/status-im/status-mobile/assets/19339952/9cf31d49-1317-4d56-9158-1fe975f09961" /> | 

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to `Profile > Wallet > Saved Addresses`
- Add a new saved address with a name starts with `Z`
- Add another new saved address with a name starts with `a` (lowercase)
- Verify the list is ordered alphabetically

status: ready

