### PR TITLE
enable light client by default

### DIFF
--- a/src/status_im/contexts/profile/config.cljs
+++ b/src/status_im/contexts/profile/config.cljs
@@ -40,7 +40,7 @@
             :verifyENSURL             config/verify-ens-url
             :verifyENSContractAddress config/verify-ens-contract-address
             :verifyTransactionChainID config/verify-transaction-chain-id
-            :wakuV2LightClient        false
+            :wakuV2LightClient        true
             :previewPrivacy           config/blank-preview?
             :testNetworksEnabled      config/test-networks-enabled?})))
 


### PR DESCRIPTION
This commit enables light client by default on newly created accounts.