### PR TITLE
[#20479] - Skip "From" page on wallet home

### DIFF
--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -262,7 +262,7 @@
 
         can-edit-addresses? (rf/sub [:communities/can-edit-shared-addresses? id])
 
-        wallet-accounts (rf/sub [:wallet/operable-accounts-without-watched-accounts])
+        wallet-accounts (rf/sub [:wallet/operable-accounts])
         joined (rf/sub [:communities/community-joined id])
         unmodified-addresses-to-reveal (rf/sub [:communities/addresses-to-reveal id])
         [addresses-to-reveal set-addresses-to-reveal] (rn/use-state unmodified-addresses-to-reveal)

--- a/src/status_im/contexts/wallet/home/tabs/assets/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/assets/view.cljs
@@ -18,4 +18,5 @@
       [rn/flat-list
        {:render-fn               token-value/view
         :data                    tokens
+        :render-data             {:entry-point :wallet-stack}
         :content-container-style style/list-container}])))

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -42,7 +42,6 @@
                                  {:on-press      #(rf/dispatch [:navigate-back])
                                   :margin-top    (safe-area/get-top)
                                   :switcher-type :select-account}]}
-
      [quo/page-top
       {:title                     (i18n/label :t/from-label)
        :title-accessibility-label :title-label}]

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -177,7 +177,9 @@
                          (rf/dispatch [:wallet/clean-selected-collectible])
                          (rf/dispatch [:wallet/clean-send-address])
                          (rf/dispatch [:wallet/clean-disabled-from-networks])
-                         (rf/dispatch [:wallet/select-address-tab nil]))
+                         (rf/dispatch [:wallet/select-address-tab nil])
+                         (rf/dispatch [:wallet/clean-current-viewing-account
+                                       :ignore-just-complete-transaction]))
         on-change-tab  #(rf/dispatch [:wallet/select-address-tab %])
         input-value    (reagent/atom "")
         input-focused? (reagent/atom false)]

--- a/src/status_im/contexts/wallet/sheets/select_account/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/select_account/view.cljs
@@ -20,7 +20,7 @@
 (defn view
   []
   (let [selected-account-address (rf/sub [:wallet/current-viewing-account-address])
-        accounts                 (rf/sub [:wallet/operable-accounts-without-watched-accounts])]
+        accounts                 (rf/sub [:wallet/operable-accounts])]
     [:<>
      [quo/drawer-top {:title (i18n/label :t/select-account)}]
      [gesture/flat-list

--- a/src/status_im/contexts/wallet/wallet_connect/session_proposal/view.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/session_proposal/view.cljs
@@ -70,7 +70,7 @@
 
 (defn- accounts-list
   []
-  (let [accounts         (rf/sub [:wallet/operable-accounts-without-watched-accounts])
+  (let [accounts         (rf/sub [:wallet/operable-accounts])
         selected-address (rf/sub [:wallet-connect/current-proposal-address])]
     [rn/view {:style style/account-switcher-list}
      (for [{:keys [address] :as account} accounts]

--- a/src/status_im/subs/community/account_selection.cljs
+++ b/src/status_im/subs/community/account_selection.cljs
@@ -53,7 +53,7 @@
 
 (re-frame/reg-sub :communities/accounts-to-reveal
  (fn [[_ community-id]]
-   [(re-frame/subscribe [:wallet/operable-accounts-without-watched-accounts])
+   [(re-frame/subscribe [:wallet/operable-accounts])
     (re-frame/subscribe [:communities/addresses-to-reveal community-id])])
  (fn [[accounts addresses] _]
    (filter #(contains? addresses (:address %))
@@ -61,7 +61,7 @@
 
 (re-frame/reg-sub :communities/airdrop-account
  (fn [[_ community-id]]
-   [(re-frame/subscribe [:wallet/operable-accounts-without-watched-accounts])
+   [(re-frame/subscribe [:wallet/operable-accounts])
     (re-frame/subscribe [:communities/airdrop-address community-id])])
  (fn [[accounts airdrop-address] _]
    (->> accounts

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -13,16 +13,22 @@
               {:before #(reset! rf-db/app-db {})})
 
 (def ^:private accounts-with-tokens
-  {:0x1 {:tokens                    [{:symbol "ETH"} {:symbol "SNT"}]
+  {:0x1 {:tokens                    [{:symbol             "ETH"
+                                      :balances-per-chain {1 {:raw-balance "100"}}}
+                                     {:symbol             "SNT"
+                                      :balances-per-chain {1 {:raw-balance "100"}}}]
          :network-preferences-names #{}
          :customization-color       nil
          :operable?                 true
-         :operable                  :fully}
-   :0x2 {:tokens                    [{:symbol "SNT"}]
+         :operable                  :fully
+         :address                   "0x1"}
+   :0x2 {:tokens                    [{:symbol             "SNT"
+                                      :balances-per-chain {1 {:raw-balance "200"}}}]
          :network-preferences-names #{}
          :customization-color       nil
          :operable?                 true
-         :operable                  :partially}})
+         :operable                  :partially
+         :address                   "0x2"}})
 
 (def tokens-0x1
   [{:decimals                   1
@@ -495,11 +501,15 @@
            (assoc-in [:wallet :ui :send :token-symbol] "ETH")))
     (let [result (rf/sub [sub-name])]
       (is (match? result
-                  [{:tokens                    [{:symbol "ETH"} {:symbol "SNT"}]
+                  [{:tokens                    [{:symbol             "ETH"
+                                                 :balances-per-chain {1 {:raw-balance "100"}}}
+                                                {:symbol             "SNT"
+                                                 :balances-per-chain {1 {:raw-balance "100"}}}]
                     :network-preferences-names #{}
                     :customization-color       nil
                     :operable?                 true
-                    :operable                  :fully}]))))
+                    :operable                  :fully
+                    :address                   "0x1"}]))))
 
   (testing "returns the accounts list with the current asset using token"
     (swap! rf-db/app-db
@@ -508,11 +518,15 @@
            (assoc-in [:wallet :ui :send :token] {:symbol "ETH"})))
     (let [result (rf/sub [sub-name])]
       (is (match? result
-                  [{:tokens                    [{:symbol "ETH"} {:symbol "SNT"}]
+                  [{:tokens                    [{:symbol             "ETH"
+                                                 :balances-per-chain {1 {:raw-balance "100"}}}
+                                                {:symbol             "SNT"
+                                                 :balances-per-chain {1 {:raw-balance "100"}}}]
                     :network-preferences-names #{}
                     :customization-color       nil
                     :operable?                 true
-                    :operable                  :fully}]))))
+                    :operable                  :fully
+                    :address                   "0x1"}]))))
 
   (testing
     "returns the full accounts list with the current asset using token-symbol if each account has the asset"


### PR DESCRIPTION
fixes #20479

### Summary

This PR is not addressing 
- #20472

yet, but it'll be addressed in a follow-up.


The "From" page now it's not shown when we only own one account with the desired asset to send.

#### Demo 1 (ETH):

https://github.com/user-attachments/assets/940b48a9-0d3c-4cbd-8e66-d7b0a2730f4b

#### Demo 2 (USDC):

https://github.com/user-attachments/assets/e8282b8a-12b1-4c44-a64e-6ccd6e58a742

#### Demo 3 (Collectible):

https://github.com/user-attachments/assets/5bd4060a-4d44-4e83-a24b-7625d24c9d73


### Review notes
Right now, a lot of flows depend on the current state of the re-frame DB, so, in order to not break anything and keep things flexible, some changes have been made in the APIs. These changes are made in a flexible way (by extending the APIs instead of adding constraints to them).

### Testing notes

Please test the existing send flows are still working, I've tested them but, since the mechanism is becoming more and more complex, there might be a forgotten edge case.

### Steps to test

- Open Status
- Own two accounts having the some assets in common
- On the wallet home page, long press on send over the token. The "From" page should be skipped if there's only one account owning the asset.
- All the existing flows should work as expected

status: ready