### PR TITLE
fix(wallet): Remove redirection to "send flow" when the user scans an address QR code

### DIFF
--- a/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
+++ b/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
@@ -13,16 +13,16 @@
                 {:type :positive
                  :text (i18n/label :t/address-copied)}]))
 
-(comment
- (defn- send-to-address [address]
-   (let [[_ split-address] (network-utils/split-network-full-address address)]
-     (rf/dispatch
-      [:wallet/select-send-address
-       {:address     address
-        :recipient   {:recipient-type :address
-                      :label          (utils/get-shortened-address split-address)}
-        :stack-id    :wallet-select-address
-        :start-flow? true}]))))
+#_(defn- send-to-address
+    [address]
+    (let [[_ split-address] (network-utils/split-network-full-address address)]
+      (rf/dispatch
+       [:wallet/select-send-address
+        {:address     address
+         :recipient   {:recipient-type :address
+                       :label          (utils/get-shortened-address split-address)}
+         :stack-id    :wallet-select-address
+         :start-flow? true}])))
 
 (defn view
   [address]
@@ -36,11 +36,10 @@
       ;; Originally, the flow went to the send flow, but it has been removed to avoid bugs,
       ;; please check https://github.com/status-im/status-mobile/issues/20972 for more context
       ;; The previous code has been commented out to be reintroduced in the future easily.
-      (comment
-       {:icon                :i/send
-        :accessibility-label :send-asset
-        :label               (i18n/label :t/send-to-this-address)
-        :on-press            #(send-to-address address)})
+      #_{:icon                :i/send
+         :accessibility-label :send-asset
+         :label               (i18n/label :t/send-to-this-address)
+         :on-press            #(send-to-address address)}
       (when (ff/enabled? :ff/wallet.saved-addresses)
         {:icon                :i/save
          :accessibility-label :save-address

--- a/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
+++ b/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
@@ -11,12 +11,12 @@
   ;; Originally, the flow went to the send flow, but it has been removed to avoid bugs. Please check
   ;; https://github.com/status-im/status-mobile/issues/20972. The previous code has been commented
   ;; out.
-  (let [#_#_[_ split-address] (network-utils/split-network-full-address address)]
-    (clipboard/set-string address)
-    (rf/dispatch [:toasts/upsert
-                  {:type :positive
-                   :text (i18n/label :t/address-copied)}])
-    #_(rf/dispatch
+  (clipboard/set-string address)
+  (rf/dispatch [:toasts/upsert
+                {:type :positive
+                 :text (i18n/label :t/address-copied)}])
+  #_(let [[_ split-address] (network-utils/split-network-full-address address)]
+      (rf/dispatch
        [:wallet/select-send-address
         {:address     address
          :recipient   {:recipient-type :address

--- a/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
+++ b/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
@@ -6,23 +6,23 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn- on-press
+(defn- copy-address
   [address]
-  ;; Originally, the flow went to the send flow, but it has been removed to avoid bugs. Please check
-  ;; https://github.com/status-im/status-mobile/issues/20972. The previous code has been commented
-  ;; out.
   (clipboard/set-string address)
   (rf/dispatch [:toasts/upsert
                 {:type :positive
-                 :text (i18n/label :t/address-copied)}])
-  #_(let [[_ split-address] (network-utils/split-network-full-address address)]
-      (rf/dispatch
-       [:wallet/select-send-address
-        {:address     address
-         :recipient   {:recipient-type :address
-                       :label          (utils/get-shortened-address split-address)}
-         :stack-id    :wallet-select-address
-         :start-flow? true}])))
+                 :text (i18n/label :t/address-copied)}]))
+
+(comment
+ (defn- send-to-address [address]
+   (let [[_ split-address] (network-utils/split-network-full-address address)]
+     (rf/dispatch
+      [:wallet/select-send-address
+       {:address     address
+        :recipient   {:recipient-type :address
+                      :label          (utils/get-shortened-address split-address)}
+        :stack-id    :wallet-select-address
+        :start-flow? true}]))))
 
 (defn view
   [address]
@@ -32,7 +32,15 @@
     [[{:icon                :i/copy
        :accessibility-label :send-asset
        :label               (i18n/label :t/copy-address)
-       :on-press            #(on-press address)}
+       :on-press            #(copy-address address)}
+      ;; Originally, the flow went to the send flow, but it has been removed to avoid bugs,
+      ;; please check https://github.com/status-im/status-mobile/issues/20972 for more context
+      ;; The previous code has been commented out to be reintroduced in the future easily.
+      (comment
+       {:icon                :i/send
+        :accessibility-label :send-asset
+        :label               (i18n/label :t/send-to-this-address)
+        :on-press            #(send-to-address address)})
       (when (ff/enabled? :ff/wallet.saved-addresses)
         {:icon                :i/save
          :accessibility-label :save-address

--- a/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
+++ b/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
@@ -1,33 +1,40 @@
 (ns status-im.contexts.shell.qr-reader.sheets.scanned-wallet-address
   (:require
-    [quo.core :as quo]
-    [status-im.contexts.wallet.common.utils :as utils]
-    [status-im.contexts.wallet.common.utils.networks :as network-utils]
-    [status-im.feature-flags :as ff]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+   [quo.core :as quo]
+   [react-native.clipboard :as clipboard]
+   [status-im.contexts.wallet.common.utils :as utils]
+   [status-im.contexts.wallet.common.utils.networks :as network-utils]
+   [status-im.feature-flags :as ff]
+   [utils.i18n :as i18n]
+   [utils.re-frame :as rf]))
+
+(defn- on-press [address]
+  ;; Originally, the flow went to the send flow, but it has been removed to avoid bugs.
+  ;; Please check https://github.com/status-im/status-mobile/issues/20972
+  ;; The previous code has been commented out.
+  (let [#_#_[_ split-address] (network-utils/split-network-full-address address)]
+    (clipboard/set-string address)
+    (rf/dispatch [:toasts/upsert {:type :positive
+                                  :text (i18n/label :t/address-copied)}])
+    #_(rf/dispatch
+       [:wallet/select-send-address
+        {:address     address
+         :recipient   {:recipient-type :address
+                       :label          (utils/get-shortened-address split-address)}
+         :stack-id    :wallet-select-address
+         :start-flow? true}])))
 
 (defn view
   [address]
-  (let [[_ splitted-address] (network-utils/split-network-full-address address)]
-    [:<>
-     [quo/drawer-top
-      {:title address
-       :type  :address}]
-     [quo/action-drawer
-      [[{:icon                :i/send
-         :accessibility-label :send-asset
-         :label               (i18n/label :t/send-to-this-address)
-         :on-press            (fn []
-                                (rf/dispatch [:wallet/select-send-address
-                                              {:address     address
-                                               :recipient   {:recipient-type :address
-                                                             :label          (utils/get-shortened-address
-                                                                              splitted-address)}
-                                               :stack-id    :wallet-select-address
-                                               :start-flow? true}]))}
-        (when (ff/enabled? :ff/wallet.saved-addresses)
-          {:icon                :i/save
-           :accessibility-label :save-address
-           :label               (i18n/label :t/save-address)
-           :on-press            #(js/alert "feature not implemented")})]]]]))
+  [:<>
+   [quo/drawer-top {:title address :type :address}]
+   [quo/action-drawer
+    [[{:icon                :i/copy
+       :accessibility-label :send-asset
+       :label               (i18n/label :t/copy-address)
+       :on-press            #(on-press address)}
+      (when (ff/enabled? :ff/wallet.saved-addresses)
+        {:icon                :i/save
+         :accessibility-label :save-address
+         :label               (i18n/label :t/save-address)
+         :on-press            #(js/alert "feature not implemented")})]]]])

--- a/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
+++ b/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
@@ -1,21 +1,21 @@
 (ns status-im.contexts.shell.qr-reader.sheets.scanned-wallet-address
   (:require
-   [quo.core :as quo]
-   [react-native.clipboard :as clipboard]
-   [status-im.contexts.wallet.common.utils :as utils]
-   [status-im.contexts.wallet.common.utils.networks :as network-utils]
-   [status-im.feature-flags :as ff]
-   [utils.i18n :as i18n]
-   [utils.re-frame :as rf]))
+    [quo.core :as quo]
+    [react-native.clipboard :as clipboard]
+    [status-im.feature-flags :as ff]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
-(defn- on-press [address]
-  ;; Originally, the flow went to the send flow, but it has been removed to avoid bugs.
-  ;; Please check https://github.com/status-im/status-mobile/issues/20972
-  ;; The previous code has been commented out.
+(defn- on-press
+  [address]
+  ;; Originally, the flow went to the send flow, but it has been removed to avoid bugs. Please check
+  ;; https://github.com/status-im/status-mobile/issues/20972. The previous code has been commented
+  ;; out.
   (let [#_#_[_ split-address] (network-utils/split-network-full-address address)]
     (clipboard/set-string address)
-    (rf/dispatch [:toasts/upsert {:type :positive
-                                  :text (i18n/label :t/address-copied)}])
+    (rf/dispatch [:toasts/upsert
+                  {:type :positive
+                   :text (i18n/label :t/address-copied)}])
     #_(rf/dispatch
        [:wallet/select-send-address
         {:address     address

--- a/src/test_helpers/unit.cljs
+++ b/src/test_helpers/unit.cljs
@@ -12,9 +12,10 @@
     [re-frame.events :as rf-events]
     [re-frame.registrar :as rf-registrar]
     [re-frame.subs :as rf-subs]
-    [taoensso.timbre :as log] ;; We must require this namespace to register the custom cljs.test
-                              ;; directive `match-strict?`.
+    [taoensso.timbre :as log]
     test-helpers.matchers))
+;; We must require `test-helpers.matchers` this namespace to register the custom cljs.test
+;; directive `match-strict?`.
 
 (defn db
   "A simple wrapper to get the latest value from the app db."


### PR DESCRIPTION
fixes #20972 

### Summary

The new flow looks as follows:

https://github.com/user-attachments/assets/da8abbd2-3e2c-4fa9-acae-4969e3133510


### Review notes
The previous implementations has been commented out because we may fix it in the future.

#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Scan a QR code from another wallet address
- Press on copy
- Close the modal


status: ready