### PR TITLE
[#20463] Fix iOS can't fetch collectible error

### DIFF
--- a/src/quo/components/profile/expanded_collectible/view.cljs
+++ b/src/quo/components/profile/expanded_collectible/view.cljs
@@ -79,14 +79,20 @@
         [counter-view counter])
       [rn/view {:style (style/collectible-border theme)}]]]))
 
+(defn invalid-image?
+  [image-src]
+  (or (nil? image-src)
+      (string/blank? image-src)))
+
 (defn view-internal
   [{:keys [container-style square? on-press counter image-src native-ID supported-file?
            on-collectible-load aspect-ratio gradient-color-index]
     :or   {gradient-color-index :gradient-1
            on-collectible-load  (fn [])}}]
   (let [theme              (quo.theme/use-theme)
-        [error? set-error] (rn/use-state (or (nil? image-src)
-                                             (string/blank? image-src)))]
+        [error? set-error] (rn/use-state (invalid-image? image-src))]
+    (rn/use-effect #(set-error (invalid-image? image-src))
+                   [image-src])
     [rn/pressable
      {:style               (merge container-style (style/container aspect-ratio))
       :accessibility-label :expanded-collectible

--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -185,7 +185,7 @@
            ;; We delay the navigation because we need re-frame to update the DB on time.
            ;; By doing it, we skip a blink while visiting the collectible detail page.
            [:dispatch-later
-            {:ms       1
+            {:ms       17
              :dispatch [:navigate-to :screen/wallet.collectible]}]]})))
 
 (defn- keep-not-empty-value

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -79,12 +79,20 @@
   (rf/dispatch [:wallet/clear-collectible-details]))
 
 (defn animated-header
-  [{:keys [scroll-amount title-opacity page-nav-type picture title description theme id]}]
-  (let [blur-amount   (header-animations/use-blur-amount scroll-amount)
-        layer-opacity (header-animations/use-layer-opacity
-                       scroll-amount
-                       (colors/theme-colors colors/white-opa-0 colors/neutral-95-opa-0 theme)
-                       (colors/theme-colors colors/white-opa-50 colors/neutral-95-opa-70-blur theme))]
+  [{:keys [scroll-amount title-opacity page-nav-type theme]}]
+  (let [blur-amount               (header-animations/use-blur-amount scroll-amount)
+        layer-opacity             (header-animations/use-layer-opacity
+                                   scroll-amount
+                                   (colors/theme-colors colors/white-opa-0
+                                                        colors/neutral-95-opa-0
+                                                        theme)
+                                   (colors/theme-colors colors/white-opa-50
+                                                        colors/neutral-95-opa-70-blur
+                                                        theme))
+        {{preview-uri :uri}  :preview-url
+         {title :name}       :collectible-data
+         {description :name} :collection-data
+         id                  :id} (rf/sub [:wallet/collectible-details])]
     [rn/view {:style (style/animated-header)}
      [reanimated/blur-view
       {:style         {:flex             1
@@ -97,7 +105,7 @@
       [reanimated/view {:style layer-opacity}
        [quo/page-nav
         {:type                page-nav-type
-         :picture             picture
+         :picture             preview-uri
          :title               title
          :description         description
          :background          :blur
@@ -110,7 +118,7 @@
                                               {:content (fn []
                                                           [options-drawer/view
                                                            {:name  title
-                                                            :image picture
+                                                            :image preview-uri
                                                             :id    id}])
                                                :theme   theme}])}]
          :center-opacity      title-opacity}]]]]))
@@ -144,10 +152,11 @@
   [_]
   (let [selected-tab  (reagent/atom :overview)
         on-tab-change #(reset! selected-tab %)]
-    (fn [{:keys [collectible set-title-bottom theme]}]
+    (fn [{:keys [set-title-bottom theme]}]
       (let [title-ref                      (rn/use-ref-atom nil)
             set-title-ref                  (rn/use-callback #(reset! title-ref %))
             animation-shared-element-id    (rf/sub [:animation-shared-element-id])
+            collectible                    (rf/sub [:wallet/collectible-details])
             collectible-owner              (rf/sub [:wallet/collectible-details-owner collectible])
             aspect-ratio                   (rf/sub [:wallet/collectible-aspect-ratio])
             gradient-color                 (rf/sub [:wallet/collectible-gradient-color])
@@ -196,14 +205,14 @@
                                         token-id
                                         {:images           [collectible-image]
                                          :index            0
-                                         :on-options-press #(rf/dispatch [:show-bottom-sheet
-                                                                          {:content
-                                                                           (fn []
-                                                                             [options-drawer/view
-                                                                              {:name collectible-name
-                                                                               :image
-                                                                               preview-uri
-                                                                               :id id}])}])}])))
+                                         :on-options-press #(rf/dispatch
+                                                             [:show-bottom-sheet
+                                                              {:content
+                                                               (fn []
+                                                                 [options-drawer/view
+                                                                  {:name  collectible-name
+                                                                   :image preview-uri
+                                                                   :id    id}])}])}])))
             :on-collectible-load  (fn []
                                     ;; We need to delay the measurement because the
                                     ;; navigation has an animation
@@ -241,33 +250,24 @@
 
 (defn view
   [_]
-  (let [{:keys [top]}       (safe-area/get-insets)
-        theme               (quo.theme/use-theme)
-        title-bottom-coord  (rn/use-ref-atom 0)
-        set-title-bottom    (rn/use-callback
-                             (fn [_ y _ height]
-                               (reset! title-bottom-coord
-                                 (get-title-bottom-y-position y height))))
-        scroll-amount       (reanimated/use-shared-value 0)
-        title-opacity       (reanimated/use-shared-value 0)
-        {:keys [collection-data
-                collectible-data
-                preview-url]
-         :as   collectible} (rf/sub [:wallet/collectible-details])]
+  (let [{:keys [top]}      (safe-area/get-insets)
+        theme              (quo.theme/use-theme)
+        title-bottom-coord (rn/use-ref-atom 0)
+        set-title-bottom   (rn/use-callback
+                            (fn [_ y _ height]
+                              (reset! title-bottom-coord
+                                (get-title-bottom-y-position y height))))
+        scroll-amount      (reanimated/use-shared-value 0)
+        title-opacity      (reanimated/use-shared-value 0)]
     [rn/view {:style (style/background-color theme)}
      [animated-header
-      {:id            (:id collectible)
-       :scroll-amount scroll-amount
+      {:scroll-amount scroll-amount
        :title-opacity title-opacity
        :page-nav-type :title-description
-       :picture       (:uri preview-url)
-       :title         (:name collectible-data)
-       :description   (:name collection-data)
        :theme         theme}]
      [reanimated/scroll-view
       {:style     (style/scroll-view top)
        :on-scroll #(on-scroll % scroll-amount title-opacity title-bottom-coord)}
       [collectible-details
-       {:collectible      collectible
-        :set-title-bottom set-title-bottom
+       {:set-title-bottom set-title-bottom
         :theme            theme}]]]))


### PR DESCRIPTION

fixes #20463

### Summary

This is a small PR addressing the comment added by @VolodLytvynenko:

https://github.com/status-im/status-mobile/issues/20463#issuecomment-2219816210


### Review notes
The error only happens on iOS and it is due to the navigation timing on that plaform, it seems re-frame needs more time to perform the update, so now we wait more than one frame (17ms) to perform the navigation.

Additionally, a use-effect hook has been added in case the `image-src` changes while visiting the collectible details page.

status: ready

