### PR TITLE
fix_: Adding own wallet address as saved addresses

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -105,24 +105,25 @@
                          [ens ens? open-network-preferences address-text])]
     [quo/overlay {:type :shell}
      [floating-button-page/view
-      {:footer-container-padding (if edit? (+ (safe-area/get-bottom) 12) 0)
-       :header                   [quo/page-nav
-                                  {:type                :no-title
-                                   :background          :blur
-                                   :icon-name           (if edit? :i/close :i/arrow-left)
-                                   :on-press            navigate-back
-                                   :margin-top          (when-not edit? (safe-area/get-top))
-                                   :accessibility-label :save-address-page-nav}]
-       :footer                   [quo/button
-                                  {:accessibility-label :save-address-button
-                                   :type                :primary
-                                   :customization-color address-color
-                                   :disabled?           (string/blank? address-label)
-                                   :on-press            on-press-save}
-                                  (i18n/label :t/save-address)]
-       :customization-color      address-color
-       :gradient-cover?          true
-       :shell-overlay?           true}
+      {:footer-container-padding     (if edit? (+ (safe-area/get-bottom) 12) 0)
+       :keyboard-should-persist-taps :handled
+       :header                       [quo/page-nav
+                                      {:type                :no-title
+                                       :background          :blur
+                                       :icon-name           (if edit? :i/close :i/arrow-left)
+                                       :on-press            navigate-back
+                                       :margin-top          (when-not edit? (safe-area/get-top))
+                                       :accessibility-label :save-address-page-nav}]
+       :footer                       [quo/button
+                                      {:accessibility-label :save-address-button
+                                       :type                :primary
+                                       :customization-color address-color
+                                       :disabled?           (string/blank? address-label)
+                                       :on-press            on-press-save}
+                                      (i18n/label :t/save-address)]
+       :customization-color          address-color
+       :gradient-cover?              true
+       :shell-overlay?               true}
       [quo/wallet-user-avatar
        {:full-name           (if (string/blank? address-label)
                                placeholder


### PR DESCRIPTION
fixes #20702
fixes #20751

### Summary

This PR 
 - prevents the user from saving their wallet address as the saved address
 - fixes button not capturing taps when the keyboard is open

### Review notes

The bug is caused by the validation failure when using a multi-chain prefix. This PR updates the validation method to extract and validate the address.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the Wallet tab or Open share screen
- Copy the address of your wallet account address with multi-chain prefixes
- Navigate to `Profile > Wallet > Saved addresses` and tap on `+`
- Paste the address into the input field
- Verify the error is thrown 
- Copy any of the saved addresses with multi-chain prefixes
- Paste the address into the input field
- Verify the error is thrown
- Verify the `paste` button and `[-]` button are tappable when the keyboard is open

status: ready

