### PR TITLE
chore_: Remove passing emoji on profile creation

### DIFF
--- a/src/status_im/contexts/profile/create/events.cljs
+++ b/src/status_im/contexts/profile/create/events.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.profile.create.events
   (:require
     [native-module.core :as native-module]
-    [status-im.common.emoji-picker.utils :as emoji-picker.utils]
     [status-im.contexts.profile.config :as profile.config]
     status-im.contexts.profile.create.effects
     [utils.re-frame :as rf]
@@ -17,5 +16,4 @@
             :displayName        display-name
             :password           login-sha3-password
             :imagePath          (profile.config/strip-file-prefix image-path)
-            :customizationColor color
-            :emoji              (emoji-picker.utils/random-emoji))}))
+            :customizationColor color)}))

--- a/src/status_im/contexts/profile/recover/events.cljs
+++ b/src/status_im/contexts/profile/recover/events.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.profile.recover.events
   (:require
     [native-module.core :as native-module]
-    [status-im.common.emoji-picker.utils :as emoji-picker.utils]
     [status-im.contexts.profile.config :as profile.config]
     status-im.contexts.profile.recover.effects
     [utils.re-frame :as rf]
@@ -23,5 +22,4 @@
              :password           login-sha3-password
              :imagePath          (profile.config/strip-file-prefix image-path)
              :customizationColor color
-             :emoji              (emoji-picker.utils/random-emoji)
              :fetchBackup        true})}))


### PR DESCRIPTION

### Summary

This PR removes passing random emoji on account creation for the default wallet account as this will be set by status-go.

status go PR: https://github.com/status-im/status-go/pull/5667

The above status-go PR has been merged and is already part of the existing tag [v0.182.42](https://github.com/status-im/status-go/releases/tag/v0.182.42) used by mobile. 

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Create a new profile
- Verify the emoji is set for the default wallet account

status: ready 
