### PR TITLE
Fix absent DEBUG messages in geth.log

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "logger-check",
-    "commit-sha1": "f36bb038a88e1323557e8ffa285ca3aa65b654dd",
+    "commit-sha1": "156b848c1a0b4b07b249f453f6b7b82a5592f09c",
     "src-sha256": "1sq62z1zg0jnbw1yzds4f0d26kvakyqw3b1zkwpl2mhfvm344j68"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "logger-check",
-    "commit-sha1": "d6d636c6acf0dc0a93d7e5affecee334c4d50327",
+    "commit-sha1": "f36bb038a88e1323557e8ffa285ca3aa65b654dd",
     "src-sha256": "1sq62z1zg0jnbw1yzds4f0d26kvakyqw3b1zkwpl2mhfvm344j68"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "b74d9e6b4e9177f1aa9ba57f9de8beebf5b352e1",
-    "commit-sha1": "b74d9e6b4e9177f1aa9ba57f9de8beebf5b352e1",
-    "src-sha256": "1fvx0jgqkd9zx559m59kh73lyyzf1ryshjhs6r99q8kas7kkmjhx"
+    "version": "logger-check",
+    "commit-sha1": "d6d636c6acf0dc0a93d7e5affecee334c4d50327",
+    "src-sha256": "1sq62z1zg0jnbw1yzds4f0d26kvakyqw3b1zkwpl2mhfvm344j68"
 }


### PR DESCRIPTION
fixes #20944

### Summary


Debug logs don't show up in geth.log file. After investigation, it turned out that `InitLogger` function in status-go was implemented in a way that implies it will be called only once on app start. But in fact, status mobile app calls it once on app startup, plus whenever a user logs in to set the debug level for that user. That last call didn't work due to var `initLoggingOnce sync.Once` in code. So per discussion with @qfrank that restriction was removed.

This PR points to a branch with fixed problem

### Review notes
Corresponding [status-go PR](https://github.com/status-im/status-go/pull/5670)

### Steps to test
- Install build
- Create/recover a user
- Change log level to DEBUG (Profile - Advanced - Log level - DEBUG)
- Download the logs
- Check if geth.log contains debug logs


status: ready 



