### PR TITLE
Fix rounding of fiat and crypto on send page

### DIFF
--- a/src/quo/components/wallet/token_input/component_spec.cljs
+++ b/src/quo/components/wallet/token_input/component_spec.cljs
@@ -6,16 +6,16 @@
 (h/describe "Wallet: Token Input"
   (h/test "Token label renders"
     (h/render-with-theme-provider [token-input/view
-                                   {:token           :snt
-                                    :currency        :eur
-                                    :currency-symbol "€"
-                                    :conversion      1}])
+                                   {:token      :snt
+                                    :currency   :eur
+                                    :crypto?    true
+                                    :conversion 1}])
     (h/is-truthy (h/get-by-text "SNT")))
 
   (h/test "Amount renders"
     (h/render-with-theme-provider [token-input/view
                                    {:token           :snt
                                     :currency        :eur
-                                    :currency-symbol "€"
+                                    :converted-value "€0.00"
                                     :conversion      1}])
     (h/is-truthy (h/get-by-text "€0.00"))))

--- a/src/status_im/contexts/preview/quo/wallet/token_input.cljs
+++ b/src/status_im/contexts/preview/quo/wallet/token_input.cljs
@@ -54,7 +54,7 @@
                                                (controlled-input/set-input-value
                                                 input-state
                                                 (let [new-value
-                                                      (if (not crypto?)
+                                                      (if-not crypto?
                                                         (utils/cut-crypto-decimals-to-fit-usd-cents
                                                          conversion-rate
                                                          (money/fiat->crypto input-amount

--- a/src/status_im/contexts/preview/quo/wallet/token_input.cljs
+++ b/src/status_im/contexts/preview/quo/wallet/token_input.cljs
@@ -2,9 +2,14 @@
   (:require
     [quo.core :as quo]
     [quo.foundations.resources :as resources]
+    [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
-    [status-im.contexts.preview.quo.preview :as preview]))
+    [status-im.common.controlled-input.utils :as controlled-input]
+    [status-im.contexts.preview.quo.preview :as preview]
+    [status-im.contexts.wallet.common.utils :as utils]
+    [utils.money :as money]
+    [utils.number :as number]))
 
 (def networks
   [{:source (resources/get-network :arbitrum)}
@@ -20,8 +25,8 @@
               {:key :snt}]}
    {:key     :currency
     :type    :select
-    :options [{:key :usd}
-              {:key :eur}]}
+    :options [{:key "$"}
+              {:key "€"}]}
    {:key  :error?
     :type :boolean}
    {:key  :allow-selection?
@@ -29,30 +34,63 @@
 
 (defn view
   []
-  (let [state     (reagent/atom {:token               :eth
-                                 :currency            :usd
-                                 :conversion          0.02
-                                 :networks            networks
-                                 :title               title
-                                 :customization-color :blue
-                                 :show-keyboard?      false
-                                 :allow-selection?    true})
-        value     (reagent/atom "")
-        set-value (fn [v]
-                    (swap! value str v))
-        delete    (fn [_]
-                    (swap! value #(subs % 0 (dec (count %)))))]
+  (let [state (reagent/atom {:token               :eth
+                             :currency            "$"
+                             :conversion-rate     3450.28
+                             :networks            networks
+                             :title               title
+                             :customization-color :blue
+                             :show-keyboard?      false
+                             :allow-selection?    true
+                             :crypto?             true})]
     (fn []
-      [preview/preview-container
-       {:state                     state
-        :descriptor                descriptor
-        :full-screen?              true
-        :component-container-style {:flex            1
-                                    :justify-content :space-between}}
-       [quo/token-input (assoc @state :value @value)]
-       [quo/numbered-keyboard
-        {:container-style {:padding-bottom (safe-area/get-top)}
-         :left-action     :dot
-         :delete-key?     true
-         :on-press        set-value
-         :on-delete       delete}]])))
+      (let [{:keys [currency token conversion-rate
+                    crypto?]}             @state
+            [input-state set-input-state] (rn/use-state controlled-input/init-state)
+            input-amount                  (controlled-input/input-value input-state)
+            swap-between-fiat-and-crypto  (fn []
+                                            (set-input-state
+                                             (fn [input-state]
+                                               (controlled-input/set-input-value
+                                                input-state
+                                                (let [new-value
+                                                      (if (not crypto?)
+                                                        (utils/cut-crypto-decimals-to-fit-usd-cents
+                                                         conversion-rate
+                                                         (money/fiat->crypto input-amount
+                                                                             conversion-rate))
+                                                        (utils/cut-fiat-balance-to-two-decimals
+                                                         (money/crypto->fiat input-amount
+                                                                             conversion-rate)))]
+                                                  (number/remove-trailing-zeroes
+                                                   new-value))))))
+            converted-value               (if crypto?
+                                            (utils/prettify-balance currency
+                                                                    (money/crypto->fiat input-amount
+                                                                                        conversion-rate))
+                                            (utils/prettify-crypto-balance
+                                             (or (clj->js token) "")
+                                             (money/fiat->crypto input-amount conversion-rate)
+                                             conversion-rate))]
+        [preview/preview-container
+         {:state                     state
+          :descriptor                descriptor
+          :full-screen?              true
+          :component-container-style {:flex            1
+                                      :justify-content :space-between}}
+         [quo/token-input
+          (merge @state
+                 {:value           input-amount
+                  :converted-value converted-value
+                  :on-swap         (fn [crypto]
+                                     (swap! state assoc :crypto? crypto)
+                                     (swap-between-fiat-and-crypto))})]
+         [quo/numbered-keyboard
+          {:container-style {:padding-bottom (safe-area/get-top)}
+           :left-action     :dot
+           :delete-key?     true
+           :on-press        (fn [c]
+                              (set-input-state #(controlled-input/add-character % c)))
+
+           :on-delete       (fn []
+                              (set-input-state controlled-input/delete-last))}]]))))

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -73,7 +73,12 @@
           token-units                (money/bignumber 0.01)]
       (is (= (utils/get-standard-crypto-format {:market-values-per-currency market-values-per-currency}
                                                token-units)
-             "<2")))))
+             "<2")))
+    (let [market-values-per-currency {:usd {:price 0.005}}
+          token-units                "0.01"]
+      (is (= (utils/get-standard-crypto-format {:market-values-per-currency market-values-per-currency}
+                                               token-units)
+             "0")))))
 
 (deftest calculate-total-token-balance-test
   (testing "calculate-total-token-balance function"
@@ -162,6 +167,4 @@
           sorted-tokens  (map :symbol (utils/sort-tokens mock-tokens))
           expected-order ["DAI" "ETH" "SNT"]]
       (is (= expected-order sorted-tokens)))))
-
-
 

--- a/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/component_spec.cljs
@@ -113,33 +113,10 @@
                                     :limit-crypto             250
                                     :initial-crypto-currency? false}])
     (h/is-truthy (h/get-by-text "0"))
-    (h/is-truthy (h/get-by-text "ETH"))
-    (h/is-truthy (h/get-by-text "$0.00"))
+    (h/is-truthy (h/get-by-text "USD"))
+    (h/is-truthy (h/get-by-text "0 ETH"))
     (h/is-truthy (h/get-by-label-text :container))
     (h/is-disabled (h/get-by-label-text :button-one)))
-
-  (h/test "Fill token input and confirm"
-    (h/setup-subs sub-mocks)
-    (let [on-confirm (h/mock-fn)]
-      (h/render-with-theme-provider [input-amount/view
-                                     {:on-confirm               on-confirm
-                                      :crypto-decimals          10
-                                      :limit-crypto             1000
-                                      :initial-crypto-currency? false}])
-
-      (h/fire-event :press (h/query-by-label-text :keyboard-key-1))
-      (h/fire-event :press (h/query-by-label-text :keyboard-key-2))
-      (h/fire-event :press (h/query-by-label-text :keyboard-key-3))
-      (h/fire-event :press (h/query-by-label-text :keyboard-key-.))
-      (h/fire-event :press (h/query-by-label-text :keyboard-key-4))
-      (h/fire-event :press (h/query-by-label-text :keyboard-key-5))
-
-      (-> (h/wait-for #(h/get-by-text "$1234.50"))
-          (.then (fn []
-                   (h/is-truthy (h/get-by-label-text :button-one))
-                   (h/is-truthy (h/get-by-label-text :container))
-                   (h/fire-event :press (h/get-by-label-text :button-one))
-                   (h/was-called on-confirm))))))
 
   (h/test "Fill token input and confirm"
     (h/setup-subs sub-mocks)
@@ -149,7 +126,7 @@
                                      {:crypto-decimals          10
                                       :limit-crypto             1000
                                       :on-confirm               on-confirm
-                                      :initial-crypto-currency? false}])
+                                      :initial-crypto-currency? true}])
 
       (h/fire-event :press (h/query-by-label-text :keyboard-key-1))
       (h/fire-event :press (h/query-by-label-text :keyboard-key-2))

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -375,7 +375,7 @@
                             (money/crypto->fiat input-amount
                                                 conversion-rate))
                            (utils/prettify-crypto-balance
-                            (or (name token-symbol) "")
+                            (or (clj->js token-symbol) "")
                             (money/fiat->crypto input-amount
                                                 conversion-rate)
                             conversion-rate))}]

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -163,7 +163,6 @@
         {fiat-currency :currency}                   (rf/sub [:profile/profile])
         {token-symbol :symbol
          token-networks :networks
-         token-decimals :decimals
          :as
          token}                                     (rf/sub [:wallet/wallet-send-token])
         send-from-locked-amounts                    (rf/sub [:wallet/wallet-send-from-locked-amounts])
@@ -178,6 +177,10 @@
                                                         :market-values-per-currency
                                                         currency
                                                         :price)
+        token-decimals                              (-> token
+                                                        utils/token-usd-price
+                                                        utils/one-cent-value
+                                                        utils/calc-max-crypto-decimals)
         loading-routes?                             (rf/sub
                                                      [:wallet/wallet-send-loading-suggested-routes?])
         route                                       (rf/sub [:wallet/wallet-send-route])

--- a/src/test_helpers/unit.cljs
+++ b/src/test_helpers/unit.cljs
@@ -6,6 +6,8 @@
   prefer to use it for more general purpose concepts, such as the re-frame event
   layer."
   (:require-macros test-helpers.unit)
+  ;; We must require test-helpers.matchers namespace to register the custom cljs.test directive
+  ;; `match-strict?`
   (:require
     [re-frame.core :as rf]
     [re-frame.db :as rf-db]

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -262,6 +262,12 @@
   [bn1 bn2]
   (.round (.dividedBy ^js bn1 bn2) 0))
 
+(defn fiat->crypto
+  [crypto fiat-price]
+  (when-let [crypto-bn (bignumber crypto)]
+    (div crypto-bn
+         (bignumber fiat-price))))
+
 (defn absolute-value
   [bn]
   (when bn


### PR DESCRIPTION
fixes #20417

### Summary
On send screen fiat values round to 2 decimal digits and crypto values round so that “1” in the final decimal place always has a value of between $0.01 and $0.10 USD


https://github.com/user-attachments/assets/be38ecd0-99d8-4b90-83d1-cce7f10d8c4c



### Review notes
Implementing this in main input dragged few changes in `token-input` component that resulted in such changes:
- `token-input` component previously had internal conversion (incorrect) and now it is external
- `token-input` maintained own internal state to check if displayed value is in crypto and that led to bugs, so now it gets this info from outside also
- incorrect component tests fixed

### Testing notes


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional
- wallet / transactions

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Go to send screen
- Enter some amount
- Make sure that when values swapped between crypto and fiat, fiat always has 2 decimals and amount of decimals in crypto follows rule in the PR description 
- also make sure that converted value in right top corner of input field is the same as you will get when push the `swap` button


status: wip
