### PR TITLE
[#20742] fix: blue background behind the "Save address" button

### DIFF
--- a/src/status_im/common/floating_button_page/floating_container/style.cljs
+++ b/src/status_im/common/floating_button_page/floating_container/style.cljs
@@ -1,5 +1,6 @@
 (ns status-im.common.floating-button-page.floating-container.style
-  (:require [react-native.safe-area :as safe-area]))
+  (:require [quo.foundations.colors :as colors]
+            [react-native.safe-area :as safe-area]))
 
 (defn content-container
   [blur? keyboard-shown?]
@@ -11,7 +12,12 @@
              :padding-horizontal 20}
       blur? (dissoc :padding-vertical :padding-horizontal))))
 
-(def blur-inner-container
-  {:background-color   :transparent ; required, otherwise blur-view will shrink
+(defn blur-inner-container
+  [theme shell-overlay?]
+  {:background-color   (colors/theme-colors colors/white-70-blur
+                                            (if shell-overlay?
+                                              colors/neutral-80-opa-80-blur
+                                              colors/neutral-95-opa-70-blur)
+                                            theme)
    :padding-vertical   12
    :padding-horizontal 20})

--- a/src/status_im/common/floating_button_page/floating_container/view.cljs
+++ b/src/status_im/common/floating_button_page/floating_container/view.cljs
@@ -1,27 +1,25 @@
 (ns status-im.common.floating-button-page.floating-container.view
   (:require
     [quo.core :as quo]
-    [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [status-im.common.floating-button-page.floating-container.style :as style]))
 
 (defn- blur-container
-  [child]
+  [child shell-overlay?]
   (let [theme (quo.theme/use-theme)]
     [quo/blur
-     {:blur-amount        52
-      :blur-radius        20
-      :blur-type          :transparent
-      :blur-overlay-color (colors/theme-colors colors/white-70-blur colors/neutral-95-opa-70-blur theme)}
-     [rn/view {:style style/blur-inner-container}
+     {:blur-amount   20
+      :blur-type     :transparent
+      :overlay-color :transparent}
+     [rn/view {:style (style/blur-inner-container theme shell-overlay?)}
       child]]))
 
 (defn view
-  [{:keys [on-layout keyboard-shown? blur?]} child]
+  [{:keys [on-layout keyboard-shown? blur? shell-overlay?]} child]
   [rn/view
    {:style     (style/content-container blur? keyboard-shown?)
     :on-layout on-layout}
    (if blur?
-     [blur-container child]
+     [blur-container child shell-overlay?]
      child)])

--- a/src/status_im/common/floating_button_page/view.cljs
+++ b/src/status_im/common/floating_button_page/view.cljs
@@ -58,7 +58,7 @@
 
 (defn view
   [{:keys [header footer customization-color footer-container-padding header-container-style
-           content-container-style gradient-cover? keyboard-should-persist-taps]
+           content-container-style gradient-cover? keyboard-should-persist-taps shell-overlay?]
     :or   {footer-container-padding (safe-area/get-top)}}
    & children]
   (reagent/with-let [scroll-view-ref              (atom nil)
@@ -121,7 +121,8 @@
          [floating-container/view
           {:on-layout       set-footer-container-height
            :keyboard-shown? keyboard-shown?
-           :blur?           show-background?}
+           :blur?           show-background?
+           :shell-overlay?  shell-overlay?}
           footer]]]])
     (finally
      (remove-listeners))))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -113,7 +113,8 @@
 
 (defn view
   []
-  (let [profile-color                       (rf/sub [:profile/customization-color])
+  (let [view-id                             (rf/sub [:view-id])
+        profile-color                       (rf/sub [:profile/customization-color])
         accounts-addresses                  (rf/sub [:wallet/addresses])
         saved-addresses-addresses           (rf/sub [:wallet/saved-addresses-addresses])
         [address-or-ens set-address-or-ens] (rn/use-state "")
@@ -175,11 +176,12 @@
                                    :on-press            navigate-back
                                    :margin-top          (safe-area/get-top)
                                    :accessibility-label :add-address-to-save-page-nav}]
-       :footer                   [quo/button
-                                  {:customization-color profile-color
-                                   :disabled?           button-disabled?
-                                   :on-press            on-press-continue}
-                                  (i18n/label :t/continue)]}
+       :footer                   (when (= view-id :screen/settings.add-address-to-save)
+                                   [quo/button
+                                    {:customization-color profile-color
+                                     :disabled?           button-disabled?
+                                     :on-press            on-press-continue}
+                                    (i18n/label :t/continue)])}
       [quo/page-top
        {:container-style  style/header-container
         :blur?            true

--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -121,7 +121,8 @@
                                    :on-press            on-press-save}
                                   (i18n/label :t/save-address)]
        :customization-color      address-color
-       :gradient-cover?          true}
+       :gradient-cover?          true
+       :shell-overlay?           true}
       [quo/wallet-user-avatar
        {:full-name           (if (string/blank? address-label)
                                placeholder


### PR DESCRIPTION
fixes #20742

### Summary

Blue background behind the "Save address" button


#### Platforms

- iOS


### Steps to test

- Open Profile > Wallet > Saved addresses
- Add address > paste an address > press Continue
- Enter name


### Result

#### Before

https://github.com/user-attachments/assets/f880e0fd-e019-4adf-8c2d-64539e046551


#### After


https://github.com/user-attachments/assets/874e5056-7330-45a0-9a18-36c28821475c


status: ready

