### PR TITLE
chore(settings)_: Remove testnet toggle from old advanced settings

### DIFF
--- a/src/legacy/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/legacy/status_im/ui/screens/advanced_settings/views.cljs
@@ -20,8 +20,6 @@
            light-client-enabled?
            store-confirmations-enabled?
            current-fleet
-           test-networks-enabled?
-           is-goerli-enabled?
            peer-syncing-enabled?]}]
   (keep
    identity
@@ -88,22 +86,6 @@
      :accessory :switch
      :active store-confirmations-enabled?}
     {:size :small
-     :title "Testnet mode"
-     :accessibility-label :test-networks-enabled
-     :container-margin-bottom 8
-     :on-press
-     #(re-frame/dispatch [:profile.settings/toggle-test-networks])
-     :accessory :switch
-     :active test-networks-enabled?}
-    {:size :small
-     :title "Enable Goerli as test network"
-     :accessibility-label :enable-sepolia-as-test-network
-     :container-margin-bottom 8
-     :on-press
-     #(re-frame/dispatch [:profile.settings/toggle-goerli-test-network])
-     :accessory :switch
-     :active is-goerli-enabled?}
-    {:size :small
      :title "Peer syncing"
      :accessibility-label :peer-syncing
      :container-margin-bottom 8
@@ -124,9 +106,7 @@
 
 (views/defview advanced-settings
   []
-  (views/letsubs [test-networks-enabled?       [:profile/test-networks-enabled?]
-                  is-goerli-enabled?           [:profile/is-goerli-enabled?]
-                  light-client-enabled?        [:profile/light-client-enabled?]
+  (views/letsubs [light-client-enabled?        [:profile/light-client-enabled?]
                   store-confirmations-enabled? [:profile/store-confirmations-enabled?]
                   telemetry-enabled?           [:profile/telemetry-enabled?]
                   current-log-level            [:log-level/current-log-level]
@@ -147,8 +127,6 @@
                     :store-confirmations-enabled? store-confirmations-enabled?
                     :current-fleet                current-fleet
                     :dev-mode?                    false
-                    :test-networks-enabled?       test-networks-enabled?
-                    :is-goerli-enabled?           is-goerli-enabled?
                     :peer-syncing-enabled?        peer-syncing-enabled?})
        :key-fn    (fn [_ i] (str i))
        :render-fn render-item}]]))


### PR DESCRIPTION
fixes #20568

### Summary

This PR removes two toggles from legacy advanced settings
- `Testnet mode` - duplicate toggle as the user can switch to testnet from wallet settings
- `Enable Goerli as test network` - Goerli is depreciated and wallet services use Sepolia testnet as default. A mass Goerli cleanup is already in place with PR https://github.com/status-im/status-mobile/pull/20276 and will be merged post 2.30 release. For 2.30, We don't want our users to play with this toggle. So, we remove just the toggle.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to `Profile > Advanced`
- Verify `Testnet mode` and `Enable Goerli as test network` are removed

status: ready

