### PR TITLE
fix: remove mobile-data sync setting inside legacy settings

### DIFF
--- a/src/legacy/status_im/ui/screens/sync_settings/views.cljs
+++ b/src/legacy/status_im/ui/screens/sync_settings/views.cljs
@@ -13,8 +13,7 @@
 
 (views/defview sync-settings
   []
-  (views/letsubs [{:keys [syncing-on-mobile-network?
-                          backup-enabled?
+  (views/letsubs [{:keys [backup-enabled?
                           default-sync-period
                           use-mailservers?]}
                   [:profile/profile]
@@ -27,16 +26,6 @@
        :on-press   #(rf/dispatch [:navigate-back])}]
      [react/scroll-view
       [components/list-header (i18n/label :t/data-syncing)]
-      [list.item/list-item
-       {:size                :small
-        :title               (i18n/label :t/mobile-network-settings)
-        :accessibility-label :notifications-button
-        :on-press            #(re-frame/dispatch [:navigate-to :mobile-network-settings])
-        :chevron             true
-        :accessory           :text
-        :accessory-text      (if syncing-on-mobile-network?
-                               (i18n/label :t/mobile-network-use-mobile)
-                               (i18n/label :t/mobile-network-use-wifi))}]
       [list.item/list-item
        {:size                :small
         :title               (i18n/label :t/backup-settings)


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #20936 

### Summary

* This PR attempts to remove the "Mobile Data" setting from the "Sync Settings" inside "Legacy Settings" screen in the mobile app.

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

- Android
- iOS

##### Functional

- Sync settings inside legacy settings 

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile 
- Open the Settings screen
- Open the Legacy settings screen
- Open the Sync settings screen

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before changes

https://private-user-images.githubusercontent.com/4557972/353899297-c75fa35f-ed72-45e3-8993-2916f3d0537c.MP4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjI0NDQyNzgsIm5iZiI6MTcyMjQ0Mzk3OCwicGF0aCI6Ii80NTU3OTcyLzM1Mzg5OTI5Ny1jNzVmYTM1Zi1lZDcyLTQ1ZTMtODk5My0yOTE2ZjNkMDUzN2MuTVA0P1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDczMSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA3MzFUMTYzOTM4WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9OTQwY2VmMjA3ZGYxNmI2M2IzZDhiNDg5NDZjY2FlZGRjYTgwYzU5NjI2ZWY1Njg4NTI4OThlYWMwNDI0YmI0ZCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.FVfOHBZrSRxuJCCwmuhy_Nn04BxfMEh5C8MxtBpQYSg

#### After changes

https://github.com/user-attachments/assets/ab347455-4486-437c-83f4-e3700e1cedfa

status: ready <!-- Can be ready or wip -->