### PR TITLE
feat(wallet): Make wallet behave well when device is offline

### DIFF
--- a/src/status_im/contexts/network/data_store.cljs
+++ b/src/status_im/contexts/network/data_store.cljs
@@ -1,0 +1,5 @@
+(ns status-im.contexts.network.data-store)
+
+(defn online?
+  [{:network/keys [status]}]
+  (= :online status))

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -262,3 +262,7 @@
      ;;  :cost () ;; tbd not used on desktop
      :token-fees                token-fees
      :gas-amount                (:tx-gas-amount new-path)}))
+
+(defn tokens-never-loaded?
+  [db]
+  (nil? (get-in db [:wallet :ui :tokens-loading])))

--- a/src/status_im/contexts/wallet/db.cljs
+++ b/src/status_im/contexts/wallet/db.cljs
@@ -7,4 +7,7 @@
 
 (def defaults
   {:ui {:network-filter network-filter-defaults
-        :tokens-loading {}}})
+        ;; Note: we set it to nil by default to differentiate when the user logs
+        ;; in and the device is offline, versus re-fetching when offline and
+        ;; tokens already exist in the app-db.
+        :tokens-loading nil}})

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -138,7 +138,8 @@
          new-account?        (:new-account? wallet-db)
          navigate-to-account (:navigate-to-account wallet-db)]
      {:db (update-in db [:wallet :accounts] reconcile-accounts wallet-accounts)
-      :fx (concat (when (network.data-store/online? db)
+      :fx (concat (when (or (data-store/tokens-never-loaded? db)
+                            (network.data-store/online? db))
                     refresh-accounts-fx-dispatches)
                   [(when new-account?
                      [:dispatch [:wallet/navigate-to-new-account navigate-to-account]])])})))

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -5,6 +5,7 @@
     [clojure.string :as string]
     [react-native.platform :as platform]
     [status-im.constants :as constants]
+    [status-im.contexts.network.data-store :as network.data-store]
     [status-im.contexts.settings.wallet.effects]
     [status-im.contexts.settings.wallet.events]
     [status-im.contexts.wallet.common.activity-tab.events]
@@ -107,23 +108,43 @@
          [:dispatch [:wallet/request-new-collectibles-for-account-from-signal address]]
          [:dispatch [:wallet/check-recent-history-for-account address]]]}))
 
-(rf/reg-event-fx
- :wallet/get-accounts-success
+(defn- reconcile-accounts
+  [db-accounts-by-address new-accounts]
+  (reduce
+   (fn [res {:keys [address] :as account}]
+     ;; Because we add extra fields (tokens and collectibles) into the RPC
+     ;; response from accounts_getAccounts, if we are offline we want to keep
+     ;; the old balances in the accounts, thus we merge the up-to-date account
+     ;; from status-go into the cached accounts. We also merge when online
+     ;; because we will re-fetch balances anyway.
+     ;;
+     ;; Refactor improvement: don't augment entities from status-go, store
+     ;; tokens and collectibles in separate keys in the app-db indexed by
+     ;; account address.
+     (assoc res
+            address
+            (-> (get db-accounts-by-address address)
+                (merge account)
+                ;; These should not be cached, otherwise when going
+                ;; offline->online collectibles won't be fetched.
+                (dissoc :current-collectible-idx :has-more-collectibles?))))
+   {}
+   new-accounts))
+
+(rf/reg-event-fx :wallet/get-accounts-success
  (fn [{:keys [db]} [accounts]]
    (let [wallet-accounts     (data-store/rpc->accounts accounts)
          wallet-db           (get db :wallet)
          new-account?        (:new-account? wallet-db)
          navigate-to-account (:navigate-to-account wallet-db)]
-     {:db (assoc-in db
-           [:wallet :accounts]
-           (utils.collection/index-by :address wallet-accounts))
-      :fx (concat refresh-accounts-fx-dispatches
+     {:db (update-in db [:wallet :accounts] reconcile-accounts wallet-accounts)
+      :fx (concat (when (network.data-store/online? db)
+                    refresh-accounts-fx-dispatches)
                   [(when new-account?
                      [:dispatch [:wallet/navigate-to-new-account navigate-to-account]])])})))
 
-(rf/reg-event-fx
- :wallet/get-accounts
- (fn [_]
+(rf/reg-event-fx :wallet/get-accounts
+ (fn []
    {:fx [[:json-rpc/call
           [{:method     "accounts_getAccounts"
             :on-success [:wallet/get-accounts-success]
@@ -486,7 +507,7 @@
                                   {:test-networks-enabled? test-networks-enabled?
                                    :is-goerli-enabled?     is-goerli-enabled?})
          chains-filtered-by-mode (remove #(not (contains? chain-ids-by-mode %)) down-chain-ids)
-         chains-down?            (seq chains-filtered-by-mode)
+         chains-down?            (and (network.data-store/online? db) (seq chains-filtered-by-mode))
          chain-names             (when chains-down?
                                    (->> (map #(-> (network-utils/id->network %)
                                                   name

--- a/src/status_im/contexts/wallet/signals.cljs
+++ b/src/status_im/contexts/wallet/signals.cljs
@@ -43,9 +43,15 @@
        {:fx [[:dispatch [:wallet/reload]]]}
 
        "wallet-blockchain-status-changed"
-       {:fx [[:dispatch
-              [:wallet/blockchain-status-changed
-               (transforms/js->clj event-js)]]]}
+       {:fx [[:dispatch-later
+              ;; Don't dispatch immediately because the signal may arrive as
+              ;; soon as the device goes offline. We need to give some time for
+              ;; RN to dispatch the network status update, otherwise when going
+              ;; offline the user will immediately see a toast saying "provider
+              ;; X is down".
+              [{:ms       500
+                :dispatch [:wallet/blockchain-status-changed
+                           (transforms/js->clj event-js)]}]]]}
 
        "wallet-activity-filtering-done"
        {:fx

--- a/src/status_im/subs/general.cljs
+++ b/src/status_im/subs/general.cljs
@@ -152,8 +152,12 @@
  (fn [toasts [_ toast-id & cursor]]
    (get-in toasts (into [:toasts toast-id] cursor))))
 
-(re-frame/reg-sub
- :network/offline?
+(re-frame/reg-sub :network/offline?
  :<- [:network/status]
  (fn [status]
    (= status :offline)))
+
+(re-frame/reg-sub :network/online?
+ :<- [:network/status]
+ (fn [status]
+   (= status :online)))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -48,11 +48,10 @@
  :wallet/home-tokens-loading?
  :<- [:wallet/tokens-loading]
  (fn [tokens-loading]
-   (or (empty? tokens-loading)
-       (->> tokens-loading
-            vals
-            (some true?)
-            boolean))))
+   (->> tokens-loading
+        vals
+        (some true?)
+        boolean)))
 
 (rf/reg-sub
  :wallet/current-viewing-account-tokens-loading?
@@ -351,9 +350,10 @@
  :<- [:wallet/accounts]
  :<- [:wallet/balances-in-selected-networks]
  :<- [:wallet/tokens-loading]
+ :<- [:network/online?]
  :<- [:profile/currency-symbol]
  :<- [:wallet/keypairs]
- (fn [[accounts balances tokens-loading currency-symbol keypairs]]
+ (fn [[accounts balances tokens-loading online? currency-symbol keypairs]]
    (mapv (fn [{:keys [color address watch-only? key-uid operable] :as account}]
            (let [account-type (cond
                                 (= operable :no) :missing-keypair
@@ -373,8 +373,9 @@
                                                                        account
                                                                        keypair)}]))
                                            #(rf/dispatch [:wallet/navigate-to-account address]))
-                    :loading?            (or (get tokens-loading address)
-                                             (not (contains? tokens-loading address)))
+                    :loading?            (and online?
+                                              (or (get tokens-loading address)
+                                                  (not (contains? tokens-loading address))))
                     :balance             (utils/prettify-balance currency-symbol
                                                                  (get balances address)))))
          accounts)))


### PR DESCRIPTION
- Fixes https://github.com/status-im/status-mobile/issues/21066

### Summary

We make the wallet closer to being offline-first, that is, once data is loaded, going offline won't cause unnecessary data re-fetches which currently cause all balances and data to stay loading forever or eventually balances end up zeroed.

### Demo

In this demo we show:

1. User logs in offline, we correctly display zeroed values instead of loading skeletons forever.
2. User can edit account while offline.
3. User goes back online and pull to refresh. All data is loaded as usual.
4. User goes offline. No automatic reloads and pull to refresh keeps the data cached.

Notice that no toasts are displayed when offline. We temporarily disabled _provider down_ toasts, but this PR already works as intended if they were enabled.

**The video is outdated. It's better now, if the user had already logged in and loaded all balances, we display token values (work done from this other PR https://github.com/status-im/status-mobile/pull/21063)**

https://github.com/user-attachments/assets/d36a7815-6bfb-4e0a-bacb-46af7cf205fa

#### Areas that may be impacted

Read-only data displayed in the wallet and editing accounts.

### Steps to test

Please, refer to the issue's acceptance criteria.

status: ready