### PR TITLE
[#20664] feat: add share usage data confirmation modal

### DIFF
--- a/src/status_im/common/metrics_confirmation_modal/style.cljs
+++ b/src/status_im/common/metrics_confirmation_modal/style.cljs
@@ -1,0 +1,14 @@
+(ns status-im.common.metrics-confirmation-modal.style)
+
+(def points-wrapper
+  {:margin-top        11
+   :margin-horizontal 20
+   :gap               21
+   :margin-bottom     15})
+
+(def item-text
+  {:margin-top  10
+   :margin-left -4})
+
+(def info-text
+  {:margin-top -5})

--- a/src/status_im/common/metrics_confirmation_modal/view.cljs
+++ b/src/status_im/common/metrics_confirmation_modal/view.cljs
@@ -1,0 +1,69 @@
+(ns status-im.common.metrics-confirmation-modal.view
+  (:require
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [status-im.common.metrics-confirmation-modal.style :as style]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
+
+(defn- hide-bottom-sheet
+  []
+  (rf/dispatch [:hide-bottom-sheet]))
+
+(def will-receive-points
+  [(i18n/label :t/ip-address)
+   (i18n/label :t/universally-unique-identifiers-of-device)
+   (i18n/label :t/logs-of-actions-withing-the-app)])
+
+(def not-receive-points
+  [(i18n/label :t/your-profile-information)
+   (i18n/label :t/your-addresses)
+   (i18n/label :t/information-you-input-and-send)])
+
+(defn- render-points
+  [{:keys [title points]}]
+  [rn/view
+   [quo/text {:weight :semi-bold}
+    title]
+   (map-indexed
+    (fn [idx label]
+      ^{:key (str idx label)}
+      [quo/markdown-list
+       {:description     label
+        :blur?           true
+        :container-style style/item-text}])
+    points)])
+
+(defn view
+  [{:keys [settings?]}]
+  (let [on-cancel       hide-bottom-sheet
+        on-share-usage  (rn/use-callback
+                         (fn []
+                           (hide-bottom-sheet)))
+        on-do-not-share (rn/use-callback
+                         (fn []
+                           (hide-bottom-sheet)))]
+    [rn/view
+     [quo/drawer-top
+      {:title       (i18n/label :t/help-us-improve-status)
+       :description (i18n/label :t/collecting-usage-data)}]
+     [rn/view {:style style/points-wrapper}
+      [render-points
+       {:title  (i18n/label :t/what-we-will-receive)
+        :points will-receive-points}]
+      [render-points
+       {:title  (i18n/label :t/what-we-not-receive)
+        :points not-receive-points}]
+      (when-not settings?
+        [quo/text
+         {:size  :paragraph-2
+          :style style/info-text}
+         (i18n/label :t/sharing-usage-data-can-be-turned-off)])]
+     [quo/bottom-actions
+      {:actions          :two-actions
+       :blur?            true
+       :button-one-label (i18n/label :t/share-usage-data)
+       :button-one-props {:on-press on-share-usage}
+       :button-two-label (i18n/label (if settings? :t/do-not-share :t/not-now))
+       :button-two-props {:type     :grey
+                          :on-press (if settings? on-do-not-share on-cancel)}}]]))

--- a/src/status_im/contexts/onboarding/intro/view.cljs
+++ b/src/status_im/contexts/onboarding/intro/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [quo.core :as quo]
     [react-native.core :as rn]
+    [status-im.common.metrics-confirmation-modal.view :as metrics-modal]
     [status-im.contexts.onboarding.common.background.view :as background]
     [status-im.contexts.onboarding.common.overlay.view :as overlay]
     [status-im.contexts.onboarding.intro.style :as style]
@@ -11,6 +12,11 @@
 
 (defn view
   []
+  (rn/use-mount (fn []
+                  (rf/dispatch
+                   [:show-bottom-sheet
+                    {:content (fn [] [metrics-modal/view])
+                     :shell?  true}])))
   [rn/view {:style style/page-container}
    [background/view false]
    [quo/bottom-actions

--- a/translations/en.json
+++ b/translations/en.json
@@ -2749,5 +2749,19 @@
     "import-keypair-to-use-account": "Import key pair to use this account",
     "import-keypair-steps": "{{account-name}} was derived from your {{keypair-name}} key pair, which has not yet been imported to this device. To transact using this account, you will need to import the {{keypair-name}} key pair first.",
     "not-now": "Not now",
-    "value-higher-than-send-amount": "This value is higher than entered amount to send"
+    "value-higher-than-send-amount": "This value is higher than entered amount to send",
+    "help-us-improve-status": "Help us improve Status",
+    "collecting-usage-data": "Collecting usage data helps us improve Status.",
+    "what-we-will-receive":"What we will receive:",
+    "ip-address":"IP address",
+    "universally-unique-identifiers-of-device":"Universally Unique Identifiers of device",
+    "logs-of-actions-withing-the-app":"Logs of actions within the app, including button presses and screen visits",
+    "what-we-not-receive":"What we not receive:",
+    "your-profile-information":"Your profile information",
+    "your-addresses":"Your addresses",
+    "information-you-input-and-send":"Information you input and send",
+    "sharing-usage-data-can-be-turned-off":"Sharing usage data can be turned off anytime in Settings / Privacy and Security.",
+    "share-usage-data":"Share usage data",
+    "do-not-share":"Do not share"
+
 }


### PR DESCRIPTION
fixes #20664

### Summary
 
Get confirmation to share usage data from user.


### Steps to test

- Open Status
- In Onboarding you will see modal

### Result

<img src="https://github.com/status-im/status-mobile/assets/71308738/5f28e32e-8a03-441f-b17b-1dd5a35a806d" width="390px"/>

status: wip
