### PR TITLE
Ensure keycard account can send transaction after upgrading from v1 to v2

### DIFF
--- a/src/status_im/common/signals/events.cljs
+++ b/src/status_im/common/signals/events.cljs
@@ -38,6 +38,12 @@
       "wallet"
       {:fx [[:dispatch [:wallet/signal-received event-js]]]}
 
+      "wallet.sign.transactions"
+      {:fx [[:dispatch
+             [:standard-auth/authorize-with-keycard
+              {:on-complete #(rf/dispatch [:keycard/sign-hash %
+                                           (first (transforms/js->clj event-js))])}]]]}
+
       "wallet.suggested.routes"
       {:fx [[:dispatch [:wallet/handle-suggested-routes (transforms/js->clj event-js)]]]}
 

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -8,7 +8,7 @@
 
 (defn view
   [{:keys [track-text customization-color auth-button-label on-auth-success on-auth-fail
-           auth-button-icon-left size blur? container-style disabled? dependencies]
+           auth-button-icon-left size blur? container-style disabled? dependencies keycard-supported?]
     :or   {container-style {:flex 1}}}]
   (let [theme           (quo.theme/use-theme)
         auth-method     (rf/sub [:auth-method])
@@ -21,6 +21,7 @@
                                           :auth-button-icon-left auth-button-icon-left
                                           :theme                 theme
                                           :blur?                 blur?
+                                          :keycard-supported?    keycard-supported?
                                           :biometric-auth?       biometric-auth?
                                           :on-auth-success       on-auth-success
                                           :on-auth-fail          on-auth-fail

--- a/src/status_im/contexts/keycard/effects.cljs
+++ b/src/status_im/contexts/keycard/effects.cljs
@@ -109,3 +109,22 @@
   [pairings]
   (keycard/set-pairings pairings))
 (rf/reg-fx :effects.keycard/set-pairing-to-keycard set-pairing-to-keycard)
+
+(defn sign
+  [{:keys [on-success on-failure] :as args}]
+  (log/debug "[keycard] sign")
+  (keycard/sign
+   (assoc
+    args
+    :on-success
+    (fn [response]
+      (log/debug "[keycard response succ] sign")
+      (when on-success
+        (on-success (transforms/js->clj response))))
+    :on-failure
+    (fn [response]
+      (log/warn "[keycard response fail] sign"
+                (error-object->map response))
+      (when on-failure
+        (on-failure (error-object->map response)))))))
+(rf/reg-fx :effects.keycard/sign sign)

--- a/src/status_im/contexts/keycard/pin/events.cljs
+++ b/src/status_im/contexts/keycard/pin/events.cljs
@@ -9,13 +9,17 @@
                 (assoc-in [:keycard :pin :text] (.slice pin 0 -1))
                 (assoc-in [:keycard :pin :status] nil))}))))
 
+(rf/reg-fx :effects.keycard.pin/dispatch-on-complete
+ (fn [[on-complete new-pin]]
+   (on-complete new-pin)))
+
 (rf/reg-event-fx :keycard.pin/number-pressed
- (fn [{:keys [db]} [number max-numbers on-complete-event]]
+ (fn [{:keys [db]} [number max-numbers on-complete]]
    (let [pin     (get-in db [:keycard :pin :text])
          new-pin (str pin number)]
      (when (<= (count new-pin) max-numbers)
        {:db (-> db
                 (assoc-in [:keycard :pin :text] new-pin)
                 (assoc-in [:keycard :pin :status] nil))
-        :fx [(when (= (dec max-numbers) (count pin))
-               [:dispatch [on-complete-event]])]}))))
+        :fx [(when (and on-complete (= (dec max-numbers) (count pin)))
+               [:effects.keycard.pin/dispatch-on-complete [on-complete new-pin]])]}))))

--- a/src/status_im/contexts/keycard/pin/view.cljs
+++ b/src/status_im/contexts/keycard/pin/view.cljs
@@ -6,7 +6,7 @@
             [utils.re-frame :as rf]))
 
 (defn auth
-  [callback-event-key]
+  [{:keys [on-complete]}]
   (let [{:keys [text status]} (rf/sub [:keycard/pin])
         pin-retry-counter     (rf/sub [:keycard/pin-retry-counter])
         error?                (= status :error)]
@@ -23,4 +23,4 @@
       {:delete-key? true
        :on-delete   #(rf/dispatch [:keycard.pin/delete-pressed])
        :on-press    #(rf/dispatch [:keycard.pin/number-pressed % constants/pincode-length
-                                   callback-event-key])}]]))
+                                   on-complete])}]]))

--- a/src/status_im/contexts/keycard/sign/events.cljs
+++ b/src/status_im/contexts/keycard/sign/events.cljs
@@ -1,0 +1,29 @@
+(ns status-im.contexts.keycard.sign.events
+  (:require [utils.address]
+            [utils.re-frame :as rf]))
+
+(defn get-signature-map
+  [tx-hash signature]
+  {tx-hash {:r (subs signature 0 64)
+            :s (subs signature 64 128)
+            :v (str (js/parseInt (subs signature 128 130) 16))}})
+
+(rf/reg-event-fx :keycard/sign-hash
+ (fn [{:keys [db]} [pin-text tx-hash]]
+   (let [current-address (get-in db [:wallet :current-viewing-account-address])
+         path            (get-in db [:wallet :accounts current-address :path])
+         key-uid         (get-in db [:profile/profile :key-uid])]
+     {:fx [[:dispatch
+            [:keycard/read-card
+             {:key-uid    key-uid
+              :on-read-fx [[:effects.keycard/sign
+                            {:pin pin-text
+                             :path path
+                             :hash (utils.address/naked-address tx-hash)
+                             :on-success
+                             #(do
+                                (rf/dispatch [:keycard/hide-connection-sheet])
+                                (rf/dispatch
+                                 [:wallet/proceed-with-transactions-signatures
+                                  (get-signature-map tx-hash %)]))
+                             :on-failure #(rf/dispatch [:keycard/on-action-with-pin-error %])}]]}]]]})))

--- a/src/status_im/contexts/keycard/utils.cljs
+++ b/src/status_im/contexts/keycard/utils.cljs
@@ -16,8 +16,8 @@
    (re-matches #".*NFCError:100.*" error)))
 
 (defn validate-application-info
-  [profile {:keys [key-uid paired? pin-retry-counter puk-retry-counter] :as application-info}]
-  (let [profile-mismatch? (or (nil? profile) (not= (:key-uid profile) key-uid))]
+  [profile-key-uid {:keys [key-uid paired? pin-retry-counter puk-retry-counter] :as application-info}]
+  (let [profile-mismatch? (or (nil? profile-key-uid) (not= profile-key-uid key-uid))]
     (log/debug "[keycard] login-with-keycard"
                "empty application info" (empty? application-info)
                "no key-uid"             (empty? key-uid)

--- a/src/status_im/contexts/profile/profiles/view.cljs
+++ b/src/status_im/contexts/profile/profiles/view.cljs
@@ -239,7 +239,16 @@
         :profile-picture     profile-picture
         :card-style          style/login-profile-card}]
       (if keycard-pairing
-        [keycard.pin/auth :keycard/read-card-and-login]
+        [keycard.pin/auth
+         {:on-complete
+          (fn [pin-text]
+            (rf/dispatch
+             [:keycard/read-card
+              {:key-uid    key-uid
+               :on-read-fx [[:effects.keycard/get-keys
+                             {:pin        pin-text
+                              :on-success #(rf/dispatch [:keycard.login/on-get-keys-success %])
+                              :on-failure #(rf/dispatch [:keycard/on-action-with-pin-error %])}]]}]))}]
         [password-input])]
      (when-not keycard-pairing
        [quo/button

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -698,8 +698,9 @@
      {:json-rpc/call [{:method     "wallet_createMultiTransaction"
                        :params     request-params
                        :on-success (fn [result]
-                                     (rf/dispatch [:wallet/add-authorized-transaction result])
-                                     (rf/dispatch [:hide-bottom-sheet]))
+                                     (when result
+                                       (rf/dispatch [:wallet/add-authorized-transaction result])
+                                       (rf/dispatch [:hide-bottom-sheet])))
                        :on-error   (fn [error]
                                      (log/error "failed to send transaction"
                                                 {:event  :wallet/send-transaction
@@ -709,6 +710,23 @@
                                                    {:id   :send-transaction-error
                                                     :type :negative
                                                     :text (:message error)}]))}]})))
+
+(rf/reg-event-fx :wallet/proceed-with-transactions-signatures
+ (fn [_ [signatures]]
+   {:json-rpc/call [{:method     "wallet_proceedWithTransactionsSignatures"
+                     :params     [signatures]
+                     :on-success (fn [result]
+                                   (when result
+                                     (rf/dispatch [:wallet/add-authorized-transaction result])
+                                     (rf/dispatch [:hide-bottom-sheet])))
+                     :on-error   (fn [error]
+                                   (log/error "failed to proceed-with-transactions-signatures"
+                                              {:event :wallet/proceed-with-transactions-signatures
+                                               :error error})
+                                   (rf/dispatch [:toasts/upsert
+                                                 {:id   :send-transaction-error
+                                                  :type :negative
+                                                  :text (:message error)}]))}]}))
 
 (rf/reg-event-fx
  :wallet/select-from-account

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -257,7 +257,8 @@
                                         :transaction-type   transaction-type}]
                                       (when (and (not loading-suggested-routes?) route (seq route))
                                         [standard-auth/slide-button
-                                         {:size                :size-48
+                                         {:keycard-supported?  true
+                                          :size                :size-48
                                           :track-text          (if (= transaction-type :tx/bridge)
                                                                  (i18n/label :t/slide-to-bridge)
                                                                  (i18n/label :t/slide-to-send))
@@ -265,8 +266,7 @@
                                           :customization-color account-color
                                           :on-auth-success     #(rf/dispatch
                                                                  [:wallet/send-transaction
-                                                                  (security/safe-unmask-data
-                                                                   %)])
+                                                                  (security/safe-unmask-data %)])
                                           :auth-button-label   (i18n/label :t/confirm)}])]
            :gradient-cover?          true
            :customization-color      (:color account)}


### PR DESCRIPTION
fixes #20552

status-go: https://github.com/status-im/status-go/pull/5557

steps to test
1) install 1.20 PR version
2) create account with keycard
3) install this PR on top
4) try to send transaction with keycard