### PR TITLE
feat: approve token transactions on swap

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -591,11 +591,17 @@
 (def ^:const default-slippage 0.5)
 (def ^:const max-recommended-slippage 5)
 (def ^:const max-slippage-decimal-places 2)
-(def ^:const swap-default-provider
+(def ^:const swap-provider-paraswap
   {:name                     :paraswap
    :full-name                "Paraswap"
    :color                    :blue
    :contract-address         "0xdef171fe48cf0115b1d80b88dc8eab59176fee57"
    :terms-and-conditions-url "https://files.paraswap.io/tos_v4.pdf"})
+(def ^:const swap-providers
+  {:paraswap swap-provider-paraswap})
 
 (def ^:const token-for-fees-symbol "ETH")
+
+(def ^:const transaction-status-success "Success")
+(def ^:const transaction-status-pending "Pending")
+(def ^:const transaction-status-failed "Failed")

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -11,7 +11,7 @@
     [taoensso.timbre :as log]
     [utils.address :as address]
     [utils.hex :as utils.hex]
-    [utils.money :as money]
+    [utils.money :as utils.money]
     [utils.number]
     [utils.re-frame :as rf]))
 
@@ -582,124 +582,6 @@
             [{:ms       20
               :dispatch [:wallet/clean-up-transaction-flow]}]]]})))
 
-(defn- transaction-data
-  [{:keys [from-address to-address token-address route data eth-transfer?]}]
-  (let [{:keys [amount-in gas-amount gas-fees]} route
-        eip-1559-enabled?                       (:eip-1559-enabled gas-fees)
-        {:keys [gas-price max-fee-per-gas-medium
-                max-priority-fee-per-gas]}      gas-fees]
-    (cond-> {:From  from-address
-             :To    (or token-address to-address)
-             :Gas   (money/to-hex gas-amount)
-             :Value (when eth-transfer? amount-in)
-             :Nonce nil
-             :Input ""
-             :Data  (or data "0x")}
-      eip-1559-enabled?       (assoc
-                               :TxType "0x02"
-                               :MaxFeePerGas
-                               (money/to-hex
-                                (money/->wei
-                                 :gwei
-                                 max-fee-per-gas-medium))
-                               :MaxPriorityFeePerGas
-                               (money/to-hex
-                                (money/->wei
-                                 :gwei
-                                 max-priority-fee-per-gas)))
-      (not eip-1559-enabled?) (assoc :TxType "0x00"
-                                     :GasPrice
-                                     (money/to-hex
-                                      (money/->wei
-                                       :gwei
-                                       gas-price))))))
-
-(defn- approval-path
-  [{:keys [route from-address to-address token-address]}]
-  (let [{:keys [from]}                     route
-        from-chain-id                      (:chain-id from)
-        approval-amount-required           (:approval-amount-required route)
-        approval-amount-required-sanitized (-> approval-amount-required
-                                               (utils.hex/normalize-hex)
-                                               (native-module/hex-to-number))
-        approval-contract-address          (:approval-contract-address route)
-        data                               (native-module/encode-function-call
-                                            constants/contract-function-signature-erc20-approve
-                                            [approval-contract-address
-                                             approval-amount-required-sanitized])
-        tx-data                            (transaction-data {:from-address  from-address
-                                                              :to-address    to-address
-                                                              :token-address token-address
-                                                              :route         route
-                                                              :data          data
-                                                              :eth-transfer? false})]
-    {:BridgeName constants/bridge-name-transfer
-     :ChainID    from-chain-id
-     :TransferTx tx-data}))
-
-(defn- transaction-path
-  [{:keys [from-address to-address token-id token-address route data eth-transfer?]}]
-  (let [{:keys [bridge-name amount-in bonder-fees from
-                to]}  route
-        tx-data       (transaction-data {:from-address  from-address
-                                         :to-address    to-address
-                                         :token-address token-address
-                                         :route         route
-                                         :data          data
-                                         :eth-transfer? eth-transfer?})
-        to-chain-id   (:chain-id to)
-        from-chain-id (:chain-id from)]
-    (cond-> {:BridgeName bridge-name
-             :ChainID    from-chain-id}
-
-      (= bridge-name constants/bridge-name-erc-721-transfer)
-      (assoc :ERC721TransferTx
-             (assoc tx-data
-                    :Recipient to-address
-                    :TokenID   token-id
-                    :ChainID   to-chain-id))
-
-      (= bridge-name constants/bridge-name-erc-1155-transfer)
-      (assoc :ERC1155TransferTx
-             (assoc tx-data
-                    :Recipient to-address
-                    :TokenID   token-id
-                    :ChainID   to-chain-id
-                    :Amount    amount-in))
-
-      (= bridge-name constants/bridge-name-transfer)
-      (assoc :TransferTx tx-data)
-
-      (= bridge-name constants/bridge-name-hop)
-      (assoc :HopTx
-             (assoc tx-data
-                    :ChainID   from-chain-id
-                    :ChainIDTo to-chain-id
-                    :Symbol    token-id
-                    :Recipient to-address
-                    :Amount    amount-in
-                    :BonderFee bonder-fees))
-
-      (not (or (= bridge-name constants/bridge-name-erc-721-transfer)
-               (= bridge-name constants/bridge-name-transfer)
-               (= bridge-name constants/bridge-name-hop)))
-      (assoc :CbridgeTx
-             (assoc tx-data
-                    :ChainID   to-chain-id
-                    :Symbol    token-id
-                    :Recipient to-address
-                    :Amount    amount-in)))))
-
-(defn- multi-transaction-command
-  [{:keys [from-address to-address from-asset to-asset amount-out multi-transaction-type]
-    :or   {multi-transaction-type constants/multi-transaction-type-unknown}}]
-  {:fromAddress from-address
-   :toAddress   to-address
-   :fromAsset   from-asset
-   :toAsset     to-asset
-   :fromAmount  amount-out
-   :type        multi-transaction-type})
-
 (rf/reg-event-fx :wallet/send-transaction
  (fn [{:keys [db]} [sha3-pwd]]
    (let [routes (get-in db [:wallet :ui :send :route])
@@ -731,7 +613,7 @@
                                                                (native-module/encode-transfer
                                                                 (address/normalized-hex to-address)
                                                                 (:amount-in route)))
-                                          base-path          (transaction-path
+                                          base-path          (utils/transaction-path
                                                               {:to-address    to-address
                                                                :from-address  from-address
                                                                :route         route
@@ -743,15 +625,15 @@
                                                                :data          data
                                                                :eth-transfer? eth-transfer?})]
                                       (if approval-required?
-                                        [(approval-path {:route         route
-                                                         :token-address token-address
-                                                         :from-address  from-address
-                                                         :to-address    to-address})
+                                        [(utils/approval-path {:route         route
+                                                               :token-address token-address
+                                                               :from-address  from-address
+                                                               :to-address    to-address})
                                          base-path]
                                         [base-path]))))
                                  routes)
          request-params
-         [(multi-transaction-command
+         [(utils/multi-transaction-command
            {:from-address           from-address
             :to-address             to-address
             :from-asset             token-id

--- a/src/status_im/contexts/wallet/signals.cljs
+++ b/src/status_im/contexts/wallet/signals.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.wallet.signals
   (:require
     [oops.core :as oops]
+    [status-im.constants :as constants]
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]
     [utils.transforms :as transforms]))
@@ -8,9 +9,21 @@
 (rf/reg-event-fx
  :wallet/pending-transaction-status-changed-received
  (fn [{:keys [db]} [{:keys [message]}]]
-   (let [details (transforms/json->clj message)
-         tx-hash (:hash details)]
-     {:db (update-in db [:wallet :transactions tx-hash] assoc :status :confirmed :blocks 1)})))
+   (let [details                      (transforms/json->clj message)
+         tx-hash                      (:hash details)
+         tx-status                    (:status details)
+         status                       (cond
+                                        (= tx-status constants/transaction-status-success)
+                                        :confirmed
+                                        (= tx-status constants/transaction-status-pending)
+                                        :pending
+                                        (= tx-status constants/transaction-status-failed)
+                                        :failed)
+         swap-approval-transaction-id (get-in db [:wallet :ui :swap :approval-transaction-id])
+         swap-approval-transaction?   (= swap-approval-transaction-id tx-hash)]
+     (cond-> {:db (update-in db [:wallet :transactions tx-hash] assoc :status status)}
+       swap-approval-transaction?
+       (assoc :fx [[:dispatch [:wallet.swap/approve-transaction-update status]]])))))
 
 (rf/reg-event-fx
  :wallet/signal-received

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -81,6 +81,18 @@
  :-> :loading-fees?)
 
 (rf/reg-sub
+ :wallet/swap-approval-transaction-id
+ :<- [:wallet/swap]
+ :-> :approval-transaction-id)
+
+(rf/reg-sub
+ :wallet/swap-approval-transaction-status
+ :<- [:wallet/transactions]
+ :<- [:wallet/swap-approval-transaction-id]
+ (fn [[transactions approval-transaction-id]]
+   (get-in transactions [approval-transaction-id :status])))
+
+(rf/reg-sub
  :wallet/swap-proposal
  :<- [:wallet/swap]
  :-> :swap-proposal)
@@ -96,6 +108,19 @@
  :-> :amount-out)
 
 (rf/reg-sub
+ :wallet/swap-proposal-amount-in
+ :<- [:wallet/swap-proposal]
+ :-> :amount-in)
+
+(rf/reg-sub
+ :wallet/swap-proposal-provider
+ :<- [:wallet/swap-proposal]
+ (fn [swap-proposal]
+   (let [bridge-name  (:bridge-name swap-proposal)
+         provider-key (keyword (string/lower-case bridge-name))]
+     (get constants/swap-providers provider-key))))
+
+(rf/reg-sub
  :wallet/swap-proposal-approval-required
  :<- [:wallet/swap-proposal]
  :-> :approval-required)
@@ -104,6 +129,11 @@
  :wallet/swap-proposal-approval-amount-required
  :<- [:wallet/swap-proposal]
  :-> :approval-amount-required)
+
+(rf/reg-sub
+ :wallet/swap-proposal-estimated-time
+ :<- [:wallet/swap-proposal]
+ :-> :estimated-time)
 
 (rf/reg-sub
  :wallet/wallet-swap-proposal-fee-fiat-formatted

--- a/translations/en.json
+++ b/translations/en.json
@@ -2313,6 +2313,8 @@
   "specify-symbol": "Specify a symbol",
   "spender-contract": "Spender contract",
   "spending-cap": "Spending cap",
+  "spending-cap-failed": "Spending cap failed: {{amount}} {{token-symbol}} for {{provider-name}} in {{account-name}}",
+  "spending-cap-set": "Spending cap set: {{amount}} {{token-symbol}} for {{provider-name}} in {{account-name}}",
   "start-chat": "Start chat",
   "start-conversation": "Start conversation",
   "start-group-chat": "Start group chat",


### PR DESCRIPTION
fixes #20343 

### Summary

This PR implements Approve transctions for ERC20 tokens when getting a Swap Proposal that needs the pay token to be approved before proceeding.

In the video below, an example of Approving 8 DAI on Mainnet

https://github.com/user-attachments/assets/0ea03a1e-a60c-4dd4-a2a6-8141a4d371ca

#### Platforms

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test

- Open Status
- Login
- Go to wallet
- Select an account
- Select Swap option
- Select a ERC20 token on Select asset to pay screen
- Enter a valid amount which is higher than the current approved amount for Paraswap contract
- Wait for swap proposal to appear
- At this stage, a valid amount appears on the receive token side, but "Review swap" button should be disabled because we need to first Approve / Set spending cap for the paying amount for the pay token.
- Tap on Approve
- Slide to execute the transction
- Enter password
- Wait for the approve transction to be confirmed and the status is shown correctly below the token input
- When the Approve transaction is confirmed, a toast should appear

status: ready