### PR TITLE
Fix WalletConnect declining proposal error

### DIFF
--- a/src/react_native/wallet_connect.cljs
+++ b/src/react_native/wallet_connect.cljs
@@ -51,9 +51,10 @@
 
 (defn reject-session
   [{:keys [web3-wallet id reason]}]
-  (.rejectSession web3-wallet
-                  (clj->js {:id     id
-                            :reason reason})))
+  (oops/ocall web3-wallet
+              "rejectSession"
+              (bean/->js {:id     id
+                          :reason reason})))
 
 (defn approve-session
   [{:keys [web3-wallet id approved-namespaces]}]


### PR DESCRIPTION
fixes #20796

### Summary

Making sure the usage of web3-wallet doesn't scramble the method name during advanced compilation.

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Send proposal
- Decline proposal


status: ready <!-- Can be ready or wip -->


