### PR TITLE
[#20472] hide account switcher in send flow

### DIFF
--- a/src/status_im/contexts/wallet/common/account_switcher/view.cljs
+++ b/src/status_im/contexts/wallet/common/account_switcher/view.cljs
@@ -26,7 +26,8 @@
            switcher-type       :account-options
            type                :no-title}}]
   (let [{:keys [color emoji watch-only?]} (rf/sub [:wallet/current-viewing-account])
-        networks                          (rf/sub [:wallet/selected-network-details])]
+        networks                          (rf/sub [:wallet/selected-network-details])
+        sending-collectible?              (rf/sub [:wallet/sending-collectible?])]
     [quo/page-nav
      {:type                type
       :icon-name           icon-name
@@ -41,8 +42,9 @@
                                        (not watch-only?))
                               {:icon-name :i/dapps
                                :on-press  #(rf/dispatch [:navigate-to :screen/wallet.connected-dapps])})
-                            {:content-type        :account-switcher
-                             :customization-color color
-                             :on-press            #(on-dapps-press switcher-type)
-                             :emoji               emoji
-                             :type                (when watch-only? :watch-only)}]}]))
+                            (when-not sending-collectible?
+                              {:content-type        :account-switcher
+                               :customization-color color
+                               :on-press            #(on-dapps-press switcher-type)
+                               :emoji               emoji
+                               :type                (when watch-only? :watch-only)})]}]))

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -85,8 +85,9 @@
 (rf/reg-event-fx :wallet/close-account-page
  (fn [{:keys [db]}]
    (let [just-completed-transaction? (get-in db [:wallet :ui :send :just-completed-transaction?])]
-     (when-not just-completed-transaction?
-       {:fx [[:dispatch [:wallet/clear-account-tab]]]}))))
+     {:db (update db :wallet dissoc :current-viewing-account-address)
+      :fx [(when-not just-completed-transaction?
+             [:dispatch [:wallet/clear-account-tab]])]})))
 
 (defn log-rpc-error
   [_ [{:keys [event params]} error]]

--- a/src/status_im/contexts/wallet/home/view.cljs
+++ b/src/status_im/contexts/wallet/home/view.cljs
@@ -60,7 +60,7 @@
     :size           32
     :default-active default-active
     :data           data
-    :on-change      #(on-change %)}])
+    :on-change      on-change}])
 
 (defn view
   []

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -215,7 +215,7 @@
                                               :token-display-name (:symbol token-data)))
               unique-owner (assoc-in [:wallet :current-viewing-account-address] unique-owner)
               entry-point  (assoc-in [:wallet :ui :send :entry-point] entry-point))
-        :fx [[:dispatch [:wallet/clean-suggested-routes]]
+        :fx [[:dispatch ^:flush-dom [:wallet/clean-suggested-routes]]
              [:dispatch
               ;; ^:flush-dom allows us to make sure the re-frame DB state is always synced
               ;; before the navigation occurs, so the new screen is always rendered with

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -215,7 +215,7 @@
                                               :token-display-name (:symbol token-data)))
               unique-owner (assoc-in [:wallet :current-viewing-account-address] unique-owner)
               entry-point  (assoc-in [:wallet :ui :send :entry-point] entry-point))
-        :fx [[:dispatch ^:flush-dom [:wallet/clean-suggested-routes]]
+        :fx [[:dispatch [:wallet/clean-suggested-routes]]
              [:dispatch
               ;; ^:flush-dom allows us to make sure the re-frame DB state is always synced
               ;; before the navigation occurs, so the new screen is always rendered with
@@ -263,9 +263,12 @@
 
 (rf/reg-event-fx
  :wallet/set-collectible-to-send
- (fn [{db :db} [{:keys [collectible current-screen start-flow?]}]]
+ (fn [{db :db} [{:keys [collectible current-screen start-flow? entry-point]}]]
    (let [viewing-account?   (some? (-> db :wallet :current-viewing-account-address))
-         entry-point        (when-not viewing-account? :wallet-stack)
+         entry-point        (cond
+                              entry-point      entry-point
+                              viewing-account? :account-collectible-tab
+                              :else            :wallet-stack)
          collection-data    (:collection-data collectible)
          collectible-data   (:collectible-data collectible)
          contract-type      (:contract-type collectible)
@@ -702,3 +705,27 @@
              {:current-screen stack-id
               :start-flow?    start-flow?
               :flow-id        flow-id}]]]})))
+
+(rf/reg-event-fx
+ :wallet/transaction-confirmation-navigate-back
+ (fn [{db :db} [{:keys []}]]
+   (let [tx-type       (-> db :wallet :ui :send :tx-type)
+         keep-tx-data? (#{:account-collectible-tab :wallet-stack}
+                        (-> db :wallet :ui :send :entry-point))]
+     {:db (cond-> db
+            (and (= tx-type :tx/collectible-erc-721) (not keep-tx-data?))
+            (update-in [:wallet :ui :send] dissoc :tx-type :amount :route :suggested-routes)
+
+            (= tx-type :tx/collectible-erc-1155)
+            (update-in [:wallet :ui :send] dissoc :route :suggested-routes))
+      :fx [[:dispatch [:navigate-back]]]})))
+
+(rf/reg-event-fx
+ :wallet/collectible-amount-navigate-back
+ (fn [{db :db} [{:keys []}]]
+   (let [keep-tx-data? (#{:account-collectible-tab :wallet-stack}
+                        (-> db :wallet :ui :send :entry-point))]
+     {:db (cond-> db
+            :always             (update-in [:wallet :ui :send] dissoc :amount :route)
+            (not keep-tx-data?) (update-in [:wallet :ui :send] dissoc :tx-type))
+      :fx [[:dispatch [:navigate-back]]]})))

--- a/src/status_im/contexts/wallet/send/flow_config.cljs
+++ b/src/status_im/contexts/wallet/send/flow_config.cljs
@@ -22,7 +22,7 @@
     :skip-step? (fn [db] (or (token-selected? db) (collectible-selected? db)))}
    {:screen-id  :screen/wallet.send-input-amount
     :skip-step? (fn [db]
-                  (send-utils/tx-type-collectible? (get-in db [:wallet :ui :send :tx-type])))}
+                  (-> db :wallet :ui :send :tx-type send-utils/tx-type-collectible?))}
    {:screen-id  :screen/wallet.select-collectible-amount
     :skip-step? (fn [db]
                   (or (not (collectible-selected? db))

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -101,6 +101,7 @@
    :wallet/send-amount                             nil
    :wallet/wallet-send-tx-type                     :tx/send
    :wallet/wallet-send-fee-fiat-formatted          "$5,00"
+   :wallet/sending-collectible?                    false
    :wallet/total-amount                            (money/bignumber "250")})
 
 (h/describe "Send > input amount screen"

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -19,38 +19,38 @@
                                                      :chain-id         1
                                                      :related-chain-id 5}]
    :wallet/current-viewing-account-address         "0x1"
-   :wallet/current-viewing-account                 {:path                      "m/44'/60'/0'/0/1"
-                                                    :emoji                     "💎"
-                                                    :key-uid                   "0x2f5ea39"
-                                                    :address                   "0x1"
-                                                    :wallet                    false
-                                                    :name                      "Account One"
-                                                    :type                      :generated
-                                                    :watch-only?               false
-                                                    :chat                      false
-                                                    :test-preferred-chain-ids  #{5 420 421613}
-                                                    :color                     :purple
-                                                    :hidden                    false
-                                                    :prod-preferred-chain-ids  #{1 10 42161}
+   :wallet/current-viewing-account                 {:path "m/44'/60'/0'/0/1"
+                                                    :emoji "💎"
+                                                    :key-uid "0x2f5ea39"
+                                                    :address "0x1"
+                                                    :wallet false
+                                                    :name "Account One"
+                                                    :type :generated
+                                                    :watch-only? false
+                                                    :chat false
+                                                    :test-preferred-chain-ids #{5 420 421613}
+                                                    :color :purple
+                                                    :hidden false
+                                                    :prod-preferred-chain-ids #{1 10 42161}
                                                     :network-preferences-names #{:mainnet :arbitrum
                                                                                  :optimism}
-                                                    :position                  1
-                                                    :clock                     1698945829328
-                                                    :created-at                1698928839000
-                                                    :operable                  :fully
-                                                    :mixedcase-address         "0x7bcDfc75c431"
-                                                    :public-key                "0x04371e2d9d66b82f056bc128064"
-                                                    :removed                   false}
+                                                    :position 1
+                                                    :clock 1698945829328
+                                                    :created-at 1698928839000
+                                                    :operable :fully
+                                                    :mixedcase-address "0x7bcDfc75c431"
+                                                    :public-key "0x04371e2d9d66b82f056bc128064"
+                                                    :removed false}
    :wallet/wallet-send-token                       {:symbol                     :eth
-                                                    :networks                   [{:source           879
-                                                                                  :short-name       "eth"
-                                                                                  :network-name     :mainnet
+                                                    :networks                   [{:source 879
+                                                                                  :short-name "eth"
+                                                                                  :network-name :mainnet
                                                                                   :abbreviated-name
                                                                                   "Eth."
-                                                                                  :full-name        "Mainnet"
-                                                                                  :chain-id         1
+                                                                                  :full-name "Mainnet"
+                                                                                  :chain-id 1
                                                                                   :related-chain-id 1
-                                                                                  :layer            1}]
+                                                                                  :layer 1}]
                                                     :balances-per-chain         {1 {:raw-balance
                                                                                     (money/bignumber
                                                                                      "2500")
@@ -64,9 +64,9 @@
                                                      :to         {:chain-id               1
                                                                   :native-currency-symbol "ETH"}
                                                      :gas-amount "23487"
-                                                     :gas-fees   {:base-fee                 "32.325296406"
+                                                     :gas-fees   {:base-fee "32.325296406"
                                                                   :max-priority-fee-per-gas "0.011000001"
-                                                                  :eip1559-enabled          true}}]
+                                                                  :eip1559-enabled true}}]
    :wallet/wallet-send-suggested-routes            nil
    :wallet/wallet-send-receiver-networks           [1]
    :view-id                                        :screen/wallet.send-input-amount

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -19,38 +19,38 @@
                                                      :chain-id         1
                                                      :related-chain-id 5}]
    :wallet/current-viewing-account-address         "0x1"
-   :wallet/current-viewing-account                 {:path "m/44'/60'/0'/0/1"
-                                                    :emoji "💎"
-                                                    :key-uid "0x2f5ea39"
-                                                    :address "0x1"
-                                                    :wallet false
-                                                    :name "Account One"
-                                                    :type :generated
-                                                    :watch-only? false
-                                                    :chat false
-                                                    :test-preferred-chain-ids #{5 420 421613}
-                                                    :color :purple
-                                                    :hidden false
-                                                    :prod-preferred-chain-ids #{1 10 42161}
+   :wallet/current-viewing-account                 {:path                      "m/44'/60'/0'/0/1"
+                                                    :emoji                     "💎"
+                                                    :key-uid                   "0x2f5ea39"
+                                                    :address                   "0x1"
+                                                    :wallet                    false
+                                                    :name                      "Account One"
+                                                    :type                      :generated
+                                                    :watch-only?               false
+                                                    :chat                      false
+                                                    :test-preferred-chain-ids  #{5 420 421613}
+                                                    :color                     :purple
+                                                    :hidden                    false
+                                                    :prod-preferred-chain-ids  #{1 10 42161}
                                                     :network-preferences-names #{:mainnet :arbitrum
                                                                                  :optimism}
-                                                    :position 1
-                                                    :clock 1698945829328
-                                                    :created-at 1698928839000
-                                                    :operable :fully
-                                                    :mixedcase-address "0x7bcDfc75c431"
-                                                    :public-key "0x04371e2d9d66b82f056bc128064"
-                                                    :removed false}
+                                                    :position                  1
+                                                    :clock                     1698945829328
+                                                    :created-at                1698928839000
+                                                    :operable                  :fully
+                                                    :mixedcase-address         "0x7bcDfc75c431"
+                                                    :public-key                "0x04371e2d9d66b82f056bc128064"
+                                                    :removed                   false}
    :wallet/wallet-send-token                       {:symbol                     :eth
-                                                    :networks                   [{:source 879
-                                                                                  :short-name "eth"
-                                                                                  :network-name :mainnet
+                                                    :networks                   [{:source           879
+                                                                                  :short-name       "eth"
+                                                                                  :network-name     :mainnet
                                                                                   :abbreviated-name
                                                                                   "Eth."
-                                                                                  :full-name "Mainnet"
-                                                                                  :chain-id 1
+                                                                                  :full-name        "Mainnet"
+                                                                                  :chain-id         1
                                                                                   :related-chain-id 1
-                                                                                  :layer 1}]
+                                                                                  :layer            1}]
                                                     :balances-per-chain         {1 {:raw-balance
                                                                                     (money/bignumber
                                                                                      "2500")
@@ -64,9 +64,9 @@
                                                      :to         {:chain-id               1
                                                                   :native-currency-symbol "ETH"}
                                                      :gas-amount "23487"
-                                                     :gas-fees   {:base-fee "32.325296406"
+                                                     :gas-fees   {:base-fee                 "32.325296406"
                                                                   :max-priority-fee-per-gas "0.011000001"
-                                                                  :eip1559-enabled true}}]
+                                                                  :eip1559-enabled          true}}]
    :wallet/wallet-send-suggested-routes            nil
    :wallet/wallet-send-receiver-networks           [1]
    :view-id                                        :screen/wallet.send-input-amount
@@ -98,7 +98,7 @@
                                                      :related-chain-id 1
                                                      :layer            1}]
    :wallet/wallet-send-enabled-from-chain-ids      [1]
-   :wallet/wallet-send-amount                      nil
+   :wallet/send-amount                             nil
    :wallet/wallet-send-tx-type                     :tx/send
    :wallet/wallet-send-fee-fiat-formatted          "$5,00"
    :wallet/total-amount                            (money/bignumber "250")})

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -9,6 +9,25 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
+(defn other-account-item
+  [{:keys        [address color emoji network-preferences-names]
+    account-name :name
+    :as          account}]
+  (let [full-address (rf/sub [:wallet/account-address address network-preferences-names])]
+    [quo/account-item
+     {:account-props (assoc account
+                       :customization-color color
+                       :address             full-address
+                       :full-address?       true)
+      :on-press      (fn []
+                       (rf/dispatch [:wallet/select-send-address
+                                     {:address   address
+                                      :recipient {:recipient-type      :account
+                                                  :label               account-name
+                                                  :customization-color color
+                                                  :emoji               emoji}
+                                      :stack-id  :screen/wallet.select-address}]))}]))
+
 (defn- my-accounts
   [theme]
   (let [other-accounts (rf/sub [:wallet/accounts-without-current-viewing-account])]
@@ -20,22 +39,8 @@
         :container-style style/empty-container-style}]
       [rn/view {:style style/my-accounts-container}
        (doall
-        (for [{:keys [color address] :as account} other-accounts]
-          ^{:key (str address)}
-          (let [transformed-address (rf/sub [:wallet/account-address address
-                                             (:network-preferences-names account)])]
-            [quo/account-item
-             {:account-props (assoc account
-                                    :customization-color color
-                                    :address             transformed-address
-                                    :full-address?       true)
-              :on-press      #(rf/dispatch [:wallet/select-send-address
-                                            {:address   address
-                                             :recipient {:recipient-type      :account
-                                                         :label               (:name account)
-                                                         :customization-color (:color account)
-                                                         :emoji               (:emoji account)}
-                                             :stack-id  :screen/wallet.select-address}])}])))])))
+        (for [{:keys [address] :as account} other-accounts]
+          ^{:key (str address)} [other-account-item account]))])))
 
 (defn- recent-transactions
   [theme]

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -16,9 +16,9 @@
   (let [full-address (rf/sub [:wallet/account-address address network-preferences-names])]
     [quo/account-item
      {:account-props (assoc account
-                       :customization-color color
-                       :address             full-address
-                       :full-address?       true)
+                            :customization-color color
+                            :address             full-address
+                            :full-address?       true)
       :on-press      (fn []
                        (rf/dispatch [:wallet/select-send-address
                                      {:address   address

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -44,7 +44,7 @@
     (let [current-screen-id        (rf/sub [:view-id])
           scanned-address          (rf/sub [:wallet/scanned-address])
           send-address             (rf/sub [:wallet/wallet-send-to-address])
-          recipient                (rf/sub [:wallet/wallet-send-recipient])
+          recipient                (rf/sub [:wallet/send-recipient])
           recipient-plain-address? (= send-address recipient)
           valid-ens-or-address?    (rf/sub [:wallet/valid-ens-or-address?])
           contacts                 (rf/sub [:contacts/active])]

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -191,7 +191,7 @@
         [floating-button-page/view
          {:content-container-style      {:flex 1}
           :footer-container-padding     0
-          :keyboard-should-persist-taps true
+          :keyboard-should-persist-taps :always
           :header                       [account-switcher/view
                                          {:on-press      #(rf/dispatch [:navigate-back])
                                           :margin-top    (safe-area/get-top)

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -36,7 +36,8 @@
       :on-collectible-press (fn [{:keys [collectible]}]
                               (rf/dispatch [:wallet/set-collectible-to-send
                                             {:collectible    collectible
-                                             :current-screen :screen/wallet.select-asset}]))}]))
+                                             :current-screen :screen/wallet.select-asset
+                                             :entry-point    :account-send-button}]))}]))
 
 (defn- tab-view
   [search-text selected-tab on-change-text]

--- a/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
@@ -23,8 +23,9 @@
         increase-value        (rn/use-callback #(set-value controlled-input/increase))
         decrease-value        (rn/use-callback #(set-value controlled-input/decrease))
         delete-character      (rn/use-callback #(set-value controlled-input/delete-last))
-        add-character         (rn/use-callback (fn [c]
-                                                 (set-value #(controlled-input/add-character % c))))]
+        add-character         (rn/use-callback
+                               (fn [c]
+                                 (set-value #(controlled-input/add-character % c))))]
     (rn/use-effect
      (fn []
        (set-value #(controlled-input/set-upper-limit % balance)))

--- a/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
@@ -11,7 +11,8 @@
 
 (defn view
   []
-  (let [on-close              (rn/use-callback #(rf/dispatch [:navigate-back]))
+  (let [on-close              (rn/use-callback
+                               #(rf/dispatch [:wallet/collectible-amount-navigate-back]))
         send-transaction-data (rf/sub [:wallet/wallet-send])
         collectible           (:collectible send-transaction-data)
         balance               (utils/collectible-balance collectible)

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -195,7 +195,7 @@
 
 (defn view
   [_]
-  (let [on-close #(rf/dispatch [:navigate-back])]
+  (let [on-close #(rf/dispatch [:wallet/transaction-confirmation-navigate-back])]
     (fn []
       (let [theme                     (quo.theme/use-theme)
             send-transaction-data     (rf/sub [:wallet/wallet-send])

--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -43,8 +43,7 @@
 
 (rf/reg-event-fx :wallet.swap/set-default-slippage
  (fn [{:keys [db]}]
-   {:db
-    (assoc-in db [:wallet :ui :swap :max-slippage] constants/default-slippage)}))
+   {:db (assoc-in db [:wallet :ui :swap :max-slippage] constants/default-slippage)}))
 
 (rf/reg-event-fx :wallet.swap/set-max-slippage
  (fn [{:keys [db]} [max-slippage]]

--- a/src/status_im/subs/wallet/send.cljs
+++ b/src/status_im/subs/wallet/send.cljs
@@ -1,9 +1,9 @@
 (ns status-im.subs.wallet.send
   (:require
-   [re-frame.core :as rf]
-   [status-im.contexts.wallet.common.activity-tab.constants :as constants]
-   [status-im.contexts.wallet.send.utils :as send-utils]
-   [utils.number]))
+    [re-frame.core :as rf]
+    [status-im.contexts.wallet.common.activity-tab.constants :as constants]
+    [status-im.contexts.wallet.send.utils :as send-utils]
+    [utils.number]))
 
 (rf/reg-sub
  :wallet/send-tab
@@ -35,6 +35,16 @@
  :wallet/send-amount
  :<- [:wallet/wallet-send]
  :-> :amount)
+
+(rf/reg-sub
+ :wallet/send-tx-type
+ :<- [:wallet/wallet-send]
+ :-> :tx-type)
+
+(rf/reg-sub
+ :wallet/sending-collectible?
+ :<- [:wallet/send-tx-type]
+ #(send-utils/tx-type-collectible? %))
 
 (rf/reg-sub
  :wallet/send-transaction-progress

--- a/src/status_im/subs/wallet/send.cljs
+++ b/src/status_im/subs/wallet/send.cljs
@@ -1,8 +1,9 @@
 (ns status-im.subs.wallet.send
   (:require
-    [re-frame.core :as rf]
-    [status-im.contexts.wallet.common.activity-tab.constants :as constants]
-    [utils.number]))
+   [re-frame.core :as rf]
+   [status-im.contexts.wallet.common.activity-tab.constants :as constants]
+   [status-im.contexts.wallet.send.utils :as send-utils]
+   [utils.number]))
 
 (rf/reg-sub
  :wallet/send-tab
@@ -16,7 +17,7 @@
  :-> :send)
 
 (rf/reg-sub
- :wallet/wallet-send-recipient
+ :wallet/send-recipient
  :<- [:wallet/wallet-send]
  :-> :recipient)
 
@@ -31,7 +32,7 @@
  :-> :just-completed-transaction?)
 
 (rf/reg-sub
- :wallet/wallet-send-amount
+ :wallet/send-amount
  :<- [:wallet/wallet-send]
  :-> :amount)
 


### PR DESCRIPTION
fixes #20472

# Important

This PR depends on the work done for:
- https://github.com/status-im/status-mobile/pull/20852

So please, do the testing after that PR is merged

### Summary

This PR hides the account switcher while the user is sending a collectible from any entry point.

Demo for ERC-721 for any entry point:

https://github.com/user-attachments/assets/263b6d29-7d55-46bb-b21e-ba7a4901637c

Demo for ERC-1155 for any entry point:

https://github.com/user-attachments/assets/b52b5da6-c8a4-4b43-8ca4-3293ab40c840

Additionally, this PR solves an existing bug in develop where the user was unable to pick the collectible amount for ERC-1155 collectibles:

Develop:

https://github.com/user-attachments/assets/c279b31b-e173-4e9e-8c81-4c41ce83b8a4

This PR:

https://github.com/user-attachments/assets/58336a23-4b79-4d41-b597-fcc3c1cae4d0





### Review notes

We should extend and improve the wizard mechanism, checking for something like "the user sending a collectible" has become a task hard to perform, since there are multiple flows depending on re-frame DB values. Depending on designs, we should design a new mechanism.

### Testing notes

Please carefully test these flows to make sure nothing is broken, there are many possible cases, they were showed in the Demo videos, but there may be something forgotten.

#### Platforms

- Android
- iOS

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Please check the Demo videos and the issue description.

status: ready