### PR TITLE
Update release branch 2.30.x

### DIFF
--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -20,9 +20,9 @@
 
 (re-frame/reg-sub
  :profile/currency
- :<- [:profile/profile]
- (fn [{:keys [currency]}]
-   (or currency constants/profile-default-currency)))
+ (fn []
+   ;; returns "usd" by default as the support for other currencies are in progress on Mobile
+   constants/profile-default-currency))
 
 (re-frame/reg-sub
  :profile/syncing-on-mobile-network?

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "release/0.182.x",
-    "commit-sha1": "9570cd2a270e2f690ac6466ff9417d8a24f24c91",
-    "src-sha256": "10h79np73wrgks99b0z6k52b7ipzn29l5cfbhkv06g9ss6acdgss"
+    "commit-sha1": "003058915e1a613160e7ee1f976185823a9cd465",
+    "src-sha256": "09infws69nxwdxfqcr5z6i4sxkgzwnflxiira378pd2qpfw7c2c5"
 }


### PR DESCRIPTION
### Summary

- Bump status-go to latest revision in `release/0.182.x`. Includes the work from PR https://github.com/status-im/status-go/pull/5614

Cherry-pick:

- https://github.com/status-im/status-mobile/pull/20916
- Waiting for PR https://github.com/status-im/status-mobile/pull/20921 to be tested and merged. Edit: `Tested OK`

status: ready