### PR TITLE
Fix typed-data chainid check

### DIFF
--- a/src/status_im/contexts/wallet/wallet_connect/events.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events.cljs
@@ -265,9 +265,7 @@
                              persisted-sessions)]
      (when (seq expired-sessions)
        (log/info "Updating WalletConnect persisted sessions due to expired/inactive sessions"
-                 {:expired   expired-sessions
-                  :persisted persisted-sessions
-                  :active    sessions}))
+                 {:expired expired-sessions}))
      {:fx (mapv (fn [{:keys [topic]}]
                   [:dispatch [:wallet-connect/disconnect-session topic]])
                 expired-sessions)

--- a/src/status_im/contexts/wallet/wallet_connect/responding_events.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/responding_events.cljs
@@ -106,7 +106,11 @@
                  :method               method
                  :wallet-connect-event event
                  :event                :wallet-connect/on-sign-error})
-     {:fx [[:dispatch [:wallet-connect/dismiss-request-modal]]]})))
+     {:fx [[:dispatch [:wallet-connect/dismiss-request-modal]]
+           [:dispatch
+            [:toasts/upsert
+             {:type :negative
+              :text (i18n/label :t/something-went-wrong)}]]]})))
 
 (rf/reg-event-fx
  :wallet-connect/send-response

--- a/src/status_im/contexts/wallet/wallet_connect/signing.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/signing.cljs
@@ -4,6 +4,7 @@
             [status-im.contexts.wallet.wallet-connect.core :as core]
             [status-im.contexts.wallet.wallet-connect.rpc :as rpc]
             [utils.hex :as hex]
+            [utils.number :as number]
             [utils.transforms :as transforms]))
 
 (defn typed-data-chain-id
@@ -16,7 +17,8 @@
                             (some #(= "chainId" (:name %))))
         data-chain-id  (-> typed-data
                            :domain
-                           :chainId)]
+                           :chainId
+                           number/parse-int)]
     (when chain-id-type?
       data-chain-id)))
 


### PR DESCRIPTION
fixes #20939

### Summary

For WalletConnect signTypedData requests, should only compare the typed data chainId param only if it's present in the typed data. Also different dapps send it sometimes as an int and sometimes as a string, so making sure the comparison accurate as well.

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Connect to Uniswap dapp via walletconnect
- Try to swap SNT to DOGE
- Confirm transaction (not always triggered before signing typed data)
- See toast that chainId doesn't match, even though it does


status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
