### PR TITLE
chore(wallet): feature flag adding watch only accounts

### DIFF
--- a/src/status_im/contexts/wallet/home/view.cljs
+++ b/src/status_im/contexts/wallet/home/view.cljs
@@ -21,12 +21,13 @@
       :label               (i18n/label :t/add-account)
       :sub-label           (i18n/label :t/add-account-description)
       :on-press            #(rf/dispatch [:navigate-to :screen/wallet.create-account])}
-     {:icon                :i/reveal
-      :accessibility-label :add-a-contact
-      :label               (i18n/label :t/add-address-to-watch)
-      :sub-label           (i18n/label :t/add-address-to-watch-description)
-      :on-press            #(rf/dispatch [:navigate-to :screen/wallet.add-address-to-watch])
-      :add-divider?        true}]]])
+     (when (ff/enabled? ::ff/wallet.add-watched-address)
+       {:icon                :i/reveal
+        :accessibility-label :add-a-contact
+        :label               (i18n/label :t/add-address-to-watch)
+        :sub-label           (i18n/label :t/add-address-to-watch-description)
+        :on-press            #(rf/dispatch [:navigate-to :screen/wallet.add-address-to-watch])
+        :add-divider?        true})]]])
 
 (defn- new-account-card-data
   []

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -22,6 +22,7 @@
                                          :FLAG_WALLET_SETTINGS_IMPORT_ALL_KEYPAIRS)
    ::shell.jump-to                      (enabled-in-env? :ENABLE_JUMP_TO)
 
+   ::wallet.add-watched-address         (enabled-in-env? :FLAG_ADD_WATCHED_ADDRESS)
    ::wallet.advanced-sending            (enabled-in-env? :FLAG_ADVANCED_SENDING)
    ::wallet.assets-modal-hide           (enabled-in-env? :FLAG_ASSETS_MODAL_HIDE)
    ::wallet.assets-modal-manage-tokens  (enabled-in-env? :FLAG_ASSETS_MODAL_MANAGE_TOKENS)

--- a/test/appium/tests/critical/test_wallet.py
+++ b/test/appium/tests/critical/test_wallet.py
@@ -246,6 +246,7 @@ class TestWalletOneDevice(MultipleSharedDeviceTestCase):
         self.errors.verify_no_errors()
 
     @marks.testrail_id(727232)
+    @marks.skip("The feature is disabled in https://github.com/status-im/status-mobile/pull/20955")
     @marks.xfail(reason="Missing networks in account address, https://github.com/status-im/status-mobile/issues/20166")
     def test_wallet_add_remove_watch_only_account(self):
         self.wallet_view.just_fyi("Adding new watch only account")


### PR DESCRIPTION
A simple pr to hide watch only accounts as Desktop has also decided to do this for 2.30 given that the activity on larger accounts can cause some issues.

<img src="https://github.com/user-attachments/assets/6bf5e857-8128-4ee5-9a02-5553bd2cc171" width="300px" />

