### PR TITLE
feature: require manual acceptance of terms-of-use and privacy-statement

### DIFF
--- a/resources/privacy.mdwn
+++ b/resources/privacy.mdwn
@@ -1,0 +1,54 @@
+Last updated: 2023-09-22
+
+Who we are
+
+Status is developing a set of open source projects that use peer-to-peer technologies to help people transact securely, communicate freely, and organise with confidence. Anyone participating in these projects helps to build technology and tools that empowers people to advance their own sovereign communities.
+
+Whenever “Status” or “we” or “us” or any similar variation, are used in these terms, we’re referring to Status Research & Development GmbH, a Swiss company with its registered office at Baarerstrasse 10, Zug, Switzerland, and includes its “representatives”, which means Status’ affiliates, directors, officers, employees, agents and any other representatives of Status. For the purposes of these terms, “representatives” also includes Status core contributors without prejudice to the other legal categories mentioned.
+
+Status does not provide any services, such as financial services, to users of Status Software or any third party. Status is not an intermediary, agent, advisor, or custodian, and does not owe you any fiduciary duty.
+
+
+Status Software
+
+At Status, we strive to develop open source software that can serve as a secure communication tool that helps to uphold human rights. Status Software is specifically designed to facilitate the free flow of information, protect the right to private, secure communications and promote the sovereignty of individuals.
+
+Status Software is composed of a secure messaging tool, a crypto wallet, and a Web 3 browser integrated together. The software developed by Status in this regard is simply called “Status Software” and you can find more details about its development on Status’ GitHub page.
+
+
+Our role in your privacy
+
+This Privacy Statement applies to you as a user of Status Software.
+
+Under the relevant data protection legislation, we would be under certain obligations if we process any personal data when you use Status Software. Personal data means all information by which a person can be directly or indirectly identified, in line with the definitions of the General Data Protection Regulation (GDPR), the Swiss Federal Act on Data Protection of June 19, 1992 (DPA) (as amended from time to time) and its ordinances, and other relevant legislation on the protection of personal data. When we refer to privacy legislation in this Privacy Statement, we mean GDPR and all such relevant legislation.
+
+However, since we do not collect or process any of your personal data when you use Status Software, we have decided to inform you of the following instead:
+
+- Ethereum is a public blockchain:
+Ethereum is the community-run technology powering the cryptocurrency ether (ETH) and thousands of decentralized applications (DApps). Status Software provides a mobile portal and streamlined access to Ethereum’s growing ecosystem of decentralized applications.
+
+The Ethereum public network is accessible to anyone in the world with an internet connection. Anyone can read or create transactions on a public blockchain and validate the transactions being executed. Therefore, information you share on the Ethereum blockchain is public, whether or not you use Status Software.
+
+You will also be able to create (and join) open and public communities on Status Software that are accessible to other users. We note that content in these open and public communities will be accessible to all other users of Status Software. Nonetheless, all content will still be protected by the same end-to-end encryption utilised in Status Software.
+
+Ethereum Name Service (ENS) allows Ethereum addresses to be replaced by custom text-based names. Anyone can register a stateofus.eth username by staking the required Status Network Tokens (SNT) from within the profile tab on Status Software. When you register an ENS name with a given wallet address, that address becomes associated with the username, reducing the privacy of that account.
+
+- Offering secure, private messaging:
+When generating an account, a randomisation process is started on your own device that generates a key pair. Status does not have visibility of or access to your private keys. You will then be given display name options to choose from (derived from this key pair). Your display name will only be shared if you choose to share it by chatting with Status or other users.
+
+Within Status Software, you can create a list of trusted contacts based on the chat keys you choose to trust. Your trusted contacts are also stored locally on your own device. This means that Status has no access to your contact list and does not collect or process any personal data in this respect.
+
+On Status Software, you can exchange messages with other users, including photos and audio messages. Only the recipient of a message can decrypt the message by opening it on their own device. This means that Status can never access any user messages in private chats.
+
+Messaging on Status Software uses an open source, peer-to-peer protocol with end-to-end encryption and metadata suppression, to protect your messages from third parties (including Status). End-to-end encryption means that only the sender and recipient of a message can read its contents, and no one else. This protocol, known as Waku, relies on a distributed network of nodes instead of a centralised server which means that there is no central party or server from which messages can be intercepted, modified or blocked. Learn more about Waku and how it works on Waku’s website.
+
+- A quick bite on cookies:
+We do not set any cookies for the use of Status Software. However, the Web 3.0 browser embedded within Status Software technically supports the use of cookies set by third party websites. Status is not responsible for nor is it able to influence whether such cookies are set by such third party websites and you should consult the relevant privacy policies of such third party websites.
+
+
+Changes to Status Privacy Statement
+It is unlikely that this Privacy Statement will change because we do not intend to collect or process your personal data, ever. That said, we reserve the right to modify or replace any part of this Privacy Statement at any time and in our sole discretion.
+
+If you have any questions about the Status Software Privacy Statement, please contact us at legal@status.im or through the appropriate means of communication indicated on Status’ website.
+
+This document is CC-BY-SA.

--- a/resources/terms-of-use.mdwn
+++ b/resources/terms-of-use.mdwn
@@ -38,7 +38,7 @@ You not only release Status’ liability on a number of items, but also agree th
 
 - Arbitration
 If a dispute arises between you and Status, we will seek to first solve it amicably with you before proceeding to the use of an arbitration administered by the Swiss Chambers’ Arbitration Institution.
-&nbsp;
+
 
 2. About Status Software
 
@@ -77,7 +77,7 @@ Within Messaging, you will also be able to participate in Status Community Space
 2.1.2 Web 3 browser
 
 Status Software also includes a Web 3 browser through which you may access and interact with Web 3, exchanges, marketplaces, games and more. We will refer to the Web 3 browser in these terms as the “Web 3 Browser”.
-&nbsp;
+
 
 3. Privacy
 
@@ -95,7 +95,7 @@ If you use third party services offered through Status Software, your privacy ma
 
 
 Learn more about how we protect your data on Status Software by reading the Status Privacy Statement and relevant security page on the Status website.
-&nbsp;
+
 
 4. Using third party services and interacting with Web 3
 
@@ -114,19 +114,19 @@ You are solely responsible for your use of Third Party Services and your interac
 In principle, Status does not provide any advice, recommendation, support or endorse Third Party Services you may use or any aspect of Web 3 that you may interact with through Status Software. Their integration or availability through Status Software does not imply any support or endorsement by Status. Status may also receive a fee from certain third parties who provide the Third Party Services.
 
 Please also note that Status participates in the development of other open source projects that utilise peer-to-peer technologies, which you can find more details about on Status’ GitHub page.
-&nbsp;
+
 
 5. Nodes
 
 The use of Status Software on your device will turn it into a node that supports the Waku network.
 
 In general, by participating in or interacting with Web 3 networks, you may choose or be required to operate a node or perform other functions in support of such a network. Status is not responsible for the operation or functioning of such nodes.
-&nbsp;
+
 
 6. Security
 
 Although security is a top priority for us and many functions of Status Software are privacy-mode by default, we cannot guarantee the full security of Status Software and we are not responsible for alerting you to potential security risks. We intend to continuously update the security measures of Status Software and we will from time to time post updates on the security of Status Software through our communication channels.
-&nbsp;
+
 
 7. Content
 
@@ -142,7 +142,7 @@ You acknowledge that Status has no means of monitoring, moderating, removing, mo
 1. could be offensive, indecent, or otherwise objectionable;
 2. contains technical inaccuracies, typographical mistakes, and other errors; or
 3. could violate others’ rights, including but not limited to privacy, publicity, intellectual property, or other proprietary rights.
-&nbsp;
+
 
 8. Acceptable use of Status software
 
@@ -167,12 +167,12 @@ You shall not, nor try to, encourage or assist others using Status Software to:
 12. engage in any activity through Status Software that may be in violation of applicable law, rules or regulations in your jurisdiction;
 13. interfere, disrupt, negatively affect, or inhibit other users from their use of Status Software; or
 14. engage in any attack, hack, denial-of-service attack, interference, or exploit of any smart contract in connection with use of Status Software.
-&nbsp;
+
 
 9. Fees
 
 When you use Status Software to interact with Third Party Services or Web 3, you may incur costs and may have to pay various fees, such as service fees, transfer fees, transaction fees, swap fees, bridge fees or network fees. You will be solely liable for any such fees, costs and expenses. Status has no control over and is unable to influence these fees in any manner.
-&nbsp;
+
 
 10. Intellectual property and branding
 
@@ -187,7 +187,7 @@ Status (and its affiliates as the case may be) owns all the rights to Status bra
 We love to see creative work from the Status community, but please let us know in advance and in writing if you want to use trademarks, logos, or graphics or modify them from our standard colours and designs. If you write articles, blogs, create websites, or talk about Status, please make sure it is clear that you are not speaking for, on behalf of, or under endorsement by Status.
 
 To request permission to use our copyrighted material or trademarks or any other intellectual property, such as logos, please contact: marketing@status.im. If we grant you permission, you must follow our guidelines and instructions for using our intellectual property.
-&nbsp;
+
 
 11. Risks
 
@@ -222,7 +222,7 @@ With Status Software, you can interact with and transact in Digital Assets and t
 You acknowledge that there may be legal and regulatory implications applicable to you while using Status Software and interacting with Web 3 and that may also adversely impact your use of Status Software.
 
 You are solely responsible for evaluating the legal and regulatory implications and taking appropriate actions, which could include obtaining any necessary licences, permits or approvals. Additionally, you are solely responsible for any tax implications, such as the payment of any taxes, resulting from your activities conducted through Status Software, including any transactions in Digital Assets.
-&nbsp;
+
 
 12. Disclaimers
 
@@ -233,7 +233,7 @@ Status Software is provided on an “as is” basis. Status does not make any ex
 4. regarding the value, utility or legality of any Digital Asset;
 5. regarding the completeness, accuracy, legality, utility, suitability, functionality, security or availability of any smart contract that you may interact with or deploy; or
 6. regarding the completeness, accuracy, legality, utility, reliability, suitability or availability of any user content.
-&nbsp;
+
 
 13. Releases you should read closely
 
@@ -250,13 +250,13 @@ You release Status from all liability related to any claim, cause of action, con
 10. your content or other users’ content;
 11. any unauthorised third party activities, including without limitation the use of viruses, phishing, brute forcing, or other means of attack against Status Software; and
 12. any risks identified in these terms or any that a reasonable person should have been aware of in relation to using Status Software.
-&nbsp;
+
 
 14. Limitation of liability
 
 Status will not be held liable to you under any contract, negligence, strict liability, or other legal or equitable theory for any lost profits, cost of procurement for substitute services, or any special, incidental, or consequential damages related to, arising from, or in any way connected with these terms, Status, your use of Status Software, particularly where Status has indicated that it is not responsible. This includes without limitation, your use of SNT or other Digital Assets (creating, distributing, transacting in or otherwise) even if Status has been advised of the possibility of such damages.
 In any event, Status’ aggregate liability for any claims is limited to EUR 100 (one hundred Euros). This limitation of liability will apply to the extent permitted by applicable law.
-&nbsp;
+
 
 15. Indemnity
 
@@ -268,7 +268,7 @@ You shall indemnify and hold harmless Status from and against any and all claims
 5. your harm to or violation of the rights of any third party, including any privacy, intellectual property, publicity, confidentiality, property or any other rights;
 6. your use of Third Party Services or any aspect of Web 3; or
 7. any misrepresentation or fraudulent statements made by you.
-&nbsp;
+
 
 16. Restricted jurisdictions
 
@@ -277,7 +277,7 @@ Status is a Swiss company which makes Status Software available through third pa
 You acknowledge that Status Software is not intended for use or distribution in any jurisdiction where such use or distribution of software that is similar or identical to Status Software is prohibited or restricted in any way. Your use of Status Software does not and will not subject Status to such jurisdiction under any circumstance, particularly if there are any prohibitions or restrictions on the use of such software. Status reserves the right to limit the availability of Status Software in any jurisdiction.
 
 Status does not conduct any business activities (i.e. activities undertaken for the purpose of earning a profit) within the United States of America, District of Columbia, Puerto Rico, the U.S. Virgin Islands, and all other U.S. territories and possessions, as well as all Swiss embargoed countries.
-&nbsp;
+
 
 17. Materials provided are solely for informational purposes
 
@@ -286,7 +286,7 @@ Status provides materials and other information through Status Software for info
 You should always conduct your own research and seek independent professional advice if necessary. The materials and other information that Status may provide through Status Software does not constitute financial, legal, tax, or other advice and should not be treated as such.
 
 Additionally, Status is not responsible for any information, content, or services contained on any third party websites accessible or linked through the Status Software. By linking such third party websites, Status does not represent or imply that it endorses or supports such third party websites or content therein, or that it believes such third party websites and content therein to be accurate, useful or non-harmful. Status has no control over such third party websites and will not be liable for your use of or activities on any third party websites accessed through Status Software. The terms and conditions, including privacy policies, of such third party websites govern your use of their websites.If you access such third party websites through Status Software, it is at your own risk and you are solely responsible for your activities on such third party websites.
-&nbsp;
+
 
 18. Governing law and dispute resolution
 
@@ -305,14 +305,14 @@ If a (potential) dispute arises, you must first use your reasonable efforts to r
 If you and Status are unable to further resolve this dispute within sixty (60) calendar days of Status receiving this notice of dispute, then any such dispute will be referred to and finally resolved by you and Status through an arbitration administered by the Swiss Chambers’ Arbitration Institution in accordance with the Swiss Rules of International Arbitration for the time being in force, which rules are deemed to be incorporated herein by reference. The arbitral decision may be enforced in any court. The arbitration will be held in Zug, Switzerland, and may be conducted via video conference virtual/online methods if possible. The tribunal will consist of one arbitrator, and all proceedings as well as communications between the parties will be kept confidential. The language of the arbitration will be in English. Payment of all relevant fees in respect of the arbitration, including filing, administration and arbitrator fees will be in accordance with the Swiss Rules of International Arbitration.
 
 Regardless of any applicable statute of limitations, you must bring any claims within one year after the claim arose or the time when you should have reasonably known about the claim. You also waive the right to participate in a class action lawsuit or a classwide arbitration against Status.
-&nbsp;
+
 
 19. What happens if you stop using Status Software
 
 If, at any time, you no longer agree to these terms, you must immediately stop using Status Software and uninstall it from all your devices. You acknowledge that even after uninstalling Status Software from all your devices, messages (including content) you have sent may still remain on the recipient’s device, blockchain transactions you have may still be recorded on the blockchain, and any smart contracts you have deployed to a blockchain may still remain deployed.
 
 Even after you have stopped using Status Software, all provisions of these terms which by their nature should survive termination shall survive termination. These provisions include, but are not limited to, warranty disclaimers, indemnity, limitations of liability, dispute resolution, and governing law.
-&nbsp;
+
 
 20. General provisions
 

--- a/src/quo/components/drawers/bottom_actions/view.cljs
+++ b/src/quo/components/drawers/bottom_actions/view.cljs
@@ -20,7 +20,7 @@
       [:actions [:maybe [:enum :one-action :two-actions :two-vertical-actions]]]
       [:description {:optional true} [:maybe [:enum :top :bottom :top-error]]]
       [:description-text {:optional true} [:maybe [:or :string :schema.common/hiccup]]]
-      [:description-top-text {:optional true} [:maybe :string]]
+      [:description-top-text {:optional true} [:maybe [:or :string :schema.common/hiccup]]]
       [:error-message {:optional true} [:maybe :string]]
       [:role {:optional true} [:maybe [:enum :admin :member :token-master :owner]]]
       [:context-tag-props {:optional true} [:maybe context-tag.schema/?schema]]
@@ -58,7 +58,7 @@
           :style {:color (colors/theme-colors colors/danger-50 colors/danger-60 theme)}}
          error-message]])
 
-     (when (and (= description :top) (or role context-tag-props))
+     (when (and (= description :top) (string? description-top-text) (or role context-tag-props))
        [rn/view {:style style/description-top}
         [text/text
          {:size  :paragraph-2
@@ -72,6 +72,10 @@
             :blur?   blur?
             :context (i18n/label (keyword "t" role))}
            context-tag-props)]])
+
+     (when (and (= description :top)
+                (vector? description-top-text))
+       description-top-text)
 
      [rn/view {:style (style/buttons-container actions buttons-container-style)}
       (when (or (= actions :two-actions)

--- a/src/quo/components/drawers/bottom_actions/view.cljs
+++ b/src/quo/components/drawers/bottom_actions/view.cljs
@@ -58,24 +58,23 @@
           :style {:color (colors/theme-colors colors/danger-50 colors/danger-60 theme)}}
          error-message]])
 
-     (when (and (= description :top) (string? description-top-text) (or role context-tag-props))
-       [rn/view {:style style/description-top}
-        [text/text
-         {:size  :paragraph-2
-          :style (style/description-top-text scroll? blur? theme)}
-         (or description-top-text (i18n/label :t/eligible-to-join-as))]
-        [context-tag/view
-         (if role
-           {:type    :icon
-            :size    24
-            :icon    (role role-icon)
-            :blur?   blur?
-            :context (i18n/label (keyword "t" role))}
-           context-tag-props)]])
-
-     (when (and (= description :top)
-                (vector? description-top-text))
-       description-top-text)
+     (when (= description :top)
+       (if (vector? description-top-text)
+         description-top-text
+         (when (or role context-tag-props)
+           [rn/view {:style style/description-top}
+            [text/text
+             {:size  :paragraph-2
+              :style (style/description-top-text scroll? blur? theme)}
+             (or description-top-text (i18n/label :t/eligible-to-join-as))]
+            [context-tag/view
+             (if role
+               {:type    :icon
+                :size    24
+                :icon    (role role-icon)
+                :blur?   blur?
+                :context (i18n/label (keyword "t" role))}
+               context-tag-props)]])))
 
      [rn/view {:style (style/buttons-container actions buttons-container-style)}
       (when (or (= actions :two-actions)

--- a/src/status_im/contexts/onboarding/intro/style.cljs
+++ b/src/status_im/contexts/onboarding/intro/style.cljs
@@ -7,9 +7,14 @@
    :justify-content :flex-end})
 
 (def text-container
-  {:text-align :center
-   :margin-top 4
-   :flex-wrap  :wrap})
+  {:flex       1
+   :flex-wrap  :wrap
+   :text-align :center})
+
+(def terms-privacy-container
+  {:gap                8
+   :padding-horizontal 20
+   :padding-vertical   8})
 
 (def plain-text
   {:color colors/white-opa-70})

--- a/src/status_im/contexts/onboarding/intro/style.cljs
+++ b/src/status_im/contexts/onboarding/intro/style.cljs
@@ -7,9 +7,10 @@
    :justify-content :flex-end})
 
 (def text-container
-  {:flex       1
-   :flex-wrap  :wrap
-   :text-align :center})
+  {:flex           1
+   :flex-direction :row
+   :flex-wrap      :wrap
+   :align-self     :center})
 
 (def terms-privacy-container
   {:gap                8
@@ -20,8 +21,7 @@
   {:color colors/white-opa-70})
 
 (def highlighted-text
-  {:flex  1
-   :color colors/white})
+  {:color colors/white})
 
 (defn bottom-actions-container
   [bottom-insets]

--- a/src/status_im/contexts/onboarding/intro/view.cljs
+++ b/src/status_im/contexts/onboarding/intro/view.cljs
@@ -6,45 +6,71 @@
     [status-im.contexts.onboarding.common.background.view :as background]
     [status-im.contexts.onboarding.common.overlay.view :as overlay]
     [status-im.contexts.onboarding.intro.style :as style]
+    [status-im.contexts.onboarding.privacy.view :as privacy]
     [status-im.contexts.onboarding.terms.view :as terms]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
 (defn view
   []
-  [rn/view {:style style/page-container}
-   [background/view false]
-   [quo/bottom-actions
-    {:container-style  (style/bottom-actions-container (safe-area/get-bottom))
-     :actions          :two-vertical-actions
-     :description      :bottom
-     :description-text [quo/text
-                        {:style  style/text-container
-                         :size   :paragraph-2
-                         :weight :regular}
-                        [quo/text {:style style/plain-text}
-                         (i18n/label :t/by-continuing-you-accept)]
-                        [quo/text
-                         {:on-press #(rf/dispatch [:show-bottom-sheet
-                                                   {:content (fn [] [terms/terms-of-use])
-                                                    :shell?  true}])
-                          :style    style/highlighted-text}
-                         (i18n/label :t/terms-of-service)]]
-     :button-one-label (i18n/label :t/sync-or-recover-profile)
-     :button-one-props {:type                :dark-grey
-                        :accessibility-label :already-use-status-button
-                        :on-press            (fn []
-                                               (when-let [blur-show-fn @overlay/blur-show-fn-atom]
-                                                 (blur-show-fn))
-                                               (rf/dispatch
-                                                [:open-modal
-                                                 :screen/onboarding.sync-or-recover-profile]))}
-     :button-two-label (i18n/label :t/create-profile)
-     :button-two-props {:accessibility-label :new-to-status-button
-                        :on-press
-                        (fn []
-                          (when-let [blur-show-fn @overlay/blur-show-fn-atom]
-                            (blur-show-fn))
-                          (rf/dispatch
-                           [:open-modal :screen/onboarding.new-to-status]))}}]
-   [overlay/view]])
+  (let [[terms-accepted? set-terms-accepted?] (rn/use-state false)]
+    [rn/view {:style style/page-container}
+     [background/view false]
+     [quo/bottom-actions
+      {:container-style      (style/bottom-actions-container (safe-area/get-bottom))
+       :actions              :two-vertical-actions
+       :description          :top
+       :description-top-text [rn/view
+                              {:style          style/terms-privacy-container
+                               :flex-direction :row}
+                              [quo/selectors
+                               {:type      :checkbox
+                                :checked?  terms-accepted?
+                                :on-change #(set-terms-accepted? not)}]
+                              [rn/view {:style {:flex 1}}
+                               [quo/text
+                                {:style style/text-container
+                                 :size  :paragraph-2}
+                                [quo/text
+                                 {:style style/plain-text
+                                  :size  :paragraph-2}
+                                 (str (i18n/label :t/accept-status-tos-prefix) " ")]
+                                [quo/text
+                                 {:on-press #(rf/dispatch [:show-bottom-sheet
+                                                           {:content (fn [] [terms/terms-of-use])
+                                                            :shell?  true}])
+                                  :style    style/highlighted-text
+                                  :size     :paragraph-2}
+                                 (i18n/label :t/terms-of-service)]
+                                [quo/text
+                                 {:style style/plain-text
+                                  :size  :paragraph-2}
+                                 " & "]
+                                [quo/text
+                                 {:on-press #(rf/dispatch [:show-bottom-sheet
+                                                           {:content (fn [] [privacy/privacy-statement])
+                                                            :shell?  true}])
+                                  :style    style/highlighted-text
+                                  :size     :paragraph-2
+                                  :weight   :regular}
+                                 (i18n/label :t/intro-privacy-statement)]]]]
+       :button-one-label     (i18n/label :t/sync-or-recover-profile)
+       :button-one-props     {:type                :dark-grey
+                              :disabled?           (not terms-accepted?)
+                              :accessibility-label :already-use-status-button
+                              :on-press            (fn []
+                                                     (when-let [blur-show-fn @overlay/blur-show-fn-atom]
+                                                       (blur-show-fn))
+                                                     (rf/dispatch
+                                                      [:open-modal
+                                                       :screen/onboarding.sync-or-recover-profile]))}
+       :button-two-label     (i18n/label :t/create-profile)
+       :button-two-props     {:accessibility-label :new-to-status-button
+                              :disabled? (not terms-accepted?)
+                              :on-press
+                              (fn []
+                                (when-let [blur-show-fn @overlay/blur-show-fn-atom]
+                                  (blur-show-fn))
+                                (rf/dispatch
+                                 [:open-modal :screen/onboarding.new-to-status]))}}]
+     [overlay/view]]))

--- a/src/status_im/contexts/onboarding/intro/view.cljs
+++ b/src/status_im/contexts/onboarding/intro/view.cljs
@@ -23,10 +23,12 @@
        :description-top-text [rn/view
                               {:style          style/terms-privacy-container
                                :flex-direction :row}
-                              [quo/selectors
-                               {:type      :checkbox
-                                :checked?  terms-accepted?
-                                :on-change #(set-terms-accepted? not)}]
+                              [rn/view
+                               {:accessibility-label :terms-privacy-checkbox-container}
+                               [quo/selectors
+                                {:type      :checkbox
+                                 :checked?  terms-accepted?
+                                 :on-change #(set-terms-accepted? not)}]]
                               [rn/view {:style {:flex 1}}
                                [quo/text
                                 {:style style/text-container

--- a/src/status_im/contexts/onboarding/intro/view.cljs
+++ b/src/status_im/contexts/onboarding/intro/view.cljs
@@ -27,12 +27,11 @@
                                {:accessibility-label :terms-privacy-checkbox-container}
                                [quo/selectors
                                 {:type      :checkbox
+                                 :blur?     true
                                  :checked?  terms-accepted?
                                  :on-change #(set-terms-accepted? not)}]]
                               [rn/view {:style {:flex 1}}
-                               [quo/text
-                                {:style style/text-container
-                                 :size  :paragraph-2}
+                               [rn/view {:style style/text-container}
                                 [quo/text
                                  {:style style/plain-text
                                   :size  :paragraph-2}
@@ -42,7 +41,8 @@
                                                            {:content (fn [] [terms/terms-of-use])
                                                             :shell?  true}])
                                   :style    style/highlighted-text
-                                  :size     :paragraph-2}
+                                  :size     :paragraph-2
+                                  :weight   :medium}
                                  (i18n/label :t/terms-of-service)]
                                 [quo/text
                                  {:style style/plain-text
@@ -54,7 +54,7 @@
                                                             :shell?  true}])
                                   :style    style/highlighted-text
                                   :size     :paragraph-2
-                                  :weight   :regular}
+                                  :weight   :medium}
                                  (i18n/label :t/intro-privacy-statement)]]]]
        :button-one-label     (i18n/label :t/sync-or-recover-profile)
        :button-one-props     {:type                :dark-grey

--- a/src/status_im/contexts/onboarding/privacy/view.cljs
+++ b/src/status_im/contexts/onboarding/privacy/view.cljs
@@ -1,0 +1,11 @@
+(ns status-im.contexts.onboarding.privacy.view
+  (:require-macros [legacy.status-im.utils.slurp :refer [slurp]])
+  (:require [quo.core :as quo]
+            [react-native.gesture :as gesture]))
+
+(def privacy-statement-text (slurp "resources/privacy.mdwn"))
+
+(defn privacy-statement
+  []
+  [gesture/scroll-view {:margin 20}
+   [quo/text privacy-statement-text]])

--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -149,6 +149,8 @@ class SignInView(BaseView):
         # intro screen
         self.i_m_new_in_status_button = Button(self.driver, accessibility_id="new-to-status-button")
 
+        self.terms_and_privacy_checkbox = Button(
+            self.driver, xpath="//*[@content-desc='terms-privacy-checkbox-container']/*[@content-desc='checkbox-off']")
         self.create_profile_button = Button(self.driver, accessibility_id='new-to-status-button')
         self.not_now_button = Button(self.driver, xpath="//*[@text='Not now']")
         self.sync_or_recover_profile_button = Button(self.driver, accessibility_id='already-use-status-button')
@@ -236,6 +238,7 @@ class SignInView(BaseView):
         self.driver.info("## Creating new multiaccount (password:'%s', keycard:'%s', enable_notification: '%s')" %
                          (password, str(keycard), str(enable_notifications)), device=False)
         if first_user:
+            self.terms_and_privacy_checkbox.click()
             self.create_profile_button.click_until_presence_of_element(self.generate_keys_button)
             self.not_now_button.wait_and_click()
         else:
@@ -279,6 +282,7 @@ class SignInView(BaseView):
         self.driver.info("## Recover access(password:%s, keycard:%s)" % (password, str(keycard)), device=False)
 
         if not second_user:
+            self.terms_and_privacy_checkbox.click()
             self.sync_or_recover_profile_button.click_until_presence_of_element(self.generate_keys_button)
             self.not_now_button.wait_and_click()
         else:

--- a/translations/en.json
+++ b/translations/en.json
@@ -1175,6 +1175,7 @@
   "intro-message1": "Welcome to Status!\nTap this message to set your password and get started.",
   "intro-privacy-policy-note1": "Status does not collect or profit from your personal data. By continuing, you agree with the ",
   "intro-privacy-policy-note2": "privacy policy",
+  "intro-privacy-statement": "Privacy Statement",
   "intro-text": "Status is your gateway to the decentralized web",
   "intro-text1": "Chat over a peer-to-peer, encrypted network where messages can’t be censored or hacked",
   "intro-text2": "Send and receive digital assets anywhere in the world—no bank account required",


### PR DESCRIPTION
fixes #21004 

### Summary

* This PR attempts to add a checkbox for manually accepting the Status terms-of-use and privacy-statement while onboarding in the mobile app.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Onboarding

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open fresh installed Status mobile app
- Or remove all profile from Status mobile app
- View the the first onboarding screen with checkbox

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before changes

<img width="461" alt="Screenshot 2024-08-12 at 10 29 25" src="https://github.com/user-attachments/assets/1ce021a0-8710-4195-a9eb-86756d0c41cc">

#### After Changes

| iOS | Android |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/7566c08b-55de-47b0-a8f7-fd0bd38d5dac" /> | <video src="https://github.com/user-attachments/assets/60f6970d-ca05-4bc9-a254-cba6119314f1" /> |

status: ready <!-- Can be ready or wip -->