### PR TITLE
fix_:enable light client after sync

### DIFF
--- a/src/status_im/contexts/syncing/events.cljs
+++ b/src/status_im/contexts/syncing/events.cljs
@@ -34,7 +34,7 @@
             :WakuV2Config {;; Temporary fix until https://github.com/status-im/status-go/issues/3024
                            ;; is resolved
                            :Nameserver  "8.8.8.8"
-                           :LightClient false}
+                           :LightClient true}
             :ShhextConfig {:VerifyTransactionURL     config/verify-transaction-url
                            :VerifyENSURL             config/verify-ens-url
                            :VerifyENSContractAddress config/verify-ens-contract-address


### PR DESCRIPTION
issue: light client not enabled after sync for mobile

this PR fixes above issue.

### Testing notes
before this PR, we can reproduce the issue by following steps:
- create a new account on device A, generate sync code
- scan the sync code generated by device A on device B
- after sync, check light client if enabled on device B
it should be disabled on device B. but we should enable it by default. 

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready.