### PR TITLE
Remove redundant visibility status update call

### DIFF
--- a/src/status_im/contexts/onboarding/welcome/view.cljs
+++ b/src/status_im/contexts/onboarding/welcome/view.cljs
@@ -2,12 +2,10 @@
   (:require
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
-    [re-frame.core :as re-frame]
     [react-native.core :as rn]
     [react-native.linear-gradient :as linear-gradient]
     [react-native.safe-area :as safe-area]
     [status-im.common.resources :as resources]
-    [status-im.constants :as constants]
     [status-im.contexts.onboarding.welcome.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -24,20 +22,12 @@
       :description                     (i18n/label :t/welcome-to-web3-sub-title)
       :description-accessibility-label :welcome-sub-title}]))
 
-(defn dispatch-visibility-status-update
-  [status-type]
-  (re-frame/dispatch
-   [:visibility-status-updates/delayed-visibility-status-update status-type]))
-
 (defn view
   []
-  (let [profile-color         (rf/sub [:onboarding/customization-color])
-        {:keys [status-type]} (rf/sub [:multiaccount/current-user-visibility-status])
-        window                (rf/sub [:dimensions/window])
-        insets                (safe-area/get-insets)]
+  (let [profile-color (rf/sub [:onboarding/customization-color])
+        window        (rf/sub [:dimensions/window])
+        insets        (safe-area/get-insets)]
     [rn/view {:style (style/page-container insets)}
-     (when (nil? status-type)
-       (dispatch-visibility-status-update constants/visibility-status-automatic))
      [quo/page-nav
       {:type       :no-title
        :background :blur


### PR DESCRIPTION
### Summary

This PR removes a redundant call to update the visibility status, which was originally introduced in [PR #15860](https://github.com/status-im/status-mobile/pull/15860) to address the "online indicator mark" issue described in [issue #15785](https://github.com/status-im/status-mobile/issues/15785). The call was intended to ensure that the [:visibility-status-updates/online?](https://github.com/status-im/status-mobile/blob/develop/src/status_im/common/home/top_nav/view.cljs#L17) function in the top-nav file had the correct value.

However, it appears that this call is not necessary, as we already set the user status type to automatic by [default](https://github.com/status-im/status-go/blob/bb6d5f602b8e472cc7257b650e0c771a82ec4714/api/defaults.go#L120).

### Testing
This PR does not require manual testing. However, notifying @status-im/mobile-qa to ensure that if they encounter any issues related to the home screen top nav visibility dot color while creating a new account, they know where to look for potential problems.

![image](https://github.com/user-attachments/assets/54569bd5-cb6a-44e0-923d-7e265a5aa053)

status: ready
