### PR TITLE
[#20524] fix: the missed keypairs are shown in the key pair list screen

### DIFF
--- a/src/status_im/contexts/wallet/add_account/create_account/select_keypair/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/select_keypair/view.cljs
@@ -73,7 +73,7 @@
   []
   (let [compressed-key                          (rf/sub [:profile/compressed-key])
         customization-color                     (rf/sub [:profile/customization-color])
-        keypairs                                (rf/sub [:wallet/keypairs-list])
+        keypairs                                (rf/sub [:wallet/fully-operable-keypairs-list])
         selected-keypair                        (rf/sub [:wallet/selected-keypair-uid])
         profile-picture                         (rf/sub [:profile/image])
         [selected-key-uid set-selected-key-uid] (rn/use-state selected-keypair)]

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -208,6 +208,12 @@
    (vals keypairs)))
 
 (rf/reg-sub
+ :wallet/fully-operable-keypairs-list
+ :<- [:wallet/keypairs-list]
+ (fn [keypairs]
+   (filter #(= :fully (:lowest-operability %)) keypairs)))
+
+(rf/reg-sub
  :wallet/keypair-names
  :<- [:wallet/keypairs-list]
  (fn [keypairs]


### PR DESCRIPTION
fixes #20524

### Summary

The missed keypairs are shown in the key pair list screen, we should eliminate missing keypairs from the list 

#### Areas that maybe impacted

- Add Wallet Account -> Keypairs list


### Steps to test

1. Device B is synced with Device A
2. Device A creates an additional wallet address importing seed phrases or generation of new keypairs
3. Device B updates the wallet (now all addresses are shown and Device B sees them as non-imported)
4. Device B attempts to create derived accounts for such non-imported accounts


### Result


https://github.com/user-attachments/assets/9effd0b4-2e90-443c-b84b-4d4545b33892



status: ready 