### PR TITLE
Add confirmation modal to onboarding

### DIFF
--- a/src/status_im/common/metrics_confirmation_modal/style.cljs
+++ b/src/status_im/common/metrics_confirmation_modal/style.cljs
@@ -1,0 +1,14 @@
+(ns status-im.common.metrics-confirmation-modal.style)
+
+(def points-wrapper
+  {:margin-top        11
+   :margin-horizontal 20
+   :gap               21
+   :margin-bottom     15})
+
+(def item-text
+  {:margin-top  10
+   :margin-left -4})
+
+(def info-text
+  {:margin-top -5})

--- a/src/status_im/common/metrics_confirmation_modal/view.cljs
+++ b/src/status_im/common/metrics_confirmation_modal/view.cljs
@@ -6,64 +6,74 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
+(defn- dismiss-keyboard
+  []
+  (rf/dispatch [:dismiss-keyboard]))
+
 (defn- hide-bottom-sheet
   []
   (rf/dispatch [:hide-bottom-sheet]))
 
-(def will-receive-points
-  [(i18n/label :t/ip-address)
-   (i18n/label :t/universally-unique-identifiers-of-device)
-   (i18n/label :t/logs-of-actions-withing-the-app)])
+(defn- toggle-metrics
+  [enabled?]
+  (rf/dispatch [:centralized-metrics/toggle-centralized-metrics enabled?]))
 
-(def not-receive-points
-  [(i18n/label :t/your-profile-information)
-   (i18n/label :t/your-addresses)
-   (i18n/label :t/information-you-input-and-send)])
+(def ^:private will-receive-points
+  [:t/ip-address
+   :t/universally-unique-identifiers-of-device
+   :t/logs-of-actions-withing-the-app])
 
-(defn- render-points
+(def ^:private not-receive-points
+  [:t/your-profile-information
+   :t/your-addresses
+   :t/information-you-input-and-send])
+
+(defn- bullet-points
   [{:keys [title points]}]
   [rn/view
    [quo/text {:weight :semi-bold}
     title]
-   (map-indexed
-    (fn [idx label]
-      ^{:key (str idx label)}
-      [quo/markdown-list
-       {:description     label
-        :blur?           true
-        :container-style style/item-text}])
-    points)])
+   (for [label points]
+     ^{:key label}
+     [quo/markdown-list
+      {:description     (i18n/label label)
+       :blur?           true
+       :container-style style/item-text}])])
+
+(defn- on-share-usage
+  []
+  (toggle-metrics true)
+  (hide-bottom-sheet))
+
+(defn- on-do-not-share
+  []
+  (toggle-metrics false)
+  (hide-bottom-sheet))
 
 (defn view
   [{:keys [settings?]}]
-  (let [on-cancel       hide-bottom-sheet
-        on-share-usage  (rn/use-callback
-                         (fn []
-                           (hide-bottom-sheet)))
-        on-do-not-share (rn/use-callback
-                         (fn []
-                           (hide-bottom-sheet)))]
-    [rn/view
-     [quo/drawer-top
-      {:title       (i18n/label :t/help-us-improve-status)
-       :description (i18n/label :t/collecting-usage-data)}]
-     [rn/view {:style style/points-wrapper}
-      [render-points
-       {:title  (i18n/label :t/what-we-will-receive)
-        :points will-receive-points}]
-      [render-points
-       {:title  (i18n/label :t/what-we-not-receive)
-        :points not-receive-points}]
-      (when-not settings?
-        [quo/text
-         {:size  :paragraph-2
-          :style style/info-text}
-         (i18n/label :t/sharing-usage-data-can-be-turned-off)])]
-     [quo/bottom-actions
-      {:actions          :two-actions
-       :blur?            true
-       :button-one-label (i18n/label :t/share-usage-data)
-       :button-one-props {:on-press on-share-usage}
-       :button-two-label (i18n/label (if settings? :t/do-not-share :t/not-now))
-       :button-two-props {:type     :grey
-                          :on-press (if settings? on-do-not-share on-cancel)}}]]))
+  (rn/use-mount #(dismiss-keyboard))
+  [:<>
+   [quo/drawer-top
+    {:title       (i18n/label :t/help-us-improve-status)
+     :description (i18n/label :t/collecting-usage-data)}]
+   [rn/view {:style style/points-wrapper}
+    [bullet-points
+     {:title  (i18n/label :t/what-we-will-receive)
+      :points will-receive-points}]
+    [bullet-points
+     {:title  (i18n/label :t/what-we-wont-receive)
+      :points not-receive-points}]
+    (when-not settings?
+      [quo/text
+       {:size  :paragraph-2
+        :style style/info-text}
+       (i18n/label :t/sharing-usage-data-can-be-turned-off)])]
+   [quo/bottom-actions
+    {:actions          :two-actions
+     :blur?            true
+     :button-one-label (i18n/label :t/share-usage-data)
+     :button-one-props {:on-press on-share-usage}
+     :button-two-label (i18n/label (if settings? :t/do-not-share :t/not-now))
+     :button-two-props {:type     :grey
+                        :on-press on-do-not-share}}]])

--- a/src/status_im/common/metrics_confirmation_modal/view.cljs
+++ b/src/status_im/common/metrics_confirmation_modal/view.cljs
@@ -1,0 +1,69 @@
+(ns status-im.common.metrics-confirmation-modal.view
+  (:require
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [status-im.common.metrics-confirmation-modal.style :as style]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
+
+(defn- hide-bottom-sheet
+  []
+  (rf/dispatch [:hide-bottom-sheet]))
+
+(def will-receive-points
+  [(i18n/label :t/ip-address)
+   (i18n/label :t/universally-unique-identifiers-of-device)
+   (i18n/label :t/logs-of-actions-withing-the-app)])
+
+(def not-receive-points
+  [(i18n/label :t/your-profile-information)
+   (i18n/label :t/your-addresses)
+   (i18n/label :t/information-you-input-and-send)])
+
+(defn- render-points
+  [{:keys [title points]}]
+  [rn/view
+   [quo/text {:weight :semi-bold}
+    title]
+   (map-indexed
+    (fn [idx label]
+      ^{:key (str idx label)}
+      [quo/markdown-list
+       {:description     label
+        :blur?           true
+        :container-style style/item-text}])
+    points)])
+
+(defn view
+  [{:keys [settings?]}]
+  (let [on-cancel       hide-bottom-sheet
+        on-share-usage  (rn/use-callback
+                         (fn []
+                           (hide-bottom-sheet)))
+        on-do-not-share (rn/use-callback
+                         (fn []
+                           (hide-bottom-sheet)))]
+    [rn/view
+     [quo/drawer-top
+      {:title       (i18n/label :t/help-us-improve-status)
+       :description (i18n/label :t/collecting-usage-data)}]
+     [rn/view {:style style/points-wrapper}
+      [render-points
+       {:title  (i18n/label :t/what-we-will-receive)
+        :points will-receive-points}]
+      [render-points
+       {:title  (i18n/label :t/what-we-not-receive)
+        :points not-receive-points}]
+      (when-not settings?
+        [quo/text
+         {:size  :paragraph-2
+          :style style/info-text}
+         (i18n/label :t/sharing-usage-data-can-be-turned-off)])]
+     [quo/bottom-actions
+      {:actions          :two-actions
+       :blur?            true
+       :button-one-label (i18n/label :t/share-usage-data)
+       :button-one-props {:on-press on-share-usage}
+       :button-two-label (i18n/label (if settings? :t/do-not-share :t/not-now))
+       :button-two-props {:type     :grey
+                          :on-press (if settings? on-do-not-share on-cancel)}}]]))

--- a/src/status_im/contexts/centralized_metrics/events_test.cljs
+++ b/src/status_im/contexts/centralized_metrics/events_test.cljs
@@ -6,6 +6,11 @@
     [status-im.contexts.centralized-metrics.tracking :as tracking]
     [test-helpers.unit :as h]))
 
+(deftest show-confirmation-modal-test
+  (testing "returns true if the user confirmed"
+    (is (false? (events/show-confirmation-modal? {events/user-confirmed-key true})))
+    (is (true? (events/show-confirmation-modal? {})))))
+
 (deftest push-event-test
   (testing "returns correct boolean value"
     (is (true? (events/push-event? {:centralized-metrics/user-confirmed? false})))

--- a/src/status_im/contexts/onboarding/create_or_sync_profile/view.cljs
+++ b/src/status_im/contexts/onboarding/create_or_sync_profile/view.cljs
@@ -5,6 +5,7 @@
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [status-im.common.check-before-syncing.view :as check-before-syncing]
+    [status-im.common.metrics-confirmation-modal.view :as metrics-modal]
     [status-im.common.not-implemented :as not-implemented]
     [status-im.common.resources :as resources]
     [status-im.config :as config]
@@ -126,6 +127,7 @@
 
 (defn- internal-view
   [sign-in-type]
+  (rn/use-mount #(rf/dispatch [:centralized-metrics/check-modal metrics-modal/view]))
   (let [{:keys [top]} (safe-area/get-insets)]
     [rn/view {:style style/content-container}
      [quo/page-nav

--- a/src/status_im/contexts/onboarding/intro/view.cljs
+++ b/src/status_im/contexts/onboarding/intro/view.cljs
@@ -2,7 +2,6 @@
   (:require
     [quo.core :as quo]
     [react-native.core :as rn]
-    [status-im.common.metrics-confirmation-modal.view :as metrics-modal]
     [status-im.contexts.onboarding.common.background.view :as background]
     [status-im.contexts.onboarding.common.overlay.view :as overlay]
     [status-im.contexts.onboarding.intro.style :as style]
@@ -12,11 +11,6 @@
 
 (defn view
   []
-  (rn/use-mount (fn []
-                  (rf/dispatch
-                   [:show-bottom-sheet
-                    {:content (fn [] [metrics-modal/view])
-                     :shell?  true}])))
   [rn/view {:style style/page-container}
    [background/view false]
    [quo/bottom-actions

--- a/src/status_im/contexts/onboarding/intro/view.cljs
+++ b/src/status_im/contexts/onboarding/intro/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [quo.core :as quo]
     [react-native.core :as rn]
+    [status-im.common.metrics-confirmation-modal.view :as metrics-modal]
     [status-im.contexts.onboarding.common.background.view :as background]
     [status-im.contexts.onboarding.common.overlay.view :as overlay]
     [status-im.contexts.onboarding.intro.style :as style]
@@ -11,6 +12,11 @@
 
 (defn view
   []
+  (rn/use-mount (fn []
+                  (rf/dispatch
+                   [:show-bottom-sheet
+                    {:content (fn [] [metrics-modal/view])
+                     :shell?  true}])))
   [rn/view {:style style/page-container}
    [background/view false]
    [quo/bottom-actions

--- a/src/status_im/contexts/profile/profiles/view.cljs
+++ b/src/status_im/contexts/profile/profiles/view.cljs
@@ -7,6 +7,7 @@
     [react-native.safe-area :as safe-area]
     [status-im.common.check-before-syncing.view :as check-before-syncing]
     [status-im.common.confirmation-drawer.view :as confirmation-drawer]
+    [status-im.common.metrics-confirmation-modal.view :as metrics-modal]
     [status-im.common.standard-authentication.core :as standard-authentication]
     [status-im.config :as config]
     [status-im.constants :as constants]
@@ -254,6 +255,7 @@
 
 (defn view
   []
+  (rn/use-mount #(rf/dispatch [:centralized-metrics/check-modal metrics-modal/view]))
   (let [[show-profiles? set-show-profiles] (rn/use-state false)
         show-profiles                      (rn/use-callback #(set-show-profiles true))
         hide-profiles                      (rn/use-callback #(set-show-profiles false))]

--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -150,6 +150,7 @@ class SignInView(BaseView):
         self.i_m_new_in_status_button = Button(self.driver, accessibility_id="new-to-status-button")
 
         self.create_profile_button = Button(self.driver, accessibility_id='new-to-status-button')
+        self.not_now_button = Button(self.driver, xpath="//*[@text='Not now']")
         self.sync_or_recover_profile_button = Button(self.driver, accessibility_id='already-use-status-button')
 
         self.migration_password_input = EditBox(self.driver, accessibility_id="enter-password-input")
@@ -236,6 +237,7 @@ class SignInView(BaseView):
                          (password, str(keycard), str(enable_notifications)), device=False)
         if first_user:
             self.create_profile_button.click_until_presence_of_element(self.generate_keys_button)
+            self.not_now_button.wait_and_click()
         else:
             if self.show_profiles_button.is_element_displayed(20):
                 self.show_profiles_button.click()
@@ -274,6 +276,7 @@ class SignInView(BaseView):
 
         if not second_user:
             self.sync_or_recover_profile_button.click_until_presence_of_element(self.generate_keys_button)
+            self.not_now_button.wait_and_click()
         else:
             self.show_profiles_button.wait_and_click(20)
             self.plus_profiles_button.click()

--- a/translations/en.json
+++ b/translations/en.json
@@ -2758,5 +2758,18 @@
     "swaps-powered-by": "Swaps powered by {{provider}}",
     "max-slippage": "Max slippage",
     "pay": "Pay",
-    "store-confirmations": "Store confirmations"
+    "store-confirmations": "Store confirmations",
+    "help-us-improve-status": "Help us improve Status",
+    "collecting-usage-data": "Collecting usage data helps us improve Status.",
+    "what-we-will-receive":"What we will receive:",
+    "ip-address":"IP address",
+    "universally-unique-identifiers-of-device":"Universally Unique Identifiers of device",
+    "logs-of-actions-withing-the-app":"Logs of actions within the app, including button presses and screen visits",
+    "what-we-not-receive":"What we not receive:",
+    "your-profile-information":"Your profile information",
+    "your-addresses":"Your addresses",
+    "information-you-input-and-send":"Information you input and send",
+    "sharing-usage-data-can-be-turned-off":"Sharing usage data can be turned off anytime in Settings / Privacy and Security.",
+    "share-usage-data":"Share usage data",
+    "do-not-share":"Do not share"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -2765,7 +2765,7 @@
     "ip-address":"IP address",
     "universally-unique-identifiers-of-device":"Universally Unique Identifiers of device",
     "logs-of-actions-withing-the-app":"Logs of actions within the app, including button presses and screen visits",
-    "what-we-not-receive":"What we not receive:",
+    "what-we-wont-receive":"What we won't receive:",
     "your-profile-information":"Your profile information",
     "your-addresses":"Your addresses",
     "information-you-input-and-send":"Information you input and send",


### PR DESCRIPTION
This commit add a confirmation for centralized metrics.
It is added in 3 places:

1) Onboarding -> Create new account
2) Onboarding -> Sync profile
3) On the accounts view if the user is upgrading

To test 1 & 2, you should just be able to do that on a newly installed
device.

To test 3, you will have to upgrade from a PR without this feature that
has at least an account. It should show the confirmation modal until you
either click on Not now or Share usage data.

The modal should also be added in settings, but I will do that as a
separate PR.

E2E tests will have to be changed cc @churik @pavloburykh 

Depends on https://github.com/status-im/status-mobile/pull/20655 and only the rest of the commits should be reviewed.