### PR TITLE
fix: assets sort order on bridge and assets screen

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -293,6 +293,8 @@
 
 (def ^:const transaction-pending-type-wallet-connect-transfer "WalletConnectTransfer")
 
+(def ^:const token-sort-priority {"SNT" 1 "STT" 1 "ETH" 2 "DAI" 3})
+
 (def ^:const dapp-permission-contact-code "contact-code")
 (def ^:const dapp-permission-web3 "web3")
 (def ^:const dapp-permission-qr-code "qr-code")

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -300,6 +300,11 @@
     (existing-account-names s)                   :existing-name
     (utils.string/contains-special-character? s) :special-character))
 
+(defn- tokens-sort-fn
+  [token]
+  [(comp - (:balance token))
+   (get constants/token-sort-priority (:symbol token) ##Inf)])
+
 (defn calculate-and-sort-tokens
   [{:keys [tokens color currency currency-symbol]}]
   (let [calculate-token   (fn [token]

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -310,6 +310,6 @@
         calculated-tokens (map calculate-token tokens)]
     (sort-by (fn [token]
                (let [fiat-value (get-in token [:values :fiat-unformatted-value])
-                     priority   (get constants/token-sort-priority (:token token) 999)]
+                     priority   (get constants/token-sort-priority (:token token) ##Inf)]
                  [(- fiat-value) priority]))
              calculated-tokens)))

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -300,11 +300,6 @@
     (existing-account-names s)                   :existing-name
     (utils.string/contains-special-character? s) :special-character))
 
-(defn- tokens-sort-fn
-  [token]
-  [(comp - (:balance token))
-   (get constants/token-sort-priority (:symbol token) ##Inf)])
-
 (defn calculate-and-sort-tokens
   [{:keys [tokens color currency currency-symbol]}]
   (let [calculate-token   (fn [token]
@@ -318,3 +313,8 @@
                      priority   (get constants/token-sort-priority (:token token) ##Inf)]
                  [(- fiat-value) priority]))
              calculated-tokens)))
+
+(defn sort-tokens
+  [tokens]
+  (let [priority #(get constants/token-sort-priority (:symbol %) ##Inf)]
+    (sort-by (juxt (comp - :balance) priority) tokens)))

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -307,10 +307,9 @@
                                                     :color           color
                                                     :currency        currency
                                                     :currency-symbol currency-symbol}))
-        calculated-tokens (map calculate-token tokens)
-        token-priority    {"SNT" 1 "STT" 1 "ETH" 2 "DAI" 3}]
+        calculated-tokens (map calculate-token tokens)]
     (sort-by (fn [token]
                (let [fiat-value (get-in token [:values :fiat-unformatted-value])
-                     priority   (get token-priority (:token token) 999)]
+                     priority   (get constants/token-sort-priority (:token token) 999)]
                  [(- fiat-value) priority]))
              calculated-tokens)))

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -310,6 +310,6 @@
         calculated-tokens (map calculate-token tokens)]
     (sort-by (fn [token]
                (let [fiat-value (get-in token [:values :fiat-unformatted-value])
-                     priority   (get constants/token-sort-priority (:token token) ##Inf)]
+                     priority   (get constants/token-sort-priority (:token token) 999)]
                  [(- fiat-value) priority]))
              calculated-tokens)))

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -149,5 +149,14 @@
                 expected-order ["DAI" "ETH" "SNT"]]
             (is (= expected-order sorted-tokens))))))))
 
+(deftest sort-tokens-test
+  (testing "sort-tokens function"
+    (let [mock-tokens    [{:symbol "ETH" :balance 5}
+                          {:symbol "DAI" :balance 10}
+                          {:symbol "SNT" :balance 1}]
+          sorted-tokens  (map :symbol (utils/sort-tokens mock-tokens))
+          expected-order ["DAI" "ETH" "SNT"]]
+      (is (= expected-order sorted-tokens)))))
+
 
 

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -404,11 +404,6 @@
  (fn [[{:keys [tokens]} chain-ids]]
    (utils/filter-tokens-in-chains tokens chain-ids)))
 
-(defn tokens-sort
-  [token]
-  [(comp - (:balance token))
-   (get constants/token-sort-priority (:symbol token) ##Inf)])
-
 (rf/reg-sub
  :wallet/current-viewing-account-tokens-filtered
  :<- [:wallet/current-viewing-account]
@@ -421,7 +416,7 @@
                                      :total-balance     (utils/calculate-total-token-balance token
                                                                                              chain-ids)))
                             (:tokens account))
-         sorted-tokens (sort-by tokens-sort tokens)]
+         sorted-tokens (sort-by utils/tokens-sort-fn tokens)]
      (if query
        (let [query-string (string/lower-case query)]
          (filter #(or (string/starts-with? (string/lower-case (:name %)) query-string)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -416,7 +416,7 @@
                                      :total-balance     (utils/calculate-total-token-balance token
                                                                                              chain-ids)))
                             (:tokens account))
-         sorted-tokens (sort-by :name compare tokens)]
+         sorted-tokens (sort-by :balance compare tokens)]
      (if query
        (let [query-string (string/lower-case query)]
          (filter #(or (string/starts-with? (string/lower-case (:name %)) query-string)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -404,6 +404,11 @@
  (fn [[{:keys [tokens]} chain-ids]]
    (utils/filter-tokens-in-chains tokens chain-ids)))
 
+(defn tokens-sort
+  [token]
+  [(comp - :balance token)
+   (get constants/token-sort-priority (:symbol token) ##Inf)])
+
 (rf/reg-sub
  :wallet/current-viewing-account-tokens-filtered
  :<- [:wallet/current-viewing-account]
@@ -416,8 +421,7 @@
                                      :total-balance     (utils/calculate-total-token-balance token
                                                                                              chain-ids)))
                             (:tokens account))
-         priority      #(get constants/token-sort-priority (:symbol %) 999)
-         sorted-tokens (sort-by (juxt (comp - :balance) priority) tokens)]
+         sorted-tokens (sort-by tokens-sort tokens)]
      (if query
        (let [query-string (string/lower-case query)]
          (filter #(or (string/starts-with? (string/lower-case (:name %)) query-string)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -404,6 +404,11 @@
  (fn [[{:keys [tokens]} chain-ids]]
    (utils/filter-tokens-in-chains tokens chain-ids)))
 
+(defn tokens-sort
+  [token]
+  [(comp - (:balance token))
+   (get constants/token-sort-priority (:symbol token) ##Inf)])
+
 (rf/reg-sub
  :wallet/current-viewing-account-tokens-filtered
  :<- [:wallet/current-viewing-account]
@@ -416,8 +421,7 @@
                                      :total-balance     (utils/calculate-total-token-balance token
                                                                                              chain-ids)))
                             (:tokens account))
-         priority      #(get constants/token-sort-priority (:symbol %) ##Inf)
-         sorted-tokens (sort-by (juxt (comp - :balance) priority) tokens)]
+         sorted-tokens (sort-by tokens-sort tokens)]
      (if query
        (let [query-string (string/lower-case query)]
          (filter #(or (string/starts-with? (string/lower-case (:name %)) query-string)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -416,7 +416,8 @@
                                      :total-balance     (utils/calculate-total-token-balance token
                                                                                              chain-ids)))
                             (:tokens account))
-         sorted-tokens (sort-by :balance compare tokens)]
+         priority      #(get constants/token-sort-priority (:symbol %) 999)
+         sorted-tokens (sort-by (juxt (comp - :balance) priority) tokens)]
      (if query
        (let [query-string (string/lower-case query)]
          (filter #(or (string/starts-with? (string/lower-case (:name %)) query-string)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -407,7 +407,7 @@
 (defn tokens-sort
   [token]
   [(comp - :balance token)
-   (get constants/token-sort-priority (:symbol token) ##Inf)])
+   (get constants/token-sort-priority (:symbol token) 999)])
 
 (rf/reg-sub
  :wallet/current-viewing-account-tokens-filtered

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -404,11 +404,6 @@
  (fn [[{:keys [tokens]} chain-ids]]
    (utils/filter-tokens-in-chains tokens chain-ids)))
 
-(defn tokens-sort
-  [token]
-  [(comp - :balance token)
-   (get constants/token-sort-priority (:symbol token) 999)])
-
 (rf/reg-sub
  :wallet/current-viewing-account-tokens-filtered
  :<- [:wallet/current-viewing-account]
@@ -421,7 +416,8 @@
                                      :total-balance     (utils/calculate-total-token-balance token
                                                                                              chain-ids)))
                             (:tokens account))
-         sorted-tokens (sort-by tokens-sort tokens)]
+         priority      #(get constants/token-sort-priority (:symbol %) ##Inf)
+         sorted-tokens (sort-by (juxt (comp - :balance) priority) tokens)]
      (if query
        (let [query-string (string/lower-case query)]
          (filter #(or (string/starts-with? (string/lower-case (:name %)) query-string)

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -416,7 +416,7 @@
                                      :total-balance     (utils/calculate-total-token-balance token
                                                                                              chain-ids)))
                             (:tokens account))
-         sorted-tokens (sort-by utils/tokens-sort-fn tokens)]
+         sorted-tokens (utils/sort-tokens tokens)]
      (if query
        (let [query-string (string/lower-case query)]
          (filter #(or (string/starts-with? (string/lower-case (:name %)) query-string)


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/20706

### Summary
This PR fixes sort order of assets on bridge and select assets screen to be in descending order of balance.

Simple fix, skipping QA.

### Demo

Before:
<img width=280 height=600 src="https://github.com/user-attachments/assets/7af61f25-9c30-440d-a492-23e21ed55e95" />

After:
<img width=280 height=600 src="https://github.com/user-attachments/assets/013dabea-2878-465d-a552-fa38362e7281" />

