### PR TITLE
fix(wallet): Fix input amount step skipped while sending a token

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -215,8 +215,13 @@
                                               :token-display-name (:symbol token-data)))
               unique-owner (assoc-in [:wallet :current-viewing-account-address] unique-owner)
               entry-point  (assoc-in [:wallet :ui :send :entry-point] entry-point))
-        :fx [[:dispatch ^:flush-dom [:wallet/clean-suggested-routes]]
+        :fx [[:dispatch [:wallet/clean-suggested-routes]]
              [:dispatch
+              ;; ^:flush-dom allows us to make sure the re-frame DB state is always synced
+              ;; before the navigation occurs, so the new screen is always rendered with
+              ;; the DB state set by this event.  By adding the metadata we are omitting
+              ;; a 1-frame blink when the screen is mounted.
+              ^:flush-dom
               [:wallet/wizard-navigate-forward
                {:current-screen stack-id
                 :start-flow?    start-flow?

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -205,7 +205,7 @@
        {:db (cond-> db
               :always      (update-in [:wallet :ui :send]
                                       #(-> %
-                                           (dissoc :collectible)
+                                           (dissoc :collectible :tx-type)
                                            (assoc :token-not-supported-in-receiver-networks?
                                                   unsupported-token?)))
               token-symbol (assoc-in [:wallet :ui :send :token-symbol] token-symbol)
@@ -215,7 +215,7 @@
                                               :token-display-name (:symbol token-data)))
               unique-owner (assoc-in [:wallet :current-viewing-account-address] unique-owner)
               entry-point  (assoc-in [:wallet :ui :send :entry-point] entry-point))
-        :fx [[:dispatch [:wallet/clean-suggested-routes]]
+        :fx [[:dispatch ^:flush-dom [:wallet/clean-suggested-routes]]
              [:dispatch
               [:wallet/wizard-navigate-forward
                {:current-screen stack-id


### PR DESCRIPTION

fixes #20677 

### Summary

This PR fixes the step skipped. Demo:

https://github.com/user-attachments/assets/01d2b946-70bf-4ea8-928e-ea180f0f5346

### Review notes
The bug was due to the transaction type. When we send regular tokens we don't stablish a new `tx-type` on re-frame. To fix it I'm removing the old transaction type when we pick a token.

### Steps to test

 Please check the video in the original issue

status: ready