### PR TITLE
fix_: use usd as default currency

### DIFF
--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -20,9 +20,9 @@
 
 (re-frame/reg-sub
  :profile/currency
- :<- [:profile/profile]
- (fn [{:keys [currency]}]
-   (or currency constants/profile-default-currency)))
+ (fn []
+   ;; returns "usd" by default as the support for other currencies are in progress on Mobile
+   constants/profile-default-currency))
 
 (re-frame/reg-sub
  :profile/syncing-on-mobile-network?


### PR DESCRIPTION

### Summary

This PR uses `usd` currency as default for the fiat price calculation for the tokens. Every currency has a different format - decimal which we need to integrate a separate RPC to fetch currency format and do the calculation. So, this PR will change to use `usd` as the default for v2.30.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the Wallet tab
- Verify the prices are displayed in USD
- Create a transaction and verify the prices are displayed in USD

status: ready 

