### PR TITLE
chore: add beta tags to communities and chat home screen titles

### DIFF
--- a/src/status_im/common/home/title_column/view.cljs
+++ b/src/status_im/common/home/title_column/view.cljs
@@ -3,14 +3,30 @@
     [quo.core :as quo]
     [react-native.core :as rn]
     [status-im.common.home.title-column.style :as style]
-    [status-im.common.plus-button.view :as plus-button]))
+    [status-im.common.plus-button.view :as plus-button]
+    [utils.i18n :as i18n]))
 
 (defn view
-  [{:keys [label handler accessibility-label customization-color]}]
+  [{:keys [beta? label handler accessibility-label customization-color]}]
   [rn/view style/title-column
-   [rn/view {:flex 1}
+   [rn/view
+    {:style {:flex           1
+             :align-items    :center
+             :flex-direction :row}}
     [quo/text style/title-column-text
-     label]]
+     label]
+    (when beta?
+      [rn/view
+       {:style {:padding-top    6
+                :padding-bottom 2}}
+       [quo/tag
+        {:accessibility-label :communities-chat-beta-tag
+         :size                32
+         :type                :label
+         :label               (i18n/label :t/beta)
+         :labelled?           true
+         :blurred?            false}]])]
+
    (when handler
      [plus-button/plus-button
       {:on-press            handler

--- a/src/status_im/common/home/title_column/view.cljs
+++ b/src/status_im/common/home/title_column/view.cljs
@@ -21,7 +21,7 @@
                 :padding-bottom 2}}
        [quo/tag
         {:accessibility-label :communities-chat-beta-tag
-         :size                32
+         :size                24
          :type                :label
          :label               (i18n/label :t/beta)
          :labelled?           true

--- a/src/status_im/contexts/chat/home/view.cljs
+++ b/src/status_im/contexts/chat/home/view.cljs
@@ -118,7 +118,8 @@
 (defn- banner-data
   [profile-link]
   {:title-props
-   {:label               (i18n/label :t/messages)
+   {:beta?               true
+    :label               (i18n/label :t/messages)
     :handler             #(rf/dispatch
                            [:show-bottom-sheet {:content chat.actions.view/new-chat}])
     :accessibility-label :new-chat-button}

--- a/src/status_im/contexts/communities/home/view.cljs
+++ b/src/status_im/contexts/communities/home/view.cljs
@@ -64,7 +64,8 @@
 
 (def ^:private banner-data
   {:title-props
-   {:label               (i18n/label :t/communities)
+   {:beta?               true
+    :label               (i18n/label :t/communities)
     :handler             (when config/fast-create-community-enabled?
                            #(rf/dispatch [:show-bottom-sheet {:content actions.home-plus/view}]))
     :accessibility-label :new-communities-button}

--- a/translations/en.json
+++ b/translations/en.json
@@ -186,6 +186,7 @@
   "balance": "Balance",
   "begin-set-up": "Begin setup",
   "below-base-fee": "max fee below base fee",
+  "beta": "Beta",
   "bio": "Bio",
   "bio-added": "Bio added",
   "bio-is-too-long": "Bio is too long",


### PR DESCRIPTION
fixes #21006 

### Summary

* This PR attempts to add the "Beta" tags to the home screen titles for Communities and Chat.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Chat and Communities home screen

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile app
- Login into a user profile
- View the communities home screen
- View the chat home screen

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### After Changes

https://github.com/user-attachments/assets/88d5a831-2849-470d-b0ba-6f150059eec0

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
