### PR TITLE
chore_: fix APK selection for run-android script

### DIFF
--- a/scripts/run-android.sh
+++ b/scripts/run-android.sh
@@ -13,7 +13,7 @@ export BUILD_TYPE=debug
 
 # Install the APK on running emulator or android device.
 installAndLaunchApp() {
-  adb install -r ./result/app-arm64-v8a-debug.apk > "${ADB_INSTALL_LOG_FILE}" 2>&1
+  adb install -r "./result/app-${ANDROID_ABI_INCLUDE}-debug.apk" > "${ADB_INSTALL_LOG_FILE}" 2>&1
   "${GIT_ROOT}/scripts/wait-for-metro-port.sh" 2>&1
   # connected android devices need this port to be exposed for metro
   adb reverse "tcp:${RCT_METRO_PORT}" "tcp:${RCT_METRO_PORT}"


### PR DESCRIPTION
## Summary

This commit fixes the APK selection process when executing `make run-android`

fixes https://github.com/status-im/status-mobile/issues/20969

## Review notes
`make run-android` should work on macOS, NixOS and other linux OSes

## Testing notes
Not required since this only affects debug android builds.

## Platforms
- Android

status: ready
