### PR TITLE
Return data from cache if present

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.182.42",
-    "commit-sha1": "a93c857238c3002ae64da1bdbebea13f3392da8b",
-    "src-sha256": "0rrny83rnirpm5pwp8br6nnglijb4whx1xl6nwkm5lzfnnichg59"
+    "version": "fix/token-cache-usage",
+    "commit-sha1": "c5991352264b881c6b34d261ca9c2748ea060d54",
+    "src-sha256": "1z3y4avg5nkl8xkhigs404g5vibk1nwpsclnh6gw1w6bzrjvnc71"
 }


### PR DESCRIPTION
When we can't update the balance but we have an original balance, the backend should return the last available data.

To test:

1) Login, make sure balances are present
2) Logout, go offline
3) Login again

It should show the latest available balance instead of 0s

https://github.com/status-im/status-go/compare/a93c8572...c5991352

