### PR TITLE
feat: changes to publish to 2 peers for lightpush 

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.181.35",
-    "commit-sha1": "1ef2434b0644581e3c0404d767550cbfee8ad829",
-    "src-sha256": "1dfw4cff1blg063xxrh78dgivcar92k1fspcr84ra1fxw674kmfk"
+    "version": "89e914575a0a0b9663b14678fbec3412aa4b2ea4",
+    "commit-sha1": "89e914575a0a0b9663b14678fbec3412aa4b2ea4",
+    "src-sha256": "0ph10465i452msh63mzf4kgpsq4nnksfx38yhs54mfyiswbjks48"
 }


### PR DESCRIPTION
### Summary

This PR  takes changes in underlying status-go so that messages are published to 2 lightpush nodes for reliability and not rely on storev3 confirmations for sent messages in lightclients.

### Testing notes
Check sending of messages in lightmode which would be by default and check for send confirmations if they are consistent.

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats


### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

status: ready 

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


@pavloburykh can we run e2e tests on this one?