### PR TITLE
fix(wallet): inverted values of receiver and sender when displaying bridging routes

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -100,7 +100,8 @@
    :wallet/wallet-send-enabled-from-chain-ids      [1]
    :wallet/wallet-send-amount                      nil
    :wallet/wallet-send-tx-type                     :tx/send
-   :wallet/wallet-send-fee-fiat-formatted          "$5,00"})
+   :wallet/wallet-send-fee-fiat-formatted          "$5,00"
+   :wallet/total-amount                            (money/bignumber "250")})
 
 (h/describe "Send > input amount screen"
   (h/setup-restorable-re-frame)

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -221,9 +221,9 @@
                                                       (number/remove-trailing-zeroes
                                                        (.toFixed (/ input-amount conversion-rate)
                                                                  crypto-decimals)))
-        send-amount                                 (rf/sub [:wallet/wallet-send-amount])
+        total-amount-receiver                       (rf/sub [:wallet/total-amount true])
         amount-text                                 (str (number/remove-trailing-zeroes
-                                                          (.toFixed (js/parseFloat send-amount)
+                                                          (.toFixed total-amount-receiver
                                                                     (min token-decimals 6)))
                                                          " "
                                                          token-symbol)

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -225,6 +225,7 @@
                                                  bridge-to-chain-id]))
             loading-suggested-routes? (rf/sub
                                        [:wallet/wallet-send-loading-suggested-routes?])
+            total-amount-receiver     (rf/sub [:wallet/total-amount true])
             from-account-props        {:customization-color account-color
                                        :size                32
                                        :emoji               (:emoji account)
@@ -249,8 +250,8 @@
                                       [transaction-details
                                        {:estimated-time-min estimated-time-min
                                         :max-fees           fee-formatted
-                                        :token-display-name token-display-name
-                                        :amount             amount
+                                        :token-display-name token-symbol
+                                        :amount             total-amount-receiver
                                         :to-network         bridge-to-network
                                         :theme              theme
                                         :route              route

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -47,7 +47,7 @@
   [{:keys [route token-decimals native-token? receiver?]}]
   (reduce
    (fn [acc path]
-     (let [amount-hex   (if receiver? (:amount-in path) (:amount-out path))
+     (let [amount-hex   (if receiver? (:amount-out path) (:amount-in path))
            amount-units (native-module/hex-to-number
                          (utils.hex/normalize-hex amount-hex))
            amount       (money/with-precision

--- a/src/status_im/contexts/wallet/send/utils_test.cljs
+++ b/src/status_im/contexts/wallet/send/utils_test.cljs
@@ -32,10 +32,10 @@
 
 (deftest network-amounts-by-chain-test
   (testing "Correctly calculates network amounts for transaction with native token"
-    (let [route          [{:amount-in "0xde0b6b3a7640000"
-                           :to        {:chain-id 1}}
-                          {:amount-in "0xde0b6b3a7640000"
-                           :to        {:chain-id 10}}]
+    (let [route          [{:amount-out "0xde0b6b3a7640000"
+                           :to         {:chain-id 1}}
+                          {:amount-out "0xde0b6b3a7640000"
+                           :to         {:chain-id 10}}]
           token-decimals 18
           native-token?  true
           receiver?      true
@@ -50,10 +50,10 @@
 
   (testing
     "Correctly calculates network amounts for transaction with native token and multiple routes to same chain-id"
-    (let [route          [{:amount-in "0xde0b6b3a7640000"
-                           :to        {:chain-id 1}}
-                          {:amount-in "0xde0b6b3a7640000"
-                           :to        {:chain-id 1}}]
+    (let [route          [{:amount-out "0xde0b6b3a7640000"
+                           :to         {:chain-id 1}}
+                          {:amount-out "0xde0b6b3a7640000"
+                           :to         {:chain-id 1}}]
           token-decimals 18
           native-token?  true
           receiver?      true
@@ -66,10 +66,10 @@
         (is (money/equal-to (get result chain-id) exp-value)))))
 
   (testing "Correctly calculates network amounts for transaction with non-native token"
-    (let [route          [{:amount-out "0x1e8480"
-                           :from       {:chain-id 1}}
-                          {:amount-out "0x1e8480"
-                           :from       {:chain-id 10}}]
+    (let [route          [{:amount-in "0x1e8480"
+                           :from      {:chain-id 1}}
+                          {:amount-in "0x1e8480"
+                           :from      {:chain-id 10}}]
           token-decimals 6
           native-token?  false
           receiver?      false

--- a/src/status_im/subs/wallet/networks.cljs
+++ b/src/status_im/subs/wallet/networks.cljs
@@ -1,6 +1,7 @@
 (ns status-im.subs.wallet.networks
   (:require [re-frame.core :as re-frame]
-            [status-im.contexts.wallet.common.utils.networks :as network-utils]))
+            [status-im.contexts.wallet.common.utils.networks :as network-utils]
+            [utils.money :as money]))
 
 (def max-network-prefixes 2)
 
@@ -80,3 +81,16 @@
                  {:amount amount :token-symbol token-symbol})))
       {}
       network-values))))
+
+(re-frame/reg-sub
+ :wallet/total-amount
+ :<- [:wallet/wallet-send]
+ (fn [{:keys [from-values-by-chain to-values-by-chain]} [_ to-values?]]
+   (let [network-values (if to-values? to-values-by-chain from-values-by-chain)]
+     (reduce
+      (fn [acc amount]
+        (if (money/bignumber? amount)
+          (money/add acc amount)
+          acc))
+      (money/bignumber 0)
+      (vals network-values)))))


### PR DESCRIPTION
fixes #20502

### Summary

When processing amount values for displaying routes in the UI, we were mistakenly showing the amount-in on the receiver side (TO column), and amount-out on the sender side (FROM column). This was not noticeable on normal send transactions because the amount-in and amount-out is generally the same value, but for some bridge operations, the amount that the receiver receives is lower than the amount the user is sending (because of bonderFees, or other type of operational cost of the bridging protocol), thus this bug is noticeable when bridging or performing a send transaction with routes that involves bridging.

This PR fixes that, and updates related unit tests accordingly.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Restore user with available assets on any mainnet network
- Go to the routes generation page or the bridge page
- Input available value to generate any bridge route

Check linked issue for more context

status: ready 

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
