### PR TITLE
enable new architecture for android PR,Release builds only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,8 @@ run-android: export TARGET := android
 # https://github.com/status-im/status-mobile/issues/18493
 run-android: export ORG_GRADLE_PROJECT_hermesEnabled := false
 run-android: export ORG_GRADLE_PROJECT_universalApk := false
+# enabling new architecture requires hermes to be enabled
+run-android: export ORG_GRADLE_PROJECT_newArchEnabled := false
 run-android: ##@run Build Android APK and start it on the device
 	@scripts/run-android.sh
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -53,6 +53,7 @@ commitHash=unknown
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
+# enabling new architecture requires hermes to be enabled
 newArchEnabled=false
 
 # Use this property to enable or disable the Hermes JS engine.

--- a/nix/mobile/android/build.nix
+++ b/nix/mobile/android/build.nix
@@ -15,6 +15,8 @@
   # Disabled for debug builds to avoid 'maximum call stack exceeded' errors.
   # https://github.com/status-im/status-mobile/issues/18493
   hermesEnabled ? lib.getEnvWithDefault "ORG_GRADLE_PROJECT_hermesEnabled" "true",
+  # enabling new architecture requires hermes to be enabled
+  newArchEnabled ? lib.getEnvWithDefault "ORG_GRADLE_PROJECT_newArchEnabled" "true",
   buildUrl ? lib.getEnvWithDefault "ORG_GRADLE_PROJECT_buildUrl" null,
   statusGoSrcOverride ? lib.getEnvWithDefault "STATUS_GO_SRC_OVERRIDE" null,
   reactMetroPort ? lib.getEnvWithDefault "RCT_METRO_PORT" 8081,
@@ -91,6 +93,8 @@ in stdenv.mkDerivation rec {
   ORG_GRADLE_PROJECT_buildUrl = buildUrl;
   ORG_GRADLE_PROJECT_hermesEnabled = hermesEnabled;
   ORG_GRADLE_PROJECT_universalApk = universalApk;
+  # enabling new architecture requires hermes to be enabled
+  ORG_GRADLE_PROJECT_newArchEnabled = newArchEnabled;
 
   # Fix for ERR_OSSL_EVP_UNSUPPORTED error.
   NODE_OPTIONS = "--openssl-legacy-provider";

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,4 +1,10 @@
 module.exports = {
+  project: {
+    android: {
+      // https://github.com/reactwg/react-native-new-architecture/discussions/135
+      unstable_reactLegacyComponentNames: ['BVLinearGradient', 'CKCameraManager', 'FastImageView'],
+    },
+  },
   dependencies: {
     'react-native-config': {
       platforms: {

--- a/src/quo/components/profile/profile_card/view.cljs
+++ b/src/quo/components/profile/profile_card/view.cljs
@@ -43,7 +43,8 @@
                 []
                 [{:x            20
                   :y            108
-                  :width        (- width 40)
+                  ;; https://github.com/status-im/status-mobile/pull/20950#issuecomment-2351505926
+                  :width        (- (int width) 40)
                   :height       50
                   :borderRadius 16}])}
       [rn/view

--- a/src/quo/components/tags/token_tag/view.cljs
+++ b/src/quo/components/tags/token_tag/view.cljs
@@ -27,7 +27,7 @@
     [rn/view {:on-layout on-layout}
      [hole-view/hole-view
       {:holes (if options
-                [{:x            (- container-width
+                [{:x            (- (int container-width)
                                    (case size
                                      :size-24 10
                                      :size-32 12

--- a/src/quo/components/wallet/approval_label/view.cljs
+++ b/src/quo/components/wallet/approval_label/view.cljs
@@ -36,7 +36,7 @@
      {:holes     [{:x                       0
                    :y                       0
                    :height                  style/top-hole-view-height
-                   :width                   container-width
+                   :width                   (int container-width)
                    :borderBottomStartRadius 16
                    :borderBottomEndRadius   16}]
       :style     {:margin-top (- style/top-hole-view-height)}

--- a/src/quo/foundations/colors.cljs
+++ b/src/quo/foundations/colors.cljs
@@ -10,29 +10,32 @@
 (defn alpha
   [value opacity]
   (when value
-    (if (string/starts-with? value "#")
-      (let [hex (string/replace value #"#" "")
-            r   (js/parseInt (subs hex 0 2) 16)
-            g   (js/parseInt (subs hex 2 4) 16)
-            b   (js/parseInt (subs hex 4 6) 16)]
-        (str "rgba(" r "," g "," b "," opacity ")"))
-      (let [rgb (string/split value #",")]
-        (str (string/join "," (butlast rgb)) "," opacity ")")))))
+    ;; https://github.com/status-im/status-mobile/pull/20950#issuecomment-2328228947
+    (let [opacity (if (zero? opacity) 0.002 opacity)]
+      (if (string/starts-with? value "#")
+        (let [hex (string/replace value #"#" "")
+              r   (js/parseInt (subs hex 0 2) 16)
+              g   (js/parseInt (subs hex 2 4) 16)
+              b   (js/parseInt (subs hex 4 6) 16)]
+          (str "rgba(" r "," g "," b "," opacity ")"))
+        (let [rgb (string/split value #",")]
+          (str (string/join "," (butlast rgb)) "," opacity ")"))))))
 
 (defn- alpha-opaque
   [value opacity]
   (when value
-    (if (string/starts-with? value "#")
-      (let [hex (string/replace value #"#" "")
-            r   (- 255 (* opacity (- 255 (js/parseInt (subs hex 0 2) 16))))
-            g   (- 255 (* opacity (- 255 (js/parseInt (subs hex 2 4) 16))))
-            b   (- 255 (* opacity (- 255 (js/parseInt (subs hex 4 6) 16))))]
-        (str "rgb(" r "," g "," b ")"))
-      (let [rgb (string/split value #",")
-            r   (- 255 (* opacity (- 255 (get rgb 0))))
-            g   (- 255 (* opacity (- 255 (get rgb 1))))
-            b   (- 255 (* opacity (- 255 (get rgb 2))))]
-        (str "rgb(" r "," g "," b ")")))))
+    (let [opacity (if (zero? opacity) 0.002 opacity)]
+      (if (string/starts-with? value "#")
+        (let [hex (string/replace value #"#" "")
+              r   (- 255 (* opacity (- 255 (js/parseInt (subs hex 0 2) 16))))
+              g   (- 255 (* opacity (- 255 (js/parseInt (subs hex 2 4) 16))))
+              b   (- 255 (* opacity (- 255 (js/parseInt (subs hex 4 6) 16))))]
+          (str "rgb(" r "," g "," b ")"))
+        (let [rgb (string/split value #",")
+              r   (- 255 (* opacity (- 255 (get rgb 0))))
+              g   (- 255 (* opacity (- 255 (get rgb 1))))
+              b   (- 255 (* opacity (- 255 (get rgb 2))))]
+          (str "rgb(" r "," g "," b ")"))))))
 
 (def theme-alpha
   (memoize

--- a/src/status_im/common/alert_banner/view.cljs
+++ b/src/status_im/common/alert_banner/view.cljs
@@ -29,7 +29,7 @@
               []
               [{:x            0
                 :y            constants/alert-banner-height
-                :width        (:width (rn/get-window))
+                :width        (int (:width (rn/get-window)))
                 :height       constants/alert-banner-height
                 :borderRadius style/border-radius}])}
     [quo/text
@@ -54,7 +54,7 @@
        {:style {:padding-bottom 0.5}
         :holes [{:x            0
                  :y            (+ safe-area-top (* constants/alert-banner-height banners-count))
-                 :width        (:width (rn/get-window))
+                 :width        (int (:width (rn/get-window)))
                  :height       constants/alert-banner-height
                  :borderRadius style/border-radius}]}
        [rn/view {:style {:background-color colors/neutral-100}}


### PR DESCRIPTION
## Summary

In this PR we use `unstable_reactLegacyComponentNames` to bridge components that are not compatible with Fabric.
We also enable `hermes` and `new architecture` for Android but only for PR and Release builds.

## Review notes
Pls test local dev environment with this branch

## Testing notes
Pls test everything

## Platforms
- Android

status: ready

fixes: https://github.com/status-im/status-mobile/issues/18138

### Found Issues 

1. [ISSUE 1 Exception in HostFunction: Loss of precision during arithmetic conversion: (long) 71.28888893127441 after login](https://github.com/status-im/status-mobile/pull/20950#issuecomment-2317081185)  
   - [ ] Fixed  (checked by dev)  
   - [ ] Verified (checked by QA)

2. [ISSUE 2 Action buttons require double tapping](https://github.com/status-im/status-mobile/pull/20950#issuecomment-2317081407)  
   - [ ] Fixed  (checked by dev)  
   - [x] Verified (checked by QA)  

3. ["ISSUE 3 Bottom sheets are closed by itself after being opened within 'Profiles on device' screen
](https://github.com/status-im/status-mobile/pull/20950#issuecomment-2353004573)  
   - [ ] Fixed  (checked by dev)  
   - [x] Verified (checked by QA)  

4. [ISSUE 4 Broken layout of Create Profile screen when creating additional profile from 'Profiles on device' screen](https://github.com/status-im/status-mobile/pull/20950#issuecomment-2353004741)
   - [ ] Fixed  (checked by dev)  
   - [ ] Verified (checked by QA)

5. [ISSUE 5 The app is not accessible after an attempt to add a contact](https://github.com/status-im/status-mobile/pull/20950#issuecomment-2663598794)
   - [ ] Fixed  (checked by dev)  
   - [ ] Verified (checked by QA)

