### PR TITLE
fix: don't delete notification by last-message id

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.182.37",
-    "commit-sha1": "4a43b2b2bebe45df2100d1a5c5034105d93e50b8",
-    "src-sha256": "0f5mm7lx6s2qcy9xpa9v7piqb60yazi6p677fy105yz7hg731cw6"
+    "version": "fix/delete-notification",
+    "commit-sha1": "3df6e79b6e6ee786b59c1ace11c56d0b572d75e6",
+    "src-sha256": "1kcdhqhmvs5anikbc3qn6jcpzzjgppcpwv4fpwvrz0lgjz1gy608"
 }


### PR DESCRIPTION
https://github.com/status-im/status-go/compare/1ef2434b...33d74c57

-------

status-go PR https://github.com/status-im/status-go/pull/5520


fixes #17052

### Summary

details at https://github.com/status-im/status-mobile/issues/17052#issuecomment-2227722751

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
delete notification when deleting message

### Steps to test
- in a community channel
- user A mention user B 3 times
- user B should see 1, 2, 3 unread notification in activity center
- user A delete last mention
- user B should see 2 unread notifications in activity center

status: ready <!-- Can be ready or wip -->