### PR TITLE
fix parse route response

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -518,8 +518,8 @@
 
 (rf/reg-event-fx
  :wallet/handle-suggested-routes
- (fn [_ data]
-   (if-let [{:keys [code details]} (-> data :ErrorResponse first)]
+ (fn [_ [data]]
+   (if-let [{:keys [code details]} (-> data :ErrorResponse)]
      (let [error-message (if (= code "0") "An error occurred" details)]
        (log/error "failed to get suggested routes (async)"
                   {:event :wallet/handle-suggested-routes
@@ -531,7 +531,6 @@
            candidates-fix  (comp ->old-route-paths
                                  remove-invalid-bonder-fees-routes)
            routes          (-> data
-                               (first)
                                (data-store/rpc->suggested-routes)
                                (update :best best-routes-fix)
                                (update :candidates candidates-fix))]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.184.46",
-    "commit-sha1": "9e7d13039e50eeb815e7fa7082080d2ec5c81493",
-    "src-sha256": "02f8s7bfq8wavdkqg4wpraan4j3vi1p8h1r22ngzp9nxfwjif8xr"
+    "version": "v0.184.47",
+    "commit-sha1": "83aa01c7daf69d518e624fc584ea22ca27b34b73",
+    "src-sha256": "07gqijx652ap0lf0kvcpd0lxx5x58air19pxgjawwymq2b8kly16"
 }


### PR DESCRIPTION
fixes #20967

Regarding the issue, backend works correctly. The fundamental reason lies in the fact that the frontend failed to parse response correctly. 

relate status-go [PR](https://github.com/status-im/status-go/pull/5749)

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready.