### PR TITLE
display group chat system message using new ui

### DIFF
--- a/src/quo/components/messages/system_message/style.cljs
+++ b/src/quo/components/messages/system_message/style.cljs
@@ -32,8 +32,7 @@
 
 (def system-message-base-wrapper
   {:flex-direction :row
-   :flex           1
-   :align-items    :center})
+   :flex           1})
 
 (def system-message-base-content-wrapper
   {:align-self     :center

--- a/src/quo/components/messages/system_message/view.cljs
+++ b/src/quo/components/messages/system_message/view.cljs
@@ -127,6 +127,14 @@
       (when incoming? [split-text "sent you a contact request" theme true])
       [sm-timestamp timestamp theme]]]))
 
+(defn system-message-group
+  [{:keys [customization-color child]}]
+  [system-message-base
+   {:icon {:icon    :i/add-user
+           :color   (or customization-color :primary)
+           :opacity 5}}
+   [rn/view child]])
+
 (defn system-message-pinned
   [{:keys [pinned-by child customization-color timestamp]}]
   (let [theme (quo.theme/use-theme)]
@@ -183,6 +191,7 @@
        :contact-request [system-message-contact-request data]
        :added           [system-message-added data]
        :removed         [system-message-removed data]
+       :group           [system-message-group data]
        nil)]))
 
 (defn system-message

--- a/src/status_im/contexts/chat/messenger/messages/content/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/style.cljs
@@ -33,3 +33,7 @@
 (def drawer-message-container
   {:padding-top    4
    :padding-bottom 4})
+
+(def group-member-mention
+  {:flex-direction :row
+   :align-items    :center})


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20488

### Summary
This pr. displays group chat system message using the new ui

### Before and after screenshots comparison
<img src="https://github.com/user-attachments/assets/e65c45ee-b27e-457e-9f4d-ee459ab2d19d" width="325">
<img src="https://github.com/user-attachments/assets/1cbcd238-12af-4a5f-bee9-c1f05499848b" width="325">

### Figma

https://www.figma.com/design/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?node-id=11522-138410&t=nzRl5xrbCFgAZrgX-4

status: ready 

