### PR TITLE
Sync process is blocked on Enabled notifications screen

### DIFF
--- a/src/status_im/contexts/onboarding/enable_notifications/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_notifications/view.cljs
@@ -38,7 +38,7 @@
                               (rf/dispatch [:push-notifications/switch true])
                               (rf/dispatch [:navigate-to-within-stack
                                             [:screen/onboarding.welcome
-                                             :screen/onboarding.generating-keys]]))
+                                             :screen/onboarding.enable-notifications]]))
        :type                :primary
        :icon-left           :i/notifications
        :accessibility-label :enable-notifications-button
@@ -52,7 +52,7 @@
                                nil)
                               (rf/dispatch [:navigate-to-within-stack
                                             [:screen/onboarding.welcome
-                                             :screen/onboarding.generating-keys]]))
+                                             :screen/onboarding.enable-notifications]]))
        :accessibility-label :enable-notifications-later-button
        :type                :grey
        :background          :blur

--- a/src/status_im/contexts/onboarding/syncing/progress/style.cljs
+++ b/src/status_im/contexts/onboarding/syncing/progress/style.cljs
@@ -2,6 +2,13 @@
   (:require
     [quo.foundations.colors :as colors]))
 
+(def absolute-fill
+  {:position :absolute
+   :top      0
+   :bottom   0
+   :left     0
+   :right    0})
+
 (defn page-container
   [in-onboarding?]
   {:flex             1

--- a/src/status_im/contexts/onboarding/syncing/progress/view.cljs
+++ b/src/status_im/contexts/onboarding/syncing/progress/view.cljs
@@ -52,7 +52,9 @@
         profile-color  (:color (rf/sub [:onboarding/profile]))
         logged-in?     (rf/sub [:multiaccount/logged-in?])]
     [rn/view {:style (style/page-container in-onboarding?)}
-     (when-not in-onboarding? [background/view true])
+     (when-not in-onboarding?
+       [rn/view {:style style/absolute-fill}
+        [background/view true]])
      [quo/page-nav {:type :no-title :background :blur}]
      [page-title (pairing-progress pairing-status)]
      (if config/show-not-implemented-features?

--- a/src/status_im/contexts/onboarding/syncing/results/style.cljs
+++ b/src/status_im/contexts/onboarding/syncing/results/style.cljs
@@ -3,6 +3,13 @@
     [quo.foundations.colors :as colors]
     [react-native.reanimated :as reanimated]))
 
+(def absolute-fill
+  {:position :absolute
+   :top      0
+   :bottom   0
+   :left     0
+   :right    0})
+
 (defn page-container
   [top]
   {:flex             1

--- a/src/status_im/contexts/onboarding/syncing/results/view.cljs
+++ b/src/status_im/contexts/onboarding/syncing/results/view.cljs
@@ -66,7 +66,8 @@
         translate-x  (reanimated/use-shared-value 0)
         window-width (:width (rn/get-window))]
     [rn/view {:style (style/page-container top)}
-     [background/view true]
+     [rn/view {:style style/absolute-fill}
+      [background/view true]]
      [reanimated/view
       {:style (style/content translate-x)}
       [page-title]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20882

### Summary
Also fixing a styling issue, where syncing progress screen is not taking full screen.

### Testing Note:
Please also test https://github.com/status-im/status-mobile/pull/20725, as issue/fix is related to that.
(In other words please test onboarding without syncing, (new account + seed phrase))

status: ready