### PR TITLE
feat: dapp connected notification

### DIFF
--- a/src/legacy/status_im/data_store/activities.cljs
+++ b/src/legacy/status_im/data_store/activities.cljs
@@ -57,13 +57,17 @@
   [item]
   (-> item
       rpc->type
-      (set/rename-keys {:lastMessage               :last-message
-                        :replyMessage              :reply-message
-                        :chatId                    :chat-id
-                        :contactVerificationStatus :contact-verification-status
-                        :communityId               :community-id
-                        :membershipStatus          :membership-status
-                        :albumMessages             :album-messages})
+      (set/rename-keys {:lastMessage                :last-message
+                        :replyMessage               :reply-message
+                        :chatId                     :chat-id
+                        :contactVerificationStatus  :contact-verification-status
+                        :communityId                :community-id
+                        :membershipStatus           :membership-status
+                        :albumMessages              :album-messages
+                        :walletProviderSessionTopic :wallet-provider-session-topic
+                        :dappURL                    :dapp-url
+                        :dappName                   :dapp-name
+                        :dappIconURL                :dapp-icon-url})
       (update :last-message #(when % (messages/<-rpc %)))
       (update :message #(when % (messages/<-rpc %)))
       (update :reply-message #(when % (messages/<-rpc %)))

--- a/src/status_im/contexts/shell/activity_center/notification/dapp_connection/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification/dapp_connection/view.cljs
@@ -25,11 +25,13 @@
        :context             [[quo/context-tag
                               {:type      :dapp
                                :size      24
+                               :blur?     true
                                :dapp-logo dapp-icon-url
                                :dapp-name (utils.url/url-host dapp-url)}]
                              (i18n/label :t/via)
                              [quo/context-tag
                               {:type      :dapp
                                :size      24
+                               :blur?     true
                                :dapp-logo (quo.resources/get-dapp :wallet-connect)
                                :dapp-name "WalletConnect"}]]}]]))

--- a/src/status_im/contexts/shell/activity_center/notification/dapp_connection/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification/dapp_connection/view.cljs
@@ -1,0 +1,35 @@
+(ns status-im.contexts.shell.activity-center.notification.dapp-connection.view
+  (:require
+    [quo.core :as quo]
+    [quo.foundations.resources :as quo.resources]
+    [status-im.contexts.shell.activity-center.notification.common.view :as common]
+    [utils.datetime :as datetime]
+    [utils.i18n :as i18n]
+    utils.url))
+
+(defn view
+  [{:keys [customization-color notification extra-fn]}]
+  (let [{:keys [timestamp read dapp-url dapp-icon-url]} notification]
+    [common/swipeable
+     {:left-button    common/swipe-button-read-or-unread
+      :left-on-press  common/swipe-on-press-toggle-read
+      :right-button   common/swipe-button-delete
+      :right-on-press common/swipe-on-press-delete
+      :extra-fn       extra-fn}
+     [quo/activity-log
+      {:title               (i18n/label :t/connected-to-dapp)
+       :customization-color customization-color
+       :icon                :i/dapps
+       :timestamp           (datetime/timestamp->relative timestamp)
+       :unread?             (not read)
+       :context             [[quo/context-tag
+                              {:type      :dapp
+                               :size      24
+                               :dapp-logo dapp-icon-url
+                               :dapp-name (utils.url/url-host dapp-url)}]
+                             (i18n/label :t/via)
+                             [quo/context-tag
+                              {:type      :dapp
+                               :size      24
+                               :dapp-logo (quo.resources/get-dapp :wallet-connect)
+                               :dapp-name "WalletConnect"}]]}]]))

--- a/src/status_im/contexts/shell/activity_center/notification_types.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification_types.cljs
@@ -10,6 +10,8 @@
 (def ^:const admin 8)
 (def ^:const community-kicked 9)
 (def ^:const contact-verification 10)
+(def ^:const dapp-connected 23)
+(def ^:const dapp-disconnected 24)
 
 (def ^:const all-supported
   #{one-to-one-chat
@@ -20,7 +22,8 @@
     community-request
     admin
     community-kicked
-    contact-verification})
+    contact-verification
+    dapp-connected})
 
 ;; TODO: Replace with correct enum values once status-go implements them.
 (def ^:const tx 66612)

--- a/src/status_im/contexts/shell/activity_center/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/view.cljs
@@ -16,6 +16,7 @@
      contact-requests]
     [status-im.contexts.shell.activity-center.notification.contact-verification.view :as
      contact-verification]
+    [status-im.contexts.shell.activity-center.notification.dapp-connection.view :as dapp-connection]
     [status-im.contexts.shell.activity-center.notification.membership.view :as membership]
     [status-im.contexts.shell.activity-center.notification.mentions.view :as mentions]
     [status-im.contexts.shell.activity-center.notification.reply.view :as reply]
@@ -50,6 +51,9 @@
 
        (= type types/admin)
        [admin/view props]
+
+       (= type types/dapp-connected)
+       [dapp-connection/view props]
 
        (some types/membership [type])
        (condp = type

--- a/src/status_im/contexts/wallet/wallet_connect/events.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events.cljs
@@ -331,14 +331,12 @@
                           (wallet-connect-core/get-dapp-redirect-url))]
      (log/info "Wallet Connect session persisted")
      {:fx [[:dispatch [:wallet-connect/fetch-active-sessions]]
-           [:activity-center.notifications/fetch-unread-count]
-           [:activity-center/update-seen-state]
            [[:dispatch [:wallet-connect/redirect-to-dapp redirect-url]]]]})))
 
 (rf/reg-event-fx
  :wallet-connect/disconnect-session
  (fn [{:keys [db]} [topic]]
-   (log/info "Removing session from persistance and state" topic)
+   (log/info "Removing session from persistence and state" topic)
    {:db (update db
                 :wallet-connect/sessions
                 (fn [sessions]

--- a/src/status_im/contexts/wallet/wallet_connect/events.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events.cljs
@@ -326,6 +326,7 @@
               :on-success (fn []
                             (log/info "Wallet Connect session persisted")
                             (rf/dispatch [:wallet-connect/fetch-persisted-sessions])
+                            (rf/dispatch [:activity-center.notifications/fetch-unread-count])
                             (rf/dispatch [:wallet-connect/redirect-to-dapp redirect-url]))
               :on-error   #(log/info "Wallet Connect session persistence failed" %)}]]]})))
 

--- a/src/status_im/subs/wallet/activities.cljs
+++ b/src/status_im/subs/wallet/activities.cljs
@@ -3,7 +3,6 @@
     [clojure.string :as string]
     [native-module.core :as native-module]
     [quo.foundations.resources :as quo.resources]
-    [quo.foundations.resources]
     [re-frame.core :as rf]
     [status-im.contexts.wallet.common.activity-tab.constants :as constants]
     [utils.datetime :as datetime]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "feat/wallet-connect-session-notification",
-    "commit-sha1": "177688f8c483ccc492834bcdae36ae76a3074a1b",
-    "src-sha256": "1y8dv545lzpy9dfvjj973hxsrzzhh0wab73d9fad16r5bs0wivc5"
+    "commit-sha1": "d608df7c3c1316265566b875d52d6582453532a4",
+    "src-sha256": "06bb3rjyzrkp9gsfkprmkw562r33lxvqj04pnfnbd4j4m4hpxw2q"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.184.52",
-    "commit-sha1": "81cfce709e8d123eb1956b87f8e0f19dc47c122c",
-    "src-sha256": "0hna30ms4ccxmi20l5v36y84pva1s4jjkqg11whwmdjgw75d0fan"
+    "version": "feat/wallet-connect-session-notification",
+    "commit-sha1": "177688f8c483ccc492834bcdae36ae76a3074a1b",
+    "src-sha256": "1y8dv545lzpy9dfvjj973hxsrzzhh0wab73d9fad16r5bs0wivc5"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "feat/wallet-connect-session-notification",
-    "commit-sha1": "d608df7c3c1316265566b875d52d6582453532a4",
-    "src-sha256": "06bb3rjyzrkp9gsfkprmkw562r33lxvqj04pnfnbd4j4m4hpxw2q"
+    "commit-sha1": "24f56c76b05cbe1c543da890505df487700b5b1e",
+    "src-sha256": "1pjdplgb7cmdbjlf28p5djag307hcbkdsp0ihyf36yhbwfs0s8y6"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -468,6 +468,7 @@
   "connected": "Connected",
   "connected-dapps": "Connected dApps",
   "connected-to": "Connected to",
+  "connected-to-dapp": "Connected to dApp",
   "connecting": "Connecting...",
   "connecting-requires-login": "Connecting to another network requires login",
   "connection-request": "Connection Request",


### PR DESCRIPTION
https://github.com/status-im/status-go/compare/4a43b2b2...9bc67a04

-------

fixes #20467

### Summary

Pressing on the notification to execute its default action will be a separate GH issue.

- add dapp connected notification type
- fetch notification unread count when wallet connect session added
- add status-im.contexts.shell.activity-center.notification.dapp-connection.view to render the notification

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
activity center

### Steps to test

- Open Status
- enable wallet connect feature flag
- scan the QR code at https://react-app.walletconnect.com/
- connect on mobile
- unread notification count should increase
- open activity center
- check the notification
- try mark notification read or delete the notification

status: ready <!-- Can be ready or wip -->