### PR TITLE
Token value shows fiat value on the transaction confirmation page #20734

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -154,11 +154,9 @@
         [input-state set-input-state]               (rn/use-state controlled-input/init-state)
         [just-toggled-mode? set-just-toggled-mode?] (rn/use-state false)
         clear-input!                                #(set-input-state controlled-input/delete-all)
-        handle-on-confirm                           (fn []
+        handle-on-confirm                           (fn [amount]
                                                       (rf/dispatch [:wallet/set-token-amount-to-send
-                                                                    {:amount
-                                                                     (controlled-input/input-value
-                                                                      input-state)
+                                                                    {:amount   amount
                                                                      :stack-id current-screen-id}]))
         {fiat-currency :currency}                   (rf/sub [:profile/profile])
         {token-symbol :symbol

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -157,7 +157,6 @@
   [quo/data-item
    {:container-style style/detail-item
     :blur?           false
-    :description     :default
     :card?           false
     :status          :default
     :size            :small


### PR DESCRIPTION
fixes #20734 

The issue was that the raw input amount was saving in the db.

https://github.com/user-attachments/assets/8908d2d6-1cc6-4501-970a-617e62270e7f

