### PR TITLE
WC: Persistance update + a bunch of visual bugfixes

### DIFF
--- a/src/quo/components/drawers/bottom_actions/style.cljs
+++ b/src/quo/components/drawers/bottom_actions/style.cljs
@@ -21,12 +21,14 @@
                        (colors/theme-colors colors/white colors/neutral-95 theme))})
 
 (defn buttons-container
-  [actions]
-  {:flex-direction     (if (= actions :two-vertical-actions) :column :row)
-   :justify-content    :space-around
-   :padding-vertical   12
-   :gap                12
-   :padding-horizontal 20})
+  [actions container-style]
+  (merge
+   {:flex-direction     (if (= actions :two-vertical-actions) :column :row)
+    :justify-content    :space-around
+    :padding-vertical   12
+    :gap                12
+    :padding-horizontal 20}
+   container-style))
 
 (def description-top
   {:flex-direction  :row

--- a/src/quo/components/drawers/bottom_actions/view.cljs
+++ b/src/quo/components/drawers/bottom_actions/view.cljs
@@ -30,7 +30,8 @@
       [:button-two-props {:optional true} [:maybe :map]]
       [:scroll? {:optional true} [:maybe :boolean]]
       [:blur? {:optional true} [:maybe :boolean]]
-      [:container-style {:optional true} [:maybe :map]]]]]
+      [:container-style {:optional true} [:maybe :map]]
+      [:buttons-container-style {:optional true} [:maybe :map]]]]]
    :any])
 
 (def ^:private role-icon
@@ -42,7 +43,7 @@
 (defn- view-internal
   [{:keys [actions description description-text description-top-text error-message role button-one-label
            button-two-label blur? button-one-props button-two-props scroll? container-style
-           context-tag-props]}]
+           buttons-container-style context-tag-props]}]
   (let [theme (quo.theme/use-theme)]
     [rn/view
      {:style (merge (style/container scroll? blur? theme) container-style)}
@@ -72,7 +73,7 @@
             :context (i18n/label (keyword "t" role))}
            context-tag-props)]])
 
-     [rn/view {:style (style/buttons-container actions)}
+     [rn/view {:style (style/buttons-container actions buttons-container-style)}
       (when (or (= actions :two-actions)
                 (= actions :two-vertical-actions))
         [button/button

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -287,6 +287,7 @@
 (def ^:const wallet-connect-supported-events #{"accountsChanged" "chainChanged"})
 (def ^:const wallet-connect-session-proposal-event "session_proposal")
 (def ^:const wallet-connect-session-request-event "session_request")
+(def ^:const wallet-connect-session-delete-event "session_delete")
 (def ^:const wallet-connect-user-rejected-error-key "USER_REJECTED")
 
 (def ^:const transaction-pending-type-wallet-connect-transfer "WalletConnectTransfer")

--- a/src/status_im/contexts/shell/qr_reader/view.cljs
+++ b/src/status_im/contexts/shell/qr_reader/view.cljs
@@ -117,13 +117,14 @@
 (defn- f-internal-view
   []
   (let [{:keys [keyboard-shown]} (hooks/use-keyboard)]
-    [:<>
-     (when keyboard-shown
-       (rn/dismiss-keyboard!))
-     [scan-qr-code/view
-      {:title           (i18n/label :t/scan-qr)
-       :share-button?   true
-       :on-success-scan on-qr-code-scanned}]]))
+    (rn/use-mount
+     (fn []
+       (when keyboard-shown
+         (rn/dismiss-keyboard!))))
+    [scan-qr-code/view
+     {:title           (i18n/label :t/scan-qr)
+      :share-button?   true
+      :on-success-scan on-qr-code-scanned}]))
 
 (defn view
   []

--- a/src/status_im/contexts/wallet/wallet_connect/effects.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/effects.cljs
@@ -32,13 +32,6 @@
      :handler     handler})))
 
 (rf/reg-fx
- :effects.wallet-connect/fetch-pairings
- (fn [{:keys [web3-wallet on-success on-fail]}]
-   (-> (wallet-connect/get-pairings web3-wallet)
-       (promesa/then on-success)
-       (promesa/catch on-fail))))
-
-(rf/reg-fx
  :effects.wallet-connect/pair
  (fn [{:keys [web3-wallet url on-success on-fail]}]
    (when web3-wallet
@@ -50,13 +43,6 @@
  :effects.wallet-connect/disconnect
  (fn [{:keys [web3-wallet topic on-success on-fail]}]
    (-> (wallet-connect/core-pairing-disconnnect web3-wallet topic)
-       (promesa/then on-success)
-       (promesa/catch on-fail))))
-
-(rf/reg-fx
- :effects.wallet-connect/fetch-active-sessions
- (fn [{:keys [web3-wallet on-success on-fail]}]
-   (-> (wallet-connect/get-active-sessions web3-wallet)
        (promesa/then on-success)
        (promesa/catch on-fail))))
 
@@ -73,6 +59,13 @@
            :approved-namespaces approved-namespaces})
          (promesa/then on-success)
          (promesa/catch on-fail)))))
+
+(rf/reg-fx
+ :effects.wallet-connect/fetch-active-sessions
+ (fn [{:keys [web3-wallet on-success on-fail]}]
+   (-> (wallet-connect/get-active-sessions web3-wallet)
+       (promesa/then on-success)
+       (promesa/catch on-fail))))
 
 (rf/reg-fx
  :effects.wallet-connect/sign-message

--- a/src/status_im/contexts/wallet/wallet_connect/modals/common/header/view.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/modals/common/header/view.cljs
@@ -10,12 +10,12 @@
    [quo/text
     {:size   :heading-1
      :weight :semi-bold}
-    (let [{:keys [name icons]} (:peerMetadata dapp)]
+    (let [{:keys [name iconUrl]} dapp]
       [rn/view {:style style/header-dapp-name}
        [quo/summary-tag
         {:type         :dapp
          :label        name
-         :image-source (first icons)}]])
+         :image-source iconUrl}]])
     (str " " label " ")
     (let [{:keys [emoji customization-color name]} account]
       [rn/view {:style style/header-account-name}

--- a/src/status_im/contexts/wallet/wallet_connect/responding_events.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/responding_events.cljs
@@ -132,7 +132,7 @@
              :proposal    current-proposal
              :on-success  #(log/info "Wallet Connect session proposal rejected")
              :on-error    #(log/error "Wallet Connect unable to reject session proposal")}]
-           [:dispatch [:wallet-connect/reset-current-session]]]})))
+           [:dispatch [:wallet-connect/reset-current-session-proposal]]]})))
 
 ;; NOTE: Currently we only reject a session if the user rejected it
 ;; But this needs to be solidified to ensure other cases:

--- a/src/status_im/contexts/wallet/wallet_connect/session_proposal/style.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/session_proposal/style.cljs
@@ -6,12 +6,13 @@
    :padding-top        12})
 
 (def approval-note-container
-  {:margin-horizontal 20
-   :padding           12
-   :border-radius     16
-   :border-width      1
-   :border-color      colors/neutral-10
-   :background-color  colors/neutral-2_5})
+  {:margin-horizontal  20
+   :padding-horizontal 16
+   :padding-vertical   12
+   :border-radius      16
+   :border-width       1
+   :border-color       colors/neutral-10
+   :background-color   colors/neutral-2_5})
 
 (def approval-note-title
   {:color         colors/neutral-50
@@ -20,10 +21,8 @@
 (def approval-note-li
   {:flex           1
    :flex-direction :row
-   :align-items    :center})
-
-(def approval-li-spacer
-  {:width 8})
+   :align-items    :center
+   :gap            8})
 
 (def account-switcher-title
   {:padding-horizontal 20})
@@ -31,3 +30,6 @@
 (def account-switcher-list
   {:margin-top         8
    :padding-horizontal 8})
+
+(def footer-buttons-container
+  {:padding-horizontal 0})

--- a/src/status_im/contexts/wallet/wallet_connect/session_proposal/view.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/session_proposal/view.cljs
@@ -33,16 +33,21 @@
         labels    [(i18n/label :t/check-your-account-balance-and-activity)
                    (i18n/label :t/request-txns-and-message-signing)]]
     [rn/view {:style style/approval-note-container}
-     [quo/text {:style style/approval-note-title}
+     [quo/text
+      {:style  style/approval-note-title
+       :weight :regular
+       :size   :paragraph-2}
       (i18n/label :t/dapp-will-be-able-to {:dapp-name dapp-name})]
      (map-indexed
       (fn [idx label]
         ^{:key (str idx label)}
         [rn/view {:style style/approval-note-li}
          [quo/icon :i/bullet
-          {:color colors/neutral-50}]
-         [rn/view {:style style/approval-li-spacer}]
-         [quo/text label]])
+          {:color colors/neutral-40}]
+         [quo/text
+          {:weight :regular
+           :size   :paragraph-2}
+          label]])
       labels)]))
 
 (defn- format-network-name
@@ -57,16 +62,14 @@
 
 (defn- accounts-list
   []
-  (let [accounts         (rf/sub [:wallet/accounts-without-watched-accounts])
+  (let [accounts         (rf/sub [:wallet/operable-accounts-without-watched-accounts])
         selected-address (rf/sub [:wallet-connect/current-proposal-address])]
     [rn/view {:style style/account-switcher-list}
-     (for [account accounts]
-       ^{:key (-> account :address str)}
+     (for [{:keys [address] :as account} accounts]
+       ^{:key (str address)}
        [quo/account-item
         {:type          :default
-         :state         (if (and selected-address
-                                 (= (account :address)
-                                    selected-address))
+         :state         (if (= address selected-address)
                           :selected
                           :default)
          :account-props account
@@ -101,12 +104,10 @@
                                                       (map format-network-name)
                                                       (string/join ", "))
         network-images                           (mapv :source session-networks)
-        data-item-common-props                   {:blur?       false
-                                                  :description :default
-                                                  :card?       false
-                                                  :label       :preview
-                                                  :status      :default
-                                                  :size        :large}
+        data-item-common-props                   {:blur?  false
+                                                  :card?  false
+                                                  :status :default
+                                                  :size   :large}
         account-data-item-props                  (assoc data-item-common-props
                                                         :right-content {:type :accounts
                                                                         :size :size-32
@@ -116,9 +117,7 @@
                                                         :on-press      show-account-switcher-bottom-sheet
                                                         :title         (i18n/label :t/account-title)
                                                         :subtitle      name
-                                                        :icon-right?   true
-                                                        :right-icon    :i/chevron-right
-                                                        :icon-color    colors/neutral-10)
+                                                        :right-icon    :i/chevron-right)
         networks-data-item-props                 (assoc data-item-common-props
                                                         :right-content {:type :network
                                                                         :data network-images}
@@ -136,18 +135,21 @@
   []
   (let [customization-color (rf/sub [:profile/customization-color])]
     [quo/bottom-actions
-     {:actions          :two-actions
-      :button-two-label (i18n/label :t/decline)
-      :button-two-props {:type                :grey
-                         :accessibility-label :wc-deny-connection
-                         :on-press            #(do (rf/dispatch [:navigate-back])
-                                                   (rf/dispatch
-                                                    [:wallet-connect/reject-session-proposal]))}
-      :button-one-label (i18n/label :t/connect)
-      :button-one-props {:customization-color customization-color
-                         :type                :primary
-                         :accessibility-label :wc-connect
-                         :on-press            #(rf/dispatch [:wallet-connect/approve-session])}}]))
+     {:actions                 :two-actions
+      :buttons-container-style style/footer-buttons-container
+      :button-two-label        (i18n/label :t/decline)
+      :button-two-props        {:type                :grey
+                                :accessibility-label :wc-deny-connection
+                                :on-press            (fn []
+                                                       (rf/dispatch [:navigate-back])
+                                                       (rf/dispatch
+                                                        [:wallet-connect/reject-session-proposal]))}
+      :button-one-label        (i18n/label :t/connect)
+      :button-one-props        {:customization-color customization-color
+                                :type                :primary
+                                :accessibility-label :wc-connect
+                                :on-press            #(rf/dispatch
+                                                       [:wallet-connect/approve-session])}}]))
 
 (defn- header
   []

--- a/src/status_im/contexts/wallet/wallet_connect/utils.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/utils.cljs
@@ -11,14 +11,14 @@
 
 (defn timestamp-expired?
   [expiry-timestamp]
-  (> (current-timestamp) expiry-timestamp))
+  (when expiry-timestamp
+    (> (current-timestamp) expiry-timestamp)))
 
 (defn valid-wc-uri?
   [parsed-uri]
-  (let [{:keys [topic version expiryTimestamp]} parsed-uri]
+  (let [{:keys [topic version]} parsed-uri]
     (and (seq topic)
-         (number? version)
-         (number? expiryTimestamp))))
+         (number? version))))
 
 (defn valid-uri?
   "Check if the uri is in the wallet-connect format.

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -169,7 +169,7 @@
 (reg-root-key-sub :wallet-connect/web3-wallet :wallet-connect/web3-wallet)
 (reg-root-key-sub :wallet-connect/current-proposal :wallet-connect/current-proposal)
 (reg-root-key-sub :wallet-connect/current-request :wallet-connect/current-request)
-(reg-root-key-sub :wallet-connect/pairings :wallet-connect/pairings)
+(reg-root-key-sub :wallet-connect/sessions :wallet-connect/sessions)
 
 ;;biometrics
 (reg-root-key-sub :biometrics :biometrics)


### PR DESCRIPTION
Fixes #20357 
Fixes [#20358](https://github.com/status-im/status-mobile/issues/20358)
Fixes #20782
Fixes https://github.com/status-im/status-mobile/issues/20753

A bunch of bugfixes I made when going through these two user stories:
- https://www.notion.so/I-want-to-connect-to-a-dApp-via-WalletConnect-0efa85076296435ba79f7d1893f048f1?pvs=4
- https://www.notion.so/I-want-to-see-my-connected-dApps-ac2e612c163d447ba969d53c365750a7

The most important change is the usage of db everywhere — it was the only big missing piece that was not implemented properly since the screens were implemented much earlier than the db was implemented.
Also it includes some visual changes, and also some bigger stuff:
1) Corrected check for unsupported networks (previously it was not showing the incorrected network toast when non-eip155 were specified in a request)
2) Support for selecting the correct account (the first one when scanning with global QR code scanner & the selected one when scanning with the QR scanner for a particular wallet)

status: ready