### PR TITLE
fix: onboarding terms-of-use and privacy-statement checkbox spacing when line wrapping

### DIFF
--- a/src/status_im/contexts/onboarding/intro/style.cljs
+++ b/src/status_im/contexts/onboarding/intro/style.cljs
@@ -13,9 +13,10 @@
    :align-self     :flex-start})
 
 (def terms-privacy-container
-  {:gap                8
+  {:flex-direction     :row
    :padding-horizontal 20
-   :padding-vertical   8})
+   :padding-vertical   8
+   :gap                8})
 
 (def plain-text
   {:color colors/white-opa-70})

--- a/src/status_im/contexts/onboarding/intro/view.cljs
+++ b/src/status_im/contexts/onboarding/intro/view.cljs
@@ -21,8 +21,7 @@
        :actions              :two-vertical-actions
        :description          :top
        :description-top-text [rn/view
-                              {:style          style/terms-privacy-container
-                               :flex-direction :row}
+                              {:style style/terms-privacy-container}
                               [rn/view
                                {:accessibility-label :terms-privacy-checkbox-container}
                                [quo/selectors
@@ -30,32 +29,31 @@
                                  :blur?     true
                                  :checked?  terms-accepted?
                                  :on-change #(set-terms-accepted? not)}]]
-                              [rn/view {:style {:flex 1}}
-                               [rn/view {:style style/text-container}
-                                [quo/text
-                                 {:style style/plain-text
-                                  :size  :paragraph-2}
-                                 (str (i18n/label :t/accept-status-tos-prefix) " ")]
-                                [quo/text
-                                 {:on-press #(rf/dispatch [:show-bottom-sheet
-                                                           {:content terms/terms-of-use
-                                                            :shell?  true}])
-                                  :style    style/highlighted-text
-                                  :size     :paragraph-2
-                                  :weight   :medium}
-                                 (i18n/label :t/terms-of-service)]
-                                [quo/text
-                                 {:style style/plain-text
-                                  :size  :paragraph-2}
-                                 " & "]
-                                [quo/text
-                                 {:on-press #(rf/dispatch [:show-bottom-sheet
-                                                           {:content privacy/privacy-statement
-                                                            :shell?  true}])
-                                  :style    style/highlighted-text
-                                  :size     :paragraph-2
-                                  :weight   :medium}
-                                 (i18n/label :t/intro-privacy-statement)]]]]
+                              [rn/view {:style style/text-container}
+                               [quo/text
+                                {:style style/plain-text
+                                 :size  :paragraph-2}
+                                (str (i18n/label :t/accept-status-tos-prefix) " ")]
+                               [quo/text
+                                {:on-press #(rf/dispatch [:show-bottom-sheet
+                                                          {:content terms/terms-of-use
+                                                           :shell?  true}])
+                                 :style    style/highlighted-text
+                                 :size     :paragraph-2
+                                 :weight   :medium}
+                                (i18n/label :t/terms-of-service)]
+                               [quo/text
+                                {:style style/plain-text
+                                 :size  :paragraph-2}
+                                " " (i18n/label :t/and) " "]
+                               [quo/text
+                                {:on-press #(rf/dispatch [:show-bottom-sheet
+                                                          {:content privacy/privacy-statement
+                                                           :shell?  true}])
+                                 :style    style/highlighted-text
+                                 :size     :paragraph-2
+                                 :weight   :medium}
+                                (i18n/label :t/intro-privacy-statement)]]]
        :button-one-label     (i18n/label :t/sync-or-recover-profile)
        :button-one-props     {:type                :dark-grey
                               :disabled?           (not terms-accepted?)


### PR DESCRIPTION
fixes #21079 

### Summary

* This PR attempts to resolve an issue with the onboarding checkbox line for the terms-of-use and privacy-statement, where the line of text does not properly wrap around with the correct spacing.
* In the screen recording that's attached to this PR, I simulate the text-area to be smaller, which causes the line to wrap around. It seem that the spacing is now properly being adding to the bottom of the line after wrapping.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Onboarding

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- If there are existing profiles, remove all profiles from app (necessary for seeing the onboarding screen)

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### After Changes on iOS

https://github.com/user-attachments/assets/c63ddb94-406e-408f-8ef4-14f28fdf87af

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
