### PR TITLE
📈 Capture onboarding funnel

### DIFF
--- a/src/status_im/contexts/centralized_metrics/events.cljs
+++ b/src/status_im/contexts/centralized_metrics/events.cljs
@@ -1,11 +1,11 @@
 (ns status-im.contexts.centralized-metrics.events
   (:require
-    [native-module.core :as native-module]
-    [re-frame.interceptor :as interceptor]
-    status-im.contexts.centralized-metrics.effects
-    [status-im.contexts.centralized-metrics.tracking :as tracking]
-    [taoensso.timbre :as log]
-    [utils.re-frame :as rf]))
+   [native-module.core :as native-module]
+   [re-frame.interceptor :as interceptor]
+   status-im.contexts.centralized-metrics.effects
+   [status-im.contexts.centralized-metrics.tracking :as tracking]
+   [taoensso.timbre :as log]
+   [utils.re-frame :as rf]))
 
 (def ^:const user-confirmed-key :centralized-metrics/user-confirmed?)
 (def ^:const enabled-key :centralized-metrics/enabled?)
@@ -33,24 +33,23 @@
    :after centralized-metrics-interceptor))
 
 (rf/reg-event-fx :centralized-metrics/toggle-centralized-metrics
- (fn [{:keys [db]} [enabled?]]
-   {:fx [[:effects.centralized-metrics/toggle-metrics enabled?]]
-    :db (assoc db
-               user-confirmed-key
-               true
-               enabled-key
-               enabled?)}))
+                 (fn [{:keys [db]} [enabled?]]
+                   {:fx [[:effects.centralized-metrics/toggle-metrics enabled?]]
+                    :db (assoc db
+                               user-confirmed-key
+                               true
+                               enabled-key
+                               enabled?)}))
 
 (rf/reg-event-fx :centralized-metrics/check-modal
- (fn [{:keys [db]} [modal-view]]
-   (when (show-confirmation-modal? db)
-     {:fx [[:dispatch
-            [:show-bottom-sheet
-             {:content  (fn [] [modal-view])
+                 (fn [{:keys [db]} [modal-view]]
+                   (when (show-confirmation-modal? db)
+                     {:fx [[:dispatch
+                            [:show-bottom-sheet
+                             {:content  (fn [] [modal-view])
               ;; When in the profiles screen do biometric auth after the metrics sheet is dismissed
               ;; https://github.com/status-im/status-mobile/issues/20932
-              :on-close (when (= (:view-id db) :screen/profile.profiles)
-                          #(rf/dispatch [:profile.login/login-with-biometric-if-available
-                                         (get-in db [:profile/login :key-uid])]))
-              :shell?   true}]]]})))
-
+                              :on-close (when (= (:view-id db) :screen/profile.profiles)
+                                          #(rf/dispatch [:profile.login/login-with-biometric-if-available
+                                                         (get-in db [:profile/login :key-uid])]))
+                              :shell?   true}]]]})))

--- a/src/status_im/contexts/centralized_metrics/events.cljs
+++ b/src/status_im/contexts/centralized_metrics/events.cljs
@@ -1,11 +1,11 @@
 (ns status-im.contexts.centralized-metrics.events
   (:require
-   [native-module.core :as native-module]
-   [re-frame.interceptor :as interceptor]
-   status-im.contexts.centralized-metrics.effects
-   [status-im.contexts.centralized-metrics.tracking :as tracking]
-   [taoensso.timbre :as log]
-   [utils.re-frame :as rf]))
+    [native-module.core :as native-module]
+    [re-frame.interceptor :as interceptor]
+    status-im.contexts.centralized-metrics.effects
+    [status-im.contexts.centralized-metrics.tracking :as tracking]
+    [taoensso.timbre :as log]
+    [utils.re-frame :as rf]))
 
 (def ^:const user-confirmed-key :centralized-metrics/user-confirmed?)
 (def ^:const enabled-key :centralized-metrics/enabled?)
@@ -33,23 +33,23 @@
    :after centralized-metrics-interceptor))
 
 (rf/reg-event-fx :centralized-metrics/toggle-centralized-metrics
-                 (fn [{:keys [db]} [enabled?]]
-                   {:fx [[:effects.centralized-metrics/toggle-metrics enabled?]]
-                    :db (assoc db
-                               user-confirmed-key
-                               true
-                               enabled-key
-                               enabled?)}))
+ (fn [{:keys [db]} [enabled?]]
+   {:fx [[:effects.centralized-metrics/toggle-metrics enabled?]]
+    :db (assoc db
+               user-confirmed-key
+               true
+               enabled-key
+               enabled?)}))
 
 (rf/reg-event-fx :centralized-metrics/check-modal
-                 (fn [{:keys [db]} [modal-view]]
-                   (when (show-confirmation-modal? db)
-                     {:fx [[:dispatch
-                            [:show-bottom-sheet
-                             {:content  (fn [] [modal-view])
+ (fn [{:keys [db]} [modal-view]]
+   (when (show-confirmation-modal? db)
+     {:fx [[:dispatch
+            [:show-bottom-sheet
+             {:content  (fn [] [modal-view])
               ;; When in the profiles screen do biometric auth after the metrics sheet is dismissed
               ;; https://github.com/status-im/status-mobile/issues/20932
-                              :on-close (when (= (:view-id db) :screen/profile.profiles)
-                                          #(rf/dispatch [:profile.login/login-with-biometric-if-available
-                                                         (get-in db [:profile/login :key-uid])]))
-                              :shell?   true}]]]})))
+              :on-close (when (= (:view-id db) :screen/profile.profiles)
+                          #(rf/dispatch [:profile.login/login-with-biometric-if-available
+                                         (get-in db [:profile/login :key-uid])]))
+              :shell?   true}]]]})))

--- a/src/status_im/contexts/centralized_metrics/tracking.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking.cljs
@@ -3,13 +3,21 @@
     [legacy.status-im.utils.build :as build]
     [react-native.platform :as platform]))
 
-(defn user-journey-event
-  [action]
+(defn key-value-event
+  [event-name val-key value]
   {:metric
-   {:eventName  "user-journey"
+   {:eventName  event-name
     :platform   platform/os
     :appVersion build/app-short-version
-    :eventValue {:action action}}})
+    :eventValue {val-key value}}})
+
+(defn user-journey-event
+  [action]
+  (key-value-event "user-journey" :action action))
+
+(defn navigation-event
+  [view-id]
+  (key-value-event "navigation" :viewId view-id))
 
 (def ^:const app-started-event "app-started")
 
@@ -39,13 +47,16 @@
 (defn track-view-id-event
   [view-id]
   (when (contains? view-ids-to-track view-id)
-    (user-journey-event (str "view-id." (name view-id)))))
+    (navigation-event (name view-id))))
 
 (defn tracked-event
   [[event-name second-parameter]]
   (case event-name
     :profile/get-profiles-overview-success
     (user-journey-event app-started-event)
+
+    :centralized-metrics/toggle-centralized-metrics
+    (key-value-event "events.metrics-enabled" :enabled second-parameter)
 
     :set-view-id
     (track-view-id-event second-parameter)

--- a/src/status_im/contexts/centralized_metrics/tracking.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking.cljs
@@ -14,31 +14,31 @@
 (def ^:const app-started-event "app-started")
 
 (def ^:const view-ids-to-track
-  [;; Tabs
-   :communities-stack
-   :chats-stack
-   :wallet-stack
+  #{;; Tabs
+    :communities-stack
+    :chats-stack
+    :wallet-stack
 
-   ;; Onboarding
-   :screen/onboarding.intro
-   :screen/onboarding.new-to-status
-   :screen/onboarding.sync-or-recover-profile
-   :screen/onboarding.enter-seed-phrase
-   :screen/onboarding.create-profile
-   :screen/onboarding.create-profile-password
-   :screen/onboarding.enable-biometrics
-   :screen/onboarding.generating-keys
-   :screen/onboarding.enable-notifications
-   :screen/onboarding.sign-in-intro
-   :screen/onboarding.sign-in
-   :screen/onboarding.syncing-progress
-   :screen/onboarding.syncing-progress-intro
-   :screen/onboarding.syncing-results
-   :screen/onboarding.welcome])
+    ;; Onboarding
+    :screen/onboarding.intro
+    :screen/onboarding.new-to-status
+    :screen/onboarding.sync-or-recover-profile
+    :screen/onboarding.enter-seed-phrase
+    :screen/onboarding.create-profile
+    :screen/onboarding.create-profile-password
+    :screen/onboarding.enable-biometrics
+    :screen/onboarding.generating-keys
+    :screen/onboarding.enable-notifications
+    :screen/onboarding.sign-in-intro
+    :screen/onboarding.sign-in
+    :screen/onboarding.syncing-progress
+    :screen/onboarding.syncing-progress-intro
+    :screen/onboarding.syncing-results
+    :screen/onboarding.welcome})
 
 (defn track-view-id-event
   [view-id]
-  (when (some #{view-id} view-ids-to-track)
+  (when (contains? view-ids-to-track view-id)
     (user-journey-event (str "view-id." (name view-id)))))
 
 (defn tracked-event

--- a/src/status_im/contexts/centralized_metrics/tracking.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking.cljs
@@ -12,25 +12,38 @@
     :eventValue {:action action}}})
 
 (def ^:const app-started-event "app-started")
-(def ^:const navigate-to-create-profile-event "navigate-to-create-profile")
-(def ^:const communities-tab-clicked "communities-tab-clicked")
-(def ^:const wallet-tab-clicked "wallet-tab-clicked")
-(def ^:const chats-tab-clicked "chats-tab-clicked")
+
+(def ^:const view-ids-to-track
+  [;; Tabs
+   :communities-stack
+   :chats-stack
+   :wallet-stack
+
+   ;; Onboarding
+   :screen/onboarding.intro
+   :screen/onboarding.new-to-status
+   :screen/onboarding.sync-or-recover-profile
+   :screen/onboarding.enter-seed-phrase
+   :screen/onboarding.create-profile
+   :screen/onboarding.create-profile-password
+   :screen/onboarding.enable-biometrics
+   :screen/onboarding.generating-keys
+   :screen/onboarding.enable-notifications
+   :screen/onboarding.sign-in-intro
+   :screen/onboarding.sign-in
+   :screen/onboarding.syncing-progress
+   :screen/onboarding.syncing-progress-intro
+   :screen/onboarding.syncing-results
+   :screen/onboarding.welcome])
 
 (defn track-view-id-event
   [view-id]
-  (case view-id
-    :communities-stack (user-journey-event communities-tab-clicked)
-    :chats-stack       (user-journey-event chats-tab-clicked)
-    :wallet-stack      (user-journey-event wallet-tab-clicked)
-    nil))
+  (when (some #{view-id} view-ids-to-track)
+    (user-journey-event (str "view-id." (name view-id)))))
 
 (defn tracked-event
   [[event-name second-parameter]]
   (case event-name
-    :onboarding/navigate-to-create-profile
-    (user-journey-event navigate-to-create-profile-event)
-
     :profile/get-profiles-overview-success
     (user-journey-event app-started-event)
 

--- a/src/status_im/contexts/centralized_metrics/tracking_test.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking_test.cljs
@@ -5,31 +5,75 @@
     [react-native.platform :as platform]
     [status-im.contexts.centralized-metrics.tracking :as tracking]))
 
+(def platform-os platform/os)
+(def app-version build/app-short-version)
+
+(deftest key-value-event-test
+  (testing "creates correct key-value event"
+    (let [event-name "test-event"
+          val-key    :test-key
+          value      "test-value"
+          expected   {:metric
+                      {:eventName  event-name
+                       :platform   platform-os
+                       :appVersion app-version
+                       :eventValue {val-key value}}}]
+      (is (= expected (tracking/key-value-event event-name val-key value))))))
+
 (deftest user-journey-event-test
-  (testing "creates correct metric event"
-    (let [action   "some-action"
-          expected {:metric {:eventName  "user-journey"
-                             :platform   platform/os
-                             :appVersion build/app-short-version
-                             :eventValue {:action action}}}]
+  (testing "creates correct user journey event"
+    (let [action   "test-action"
+          expected {:metric
+                    {:eventName  "user-journey"
+                     :platform   platform-os
+                     :appVersion app-version
+                     :eventValue {:action action}}}]
       (is (= expected (tracking/user-journey-event action))))))
 
+(deftest navigation-event-test
+  (testing "creates correct navigation event"
+    (let [view-id  :test-view-id
+          expected {:metric
+                    {:eventName  "navigation"
+                     :platform   platform-os
+                     :appVersion app-version
+                     :eventValue {:viewId view-id}}}]
+      (is (= expected (tracking/navigation-event view-id))))))
+
 (deftest track-view-id-event-test
-  (testing "returns correct event for view-id"
-    (is (= (tracking/user-journey-event tracking/communities-tab-clicked)
+  (testing "returns correct navigation event for view-id"
+    (is (= {:metric
+            {:eventName  "navigation"
+             :platform   platform-os
+             :appVersion app-version
+             :eventValue {:viewId "communities-stack"}}}
            (tracking/track-view-id-event :communities-stack)))
-    (is (= (tracking/user-journey-event tracking/chats-tab-clicked)
-           (tracking/track-view-id-event :chats-stack)))
-    (is (= (tracking/user-journey-event tracking/wallet-tab-clicked)
-           (tracking/track-view-id-event :wallet-stack)))
+    (is (= {:metric
+            {:eventName  "navigation"
+             :platform   platform-os
+             :appVersion app-version
+             :eventValue {:viewId "onboarding.create-profile"}}}
+           (tracking/track-view-id-event :screen/onboarding.create-profile)))
     (is (nil? (tracking/track-view-id-event :unknown-stack)))))
 
 (deftest tracked-event-test
   (testing "returns correct event for given inputs"
-    (is (= (tracking/user-journey-event tracking/navigate-to-create-profile-event)
-           (tracking/tracked-event [:onboarding/navigate-to-create-profile])))
-    (is (= (tracking/user-journey-event tracking/app-started-event)
+    (is (= {:metric
+            {:eventName  "user-journey"
+             :platform   platform-os
+             :appVersion app-version
+             :eventValue {:action tracking/app-started-event}}}
            (tracking/tracked-event [:profile/get-profiles-overview-success])))
-    (is (= (tracking/track-view-id-event :wallet-stack)
+    (is (= {:metric
+            {:eventName  "events.metrics-enabled"
+             :platform   platform-os
+             :appVersion app-version
+             :eventValue {:enabled true}}}
+           (tracking/tracked-event [:centralized-metrics/toggle-centralized-metrics true])))
+    (is (= {:metric
+            {:eventName  "navigation"
+             :platform   platform-os
+             :appVersion app-version
+             :eventValue {:viewId "wallet-stack"}}}
            (tracking/tracked-event [:set-view-id :wallet-stack])))
     (is (nil? (tracking/tracked-event [:unknown-event])))))


### PR DESCRIPTION
This PR updates Andrea's work to capture all views of the onboarding flow. 

It also updates the method to capture events. Instead of specifying verbs for each event, we capture all view events by screen id. 

Non view events still need a verb. 

Also fixes: #20664 