### PR TITLE
Reset hystrix circuit when going back online

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "release/0.182.x",
-    "commit-sha1": "09f8051238d5254b01afb2c174f3dc820cde3928",
-    "src-sha256": "07yn28lrj4mlh6y46cvcljfn3mzbaji66q8igmqy3fn69lvszf4m"
+    "version": "feat/close-hystrix-on-going-online",
+    "commit-sha1": "10a12762c21e9124d623a6619e8cac90116dc1b9",
+    "src-sha256": "0r1zxnfkbf16fry1nysxpl00d88r9fr59b6h07fnzp5nkpzzyxjb"
 }


### PR DESCRIPTION
Wallet doesn't handle well going offline, this PR improves the situation.

It's difficult to test as you fallback on Infura, you can check logs for proper usage (you should not see any `open circuit` error after coming back online, while you will get them when offline).

To test:

1) Fetch balances
2) Go offline, fetch a few times balances
3) Go online, fetch balances

In develop:
- You will see `open circuits` in the logs after step 3) Here:
- You will not see `open circuits`

Basically on develop from when you go offline, you will be hitting infura directly for a while.
This PR fixes that behavior so we hit our proxy instead.

https://github.com/status-im/status-go/compare/d394da0f...10a12762

