### PR TITLE
chore(tests): Allow test-watch-for-repl target to run while the app is running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,13 +353,17 @@ test: export SHADOW_NS_REGEXP := .*-test$$
 test: ##@test Run all Clojure tests
 test: _test-clojure
 
+# Note: we need to override the :output-to and :ns-regexp options because
+# shadow-cljs has a bug where it will not read from the env vars to expand the
+# configuration when the shadow-cljs mobile target is already running.
 test-watch-for-repl: export TARGET := default
 test-watch-for-repl: export SHADOW_OUTPUT_TO := target/test/test.js
 test-watch-for-repl: export SHADOW_NS_REGEXP := .*-test$$
 test-watch-for-repl: ##@test Watch all Clojure tests and support REPL connections
+	rm -f "$$SHADOW_OUTPUT_TO" && \
 	yarn install && shadow-cljs compile mocks && \
 	concurrently --kill-others --prefix-colors 'auto' --names 'build,repl' \
-		'yarn shadow-cljs watch test --verbose' \
+		"yarn shadow-cljs watch test --verbose --config-merge '{:output-to \"$(SHADOW_OUTPUT_TO)\" :ns-regexp \"$(SHADOW_NS_REGEXP)\"}'" \
 		"until [ -f $$SHADOW_OUTPUT_TO ] ; do sleep 1 ; done ; node --require ./test-resources/override.js $$SHADOW_OUTPUT_TO --repl"
 
 test-unit: export SHADOW_OUTPUT_TO := target/unit_test/test.js


### PR DESCRIPTION
### Summary

This PR fixes a long standing problem, at least in my machines: I can't run in parallel the make target `run-clojure` and `test-watch-for-repl`, or in other words, I can't do run tests via the REPL while the app is running :rage2: 

### Details

I found out that shadow-cljs fails to build because it does not expand the environment variables `SHADOW_OUTPUT_TO` and `SHADOW_NS_REGEXP` if and only if the `run-clojure` target was executed. Clearly looks like a bug.

This is the top of the stacktrace, and it happens because it doesn't know where to output the test build because the env var wasn't expanded:

```
[build] NullPointerException:
[build]         shadow.build.node/configure (node.clj:59)
[build]         shadow.build.node/configure (node.clj:45)
[build]         shadow.build.targets.node-script/configure (node_script.clj:37)
```

The solution is to pass the option `--config-merge` to shadow-cljs and override both `:ns-regexp` and `:output-to` because CLI args override options from env vars in shadow-cljs.

#### Areas that may be impacted

None.

### Steps to test

Please, check you can do `make run-clojure` in one session/terminal and `make test-watch-for-repl` in another session/terminal, and that you are able to connect with the REPL successfully.

If you are using Emacs and you are already connected to the normal app REPL (`:mobile` target), after running `test-watch-for-repl` you can connect to the test REPL by using `cider-connect-sibling-cljs`. There are probably other ways. Then, if you have selected the correct CLJS buffer, if you run the tests with something like `(cljs.test/run-tests)` it will work, as usual. I don't know the instructions to connect to two REPLs in VS Code, but I'm pretty sure this is supported.

status: ready