### PR TITLE
test: limit message hashes per query

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "release/0.182.x",
-    "commit-sha1": "5dfeb130b06f14b4fcda3dd84cbcc9c0b8496a17",
-    "src-sha256": "1dmv6vjdikwwvwv667q5bya4acvxybd4xbrfhvg4aybww7gjr93y"
+    "version": "1915ab90007a671d9731b702336913a21a1b93ec",
+    "commit-sha1": "1915ab90007a671d9731b702336913a21a1b93ec",
+    "src-sha256": "14jz0infn4zynl7hdrnjwr9myva50psryq2gy0ncsca2dwijpxd9"
 }


### PR DESCRIPTION
if the missing message verification is enabled there's no limit for the number of missing message hashes to request and that can increase the load of the storenodes while with this change we reduce the number of message hashes per query to 50.

Requires:
- https://github.com/status-im/status-go/pull/5688

To test:
- Ensure no panics happen during normal app usage or excess memory is being used compared to current release version

cc: @ilmotta  @churik  