### PR TITLE
Fix dApp tx crashing before showing modal

### DIFF
--- a/src/status_im/subs/wallet/wallet_connect.cljs
+++ b/src/status_im/subs/wallet/wallet_connect.cljs
@@ -133,8 +133,7 @@
            max-fees-fiat           (wallet-utils/calculate-token-fiat-value {:currency currency
                                                                              :balance  max-fees-ether
                                                                              :token    eth-token})
-           max-fees-fiat-formatted (-> max-fees-ether
-                                       (wallet-utils/get-standard-crypto-format eth-token)
+           max-fees-fiat-formatted (-> (wallet-utils/get-standard-crypto-format eth-token max-fees-ether)
                                        (wallet-utils/get-standard-fiat-format currency-symbol
                                                                               max-fees-fiat))
            balance                 (-> eth-token


### PR DESCRIPTION
fixes #21085

### Summary
Fix dApp tx crashing before showing modal due to a bug in the subscription (the args were passed in the wrong order, malli would've helped here) 

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Connect to a dapp (or test dapp) on whichever network
- Make sure you have eth
- Trigger eth_sendTransaction
- Crash

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
