### PR TITLE
chore(activity-center): Performance improvements and various superficial refactors

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -45,6 +45,11 @@
 (def ^:const activity-center-membership-status-accepted 2)
 (def ^:const activity-center-membership-status-declined 3)
 
+;; Choose the maximum number of notifications that *usually/safely* fit on
+;; most screens, so that the UI doesn't have to needlessly render
+;; notifications.
+(def ^:const notifications-per-page 7)
+
 (def ^:const mute-for-15-mins-type 1)
 (def ^:const mute-for-1-hour-type 2)
 (def ^:const mute-for-8-hours-type 3)

--- a/src/status_im/contexts/shell/activity_center/context.cljs
+++ b/src/status_im/contexts/shell/activity_center/context.cljs
@@ -1,0 +1,18 @@
+(ns status-im.contexts.shell.activity-center.context
+  (:require
+    ["react" :as react]
+    [oops.core :as oops]
+    [react-native.core :as rn]))
+
+(defonce ^:private context
+  (react/createContext {}))
+
+(defn provider
+  [state & children]
+  (into [:> (oops/oget context :Provider) {:value state}]
+        children))
+
+(defn use-context
+  []
+  (let [ctx (rn/use-context context)]
+    {:active-swipeable (oops/oget ctx :activeSwipeable)}))

--- a/src/status_im/contexts/shell/activity_center/events.cljs
+++ b/src/status_im/contexts/shell/activity_center/events.cljs
@@ -15,10 +15,7 @@
 (def defaults
   {:filter-status          :unread
    :filter-type            types/no-type
-   ;; Choose the maximum number of notifications that *usually/safely* fit on
-   ;; most screens, so that the UI doesn't have to needlessly render
-   ;; notifications.
-   :notifications-per-page 8})
+   :notifications-per-page constants/notifications-per-page})
 
 ;;;; Navigation
 

--- a/src/status_im/contexts/shell/activity_center/notification/common/style.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification/common/style.cljs
@@ -4,6 +4,7 @@
 
 (def swipe-action-width 80)
 (def swipe-button-border-radius 16)
+(def swipe-button-margin 8)
 
 (def user-avatar-tag
   {:background-color colors/white-opa-10})

--- a/src/status_im/contexts/shell/activity_center/notification/community_kicked/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification/community_kicked/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.shell.activity-center.notification.community-kicked.view
   (:require
     [quo.core :as quo]
+    [react-native.core :as rn]
     [react-native.gesture :as gesture]
     [status-im.contexts.shell.activity-center.notification.common.style :as common-style]
     [status-im.contexts.shell.activity-center.notification.common.view :as common]
@@ -9,33 +10,34 @@
     [utils.re-frame :as rf]))
 
 (defn- swipeable
-  [{:keys [active-swipeable extra-fn]} child]
+  [{:keys [extra-fn]} child]
   [common/swipeable
-   {:left-button      common/swipe-button-read-or-unread
-    :left-on-press    common/swipe-on-press-toggle-read
-    :right-button     common/swipe-button-delete
-    :right-on-press   common/swipe-on-press-delete
-    :active-swipeable active-swipeable
-    :extra-fn         extra-fn}
+   {:left-button    common/swipe-button-read-or-unread
+    :left-on-press  common/swipe-on-press-toggle-read
+    :right-button   common/swipe-button-delete
+    :right-on-press common/swipe-on-press-delete
+    :extra-fn       extra-fn}
    child])
 
 (defn view
-  [{:keys [notification set-swipeable-height customization-color] :as props}]
-  (let [{:keys [community-id read
+  [{:keys [notification extra-fn]}]
+  (let [{:keys [id community-id read
                 timestamp]} notification
         community           (rf/sub [:communities/community community-id])
         community-name      (:name community)
-        community-image     (get-in community [:images :thumbnail :uri])]
-    [swipeable props
-     [gesture/touchable-without-feedback
-      {:on-press (fn []
-                   (rf/dispatch [:navigate-back])
-                   (rf/dispatch [:activity-center.notifications/mark-as-read (:id notification)]))}
+        community-image     (get-in community [:images :thumbnail :uri])
+        customization-color (rf/sub [:profile/customization-color])
+        on-press            (rn/use-callback
+                             (fn []
+                               (rf/dispatch [:navigate-back])
+                               (rf/dispatch [:activity-center.notifications/mark-as-read id]))
+                             [id])]
+    [swipeable {:extra-fn extra-fn}
+     [gesture/touchable-without-feedback {:on-press on-press}
       [quo/activity-log
        {:title               (i18n/label :t/community-kicked-heading)
         :customization-color customization-color
         :icon                :i/placeholder
-        :on-layout           set-swipeable-height
         :timestamp           (datetime/timestamp->relative timestamp)
         :unread?             (not read)
         :context             [[quo/text {:style common-style/user-avatar-tag-text}

--- a/src/status_im/contexts/shell/activity_center/notification/community_request/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification/community_request/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.shell.activity-center.notification.community-request.view
   (:require
     [quo.core :as quo]
+    [react-native.core :as rn]
     [react-native.gesture :as gesture]
     [status-im.constants :as constants]
     [status-im.contexts.shell.activity-center.notification.common.style :as common-style]
@@ -10,27 +11,23 @@
     [utils.re-frame :as rf]))
 
 (defn- swipeable
-  [{:keys [active-swipeable extra-fn]} child]
+  [{:keys [extra-fn]} child]
   [common/swipeable
-   {:left-button      common/swipe-button-read-or-unread
-    :left-on-press    common/swipe-on-press-toggle-read
-    :right-button     common/swipe-button-delete
-    :right-on-press   common/swipe-on-press-delete
-    :active-swipeable active-swipeable
-    :extra-fn         extra-fn}
+   {:left-button    common/swipe-button-read-or-unread
+    :left-on-press  common/swipe-on-press-toggle-read
+    :right-button   common/swipe-button-delete
+    :right-on-press common/swipe-on-press-delete
+    :extra-fn       extra-fn}
    child])
 
 (defn- get-header-text-and-context
-  [community membership-status]
-  (let [community-name        (:name community)
-        permissions           (:permissions community)
-        open?                 (not= 3 (:access permissions))
-        community-image       (get-in community [:images :thumbnail :uri])
+  [community-logo community-name community-permissions membership-status]
+  (let [open?                 (not= 3 (:access community-permissions))
         community-context-tag [quo/context-tag
                                {:type           :community
                                 :size           24
                                 :blur?          true
-                                :community-logo community-image
+                                :community-logo community-logo
                                 :community-name community-name}]]
     (cond
       (= membership-status constants/activity-center-membership-status-idle)
@@ -56,27 +53,33 @@
                                     :t/joined-community
                                     :t/community-request-accepted-body-text)
                                   (when open? {:community community-name}))]
-                     community-context-tag]}
-
-      :else nil)))
+                     community-context-tag]})))
 
 (defn view
-  [{:keys [notification set-swipeable-height customization-color] :as props}]
+  [{:keys [notification extra-fn]}]
   (let [{:keys [community-id membership-status read
-                timestamp]}           notification
-        community                     (rf/sub [:communities/community community-id])
-        {:keys [header-text context]} (get-header-text-and-context community
-                                                                   membership-status)]
-    [swipeable props
-     [gesture/touchable-without-feedback
-      {:on-press (fn []
-                   (rf/dispatch [:navigate-back])
-                   (rf/dispatch [:communities/navigate-to-community-overview community-id]))}
+                timestamp]}   notification
+        community-name        (rf/sub [:communities/name community-id])
+        community-logo        (rf/sub [:communities/logo community-id])
+        community-permissions (rf/sub [:communities/permissions community-id])
+        customization-color   (rf/sub [:profile/customization-color])
+        {:keys [header-text
+                context]}     (get-header-text-and-context community-logo
+                                                           community-name
+                                                           community-permissions
+                                                           membership-status)
+        on-press              (rn/use-callback
+                               (fn []
+                                 (rf/dispatch [:navigate-back])
+                                 (rf/dispatch [:communities/navigate-to-community-overview
+                                               community-id]))
+                               [community-id])]
+    [swipeable {:extra-fn extra-fn}
+     [gesture/touchable-without-feedback {:on-press on-press}
       [quo/activity-log
        {:title               header-text
         :customization-color customization-color
         :icon                :i/communities
-        :on-layout           set-swipeable-height
         :timestamp           (datetime/timestamp->relative timestamp)
         :unread?             (not read)
         :context             context}]]]))

--- a/src/status_im/contexts/shell/activity_center/notification/mentions/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification/mentions/view.cljs
@@ -30,25 +30,24 @@
                        parsed-text-children))))
 
 (defn- swipeable
-  [{:keys [active-swipeable extra-fn]} child]
+  [{:keys [extra-fn]} child]
   [common/swipeable
-   {:left-button      common/swipe-button-read-or-unread
-    :left-on-press    common/swipe-on-press-toggle-read
-    :right-button     common/swipe-button-delete
-    :right-on-press   common/swipe-on-press-delete
-    :active-swipeable active-swipeable
-    :extra-fn         extra-fn}
+   {:left-button    common/swipe-button-read-or-unread
+    :left-on-press  common/swipe-on-press-toggle-read
+    :right-button   common/swipe-button-delete
+    :right-on-press common/swipe-on-press-delete
+    :extra-fn       extra-fn}
    child])
 
 (defn view
-  [{:keys [notification set-swipeable-height customization-color] :as props}]
+  [{:keys [notification extra-fn]}]
   (let [{:keys [author chat-name community-id chat-id
                 message read timestamp]} notification
         community-chat?                  (not (string/blank? community-id))
-        community                        (rf/sub [:communities/community community-id])
-        community-name                   (:name community)
-        community-image                  (get-in community [:images :thumbnail :uri])]
-    [swipeable props
+        community-name                   (rf/sub [:communities/name community-id])
+        community-logo                   (rf/sub [:communities/logo community-id])
+        customization-color              (rf/sub [:profile/customization-color])]
+    [swipeable {:extra-fn extra-fn}
      [gesture/touchable-without-feedback
       {:on-press (fn []
                    (rf/dispatch [:hide-popover])
@@ -56,7 +55,6 @@
       [quo/activity-log
        {:title               (i18n/label :t/mention)
         :customization-color customization-color
-        :on-layout           set-swipeable-height
         :icon                :i/mention
         :timestamp           (datetime/timestamp->relative timestamp)
         :unread?             (not read)
@@ -68,7 +66,7 @@
                                  {:type           :channel
                                   :blur?          true
                                   :size           24
-                                  :community-logo community-image
+                                  :community-logo community-logo
                                   :community-name community-name
                                   :channel-name   chat-name}]
                                 [quo/context-tag

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -16,11 +16,32 @@
  (fn [info [_ id]]
    (get info id)))
 
+;; Do not use this subscription directly in views. There is a significant risk
+;; of re-rendering views too frequently because an active community can change
+;; for numerous reasons.
 (re-frame/reg-sub
  :communities/community
  :<- [:communities]
  (fn [communities [_ id]]
    (get communities id)))
+
+(re-frame/reg-sub :communities/logo
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:communities/community community-id])])
+ (fn [[community]]
+   (get-in community [:images :thumbnail :uri])))
+
+(re-frame/reg-sub :communities/name
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:communities/community community-id])])
+ (fn [[{:keys [name]}]]
+   name))
+
+(re-frame/reg-sub :communities/permissions
+ (fn [[_ community-id]]
+   [(re-frame/subscribe [:communities/community community-id])])
+ (fn [[{:keys [permissions]}]]
+   permissions))
 
 (re-frame/reg-sub
  :communities/community-color


### PR DESCRIPTION
- Potentially a solution to https://github.com/status-im/status-mobile/issues/15706

# Summary

This PR's branch started with a simple goal, understand why the swipe actions on my Android device were behaving erratically (see [buggy swipe gesture.webm](https://github.com/status-im/status-mobile/assets/46027/2d269b09-6409-40a9-a1e4-52dd03f7570d)). Then I found the parent issue, and gave it a shot. I'm still not sure if it's fixed because it's hard to reproduce. The changes are all in view/UI files.

- [x] Fixes swipe button on Android and iOS.
- [x] Performance: we now subscribe only to the minimum from each community. This could be the reason the AC would lag as described in the parent issue.
- [x] Performance: was able to use flex and removed swipe button height calculation that was using `onLayout` and was causing a re-render.
- [x] Performance: reduced the initial number of items to render in the flatlist from 10 to 7.
- [x] Performance: delay rendering the heavy list of notification components. See in the video below how slow it is to open the AC with just 6 notifications and that the opening animation is never displayed. And then check the improved version with the artificial delay provided by `rn/delay-render`. By opening the AC first and animating, this gives the user something to look for, and hopefully a few milliseconds more to think the app is not stuck, which will be preciously used to render notifications.

I also ended up refactoring all views in the AC to:

- [x] Follow our newest standards with React hooks.
- [x] Removed prop-drilling by creating a separate React context to store the current swipeable item (because we need to call `.close` on a `Gesture Swipeable` instance whenever a new swipeable opens.

**Slow/clunky**

 [behavior-in-develop-slow-top-open.webm](https://github.com/status-im/status-mobile/assets/46027/7c1e459d-0265-426c-91ad-7b3bd47dd7a8)

**Improved**

 [faster-to-open-ac.webm](https://github.com/status-im/status-mobile/assets/46027/b1a199f8-d16b-4e87-bd16-f698e0f31f5b)

### Platforms

- Android
- iOS

### Areas that may be impacted

Activity Center notifications, but very unlikely to have regressions in behavior. The worst could be a UI bug.

### Steps to test

Each notification in the AC is implemented differently. Although they look the similar, whenever we refactor notifications, we have to change each notification type slightly differently. I tested only mentions, replies, and contact request notifications and they.

- Check each type of notification is displayed correctly. Types are admin, community kicked, community join request, contact request, mention, reply.
- Check each type of notification default action/press does what's expected.
- Check each type of notification can be marked as read/unread and deleted.

I would say the following don't need to be tested:

- How notifications are generated and all the tricky conditions o trigger them. This PR is not touching non-UI code in mobile and not changing status-go.
- Contact verification notifications have been mostly untested for more than a year. I actually think now we should feature flag it to not waste time with testing before going public (we can do in a follow-up)

### Risk

- [x] Low risk, but QA should verify all supported notifications are displayed correctly.
