### PR TITLE
chore(status-go): Upgrade status-go to fix endless loop when joining communities

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.182.37",
-    "commit-sha1": "4a43b2b2bebe45df2100d1a5c5034105d93e50b8",
-    "src-sha256": "0f5mm7lx6s2qcy9xpa9v7piqb60yazi6p677fy105yz7hg731cw6"
+    "version": "mp/issue-15466",
+    "commit-sha1": "6b322687efa239850628483a14150e029b4a2797",
+    "src-sha256": "1r8q54x15f2nl3b2651p970v9ydv4m5bv2ndw56jafg7x6l2qgn7"
 }


### PR DESCRIPTION
### Summary

The desktop folks asked us to verify there are no regressions in the flows to join communities on the mobile app, hence this PR points status-go to this unmerged PR https://github.com/status-im/status-go/pull/5515.

PR is in draft because we don't necessarily need to merge it.

### Areas that may be impacted

Joining communities.

### Steps to test

Please, refer to the original issue for more details about the bug https://github.com/status-im/status-desktop/issues/15466 and in the status-go PR https://github.com/status-im/status-go/pull/5515.

In terms of testing, I think we don't need to re-verify the issue's bug is fixed, although that wouldn't hurt. From the mobile PoV we just need to make sure there are no regressions to join communities.

Given the issue says there's a precondition to use _Community with minted owner token_, it's recommended to QA with and without token gated communities.

status: ready