### PR TITLE
Fix/reject on drag

### DIFF
--- a/src/status_im/contexts/wallet/wallet_connect/modals/send_transaction/view.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/modals/send_transaction/view.cljs
@@ -19,6 +19,7 @@
         network               (rf/sub [:wallet-connect/current-request-network])
         {:keys [max-fees-fiat-formatted
                 error-state]} (rf/sub [:wallet-connect/current-request-transaction-information])]
+    (rn/use-unmount #(rf/dispatch [:wallet-connect/reject-session-request]))
     [rn/view {:style (style/container bottom)}
      [quo/gradient-cover {:customization-color customization-color}]
      [page-nav/view

--- a/src/status_im/contexts/wallet/wallet_connect/processing_events.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/processing_events.cljs
@@ -10,9 +10,10 @@
 (rf/reg-event-fx
  :wallet-connect/process-session-request
  (fn [{:keys [db]} [event]]
-   (let [method (wallet-connect-core/get-request-method event)
-         screen (wallet-connect-core/method-to-screen method)]
-     (if screen
+   (let [method                (wallet-connect-core/get-request-method event)
+         screen                (wallet-connect-core/method-to-screen method)
+         current-request-event (get-in db [:wallet-connect/current-request :event])]
+     (if (and screen (not current-request-event))
        {:db (assoc-in db [:wallet-connect/current-request :event] event)
         :fx [(condp = method
                constants/wallet-connect-eth-send-transaction-method

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -122,9 +122,11 @@
 (defn dismiss-modal
   ([] (dismiss-modal nil))
   ([comp-id]
-   (reset! state/dissmissing true)
-   (navigation/dismiss-modal (name (or comp-id (last @state/modals))))
-   (state/navigation-pop-from comp-id)))
+   (when (or (not comp-id)
+             (state/modal-open? comp-id))
+     (reset! state/dissmissing true)
+     (navigation/dismiss-modal (name (or comp-id (last @state/modals))))
+     (state/navigation-pop-from comp-id))))
 
 (defn navigate-back
   []

--- a/src/status_im/navigation/state.cljs
+++ b/src/status_im/navigation/state.cljs
@@ -49,3 +49,7 @@
   [comp-id]
   (when-let [index (first (indices-of-predicate-match #(= comp-id (:id %)) @navigation-state))]
     (navigation-state-reset (vec (take (inc index) @navigation-state)))))
+
+(defn modal-open?
+  [comp-id]
+  (contains? (set @modals) comp-id))


### PR DESCRIPTION
fixes #20763 

### Summary

* Reject Wallet Connect requests when dragged down.
* Avoid potential bugs where a modal is closed by id twice, causing bugs where we can't interact with the UI elements
