### PR TITLE
fix_: crash when requesting to join community

### DIFF
--- a/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
@@ -22,7 +22,7 @@
         airdrop-account (rf/sub [:communities/airdrop-account id])
         revealed-accounts (rf/sub [:communities/accounts-to-reveal id])
         revealed-accounts-count (count revealed-accounts)
-        wallet-accounts-count (count (rf/sub [:wallet/operable-accounts-without-watched-accounts]))
+        wallet-accounts-count (count (rf/sub [:wallet/operable-accounts]))
         addresses-shared-text (if (= revealed-accounts-count wallet-accounts-count)
                                 (i18n/label :t/all-addresses)
                                 (i18n/label-pluralize


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20866

### Summary
The sub `:wallet/operable-accounts-without-watched-accounts` in this pr https://github.com/status-im/status-mobile/pull/20773 was replaced with `:wallet/operable-accounts` which causes the app to crash because the subscription called is missing. The error causing the crash is resolved by calling the right sub @smohamedjavid @flexsurfer for pointing this out