### PR TITLE
chore(settings): Disable telemetry option behind feature flag

### DIFF
--- a/src/legacy/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/legacy/status_im/ui/screens/advanced_settings/views.cljs
@@ -5,6 +5,7 @@
     [legacy.status-im.ui.components.list.views :as list]
     [quo.core :as quo]
     [re-frame.core :as re-frame]
+    [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf])
   (:require-macros [legacy.status-im.utils.views :as views]))
@@ -59,14 +60,14 @@
      :on-press
      #(re-frame/dispatch [:open-modal :peers-stats])
      :chevron true}
-    {:size :small
-     :title "Telemetry"
-     :accessibility-label :telemetry-enabled
-     :container-margin-bottom 8
-     :on-press
-     #(re-frame/dispatch [:profile.settings/toggle-telemetry])
-     :accessory :switch
-     :active telemetry-enabled?}
+    (when (ff/enabled? ::ff/settings.telemetry)
+      {:size                    :small
+       :title                   "Telemetry"
+       :accessibility-label     :telemetry-enabled
+       :container-margin-bottom 8
+       :on-press                #(re-frame/dispatch [:profile.settings/toggle-telemetry])
+       :accessory               :switch
+       :active                  telemetry-enabled?})
     {:size :small
      :title (i18n/label :t/light-client-enabled)
      :accessibility-label :light-client-enabled

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -17,9 +17,11 @@
    ;; works and we may re-enable it by default.
    ::profile-pictures-visibility        (enabled-in-env? :FLAG_PROFILE_PICTURES_VISIBILITY_ENABLED)
 
+   ::settings.telemetry                 (enabled-in-env? :FLAG_TELEMETRY_ENABLED)
    ::settings.import-all-keypairs       (enabled-in-env?
                                          :FLAG_WALLET_SETTINGS_IMPORT_ALL_KEYPAIRS)
    ::shell.jump-to                      (enabled-in-env? :ENABLE_JUMP_TO)
+
    ::wallet.advanced-sending            (enabled-in-env? :FLAG_ADVANCED_SENDING)
    ::wallet.assets-modal-hide           (enabled-in-env? :FLAG_ASSETS_MODAL_HIDE)
    ::wallet.assets-modal-manage-tokens  (enabled-in-env? :FLAG_ASSETS_MODAL_MANAGE_TOKENS)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/20849

### Summary

A quick and safe PR, this one hides the `Telemetry` option in Advanced settings behind a feature flag which is disabled by default. We have an opt-in solution now to collect data and the `Telemetry` option can be rather confusing, as it means something else.

#### Areas that may be impacted

None.

status: ready