### PR TITLE
fix 'Usage data' bottom sheet reappears after reopening the app if you swipe it down on onboarding

### DIFF
--- a/src/status_im/contexts/centralized_metrics/events.cljs
+++ b/src/status_im/contexts/centralized_metrics/events.cljs
@@ -46,6 +46,11 @@
    (when (show-confirmation-modal? db)
      {:fx [[:dispatch
             [:show-bottom-sheet
-             {:content (fn [] [modal-view])
-              :shell?  true}]]]})))
+             {:content  (fn [] [modal-view])
+              ;; When in the profiles screen do biometric auth after the metrics sheet is dismissed
+              ;; https://github.com/status-im/status-mobile/issues/20932
+              :on-close (when (= (:view-id db) :screen/profile.profiles)
+                          #(rf/dispatch [:profile.login/login-with-biometric-if-available
+                                         (get-in db [:profile/login :key-uid])]))
+              :shell?   true}]]]})))
 

--- a/src/status_im/contexts/profile/events.cljs
+++ b/src/status_im/contexts/profile/events.cljs
@@ -54,7 +54,7 @@
                     (update :profile/login #(select-profile % key-uid)))
                 db-with-settings)
           :fx [[:dispatch [:init-root :screen/profile.profiles]]
-               (when key-uid
+               (when (and key-uid userConfirmed)
                  [:effects.biometric/check-if-available
                   {:key-uid    key-uid
                    :on-success (fn [auth-method]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20932

### Summary 

If the usage data sheet dismissed without input while on boarding, we show that again in profiles screen.
But when we have biometric enabled, we automatically navigate to home screen while still having bottom sheet open. And this caused wrong theme.

In this PR we are delaying automatic login until bottom sheet is dismissed.

status: ready