### PR TITLE
👓 Hide chain down toasts

### DIFF
--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -296,7 +296,6 @@
            {:start-flow? true
             :flow-id     :wallet-bridge-flow}]]]}))
 
-
 (rf/reg-event-fx :wallet/select-bridge-network
  (fn [{:keys [db]} [{:keys [network-chain-id stack-id]}]]
    {:db (assoc-in db [:wallet :ui :send :bridge-to-chain-id] network-chain-id)
@@ -497,16 +496,15 @@
                                         (string/join ", ")))]
      (when (seq down-chain-ids)
        (log/info "[wallet] Chain(s) down: " down-chain-ids)
+       (log/info "[wallet] Chain name(s) down: " chain-names)
        (log/info "[wallet] Test network enabled: " (boolean test-networks-enabled?))
        (log/info "[wallet] Goerli network enabled: " (boolean is-goerli-enabled?)))
-     {:db (assoc-in db [:wallet :statuses :blockchains] chains)
-      :fx [(when chains-down?
-             [:dispatch
-              [:toasts/upsert
-               {:id       :chains-down
-                :type     :negative
-                :text     (i18n/label :t/provider-is-down {:chains chain-names})
-                :duration constants/toast-chain-down-duration}]])]})))
+
+     ;; NOTE <shivekkhurana>: We used to show an error toast, but disabled it because the down
+     ;; signal is sent randomly. Needs to be investigated and enabled again !
+     ;; Context: https://github.com/status-im/status-mobile/issues/21054
+
+     {:db (assoc-in db [:wallet :statuses :blockchains] chains)})))
 
 (rf/reg-event-fx :wallet/reset-selected-networks
  (fn [{:keys [db]}]


### PR DESCRIPTION
Fixes: #21054 

## Summary of the Problem:
The app is experiencing issues where a "chain down" signal is triggered when interacting with Infura. This signal is currently considered too disruptive, leading to a decision to temporarily disable notifications for it. The signal is triggered by any unexpected errors in the RPC client, which is responsible for making requests to Infura. Common triggers include 401 errors, timeouts, and other unexpected issues.

## Potential Long-Term Solutions:

### Improved Error Handling:

Differentiate between types of errors (e.g., rate limits, connectivity issues, authorization failures).
Implement more nuanced responses, such as using local cache when rate limits are hit, informing the user when they are offline, or providing specific feedback for unhandled errors.


### Investigation and Refinement:

Allocate time to investigate the root causes of the "flip-flapping" connection state and refine the logic to reduce false positives for the chain down signal.


### Investigation
1) We are making historical request to arbitrum one (non archival?) 42161, that causes the circuit to open and the "chain goes down" (it's a bit of a guess on the historical requests)
2) 
```
WARN [08-15|12:15:10.468|github.com/status-im/status-go/rpc/chain/client.go:979]                                                      Error in chain call                      error="prod.api.status.im.error: context canceled" chain-id=1
WARN [08-15|12:15:10.468|github.com/status-im/status-go/rpc/chain/client.go:979]                                                      Error in chain call                      error="prod.api.status.im.error: Post \"https://prod.api.status.im/grove/ethereum/mainnet/\": context canceled" chain-id=1
WARN [08-15|12:15:10.468|github.com/status-im/status-go/rpc/chain/client.go:979]                                                      Error in chain call                      error="prod.api.status.im.error: Post \"https://prod.api.status.im/grove/ethereum/mainnet/\": context canceled" chain-id=1
```
Requests fails in batch, very quickly, that might indicate we are hitting the limit, I can't remember, but some providers just drop the request if you hit them too hard

```
3) WARN [08-15|12:15:36.982|github.com/status-im/status-go/rpc/chain/client.go:979]                                                                   Error in chain call                      error="prod.api.status.im.error: failed with 50145786 gas: insufficient funds for gas * price + value: address 0x527d22094166ad33e7523D2CBCa287798e149C7F have 68251537427723 want 100000000000000" chain-id=42161
```
This looks like an error that should not be triggering a chain id is down
```
4) WARN [08-15|12:15:45.814|github.com/status-im/status-go/rpc/chain/client.go:979]                                                                   Error in chain call                      error="prod.api.status.im.error: execution reverted: L2_AMM_W: Bonder fee cannot exceed amount" chain-id=42161 
```
Same as above
```
5) WARN [08-15|12:15:53.013|github.com/status-im/status-go/rpc/chain/client.go:979]                                                                   Error in chain call                      error="prod.api.status.im.error: not found" chain-id=1 same
```
```
6) WARN [08-15|12:27:05.401|github.com/status-im/status-go/rpc/chain/client.go:979]                                                                   Error in chain call                      error="prod.api.status.im.error: hystrix: circuit open, prod.api.status.im.error: hystrix: circuit open, optimism-archival.rpc.grove.city.error: json: cannot unmarshal string into Go struct field jsonrpcMessage.error of type rpc.jsonError, optimism-mainnet.infura.io.error: Post \"https://optimism-mainnet.infura.io/v3/c1f79f33854e462fb2b9fbc4df1a5d62\": context canceled" chain-id=10 
```

That looks like some malformed request?

those are in <@746044567681237092> logs the thing that trigger the "network is down popup". So I would probably (though not an expert in the code):
1) Understand why 1) is happening, looks like a misunderstanding or misconfiguration
2) In 2) These probably should be relaxed, there's a flurry of the same error coming through, seems the lowest priority of all of them
3) Number 3/4/5/6 should not be considered "chain is down" errors
4) 6 looks like an application error, we should probably identify and fix

cc <@170860385845510144> <@745755173174902806> <@466216536382898198>  Maybe you have more insights