### PR TITLE
feat_: add fallback pairing support

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.182.39",
-    "commit-sha1": "9755b3de7ae64929066d2b8a26222d8d41ceda87",
-    "src-sha256": "02b2fshb7phhsr7mghg4s6qr1n1c8xawaz4pw04q8hpv5vfnjcxz"
+    "version": "v0.182.40",
+    "commit-sha1": "9ef122b89551f2210946e0d3094ee0225aa39b75",
+    "src-sha256": "0pd2kjc3g7cfvg7j0w7lsaczk5za2c2259sbidjjhr0v54cfys0l"
 }


### PR DESCRIPTION
Creating this PR for regression testing the comparability of feature `sync` between different versions(mainly current PR build vs v2.29) after adding backend fallback pairing support. Because frontend haven't added the invocations relate to fallback pairing API yet, so fallback pairing won't support with current build.

relate status-go [PR](https://github.com/status-im/status-go/pull/5614)

### Testing notes
expected: sync should work as before between different versions like following:
v2.29 <-> PR build
PR build <-> recent desktop build

NOTE: It breaks with v1 of pairing, but that's ancient (last year I believe), so safe to break.

status: ready <!-- Can be ready or wip -->