### PR TITLE
Improve and Fix Unmute Behavior for Chats and Communities

### DIFF
--- a/src/status_im/common/muting/helpers.cljs
+++ b/src/status_im/common/muting/helpers.cljs
@@ -17,7 +17,7 @@
   (let [parsed-time       (t.format/parse (t.format/formatters :date-time-no-ms) muted-till-string)
         hours-and-minutes (str (add-leading-zero (t/hour (t/plus parsed-time time-zone-offset)))
                                ":"
-                               (add-leading-zero (t/minute parsed-time)))
+                               (add-leading-zero (t/minute (t/plus parsed-time time-zone-offset))))
         when-to-unmute    (cond (= go-default-time
                                    muted-till-string)   (i18n/label :t/until-you-turn-it-back-on)
                                 (today? parsed-time)    (str hours-and-minutes " today")

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -25,7 +25,7 @@
                   token-permissions-check id last-opened-at]
            :as   community}       (data-store.communities/<-rpc community-js)
           previous-last-opened-at (get-in db [:communities id :last-opened-at])]
-      (when (> clock (get-in db [:communities id :clock]))
+      (when (>= clock (get-in db [:communities id :clock]))
         {:db (assoc-in db
               [:communities id]
               (assoc community :last-opened-at (max last-opened-at previous-last-opened-at)))

--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -181,9 +181,4 @@
 
     (testing "given a community with lower clock"
       (let [effects (events/handle-community {:db {:communities {community-id {:clock 3}}}} [community])]
-        (is (nil? effects))))
-
-    (testing "given a community without clock"
-      (let [community #js {:id community-id}
-            effects   (events/handle-community {} [community])]
         (is (nil? effects))))))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.184.49",
-    "commit-sha1": "82ba10ede7a003e4ad23008e732e4690ae5ec430",
-    "src-sha256": "1n06wj379gz83g8jxg407923cak4iic1qj5ms2zpf6qp31sgq24m"
+    "version": "v0.184.51",
+    "commit-sha1": "9e722ed09544cc798bc8aa5cdb3b7b58241fbf95",
+    "src-sha256": "1r8w9309gffb52myfgnqyv8cpn372qkq14hpwk2zmz86qphw9jvf"
 }


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20977

### Summary

#### Improvements/Bug fixes
- Previously, we only considered the timezone offset for the hour portion, which worked well for timezones with whole-hour offsets. However, for timezones with minute offsets, such as India (UTC+5:30), this approach ignored the minute component, resulting in incorrect mute timer label.
- While managing communities, we only processed communities with higher clock values, which led to ignoring signals for unmuting communities with the same clock values.

#### Status-go Improvements/Bug fixes
PR: https://github.com/status-im/status-go/pull/5720
- Execute the initial check immediately upon starting to unmute chats for which the mute timer has expired.
- If a user mutes a chat for 1 minute at 11:12:33, the client displays the mute status as lasting until 11:13. Consequently, the chat should be unmuted as soon as 11:14. Currently, the routine does not run precisely at the top of the minute (hh:mm:00), leading to inconsistencies where the mute timer may expire, but the chat remains muted. Status-go PR ensures that the unmute timer is synchronized to run exactly on the 00 seconds mark.

#### Testing
I replaced the 1-week timer with a 1-minute timer for testing purposes.

status: ready