### PR TITLE
[#19926] feat: allow for disabling testnet mode by pressing the banner

### DIFF
--- a/src/status_im/common/alert_banner/view.cljs
+++ b/src/status_im/common/alert_banner/view.cljs
@@ -19,8 +19,10 @@
     :text-color       (colors/resolve-color :danger theme)}})
 
 (defn- banner
-  [{:keys [text type second-banner? colors-map]}]
-  [rn/view (when second-banner? {:style style/second-banner-wrapper})
+  [{:keys [text type second-banner? colors-map on-press]}]
+  [rn/pressable
+   {:on-press #(when on-press (on-press))
+    :style    (when second-banner? style/second-banner-wrapper)}
    [hole-view/hole-view
     {:style (style/hole-view (get-in colors-map [type :background-color]))
      :holes (if second-banner?

--- a/src/status_im/common/bottom_sheet/view.cljs
+++ b/src/status_im/common/bottom_sheet/view.cljs
@@ -126,7 +126,8 @@
       [reanimated/view
        {:style (reanimated/apply-animations-to-style
                 {:opacity bg-opacity}
-                {:flex 1 :background-color colors/neutral-100-opa-70})}]]
+                {:flex             1
+                 :background-color (if shell? colors/neutral-100-opa-60 colors/neutral-100-opa-70)})}]]
      ;; sheet
      [gesture/gesture-detector {:gesture sheet-gesture}
       [reanimated/view
@@ -138,7 +139,7 @@
           [quo/blur
            {:style         style/shell-bg
             :blur-radius   (or blur-radius 20)
-            :blur-amount   32
+            :blur-amount   15
             :blur-type     :transparent
             :overlay-color :transparent}]])
        (when selected-item

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -251,5 +251,6 @@
               config/enable-alert-banner?)
      {:fx [[:dispatch
             [:alert-banners/add
-             {:type :alert
-              :text (i18n/label :t/testnet-mode-enabled)}]]]})))
+             {:type     :alert
+              :text     (i18n/label :t/testnet-mode-enabled)
+              :on-press #(rf/dispatch [:wallet/show-disable-testnet-mode-confirmation])}]]]})))

--- a/src/status_im/contexts/settings/wallet/events.cljs
+++ b/src/status_im/contexts/settings/wallet/events.cljs
@@ -296,11 +296,13 @@
  make-partially-operable-accounts-fully-operable)
 
 (rf/reg-event-fx :wallet/show-disable-testnet-mode-confirmation
- (fn [_]
-   {:fx [[:dispatch
-          [:show-bottom-sheet
-           {:content (fn [] [testnet/view
-                             {:enable? false
-                              :blur?   (not platform/android?)}])
-            :shell?  (not platform/android?)
-            :theme   (when-not platform/android? :dark)}]]]}))
+ (fn [{:keys [db]} _]
+   (let [theme (:theme db)
+         blur? (and (not platform/android?) (= theme :dark))]
+     {:fx [[:dispatch
+            [:show-bottom-sheet
+             {:content (fn [] [testnet/view
+                               {:enable? false
+                                :blur?   blur?}])
+              :shell?  blur?
+              :theme   (when-not platform/android? theme)}]]]})))

--- a/src/status_im/contexts/settings/wallet/events.cljs
+++ b/src/status_im/contexts/settings/wallet/events.cljs
@@ -3,6 +3,7 @@
     [clojure.string :as string]
     [native-module.core :as native-module]
     [status-im.contexts.settings.wallet.data-store :as data-store]
+    [status-im.contexts.settings.wallet.network-settings.testnet-mode.view :as testnet]
     [taoensso.timbre :as log]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
@@ -292,3 +293,13 @@
 
 (rf/reg-event-fx :wallet/make-partially-operable-accounts-fully-operable
  make-partially-operable-accounts-fully-operable)
+
+(rf/reg-event-fx :wallet/show-disable-testnet-mode-confirmation
+ (fn [_]
+   {:fx [[:dispatch
+          [:show-bottom-sheet
+           {:content (fn [] [testnet/view
+                             {:enable? false
+                              :blur?   true}])
+            :shell?  true
+            :theme   :dark}]]]}))

--- a/src/status_im/contexts/settings/wallet/events.cljs
+++ b/src/status_im/contexts/settings/wallet/events.cljs
@@ -2,6 +2,7 @@
   (:require
     [clojure.string :as string]
     [native-module.core :as native-module]
+    [react-native.platform :as platform]
     [status-im.contexts.settings.wallet.data-store :as data-store]
     [status-im.contexts.settings.wallet.network-settings.testnet-mode.view :as testnet]
     [taoensso.timbre :as log]
@@ -300,6 +301,6 @@
           [:show-bottom-sheet
            {:content (fn [] [testnet/view
                              {:enable? false
-                              :blur?   true}])
-            :shell?  true
-            :theme   :dark}]]]}))
+                              :blur?   (not platform/android?)}])
+            :shell?  (not platform/android?)
+            :theme   (when-not platform/android? :dark)}]]]}))


### PR DESCRIPTION
fixes #19926

### Summary

Implement the testnet mode UI toggle for disabling the testnet banner globally through the app.


#### Areas that maybe impacted

- Testnet Banner

### Steps to test

- Enable testnet from Wallet -> Network settings 
- Go to the main pages
- Click on testnet banner


### Result

https://github.com/user-attachments/assets/55f37869-8cf9-4960-8dc9-105a6f921ebb

### Screenshots

#### iOS
<div>
<img src="https://github.com/user-attachments/assets/336d6339-7a34-4637-845b-8a0cbb7dbb5a" width="370px"/>

<img src="https://github.com/user-attachments/assets/ac8a9815-838d-451a-bca7-83ed3de2546a" width="370px"/>
</div>

#### Android
<div>
<img src="https://github.com/user-attachments/assets/2bc76aaa-9aab-4927-9547-ef988db7ad9c" width="370px"/>
<img src="https://github.com/user-attachments/assets/acb6260f-1c2b-4d9b-8967-b63085ddada8" width="370px"/>
</div>

status: ready

