### PR TITLE
fix user lands on the Home screen after closing a community opened from Discover Communities

### DIFF
--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -343,7 +343,7 @@
              (when (get-in db [:communities community-id :joined])
                [:dispatch
                 [:activity-center.notifications/dismiss-community-overview community-id]])]}
-       (when-not (or (= current-view-id :shell) (= current-view-id :communities-stack))
+       (when-not (#{:shell :communities-stack :discover-communities} current-view-id)
          (navigation/pop-to-root :shell-stack))))))
 
 (rf/reg-event-fx :communities/navigate-to-community-overview navigate-to-community-overview)

--- a/test/appium/tests/critical/chats/test_public_chat_browsing.py
+++ b/test/appium/tests/critical/chats/test_public_chat_browsing.py
@@ -291,7 +291,6 @@ class TestCommunityOneDeviceMerged(MultipleSharedDeviceTestCase):
                         self.errors.append("Status community logo is different from expected template.")
 
                     self.community_view.close_community_view_button.click()
-                    self.home.discover_communities_button.click()
                     self.home.swipe_up()
 
             except TimeoutException:


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20679

status: ready