### PR TITLE
preserve the state of selected contacts when the screen is reloaded

### DIFF
--- a/src/status_im/subs/contact.cljs
+++ b/src/status_im/subs/contact.cljs
@@ -128,6 +128,13 @@
                 :data  data})))))
 
 (re-frame/reg-sub
+ :contacts/is-participant-selected?
+ :<- [:group-chat/selected-participants]
+ (fn [selected-participants [_ id]]
+   (-> selected-participants
+       (contains? id))))
+
+(re-frame/reg-sub
  :contacts/blocked
  :<- [:contacts/contacts]
  (fn [contacts]


### PR DESCRIPTION
fixes #

### Summary
This pr does not solve the contacts reloading issue when scrolled is disabled after the user selects or unselects contacts. It ensures already selected contacts do not become unselected when the screen is reloaded unselected by the user. 
