### PR TITLE
fix onboarding navigation to enable notification screen and blur issues

### DIFF
--- a/src/status_im/contexts/onboarding/enable_notifications/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_notifications/view.cljs
@@ -38,7 +38,7 @@
                               (rf/dispatch [:push-notifications/switch true])
                               (rf/dispatch [:navigate-to-within-stack
                                             [:screen/onboarding.welcome
-                                             :screen/onboarding.enable-notifications]]))
+                                             :screen/onboarding.generating-keys]]))
        :type                :primary
        :icon-left           :i/notifications
        :accessibility-label :enable-notifications-button
@@ -52,7 +52,7 @@
                                nil)
                               (rf/dispatch [:navigate-to-within-stack
                                             [:screen/onboarding.welcome
-                                             :screen/onboarding.enable-notifications]]))
+                                             :screen/onboarding.generating-keys]]))
        :accessibility-label :enable-notifications-later-button
        :type                :grey
        :background          :blur

--- a/src/status_im/contexts/onboarding/events.cljs
+++ b/src/status_im/contexts/onboarding/events.cljs
@@ -73,7 +73,9 @@
                                       :onboarding/navigated-to-enter-seed-phrase-from-screen
                                       :screen/onboarding.new-to-status)]]
                :dispatch-later [{:ms       constants/onboarding-generating-keys-animation-duration-ms
-                                 :dispatch [:init-root :screen/onboarding.enable-notifications]}]
+                                 :dispatch [:navigate-to-within-stack
+                                            [:screen/onboarding.enable-notifications
+                                             :screen/onboarding.generating-keys]]}]
                :db             (-> db
                                    (dissoc :profile/login)
                                    (dissoc :auth-method)
@@ -187,14 +189,3 @@
                                            {:key-uid key-uid
                                             :error   %})}))))
 
-(rf/defn navigate-to-identifiers
-  {:events [:onboarding/navigate-to-identifiers]}
-  [{:keys [db]}]
-  (if (:onboarding/generated-keys? db)
-    {:dispatch [:navigate-to-within-stack
-                [:screen/onboarding.identifiers
-                 (get db
-                      :onboarding/navigated-to-enter-seed-phrase-from-screen
-                      :screen/onboarding.new-to-status)]]}
-    {:dispatch-later [{:ms       constants/onboarding-generating-keys-navigation-retry-ms
-                       :dispatch [:onboarding/navigate-to-identifiers]}]}))

--- a/src/status_im/navigation/roots.cljs
+++ b/src/status_im/navigation/roots.cljs
@@ -37,15 +37,6 @@
                                      :id      :screen/profile.profiles
                                      :options (options/dark-root-options)}}]}}}
 
-   :screen/onboarding.enable-notifications
-   {:root {:stack {:children [{:component {:name    :screen/onboarding.enable-notifications
-                                           :id      :screen/onboarding.enable-notifications
-                                           :options (options/dark-root-options)}}]}}}
-
-   :screen/onboarding.welcome
-   {:root {:stack {:children [{:component {:name    :screen/onboarding.welcome
-                                           :id      :screen/onboarding.welcome
-                                           :options (options/dark-root-options)}}]}}}
    :screen/onboarding.syncing-results
    {:root {:stack {:children [{:component {:name    :screen/onboarding.syncing-results
                                            :id      :screen/onboarding.syncing-results

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -348,11 +348,15 @@
      :component enter-seed-phrase/view}
 
     {:name      :screen/onboarding.enable-notifications
-     :options   {:theme      :dark
-                 :layout     options/onboarding-transparent-layout
-                 :animations (merge
-                              transitions/new-to-status-modal-animations
-                              transitions/push-animations-for-transparent-background)}
+     :options   {:theme                  :dark
+                 :layout                 options/onboarding-transparent-layout
+                 :animations             (merge
+                                          transitions/new-to-status-modal-animations
+                                          transitions/push-animations-for-transparent-background)
+                 :popGesture             false
+                 :modalPresentationStyle :overCurrentContext
+                 :hardwareBackButton     {:dismissModalOnPress false
+                                          :popStackOnPress     false}}
      :component enable-notifications/view}
 
     {:name      :screen/onboarding.identifiers


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20719

In this pr, we are navigating from generate keys screen to enable notifications screen without using `init-root` while preserving blur which is crucial for enable notification screen and welcome screen. This pr fixes the issues reported https://github.com/status-im/status-mobile/pull/20503/files#r1654635905 as a result of navigating to the notification screen using `init-root`

A side note  I removed `:screen/onboarding.enable-notifications` and `:screen/onboarding.welcome` from the roots file as they dont seem to be needed

### Summary

https://github.com/status-im/status-mobile/assets/28704507/a78cc878-7f51-459f-b2f3-7c2616aaaf26

