### PR TITLE
fix(android): Send and Bridge ERC-20 tokens

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/EncryptionUtils.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/EncryptionUtils.java
@@ -63,6 +63,11 @@ public class EncryptionUtils extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
+    public String encodeFunctionCall(final String method, final String paramsJSON) {
+        return Statusgo.encodeFunctionCall(method, paramsJSON);
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
     public String decodeParameters(final String decodeParamJSON) {
         return Statusgo.decodeParameters(decodeParamJSON);
     }


### PR DESCRIPTION
fixes #20920

### Summary

This PR adds the missing `encodeFunctionCall` method in Android

### Platforms
- Android

### Areas impacted

- wallet / transactions

### Steps to test

- Open Status
- Navigate to the Wallet tab
- Send an ERC-20 token and verify the transaction is done without any errors
- Bridge an ERC-20 token and verify the transaction is done without any errors

status: ready 

