### PR TITLE
chore(waku): Enable message missing verification flag

### DIFF
--- a/src/status_im/contexts/profile/config.cljs
+++ b/src/status_im/contexts/profile/config.cljs
@@ -34,22 +34,25 @@
 (defn create
   []
   (let [log-enabled? (boolean (not-empty config/log-level))]
-    (assoc (login)
-           :deviceName                                   (native-module/get-installation-name)
-           :rootDataDir                                  (native-module/backup-disabled-data-dir)
-           :rootKeystoreDir                              (native-module/keystore-dir)
-           :logLevel                                     (when log-enabled? config/log-level)
-           :logEnabled                                   log-enabled?
-           :logFilePath                                  (native-module/log-file-directory)
-           :verifyTransactionURL                         config/verify-transaction-url
-           :verifyENSURL                                 config/verify-ens-url
-           :verifyENSContractAddress                     config/verify-ens-contract-address
-           :verifyTransactionChainID                     config/verify-transaction-chain-id
-           :wakuV2LightClient                            true
-           :wakuV2Fleet                                  config/fleet
-           :wakuV2EnableStoreConfirmationForMessagesSent false
-           :previewPrivacy                               config/blank-preview?
-           :testNetworksEnabled                          config/test-networks-enabled?)))
+    (assoc
+     (login)
+     :deviceName                                   (native-module/get-installation-name)
+     :rootDataDir                                  (native-module/backup-disabled-data-dir)
+     :rootKeystoreDir                              (native-module/keystore-dir)
+     :logLevel                                     (when log-enabled? config/log-level)
+     :logEnabled                                   log-enabled?
+     :logFilePath                                  (native-module/log-file-directory)
+     :verifyTransactionURL                         config/verify-transaction-url
+     :verifyENSURL                                 config/verify-ens-url
+     :verifyENSContractAddress                     config/verify-ens-contract-address
+     :verifyTransactionChainID                     config/verify-transaction-chain-id
+     :wakuV2LightClient                            true
+     :wakuV2Fleet                                  config/fleet
+     ;; NOTE: https://github.com/status-im/status-go/pull/5570#discussion_r1690794119
+     :wakuV2EnableMissingMessageVerification       true
+     :wakuV2EnableStoreConfirmationForMessagesSent false
+     :previewPrivacy                               config/blank-preview?
+     :testNetworksEnabled                          config/test-networks-enabled?)))
 
 (defn strip-file-prefix
   [path]


### PR DESCRIPTION
- Fixes https://github.com/status-im/status-mobile/issues/20879

### Summary

As recommended [here](https://github.com/status-im/status-go/pull/5570#discussion_r1692345230) and [here](https://github.com/status-im/status-go/pull/5570#discussion_r1690794119), we set the Waku config flag `WakuV2EnableMissingMessageVerification` to true. The flag can't be toggled in the UI because there's no supporting endpoint in status-go at the moment.

### Steps to test

In order for the flag to be used you have to create a new Profile. If you login with an existing one, it will be the same as if the flag was disabled (as in `develop`).

It would be good to get this PR in 2.30 as it can improve the UX, but only if we deem it safe.

Areas worth testing that may be impacted:

- Overall message reliability should be the same or better.
- Verify data consumption is more or less the same in a mobile network.
- Verify app's behavior in wifi and mobile networks.

status: ready