### PR TITLE
chore: status-go fix to avoid log flooding in case of DNS failure (not to merge)

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.182.42",
-    "commit-sha1": "a93c857238c3002ae64da1bdbebea13f3392da8b",
-    "src-sha256": "0rrny83rnirpm5pwp8br6nnglijb4whx1xl6nwkm5lzfnnichg59"
+    "version": "e08ed738afe03dc2243f4c0ced869b9edcca677e",
+    "commit-sha1": "e08ed738afe03dc2243f4c0ced869b9edcca677e",
+    "src-sha256": "0dmcmy0b4aqbkkz1hviydn920qi6g5d8fgiccryvzql07s00nr60"
 }


### PR DESCRIPTION
[comment]: # @qfrank  has noticed that in case of DNS failure in lightClient mode, there is a log flooding happening due to node state not being indicated properly. This PR is to be used for dogfooding the fix made in status-go so that node state is set to offline if we are not able to resolve DNS and connect to bootnodes or any other peers.

Linked status-go PR https://github.com/status-im/status-go/pull/5682

### Summary

Fix has already been verified by @qfrank in his setup where the issue was occuring and i have verified on status-desktop running in relay mode that no side-effects were introduced with this fix. 

We just need e2e tests to pass in order to merge the underlying PR.

#### Platforms
- Android
- iOS


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- networks


status: ready 

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


