### PR TITLE
fix: button width

### DIFF
--- a/src/quo/components/drawers/bottom_actions/style.cljs
+++ b/src/quo/components/drawers/bottom_actions/style.cljs
@@ -30,6 +30,9 @@
     :padding-horizontal 20}
    container-style))
 
+(def button-container
+  {:flex 1})
+
 (def description-top
   {:flex-direction  :row
    :align-items     :center

--- a/src/quo/components/drawers/bottom_actions/style.cljs
+++ b/src/quo/components/drawers/bottom_actions/style.cljs
@@ -31,7 +31,7 @@
    container-style))
 
 (def button-container
-  {:flex 1})
+  {:flex-grow 1})
 
 (def description-top
   {:flex-direction  :row

--- a/src/quo/components/drawers/bottom_actions/view.cljs
+++ b/src/quo/components/drawers/bottom_actions/view.cljs
@@ -79,6 +79,7 @@
         [button/button
          (merge
           {:size                40
+           :container-style     style/button-container
            :background          (when (or blur? scroll?) :blur)
            :theme               theme
            :accessibility-label :button-two}
@@ -87,6 +88,7 @@
       [button/button
        (merge
         {:size                40
+         :container-style     style/button-container
          :background          (when (or blur? scroll?) :blur)
          :theme               theme
          :accessibility-label :button-one}


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/20788

### Summary

This PR fixes Button component style not filling the space.

Skipping manual QA as it is a minor fix.

### Demo

Before:
<img width="300" height="600" src="https://github.com/user-attachments/assets/d603ff7d-cb0f-4c90-8bc3-d67e41fa7399" />

After:
<img width="300" height="600" src="https://github.com/user-attachments/assets/4edcf646-a7e6-4807-b6b4-119067532cee" />
