### PR TITLE
Profile with ENS fixes

### DIFF
--- a/src/legacy/status_im/data_store/settings.cljs
+++ b/src/legacy/status_im/data_store/settings.cljs
@@ -1,9 +1,10 @@
 (ns legacy.status-im.data-store.settings
   (:require
-    [clojure.set :as set]
-    [clojure.string :as string]
-    [legacy.status-im.data-store.visibility-status-updates :as visibility-status-updates]
-    [utils.ethereum.eip.eip55 :as eip55]))
+   [clojure.set :as set]
+   [clojure.string :as string]
+   [legacy.status-im.data-store.visibility-status-updates :as visibility-status-updates]
+   [status-im.contexts.wallet.common.validation :as validation]
+   [utils.ethereum.eip.eip55 :as eip55]))
 
 (defn rpc->visible-tokens
   [visible-tokens]
@@ -35,6 +36,7 @@
       (update :pinned-mailservers rpc->pinned-mailservers)
       (update :link-previews-enabled-sites set)
       (update :currency rpc->currency)
+      (assoc :ens-name? (validation/ens-name? (:preferred-name settings)))
       (visibility-status-updates/<-rpc-settings)
       (set/rename-keys {:compressedKey :compressed-key
                         :emojiHash     :emoji-hash})))

--- a/src/legacy/status_im/data_store/settings.cljs
+++ b/src/legacy/status_im/data_store/settings.cljs
@@ -1,10 +1,10 @@
 (ns legacy.status-im.data-store.settings
   (:require
-   [clojure.set :as set]
-   [clojure.string :as string]
-   [legacy.status-im.data-store.visibility-status-updates :as visibility-status-updates]
-   [status-im.contexts.wallet.common.validation :as validation]
-   [utils.ethereum.eip.eip55 :as eip55]))
+    [clojure.set :as set]
+    [clojure.string :as string]
+    [legacy.status-im.data-store.visibility-status-updates :as visibility-status-updates]
+    [status-im.contexts.wallet.common.validation :as validation]
+    [utils.ethereum.eip.eip55 :as eip55]))
 
 (defn rpc->visible-tokens
   [visible-tokens]

--- a/src/status_im/common/universal_links.cljs
+++ b/src/status_im/common/universal_links.cljs
@@ -178,13 +178,10 @@
   [{:keys [db]} [{:keys [public-key on-success]}]]
   (let [profile-public-key (get-in db [:profile/profile :public-key])
         profile?           (or (not public-key) (= public-key profile-public-key))
-        ens-name?          (if profile?
-                             (get-in db [:profile/profile :ens-name?])
-                             (get-in db [:contacts/contacts public-key :ens-name]))
         public-key         (if profile? profile-public-key public-key)]
     (when public-key
       {:json-rpc/call
-       [{:method     (if ens-name? "wakuext_shareUserURLWithENS" "wakuext_shareUserURLWithData")
+       [{:method     "wakuext_shareUserURLWithData"
          :params     [public-key]
          :on-success (fn [url]
                        (rf/dispatch [:universal-links/save-profile-url public-key url])

--- a/src/status_im/common/universal_links_test.cljs
+++ b/src/status_im/common/universal_links_test.cljs
@@ -45,8 +45,8 @@
       (let [db  {:profile/profile {:ens-name? true :public-key pubkey}}
             rst (links/generate-profile-url {:db db} [])]
         (are [result expected] (match? result expected)
-         "wakuext_shareUserURLWithENS" (-> rst :json-rpc/call first :method)
-         pubkey                        (-> rst :json-rpc/call first :params first)))))
+         "wakuext_shareUserURLWithData" (-> rst :json-rpc/call first :method)
+         pubkey                         (-> rst :json-rpc/call first :params first)))))
   (testing "user has no ens name"
     (testing "it calls the ens rpc method with public keyas param"
       (let [db  {:profile/profile {:public-key pubkey}}
@@ -60,8 +60,8 @@
             db  {:contacts/contacts {pubkey {:ens-name ens}}}
             rst (links/generate-profile-url {:db db} [{:public-key pubkey}])]
         (are [result expected] (match? result expected)
-         "wakuext_shareUserURLWithENS" (-> rst :json-rpc/call first :method)
-         pubkey                        (-> rst :json-rpc/call first :params first)))))
+         "wakuext_shareUserURLWithData" (-> rst :json-rpc/call first :method)
+         pubkey                         (-> rst :json-rpc/call first :params first)))))
   (testing "contact has no ens name"
     (testing "it calls the ens rpc method with public keyas param"
       (let [db  {:contacts/contacts {pubkey {:public-key pubkey}}}

--- a/src/status_im/contexts/profile/edit/list_items.cljs
+++ b/src/status_im/contexts/profile/edit/list_items.cljs
@@ -11,18 +11,18 @@
 
 (defn items
   [theme]
-  (let [profile             (rf/sub [:profile/profile-with-image])
-        customization-color (rf/sub [:profile/customization-color])
-        bio                 (:bio profile)
-        full-name           (profile.utils/displayed-name profile)]
+  (let [{:keys [bio ens-name?] :as profile} (rf/sub [:profile/profile-with-image])
+        customization-color                 (rf/sub [:profile/customization-color])
+        full-name                           (profile.utils/displayed-name profile)]
     [{:label (i18n/label :t/profile)
-      :items [{:title           (i18n/label :t/name)
-               :on-press        #(rf/dispatch [:open-modal :edit-name])
-               :blur?           true
-               :label           :text
-               :label-props     (utils/truncate-str full-name constants/profile-name-max-length)
-               :action          :arrow
-               :container-style style/item-container}
+      :items [(cond-> {:title           (i18n/label :t/name)
+                       :blur?           true
+                       :label           :text
+                       :label-props     (utils/truncate-str full-name constants/profile-name-max-length)
+                       :container-style style/item-container}
+                (not ens-name?)
+                (assoc :on-press #(rf/dispatch [:open-modal :edit-name])
+                       :action   :arrow))
               {:title           (i18n/label :t/bio)
                :on-press        #(rf/dispatch [:open-modal :edit-bio])
                :blur?           true

--- a/src/status_im/contexts/wallet/common/validation.cljs
+++ b/src/status_im/contexts/wallet/common/validation.cljs
@@ -2,7 +2,10 @@
   (:require [clojure.string :as string]
             [status-im.constants :as constants]))
 
-(defn ens-name? [s] (if (string/blank? s) false (boolean (re-find constants/regx-ens s))))
+(defn ens-name?
+  [s]
+  (and (not (string/blank? s))
+       (boolean (re-find constants/regx-ens s))))
 (defn private-key?
   [s]
   (or (re-find constants/regx-private-key-hex s)

--- a/src/status_im/contexts/wallet/common/validation.cljs
+++ b/src/status_im/contexts/wallet/common/validation.cljs
@@ -1,7 +1,8 @@
 (ns status-im.contexts.wallet.common.validation
-  (:require [status-im.constants :as constants]))
+  (:require [clojure.string :as string]
+            [status-im.constants :as constants]))
 
-(defn ens-name? [s] (boolean (re-find constants/regx-ens s)))
+(defn ens-name? [s] (if (string/blank? s) false (boolean (re-find constants/regx-ens s))))
 (defn private-key?
   [s]
   (or (re-find constants/regx-private-key-hex s)


### PR DESCRIPTION
fixes #20616
fixes #20511

### Summary

This PR:
 - fixes profile with ENS can edit their name
 - fixes identicon ring is shown for the profile with ENS
 - updates the profile URL for the profile with ENS to `https://status.app/u/CwSACgcKBUphdmlkAw==#zQ3shv264Sq3zcK8smDNJXxmrjfpdyvd5FPHEm2zHb7cXgjwR` as `https://status.app/u#<ENS_NAME>.eth` is NOT resolved by the [status-go](https://github.com/status-im/status-go/blob/48ebe24f8e986c174e8e933404b81a7d6a3beb3e/protocol/messenger_share_urls.go#L429-L432). Desktop app uses normal URL with data (not the URL with ENS) for ENS profiles.

| Before | After |
| --- | --- | 
| <img width="250" src="https://github.com/user-attachments/assets/31580770-0fd3-4a9f-9757-c7889b86e8d7"/> | <img width="250" src="https://github.com/user-attachments/assets/812c1481-ffaa-47fe-b8c9-da28a0e42844"/> | 
| <img width="250" src="https://github.com/user-attachments/assets/7c67fff1-89de-458a-996a-9b8dd17ed7fd"/> | <img width="250" src="https://github.com/user-attachments/assets/6cd4cb24-c025-430f-be16-26f36cedb490"/> | 
#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test

- Open Status
- Create/restore a profile with ENS (Sync profile with Desktop or upgrade an ENS user from v1 to v2)
- Navigate to `Profile` and verify the Identicon ring is not shown
- Navigate to `Profile > Edit profile` and verify the name is not editable
- Share a link to your profile and verify it is resolved when you paste it in chats or open it in the browser

status: ready 
