### PR TITLE
WC: Last account that established connection is not selected when connecting through global scanner #20801

### DIFF
--- a/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
@@ -59,18 +59,21 @@
  :wallet-connect/on-session-proposal
  (fn [{:keys [db]} [proposal]]
    (log/info "Received Wallet Connect session proposal: " proposal)
-   (let [accounts                     (get-in db [:wallet :accounts])
-         current-viewing-address      (get-in db [:wallet :current-viewing-account-address])
-         available-accounts           (sessions/filter-operable-accounts (vals accounts))
-         networks                     (networks/get-networks-by-mode db)
-         session-networks             (networks/proposal-networks-intersection proposal networks)
-         required-networks-supported? (networks/required-networks-supported? proposal networks)]
+   (let [accounts                         (get-in db [:wallet :accounts])
+         current-viewing-address          (get-in db [:wallet :current-viewing-account-address])
+         sessions                         (get db :wallet-connect/sessions)
+         available-accounts               (sessions/filter-operable-accounts (vals accounts))
+         latest-connected-account-address (sessions/latest-connected-account-address sessions)
+         networks                         (networks/get-networks-by-mode db)
+         session-networks                 (networks/proposal-networks-intersection proposal networks)
+         required-networks-supported?     (networks/required-networks-supported? proposal networks)]
      (if (and (not-empty session-networks) required-networks-supported?)
        {:db (update db
                     :wallet-connect/current-proposal assoc
                     :request                         proposal
                     :session-networks                session-networks
                     :address                         (or current-viewing-address
+                                                         latest-connected-account-address
                                                          (-> available-accounts
                                                              first
                                                              :address)))

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.wallet.wallet-connect.events.session-proposals
-  (:require [re-frame.core :as rf]
+  (:require [clojure.string :as string]
+            [re-frame.core :as rf]
             [react-native.wallet-connect :as wallet-connect]
             [status-im.contexts.wallet.wallet-connect.utils.data-store :as
              data-store]
@@ -72,11 +73,17 @@
                     :wallet-connect/current-proposal assoc
                     :request                         proposal
                     :session-networks                session-networks
-                    :address                         (or current-viewing-address
-                                                         latest-connected-account-address
-                                                         (-> available-accounts
-                                                             first
-                                                             :address)))
+                    :address                         (cond
+                                                       (not (string/blank? current-viewing-address))
+                                                       current-viewing-address
+
+                                                       (not (string/blank?
+                                                             latest-connected-account-address))
+                                                       latest-connected-account-address
+
+                                                       :else (-> available-accounts
+                                                                 first
+                                                                 :address)))
         :fx [[:dispatch [:open-modal :screen/wallet.wallet-connect-session-proposal]]]}
        {:fx [[:dispatch [:wallet-connect/show-session-networks-unsupported-toast proposal]]
              [:dispatch [:wallet-connect/reject-session-proposal proposal]]]}))))

--- a/src/status_im/contexts/wallet/wallet_connect/utils/sessions.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/utils/sessions.cljs
@@ -31,3 +31,14 @@
                           account-addresses))
                   accounts))
           sessions))
+
+(defn latest-connected-account-address
+  [sessions]
+  (let [all-accounts (->> sessions
+                          (sort-by :expiry >)
+                          first
+                          :accounts)]
+    (-> all-accounts
+        first
+        (string/split #":")
+        last)))


### PR DESCRIPTION
fixes #20801 

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready