### PR TITLE
fix(saved-addresses): clean QR scanned address

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -163,9 +163,8 @@
                                                (rf/dispatch
                                                 [:open-modal :screen/settings.save-address]))
                                              [address ens-name? address-or-ens])]
-    (rn/use-mount (fn []
-                    (rf/dispatch [:wallet/clean-scanned-address])
-                    (rf/dispatch [:wallet/clear-address-to-save])))
+    (rn/use-unmount #(rf/dispatch [:wallet/clean-scanned-address]))
+    (rn/use-mount #(rf/dispatch [:wallet/clear-address-to-save]))
     [quo/overlay {:type :shell}
      [floating-button-page/view
       {:footer-container-padding 0


### PR DESCRIPTION
fixes #20667

### Summary

This PR cleans the scanned QR address/result on the unmount of the add new saved address flow.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to `Profile > Wallet > Saved addresses > +`
- Scan a QR code with an address
- Save the address
- Navigate to the wallet tab
- Press the `+` tile/card then tap on `Add address to watch`
- Verify the scanned address is not populated in the input field

status: ready 

