### PR TITLE
[#20971] fix: app crash when collectible max limit is nan

### DIFF
--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -6,11 +6,12 @@
 
 (defn collectible-balance
   [collectible]
-  (-> collectible
-      :ownership
-      first
-      :balance
-      js/parseInt))
+  (let [balance (-> collectible
+                    :ownership
+                    first
+                    :balance
+                    js/parseInt)]
+    (if (js/Number.isNaN balance) 0 balance)))
 
 (def supported-collectible-types
   #{"image/jpeg"


### PR DESCRIPTION
fixes #20971

### Summary

App doesn't respond after ERC 1155 collectible is attempting to be send

#### Platforms

- iOS


#### Areas that maybe impacted

- Send Collectible 


### Steps to test

- Scan wallet QR using a universal scanner
- Go to collectible send flow
- Select any ERC 1155 collectible


status: ready


