### PR TITLE
fix(wallet): Collectibles not fetched for new and recovered accounts

### DIFF
--- a/src/quo/components/profile/collectible_list_item/view.cljs
+++ b/src/quo/components/profile/collectible_list_item/view.cljs
@@ -91,7 +91,7 @@
      :color-index     gradient-color-index}]])
 
 (defn- card-details
-  [{:keys [community? avatar-image-src collectible-name theme state set-state]}]
+  [{:keys [community? avatar-image-src collectible-name theme state set-state loading?]}]
   (let [loader-opacity            (reanimated/use-shared-value 1)
         avatar-opacity            (reanimated/use-shared-value 0)
         [load-time set-load-time] (rn/use-state (datetime/now))
@@ -102,7 +102,7 @@
                                                      :avatar-opacity avatar-opacity}))
         empty-name?               (string/blank? collectible-name)]
     (rn/use-mount (fn []
-                    (when (string/blank? avatar-image-src)
+                    (when (and (string/blank? avatar-image-src) (not loading?))
                       (set-avatar-loaded))))
     [rn/view {:style style/card-details-container}
      [reanimated/view {:style (style/avatar-container avatar-opacity)}
@@ -137,7 +137,7 @@
 
 (defn- card-view
   [{:keys [avatar-image-src collectible-name community? counter state set-state
-           gradient-color-index image-src supported-file?]}]
+           gradient-color-index image-src supported-file? loading?]}]
   (let [theme                     (quo.theme/use-theme)
         loader-opacity            (reanimated/use-shared-value (if supported-file? 1 0))
         image-opacity             (reanimated/use-shared-value (if supported-file? 0 1))
@@ -189,6 +189,7 @@
        :community?       community?
        :avatar-image-src avatar-image-src
        :collectible-name collectible-name
+       :loading?         loading?
        :theme            theme}]]))
 
 (defn- image-view
@@ -276,6 +277,7 @@
       [:supported-file? {:optional true} [:maybe boolean?]]
       [:native-ID {:optional true} [:maybe [:or string? keyword?]]]
       [:community? {:optional true} [:maybe boolean?]]
+      [:loading? {:optional true} [:maybe boolean?]]
       [:counter {:optional true} [:maybe [:or :string :int]]]
       [:gradient-color-index {:optional true}
        [:maybe [:enum :gradient-1 :gradient-2 :gradient-3 :gradient-4 :gradient-5]]]

--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -25,23 +25,29 @@
   []
   (rf/dispatch [:wallet/request-collectibles-for-current-viewing-account]))
 
-(defn view
-  [{:keys [selected-tab]}]
-  (let [collectible-list        (rf/sub
+(defn- collectibles-tab
+  []
+  (let [updating?               (rf/sub [:wallet/current-viewing-account-collectibles-updating?])
+        collectible-list        (rf/sub
                                  [:wallet/current-viewing-account-collectibles-in-selected-networks])
         current-account-address (rf/sub [:wallet/current-viewing-account-address])]
-    [rn/view {:style {:flex 1}}
-     (case selected-tab
-       :assets       [assets/view]
-       :collectibles [collectibles/view
-                      {:collectibles              collectible-list
-                       :current-account-address   current-account-address
-                       :on-end-reached            on-end-reached
-                       :on-collectible-press      on-collectible-press
-                       :on-collectible-long-press on-collectible-long-press}]
-       :activity     [activity/view]
-       :permissions  [empty-tab/view
-                      {:title        (i18n/label :t/no-permissions)
-                       :description  (i18n/label :t/no-collectibles-description)
-                       :placeholder? true}]
-       [about/view])]))
+    [collectibles/view
+     {:loading?                  updating?
+      :collectibles              collectible-list
+      :current-account-address   current-account-address
+      :on-end-reached            on-end-reached
+      :on-collectible-press      on-collectible-press
+      :on-collectible-long-press on-collectible-long-press}]))
+
+(defn view
+  [{:keys [selected-tab]}]
+  [rn/view {:style {:flex 1}}
+   (case selected-tab
+     :assets       [assets/view]
+     :collectibles [collectibles-tab]
+     :activity     [activity/view]
+     :permissions  [empty-tab/view
+                    {:title        (i18n/label :t/no-permissions)
+                     :description  (i18n/label :t/no-collectibles-description)
+                     :placeholder? true}]
+     [about/view])])

--- a/src/status_im/contexts/wallet/collectible/events_test.cljs
+++ b/src/status_im/contexts/wallet/collectible/events_test.cljs
@@ -43,8 +43,8 @@
 
         (is (match? result-db expected-db))))))
 
-(deftest request-new-collectibles-for-account-from-signal-test
-  (testing "request new collectibles for account from signal"
+(deftest request-collectibles-for-account-test
+  (testing "request collectibles for account"
     (let [db       {:wallet {}}
           address  "0x1"
           expected {:db {:wallet {:ui {:collectibles {:pending-requests 1}}}}
@@ -53,6 +53,6 @@
                            {:request-id 0
                             :account    address
                             :amount     events/collectibles-request-batch-size}]]]}
-          effects  (events/request-new-collectibles-for-account-from-signal {:db db}
-                                                                            [address])]
+          effects  (events/request-collectibles-for-account {:db db}
+                                                            [address])]
       (is (match? expected effects)))))

--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -70,3 +70,10 @@
                                                        test-networks-enabled?
                                                        is-goerli-enabled?)]
     (str base-link "/assets/" opensea-network-name "/" contract-address "/" token-id)))
+
+(defn get-collectible-unique-id
+  [{:keys [id]}]
+  (let [chain-id         (-> id :contract-id :chain-id)
+        contract-address (-> id :contract-id :address)
+        token-id         (-> id :token-id)]
+    (str chain-id contract-address token-id)))

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -4,6 +4,7 @@
     [clojure.set :as set]
     [clojure.string :as string]
     [status-im.constants :as constants]
+    [status-im.contexts.wallet.collectible.utils :as collectible-utils]
     [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.send.utils :as send-utils]
     [utils.collection :as utils.collection]
@@ -266,3 +267,10 @@
 (defn tokens-never-loaded?
   [db]
   (nil? (get-in db [:wallet :ui :tokens-loading])))
+
+(defn rpc->collectibles
+  [collectibles]
+  (->> collectibles
+       (cske/transform-keys transforms/->kebab-case-keyword)
+       (map #(assoc % :unique-id (collectible-utils/get-collectible-unique-id %)))
+       vec))

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -143,13 +143,6 @@
                              address-2 {:address address-2}}}})
       (is (match? expected-fx (:fx (dispatch [event-id])))))))
 
-(h/deftest-event :wallet/process-account-from-signal
-  [event-id dispatch]
-  (let [expected-effects {:db {:wallet {:accounts {address account}}}
-                          :fx [[:dispatch [:wallet/fetch-assets-for-address address]]]}]
-    (reset! rf-db/app-db {:wallet {:accounts {}}})
-    (is (match? expected-effects (dispatch [event-id raw-account])))))
-
 (h/deftest-event :wallet/reconcile-keypairs
   [event-id dispatch]
   (let [keypair-key-uid (:key-uid raw-account)]

--- a/src/status_im/contexts/wallet/home/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/view.cljs
@@ -19,17 +19,23 @@
 
 (def on-collectible-press #(rf/dispatch [:wallet/navigate-to-collectible-details %]))
 
+(def request-collectibles #(rf/dispatch [:wallet/request-collectibles-for-all-accounts {}]))
+
+(defn- collectibles-tab
+  []
+  (let [updating?        (rf/sub [:wallet/home-tab-collectibles-updating?])
+        collectible-list (rf/sub [:wallet/owned-collectibles-list-in-selected-networks])]
+    [collectibles/view
+     {:loading?                  updating?
+      :collectibles              collectible-list
+      :on-collectible-long-press on-collectible-long-press
+      :on-end-reached            request-collectibles
+      :on-collectible-press      on-collectible-press}]))
+
 (defn view
   [{:keys [selected-tab]}]
-  (let [collectible-list     (rf/sub [:wallet/owned-collectibles-list-in-selected-networks])
-        request-collectibles #(rf/dispatch
-                               [:wallet/request-collectibles-for-all-accounts {}])]
-    [rn/view {:style style/container}
-     (case selected-tab
-       :assets       [assets/view]
-       :collectibles [collectibles/view
-                      {:collectibles              collectible-list
-                       :on-collectible-long-press on-collectible-long-press
-                       :on-end-reached            request-collectibles
-                       :on-collectible-press      on-collectible-press}]
-       [activity/view {:activities []}])]))
+  [rn/view {:style style/container}
+   (case selected-tab
+     :assets       [assets/view]
+     :collectibles [collectibles-tab]
+     [activity/view {:activities []}])])

--- a/src/status_im/contexts/wallet/signals.cljs
+++ b/src/status_im/contexts/wallet/signals.cljs
@@ -29,6 +29,21 @@
           [:wallet/pending-transaction-status-changed-received
            (transforms/js->clj event-js)]]]}
 
+       "wallet-collectibles-ownership-update-finished"
+       {:fx [[:dispatch
+              [:wallet/collectible-ownership-update-finished
+               (transforms/js->clj event-js)]]]}
+
+       "wallet-collectibles-ownership-update-finished-with-error"
+       {:fx [[:dispatch
+              [:wallet/collectible-ownership-update-finished-with-error
+               (transforms/js->clj event-js)]]]}
+
+       "wallet-collectibles-data-updated"
+       {:fx [[:dispatch
+              [:wallet/collectibles-data-updated
+               (transforms/js->clj event-js)]]]}
+
        "wallet-owned-collectibles-filtering-done"
        {:fx [[:dispatch
               [:wallet/owned-collectibles-filtering-done

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -137,3 +137,29 @@
                  acc))
              0
              ownership))))
+
+(re-frame/reg-sub
+ :wallet/collectibles
+ :<- [:wallet/ui]
+ :-> :collectibles)
+
+(re-frame/reg-sub
+ :wallet/collectibles-updating
+ :<- [:wallet/collectibles]
+ :-> :updating)
+
+(re-frame/reg-sub
+ :wallet/current-viewing-account-collectibles-updating?
+ :<- [:wallet/collectibles-updating]
+ :<- [:wallet/current-viewing-account-address]
+ (fn [[updating-addresses address]]
+   (contains? updating-addresses address)))
+
+(re-frame/reg-sub
+ :wallet/home-tab-collectibles-updating?
+ :<- [:wallet/collectibles-updating]
+ :<- [:wallet/accounts-without-watched-accounts]
+ (fn [[updating-addresses accounts]]
+   (->> accounts
+        (map :address)
+        (every? #(contains? updating-addresses %)))))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "fix/send-account-event-on-handling-backedup-accounts",
-    "commit-sha1": "e34b2fb1a10dc25ed5385b9fae78cc6a18b06410",
-    "src-sha256": "1f72zwpq7s5fd89dp25l9pib04kzgbyy46imbn765pcszdabcc04"
+    "version": "v0.184.52",
+    "commit-sha1": "81cfce709e8d123eb1956b87f8e0f19dc47c122c",
+    "src-sha256": "0hna30ms4ccxmi20l5v36y84pva1s4jjkqg11whwmdjgw75d0fan"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.184.51",
-    "commit-sha1": "9e722ed09544cc798bc8aa5cdb3b7b58241fbf95",
-    "src-sha256": "1r8w9309gffb52myfgnqyv8cpn372qkq14hpwk2zmz86qphw9jvf"
+    "version": "fix/send-account-event-on-handling-backedup-accounts",
+    "commit-sha1": "e34b2fb1a10dc25ed5385b9fae78cc6a18b06410",
+    "src-sha256": "1f72zwpq7s5fd89dp25l9pib04kzgbyy46imbn765pcszdabcc04"
 }


### PR DESCRIPTION
fixes #18613

### Summary

This PR fixes collectibles not fetched for newly added or recovered accounts.

<!-- https://github.com/user-attachments/assets/137787b0-b139-4c2a-acfb-85aba34eb6d9 -->

### Review notes

When we call the `wallet_getCollectiblesAsync` RPC, it returns the cached data from the DB. For the newly added address, the collectible is not fetched for those addresses and is not cached in the DB. So, immediately we get an empty response with an updating state and the last fetched timestamp (which would be -1 for those addresses). 

status-go fetches the collectibles in the background and signals the client with `wallet-collectibles-ownership-update-*`. When the mobile receives it, it checks for any added (cached in the DB) collectibles and requests for collectibles for that chain id. The `wallet-collectibles-ownership-update-*` sends only the contract address and token ID of the collectibles added/updated/removed. Later, we can check for updated or removed collectibles and act on them accordingly on the mobile.

Another problem is that when the accounts (apart from the default wallet account) are added from the backup data, they do not initiate the collectable fetching in the status-go which is fixed in this PR: https://github.com/status-im/status-go/pull/5739

The status-go fix is to send an event on adding/removing accounts from processing the backed-up data to initiate collectibles fetch in the background.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Recover a profile with wallet accounts with collectibles
- Verify the collectibles are fetched

status: ready 
