### PR TITLE
chore: patch to use newer BlurView pom file

### DIFF
--- a/nix/deps/gradle/deps.json
+++ b/nix/deps/gradle/deps.json
@@ -1166,21 +1166,6 @@
   },
 
   {
-    "path": "androidx/databinding/databinding-common/3.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "databinding-common-3.5.3.pom": {
-        "sha1": "0f85f7500d68d4eaed465ec194e18779374a7a68",
-        "sha256": "sha256-paY7t0Iz/AxIVcvQLT4sAPgqTvvMChxgS3SmWRod2tw="
-      },
-      "databinding-common-3.5.3.jar": {
-        "sha1": "72bb6cb779ae61710a01ff76d9d3cab355c44a4f",
-        "sha256": "sha256-WRoV+qBtmUWoqA8m8n2vBosrLirqakvhN7/SixHZVgA="
-      }
-    }
-  },
-
-  {
     "path": "androidx/databinding/databinding-common/3.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -1285,21 +1270,6 @@
       "databinding-compiler-common-3.2.1.jar": {
         "sha1": "dee402009966fb2d3bb03e3186f3f16b9c503c86",
         "sha256": "sha256-ikWq3acE1DvjUuBIldHfoAFI3t1aGCIlg2PV6/Sdl7Y="
-      }
-    }
-  },
-
-  {
-    "path": "androidx/databinding/databinding-compiler-common/3.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "databinding-compiler-common-3.5.3.pom": {
-        "sha1": "345b6f4cea120faa14f118c08150de5d8afccce1",
-        "sha256": "sha256-LRdv8FuX6tdlmxdHuhK/a/bhc8zIONVFAniG0toDu+A="
-      },
-      "databinding-compiler-common-3.5.3.jar": {
-        "sha1": "32bfc30c00fdc550723ffd9bff3ef2471fbd4a3a",
-        "sha256": "sha256-yDZslWiT00cwjhF5Be1v2xq+gFW54gEhOrjyMO3GNRg="
       }
     }
   },
@@ -2988,21 +2958,6 @@
   },
 
   {
-    "path": "com/android/databinding/baseLibrary/3.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "baseLibrary-3.5.3.pom": {
-        "sha1": "81372394c257edc4595cf19c33f7460892eeaa3e",
-        "sha256": "sha256-knlU7d5unzROdh7YkGliIzSrDWc3i9B2rDIkfhX/Bmk="
-      },
-      "baseLibrary-3.5.3.jar": {
-        "sha1": "5da8b7daa2f10ec359a13ee778eeabf15c1758b1",
-        "sha256": "sha256-zebU7vY+5eBbiqtY/4Xq85zD5u2E/RhL9lWNgvjZwGc="
-      }
-    }
-  },
-
-  {
     "path": "com/android/databinding/baseLibrary/3.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -3506,21 +3461,6 @@
   },
 
   {
-    "path": "com/android/tools/analytics-library/crash/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "crash-26.5.3.pom": {
-        "sha1": "2b6f117c8542a9132bbd1982960ff93be002eb77",
-        "sha256": "sha256-ZrYgjqqWCNZ7K84UQIlBptcRC4ePlCVTmsIeuEWnqBU="
-      },
-      "crash-26.5.3.jar": {
-        "sha1": "d199e964be1fa3e7162344b91336afae6c7ea789",
-        "sha256": "sha256-86x29qjj+M7mPiqew2n87T3przHhRQzZOdiHXWcT758="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/analytics-library/crash/26.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -3640,21 +3580,6 @@
       "protos-26.2.1.jar": {
         "sha1": "db637f20d2c56d74a1b504d4e39a0bc8817fcaf4",
         "sha256": "sha256-LzcfWx9VHoWrCL5NaihzRxs9RK/R6/aqMpjzt5a/aR8="
-      }
-    }
-  },
-
-  {
-    "path": "com/android/tools/analytics-library/protos/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "protos-26.5.3.pom": {
-        "sha1": "a2452eb3233ef51f1dda9b5508cfe340134b4978",
-        "sha256": "sha256-FYV7IPvj+TmJoQA2xD32xOTygrtjh07jAghoOH7gRuY="
-      },
-      "protos-26.5.3.jar": {
-        "sha1": "16d70f0d597eac5d39180b1ce2d9b274f8802cf9",
-        "sha256": "sha256-8uut8euJZzFc/sTTw3UkQFSh8W15+N4l0eiYPVq0D70="
       }
     }
   },
@@ -3784,21 +3709,6 @@
   },
 
   {
-    "path": "com/android/tools/analytics-library/shared/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "shared-26.5.3.pom": {
-        "sha1": "14c908921dd73687f66f496dfc73fa807d57e40d",
-        "sha256": "sha256-FkUuC4D4/OiS5yBlJvWnupvlSungNjArA0ktU240P54="
-      },
-      "shared-26.5.3.jar": {
-        "sha1": "594abc68f0518057cdb150e4c8cc73bc5c94183e",
-        "sha256": "sha256-dpzYinI6GR6dmPsEGULf5Irzo+8kqP6wCI2NTNfhurA="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/analytics-library/shared/26.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -3923,21 +3833,6 @@
   },
 
   {
-    "path": "com/android/tools/analytics-library/tracker/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "tracker-26.5.3.pom": {
-        "sha1": "8551b232bde0e0cd7a9983f4acc716ed2fa8d59b",
-        "sha256": "sha256-fAbjPrxxjgXSaoM5kD9ZoVTedhcXTPha/bxi0Nsgnkc="
-      },
-      "tracker-26.5.3.jar": {
-        "sha1": "6a84a345f5155eca774cd238c233a2f6fad551b9",
-        "sha256": "sha256-dqhsU6BlaXcW4tXGEAyd4LrpHVacu5vRn6U+Pw5n63M="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/analytics-library/tracker/26.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -4057,21 +3952,6 @@
       "annotations-26.2.1.jar": {
         "sha1": "5f9b112634e53890e16cc2947989bc2bc048734e",
         "sha256": "sha256-c5HGoeCAF0uW5kzrB42t0xzk2KLS/uDsZb4gISb5DyQ="
-      }
-    }
-  },
-
-  {
-    "path": "com/android/tools/annotations/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "annotations-26.5.3.pom": {
-        "sha1": "03c6890f54f0b7c91aaeb7d66e87c52e53b10d79",
-        "sha256": "sha256-4vEHB5aOWAXrLslhHTRa1GVrKLeEpApil0rlXPIQzh4="
-      },
-      "annotations-26.5.3.jar": {
-        "sha1": "87a36f2086b41d1ec162a6e74c4f999d58eb1310",
-        "sha256": "sha256-/js3c6HdNGlY2KFUess2UN/74HfTmtdMX3b7f6k/NYw="
       }
     }
   },
@@ -4489,21 +4369,6 @@
   },
 
   {
-    "path": "com/android/tools/build/apksig/3.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "apksig-3.5.3.pom": {
-        "sha1": "fe080d599c11357971f21a2b7475d9915515d363",
-        "sha256": "sha256-5sSQBWPiQJf82rf++W6oPPf6sfSTn6teEVRL8Ng0LZ0="
-      },
-      "apksig-3.5.3.jar": {
-        "sha1": "d5ffda89f909743ad8e77b3c28ed351695037543",
-        "sha256": "sha256-SMfd+nhnEtdmpzyt1+3JGGhsGv1s6FcRyvUQYx+0CQ8="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/build/apksig/3.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -4608,21 +4473,6 @@
       "apkzlib-3.2.1.jar": {
         "sha1": "fd288c2a8a84c8acb4e43cbbd9dc34fd442b8bfb",
         "sha256": "sha256-w5rQMTkFkyQx/oHIiZws85pNkq1sTtyqSyVDL0YUUqo="
-      }
-    }
-  },
-
-  {
-    "path": "com/android/tools/build/apkzlib/3.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "apkzlib-3.5.3.pom": {
-        "sha1": "d41d21481aa9ea302638d5008d1c54e391981843",
-        "sha256": "sha256-unLu4SDrvKUNUxJUZlaH2INOewFTQfQfdi2GKoiPDrI="
-      },
-      "apkzlib-3.5.3.jar": {
-        "sha1": "8e17d7b8bb5f756c139619d86facca1675bc6164",
-        "sha256": "sha256-aNpGeSdH6yIHK7PygeptifcYAB6Mmaa75oYJM/73qdw="
       }
     }
   },
@@ -4747,21 +4597,6 @@
       "builder-model-3.2.1.jar": {
         "sha1": "3984b3e65c34b5d278e434270b63802451ec3e9d",
         "sha256": "sha256-qfaOarzsEi+cta01LT8Fo+sDrLzcqV5NJcFjEMLJZf8="
-      }
-    }
-  },
-
-  {
-    "path": "com/android/tools/build/builder-model/3.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "builder-model-3.5.3.pom": {
-        "sha1": "64d0223622a2c59fb67f8fb5c22b6535efef29b5",
-        "sha256": "sha256-8kaKB3hYve1NA/D8BkGjtpr5zskjdqqjht3XoSTIQQM="
-      },
-      "builder-model-3.5.3.jar": {
-        "sha1": "775377503072e1b6a701c3ea923c468cedd4e2eb",
-        "sha256": "sha256-U1xpawkp6LOZLwiCPpTFtci+UzCVThX8TuFhCW+gT6I="
       }
     }
   },
@@ -4903,21 +4738,6 @@
   },
 
   {
-    "path": "com/android/tools/build/builder-test-api/3.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "builder-test-api-3.5.3.pom": {
-        "sha1": "f910b8864ae8e3e3c39823ca7ca6ba99a09d7564",
-        "sha256": "sha256-9IV0lJ6wAgzUWwuGES1aMXxpH+0OPxPYzY7VNbmksUI="
-      },
-      "builder-test-api-3.5.3.jar": {
-        "sha1": "cf9ce50cd19a816c5bc7d4c6362699aa98c8ac0f",
-        "sha256": "sha256-euZFcKEsjav85tiA+KSNsVqoMRHbcC2iTAWvv3H8FUc="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/build/builder-test-api/3.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -5049,21 +4869,6 @@
       "builder-3.2.1.jar": {
         "sha1": "1303a2feb969ac0896e7c83c1f5a0fd2496b71bc",
         "sha256": "sha256-rty/0RXb6R0JtBE+Zu9QWJtVjQqjsvEzsdhnybh/roM="
-      }
-    }
-  },
-
-  {
-    "path": "com/android/tools/build/builder/3.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "builder-3.5.3.pom": {
-        "sha1": "b327e842abd63da2281e74c59de69ab2b5998443",
-        "sha256": "sha256-dNWTs6MgZG6PVaytZxU/2aWQk8a3lqkGYmbXPzO99ZA="
-      },
-      "builder-3.5.3.jar": {
-        "sha1": "39bba1af533b25f6c1140e3c795ff815a6ad86ba",
-        "sha256": "sha256-BcvZGDubmg4SisvDkSVAwXLg11pcNY2kZcb3F5JMV0E="
       }
     }
   },
@@ -5310,21 +5115,6 @@
   },
 
   {
-    "path": "com/android/tools/build/gradle-api/3.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "gradle-api-3.5.3.pom": {
-        "sha1": "ef22e3a71efd8cb517d4b039076f4b69013c0208",
-        "sha256": "sha256-1T+FRJWgpHkt+LVOWXFAdtk3HW9ah5AABwdUoYDS7kU="
-      },
-      "gradle-api-3.5.3.jar": {
-        "sha1": "c1d6a6b3e5b744caaf6eea2452d8db62c8e2882f",
-        "sha256": "sha256-yOi/eI7S+LRswAqWJOAKivQLwx/x2CmL10DxhAC9PS4="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/build/gradle-api/3.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -5490,21 +5280,6 @@
       "gradle-3.2.1.jar": {
         "sha1": "1ce0d907aa7805e19f553807b9bbdc9bb9841dbf",
         "sha256": "sha256-EIofeCMBBSHDSEjaM2pn1ggkbbjoYXSEN/UuClqNzHw="
-      }
-    }
-  },
-
-  {
-    "path": "com/android/tools/build/gradle/3.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "gradle-3.5.3.pom": {
-        "sha1": "6bfb2b4c34c37c4f2addcb6d99db19fa7a1a5810",
-        "sha256": "sha256-k8NC3tdmWdVBdyaKn9lBLf4HLozxd26vtHxZCBmOZdI="
-      },
-      "gradle-3.5.3.jar": {
-        "sha1": "12e36e5f81cc2face28e0c14cb98941d773cae6a",
-        "sha256": "sha256-Zyk97dM5uJypz2xEAJvNj4Bb9CnCVYYuq/LeuBDYuRA="
       }
     }
   },
@@ -5774,21 +5549,6 @@
   },
 
   {
-    "path": "com/android/tools/build/manifest-merger/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "manifest-merger-26.5.3.pom": {
-        "sha1": "4cc40406dfe779b3b575e66c970ae0e9986b0c94",
-        "sha256": "sha256-ZjxoTo8jLgEYXLnqBwjqCRwxAhYiDHlQthqQZlX0Vj4="
-      },
-      "manifest-merger-26.5.3.jar": {
-        "sha1": "36674041b9d2644a30b75b6d8b7106bc16eac78a",
-        "sha256": "sha256-tGBtBgLyH5GhdM+4UWtabpj/rJWNPzzYmTuVDvSbgEk="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/build/manifest-merger/26.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -5925,21 +5685,6 @@
   },
 
   {
-    "path": "com/android/tools/common/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "common-26.5.3.pom": {
-        "sha1": "ace0f2945bba30c12223d7634a69da21a4242fd7",
-        "sha256": "sha256-9ikVDGRk14qviKUSEpiyeycF0HdW2W5hH6/yuJgdgeQ="
-      },
-      "common-26.5.3.jar": {
-        "sha1": "47409edcd2331596b42c33160101a86046e1c6f5",
-        "sha256": "sha256-YAVo9B+xn8eWSHtvxTnlKr0Jj60cZ4vONcAqMVGeJPY="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/common/26.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -6064,21 +5809,6 @@
   },
 
   {
-    "path": "com/android/tools/ddms/ddmlib/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "ddmlib-26.5.3.pom": {
-        "sha1": "f69c10111005d9ed625cc0b75fed9c5c2fcd1bcb",
-        "sha256": "sha256-y79URq2NFK1PQ/kl063FlIr3hP7NdEvk04bf50sXe1s="
-      },
-      "ddmlib-26.5.3.jar": {
-        "sha1": "804a61e67286eeec17d195c78a135f0ed2fbdb8a",
-        "sha256": "sha256-IlrK31Fopg4wIKM81mm6TYatse+ePnEhcREd4t+RrCs="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/ddms/ddmlib/26.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -6198,21 +5928,6 @@
       "dvlib-26.2.1.jar": {
         "sha1": "fa3cc125cd311f65dcae6310e381b20d4b2ec0fe",
         "sha256": "sha256-cqg78oObHfmx+/Z7pF0b+5+WbNd02kMgx2Kyvo8WiKo="
-      }
-    }
-  },
-
-  {
-    "path": "com/android/tools/dvlib/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "dvlib-26.5.3.pom": {
-        "sha1": "1983f43ea2ef12519c4ac4579930af7494b4fb1c",
-        "sha256": "sha256-HNYT321rRp1fKslux7VIkAzONv7xDrPJAZVIITehh5c="
-      },
-      "dvlib-26.5.3.jar": {
-        "sha1": "9caa13fe83508ba5687199c02b7ddb885abd8f14",
-        "sha256": "sha256-+f3/TUDUJ1vhgAWJ2GlS33ErcQa7MD2o5f5zaqIogGU="
       }
     }
   },
@@ -6417,21 +6132,6 @@
   },
 
   {
-    "path": "com/android/tools/layoutlib/layoutlib-api/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "layoutlib-api-26.5.3.pom": {
-        "sha1": "75263963e8b5baa185153cbdf1a5347628a71927",
-        "sha256": "sha256-Qs1kefYxk/LNrFGbBIi08IbYhToLabRA84yCWHE09eE="
-      },
-      "layoutlib-api-26.5.3.jar": {
-        "sha1": "6549e729f3f27c7d05049494f25cfd01890c00e0",
-        "sha256": "sha256-/7VaULd7u4vTgnr7gpGhRVzZU7EmBYzP3db/rvkwM9A="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/layoutlib/layoutlib-api/26.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -6596,21 +6296,6 @@
       "lint-gradle-api-26.2.1.jar": {
         "sha1": "62f8362369c570266bcd4f030908ec1d237df331",
         "sha256": "sha256-IoPnrzLjAVZfKnl+Ux8PyMZIB31Fevs//d2+5jiXbC8="
-      }
-    }
-  },
-
-  {
-    "path": "com/android/tools/lint/lint-gradle-api/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "lint-gradle-api-26.5.3.pom": {
-        "sha1": "ce7c04f4c18db0fe372667092500726dc1436b2b",
-        "sha256": "sha256-tD6Ht965r/ZdBmPvIpAUoOyV9OsgUpxwTbEXrkq7I00="
-      },
-      "lint-gradle-api-26.5.3.jar": {
-        "sha1": "34f6edb87863c7e9f89f24c36485374ad350166a",
-        "sha256": "sha256-+xQk+cpYS2WRw5znSR5tiXYAVx4XPPkogrqTQWPGDMQ="
       }
     }
   },
@@ -6860,21 +6545,6 @@
   },
 
   {
-    "path": "com/android/tools/repository/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "repository-26.5.3.pom": {
-        "sha1": "f8f4198066a0abb5dd28ddf7e7bbb9ce9c6df714",
-        "sha256": "sha256-1VAgYQtJuNTY+UgjN7nkcyAEjcxoEYb4tLuJAxaMxUE="
-      },
-      "repository-26.5.3.jar": {
-        "sha1": "91466e99a63da0267b17bdfb617f54582e311618",
-        "sha256": "sha256-X8tsUpwFkmiZtGzyUA46ChpjOV59RY6na8sHXKoF1Lg="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/repository/26.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -6999,21 +6669,6 @@
   },
 
   {
-    "path": "com/android/tools/sdklib/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "sdklib-26.5.3.pom": {
-        "sha1": "08fa943d8253d6301e2dd02bb953fe73bd1406f7",
-        "sha256": "sha256-UQ3bott3wc/Uw37/g/L25qPv4gXqt8Zkgu7QAUgtsTs="
-      },
-      "sdklib-26.5.3.jar": {
-        "sha1": "8c305bc044ad81115859eb964c2829cbea70b036",
-        "sha256": "sha256-H8X6i5qnJUBBwF5s8fPrqfR7BJH3p4ZDwhy+eylFHkI="
-      }
-    }
-  },
-
-  {
     "path": "com/android/tools/sdklib/26.5.4",
     "repo": "https://dl.google.com/dl/android/maven2",
     "files": {
@@ -7133,21 +6788,6 @@
       "sdk-common-26.2.1.jar": {
         "sha1": "bcc236baac9d05aee927370ccaf5785d92ed5e2b",
         "sha256": "sha256-dZ1LKSymmjXPlh/KN3tUFY/GyIEIl4AGmZRC6AoBHPQ="
-      }
-    }
-  },
-
-  {
-    "path": "com/android/tools/sdk-common/26.5.3",
-    "repo": "https://dl.google.com/dl/android/maven2",
-    "files": {
-      "sdk-common-26.5.3.pom": {
-        "sha1": "3fda12d2fca4442d791813f7a73399ff5f6e1973",
-        "sha256": "sha256-RenED9V2i7mYpkVhbqjSVGv15o9fBkL34FpKhwZElZk="
-      },
-      "sdk-common-26.5.3.jar": {
-        "sha1": "cce8ff081940bb7c9b1368a4052f987091996887",
-        "sha256": "sha256-kDfQjhoo5b8rEzc6Dyo/hxRsRG/gkYeNNOtvHxyIBgk="
       }
     }
   },
@@ -7827,21 +7467,6 @@
   },
 
   {
-    "path": "com/github/Dimezis/BlurView/version-2.0.3",
-    "repo": "https://jitpack.io",
-    "files": {
-      "BlurView-version-2.0.3.pom": {
-        "sha1": "8dcfb62606434693476a8c720203492375d0718d",
-        "sha256": "sha256-GAfGRffnjP3Hpvsk/1uvt4PL7SNzkJSqbq42qILVrgw="
-      },
-      "BlurView-version-2.0.3.aar": {
-        "sha1": "1a6b90b3dbd0714e0f9fd3a09196072c7da300a0",
-        "sha256": "sha256-BuP74/LeQ+ID03WYU0m76TIRNGG0fi4ZM+In6RPQ66E="
-      }
-    }
-  },
-
-  {
     "path": "com/github/Dimezis/BlurView/version-2.0.4",
     "repo": "https://jitpack.io",
     "files": {
@@ -7942,25 +7567,6 @@
       "ucrop-2.2.6-native.aar": {
         "sha1": "a248e1b729dbb512215c845ec77e890a7b63d501",
         "sha256": "sha256-wSlQchfOmNHW/2NViapdQnF+abq0xbtQb7HBC7OZO0o="
-      }
-    }
-  },
-
-  {
-    "path": "com/adarshr/gradle-test-logger-plugin/2.0.0",
-    "repo": "https://plugins.gradle.org/m2",
-    "files": {
-      "gradle-test-logger-plugin-2.0.0.pom": {
-        "sha1": "fe5c29ddcae80215fd7ec74476880de67d66c894",
-        "sha256": "sha256-kVCmaVqB+SN+4958dClo5XcMHyWCGsS3c5kCFh9lUu4="
-      },
-      "gradle-test-logger-plugin-2.0.0-groovydoc.jar": {
-        "sha1": "6d8bed5c5b1e6daef6ac6cc7fa1ee3ba514ad96b",
-        "sha256": "sha256-jtiWgKriVFvUvRKe9AGdEc+NGIf6xdECTr1uVOD3Vys="
-      },
-      "gradle-test-logger-plugin-2.0.0.jar": {
-        "sha1": "957ca7f6f4390ea8cf4551fff43a96da50844b98",
-        "sha256": "sha256-lZFMdk+bW0P59xiCWMxr9BsLr2dnlhqjQIJtgHyAjp0="
       }
     }
   },
@@ -17078,43 +16684,6 @@
       "org.eclipse.jgit-5.13.1.202206130422-r.jar": {
         "sha1": "841d1ae74e4bc77ac7d4b106f15d0468dc7ac7f2",
         "sha256": "sha256-1nk2WmyOVcFJZwEJn15XZUM/aNy2WXWUFrpbIi61BVw="
-      }
-    }
-  },
-
-  {
-    "path": "org/fusesource/fusesource-pom/1.11",
-    "repo": "https://repo.maven.apache.org/maven2",
-    "files": {
-      "fusesource-pom-1.11.pom": {
-        "sha1": "f5547b0657be718d1ec0d2816cbcd5c398d6fccb",
-        "sha256": "sha256-aV24M14z3j1AOz0fBCWXDzcQqdtKUo7EYBmQVe8eirg="
-      }
-    }
-  },
-
-  {
-    "path": "org/fusesource/jansi/jansi-project/1.18",
-    "repo": "https://repo.maven.apache.org/maven2",
-    "files": {
-      "jansi-project-1.18.pom": {
-        "sha1": "5142f25c525a3184def79c5f690e5638971c50ff",
-        "sha256": "sha256-Asg2iTz9H1RZklohY1pdLEEHVEL7lnOtPNrtVzuegA0="
-      }
-    }
-  },
-
-  {
-    "path": "org/fusesource/jansi/jansi/1.18",
-    "repo": "https://repo.maven.apache.org/maven2",
-    "files": {
-      "jansi-1.18.pom": {
-        "sha1": "0e5be937c76095ab5b16f2cc6747cbb58b2414ce",
-        "sha256": "sha256-3Y9hnCwqTXtvgViUKNt3BRRSjlnOBTLwcY/uM6Jl+0s="
-      },
-      "jansi-1.18.jar": {
-        "sha1": "d9205bbcd4b5f9cd1effe752d18f73bd942d783f",
-        "sha256": "sha256-EJ5k/GV2fHoaO9ZUcJ128Qewo7Odsyy/EROeE6b1Ips="
       }
     }
   },

--- a/nix/deps/gradle/deps.json
+++ b/nix/deps/gradle/deps.json
@@ -7831,12 +7831,27 @@
     "repo": "https://jitpack.io",
     "files": {
       "BlurView-version-2.0.3.pom": {
-        "sha1": "678c8558151c1f1f37ab3e5e8baf00f1306ab6f5",
-        "sha256": "sha256-mgYP/aKUkj/GVVA6AxQhH1NTO0Ssv430blX/wYmImtI="
+        "sha1": "8dcfb62606434693476a8c720203492375d0718d",
+        "sha256": "sha256-GAfGRffnjP3Hpvsk/1uvt4PL7SNzkJSqbq42qILVrgw="
       },
       "BlurView-version-2.0.3.aar": {
         "sha1": "1a6b90b3dbd0714e0f9fd3a09196072c7da300a0",
         "sha256": "sha256-BuP74/LeQ+ID03WYU0m76TIRNGG0fi4ZM+In6RPQ66E="
+      }
+    }
+  },
+
+  {
+    "path": "com/github/Dimezis/BlurView/version-2.0.4",
+    "repo": "https://jitpack.io",
+    "files": {
+      "BlurView-version-2.0.4.pom": {
+        "sha1": "48eab3169b9a4ee3167ed1ed5f9c35135e9e4dad",
+        "sha256": "sha256-DjaiZmuM2CoTmZ4C+6HnNcsjc31ZYaWZSv6A0SCmmjk="
+      },
+      "BlurView-version-2.0.4.aar": {
+        "sha1": "c7d8a6464a50b430b01ce1a25f7949b75ba359b8",
+        "sha256": "sha256-w+KXiNSn0WoszuUpcxIp/M162Z+4vB30FeFvWKd1mcg="
       }
     }
   },
@@ -8169,20 +8184,20 @@
   },
 
   {
-    "path": "commons-logging/commons-logging/1.3.3",
+    "path": "commons-logging/commons-logging/1.3.4",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "commons-logging-1.3.3.pom": {
-        "sha1": "c5b1495adcb6d090cc4d333bb20e0583e716dd3d",
-        "sha256": "sha256-El1hQurD93REC6cCwF8o+eCYxS0QcSrhFJast3EGs7o="
+      "commons-logging-1.3.4.pom": {
+        "sha1": "e919eab34a66d31a9bbe15ddc563d7d2e6770826",
+        "sha256": "sha256-1L2jSJKqzL9PrTP8MjqKqQfvnXmYRlnaJJRMCoa/CGU="
       },
-      "commons-logging-1.3.3-api.jar": {
-        "sha1": "37cf34db3776550d413a8a0647937a2f38a017d4",
-        "sha256": "sha256-rgQB93pp8ZBAvucmTyrKilQEej0ALtAy2SAK9+beyaE="
+      "commons-logging-1.3.4-api.jar": {
+        "sha1": "de4050262dfa7522365a9e3c76ed8cf4683fcffa",
+        "sha256": "sha256-X1zVkiUzQHDbaxctBaaFuEei+tY+WxjtAjqqpeErgh8="
       },
-      "commons-logging-1.3.3.jar": {
-        "sha1": "580ad1a4f34876c4f964c083361de31b3d60be68",
-        "sha256": "sha256-WCj5bAnYhvmxoJk8eASyfPT87IU0UXFk9RN6yLZ+qbk="
+      "commons-logging-1.3.4.jar": {
+        "sha1": "b9fc14968d63a8b8a8a2c1885fe3e90564239708",
+        "sha256": "sha256-vC3+MvHvBlCeagZRRMGt97Qg6r8RqH8wvRJ/j6ozIBY="
       }
     }
   },
@@ -11249,16 +11264,16 @@
   },
 
   {
-    "path": "com/google/errorprone/error_prone_annotations/2.29.2",
+    "path": "com/google/errorprone/error_prone_annotations/2.30.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "error_prone_annotations-2.29.2.pom": {
-        "sha1": "cfee55ebd44b9c9e37fdcff10480534efb6d2c7f",
-        "sha256": "sha256-kTQi309RAUHmSkGaqK7Tz223itOMacz9Yk0H14HhHOg="
+      "error_prone_annotations-2.30.0.pom": {
+        "sha1": "847765ac955397a29f39553e742b60d8f317b544",
+        "sha256": "sha256-9xOEnCOzSVPoVFZdzoqnlcrgwUFmEbcgwhRhMix5X4Y="
       },
-      "error_prone_annotations-2.29.2.jar": {
-        "sha1": "23bbed35f2d071c8507984834e3e6438c7fee7d2",
-        "sha256": "sha256-4KQmskSa8jI8+1Obcp5b5vTWXHIHXJt7GMjofmOsRow="
+      "error_prone_annotations-2.30.0.jar": {
+        "sha1": "ff171acb7fb9cbe2b9f50b391e1d52459d30ee62",
+        "sha256": "sha256-FE86771uJ9rsVdN1OyxrE8Gv2vDPBIFs21ZFiO2S8b0="
       }
     }
   },
@@ -11396,12 +11411,12 @@
   },
 
   {
-    "path": "com/google/errorprone/error_prone_parent/2.29.2",
+    "path": "com/google/errorprone/error_prone_parent/2.30.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "error_prone_parent-2.29.2.pom": {
-        "sha1": "ca40178525396238286615831558689d408ae77a",
-        "sha256": "sha256-kplMj0wsSDM2GENtNmOQNGyqLtt26WAAy96sp+ISTNI="
+      "error_prone_parent-2.30.0.pom": {
+        "sha1": "9a289b8781e308a5cc315a9a7e564b5a57421770",
+        "sha256": "sha256-Xog0zMDl7Qxy8wbCULUY5q0Q0HWpt7kQz2lcuh7gKi0="
       }
     }
   },
@@ -11595,27 +11610,27 @@
   },
 
   {
-    "path": "com/google/guava/guava-parent/33.2.1-jre",
+    "path": "com/google/guava/guava-parent/33.3.0-jre",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "guava-parent-33.2.1-jre.pom": {
-        "sha1": "fc55955fab23e86fad230acc81bf570deb5660bd",
-        "sha256": "sha256-kJX22O43ZZUCB1EHhYMMwigOeBBnkV+pnP4XQNSGXBQ="
+      "guava-parent-33.3.0-jre.pom": {
+        "sha1": "24b614a34a06ced7c0fba8f4314c0e2d25bc75d6",
+        "sha256": "sha256-tGueFpaKrkokgTgA9nduyJEYjXvQCXpIqfSgyW1oUQg="
       }
     }
   },
 
   {
-    "path": "com/google/guava/guava-testlib/33.2.1-jre",
+    "path": "com/google/guava/guava-testlib/33.3.0-jre",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "guava-testlib-33.2.1-jre.pom": {
-        "sha1": "3b95376190925f23c89d9f2f990f2eb0bab9d2b2",
-        "sha256": "sha256-ZAiayFTlu6dVYLw9PB/dPqQ1cpFXJvYMgjcsq/qnTuQ="
+      "guava-testlib-33.3.0-jre.pom": {
+        "sha1": "5f3de794ff17706477e4b0f9a7e66c06d417eded",
+        "sha256": "sha256-lZrMVGkZCDw1CP/b5UotvUgT0Ly6Ox+PXr4m6CPc9F0="
       },
-      "guava-testlib-33.2.1-jre.jar": {
-        "sha1": "ba7d569795211c283c4576d17528534a618a5d59",
-        "sha256": "sha256-XsFBByZYQk9AzTC5FGf1zmPA5he5Hskn33JW79/S2Eo="
+      "guava-testlib-33.3.0-jre.jar": {
+        "sha1": "e4b14a9d25332bcd3130147741d1033e9c17577b",
+        "sha256": "sha256-YtAKfjK838Va9k2pU7alaBdNud2l17XP5p6Xi+lWFC8="
       }
     }
   },
@@ -11801,20 +11816,20 @@
   },
 
   {
-    "path": "com/google/guava/guava/33.2.1-jre",
+    "path": "com/google/guava/guava/33.3.0-jre",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "guava-33.2.1-jre.pom": {
-        "sha1": "5f72123f1bb7d99af8b4a67745fb8309b73a6294",
-        "sha256": "sha256-QoF73BwMjHN9a0Ec+vSoR2nn0nHoebAW/QhQJIoG2rU="
+      "guava-33.3.0-jre.pom": {
+        "sha1": "7ccfd20558d84416c3c0385e569d116a45202269",
+        "sha256": "sha256-08vQUY6vq2qXi7bKP/mDM93+c2eEtr/cSZVD8MlyP4Q="
       },
-      "guava-33.2.1-jre.jar": {
-        "sha1": "818e780da2c66c63bbb6480fef1f3855eeafa3e4",
-        "sha256": "sha256-RSstl4e302b6jPXtmhxAQEVC0F7/p6WY2gO7u7dtnzE="
+      "guava-33.3.0-jre.jar": {
+        "sha1": "13b4d0924e6023eda04b4c7aa83b32dfedf735a7",
+        "sha256": "sha256-363DvOMQHv8UUqrkfXyDP+5EO0e9+e8TMRtsfKtmPd8="
       },
-      "guava-33.2.1-jre.module": {
-        "sha1": "35b3a43a28bf269178f01d7097263d9ef95cac8b",
-        "sha256": "sha256-0j7aahwsC9JfijNGzd7sQ7Ufdb+Bm5MeqpgybqZEdCI="
+      "guava-33.3.0-jre.module": {
+        "sha1": "cbecd20bbaeca674a8147adf68dfa89a6a787ce4",
+        "sha256": "sha256-1WIerA4Z7qfdIY6zVMRyY+fuaT6d47rSUFS3BGSd6xw="
       }
     }
   },
@@ -11987,12 +12002,12 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-bom/4.28.0-RC1",
+    "path": "com/google/protobuf/protobuf-bom/4.28.0-RC2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-bom-4.28.0-RC1.pom": {
-        "sha1": "4dd88f5b489f6b1bb9a8db169ea31d66464d68a0",
-        "sha256": "sha256-mDFWhesHjFhmjSZ0NCqMd2emZECyz09XbTE0RgUhsZU="
+      "protobuf-bom-4.28.0-RC2.pom": {
+        "sha1": "feb628229ad894789d1c1a8d4e45fd67cee0f0ca",
+        "sha256": "sha256-ZYoRCMLJJGGjce0OUJbPE0MqTSJ7Z2+8I6S6cFReQ8Y="
       }
     }
   },
@@ -12238,16 +12253,16 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-java/4.28.0-RC1",
+    "path": "com/google/protobuf/protobuf-java/4.28.0-RC2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-java-4.28.0-RC1.pom": {
-        "sha1": "abb2a5ec826f29096389ee99365dba30c588c1d0",
-        "sha256": "sha256-3fQIOV7ElhjT1+SsDhRTXZZZYp7HGdC29kbIB/PKHXk="
+      "protobuf-java-4.28.0-RC2.pom": {
+        "sha1": "3e6707a07ceaf3d787aebaca08aabf51ade0bc05",
+        "sha256": "sha256-lz+Bw9lFqxhFjvLC+vzGE+AqY12dEaENMZapbMYesy4="
       },
-      "protobuf-java-4.28.0-RC1.jar": {
-        "sha1": "a7155c9ba741e2fbe3bfcd1ee5f01c2b220ee52b",
-        "sha256": "sha256-dJDPv1YH7q/TIA4ahs+mlZU8hJ1Mz2EsxlVTUT1oXGI="
+      "protobuf-java-4.28.0-RC2.jar": {
+        "sha1": "1dfe825e8bf400b6936dfd9113febd7cd1c34a4e",
+        "sha256": "sha256-bYicDB/fwGCS2KJtRxQ4Qnu/HV9obcv4ncvtF9Q3rTE="
       }
     }
   },
@@ -12367,12 +12382,12 @@
   },
 
   {
-    "path": "com/google/protobuf/protobuf-parent/4.28.0-RC1",
+    "path": "com/google/protobuf/protobuf-parent/4.28.0-RC2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "protobuf-parent-4.28.0-RC1.pom": {
-        "sha1": "f026cdea76c72c34f2a7d2f8fb8874659bc6f18a",
-        "sha256": "sha256-7/Ndud7DbgafiR9Gw40TdRreYRjwzqR3P/ITBAF7+bw="
+      "protobuf-parent-4.28.0-RC2.pom": {
+        "sha1": "086e862eab4dae3fad8c5019e219daa8d52a17c9",
+        "sha256": "sha256-hacKpsllAnLxZCpZwBLbUS1AtYezcsCKj1AHuB8y0Bk="
       }
     }
   },
@@ -14864,12 +14879,12 @@
   },
 
   {
-    "path": "net/bytebuddy/byte-buddy-parent/1.14.17",
+    "path": "net/bytebuddy/byte-buddy-parent/1.14.18",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "byte-buddy-parent-1.14.17.pom": {
-        "sha1": "c4c18b6ee78934ded11c060ca0dcbfffafa76105",
-        "sha256": "sha256-BuV7Xpn99O82iv/SNmF5CyO/MtLQE7vAjWjUNFAG9YI="
+      "byte-buddy-parent-1.14.18.pom": {
+        "sha1": "6b0b1f08e2d2d8166176c80fd22ee3198a26a3cf",
+        "sha256": "sha256-dpxdCxEV5z9oRSu6qjVrrZtzfV/ge4PUyeSDl1uB/jw="
       }
     }
   },
@@ -14920,16 +14935,16 @@
   },
 
   {
-    "path": "net/bytebuddy/byte-buddy/1.14.17",
+    "path": "net/bytebuddy/byte-buddy/1.14.18",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "byte-buddy-1.14.17.pom": {
-        "sha1": "0ec01a78f3832e5116bdb7b702cc30239df9832c",
-        "sha256": "sha256-7bLCWR4YBeoRfZojYVWGzGMh0lDokqnTRNwJ1aIr0T4="
+      "byte-buddy-1.14.18.pom": {
+        "sha1": "5f889814c247762909c7007bdf5ef72f2e7cea7a",
+        "sha256": "sha256-IvsZB4/nBkirYFSSZscUaZaEciaqbm9+iP7MCBRySTk="
       },
-      "byte-buddy-1.14.17.jar": {
-        "sha1": "a8d08f3c1e75ecc7f38a8cfd7e9fa47919096373",
-        "sha256": "sha256-zej4+OB7/zaUqs4NmUS6dVZlpYOwXZFT1BBiKF6aimE="
+      "byte-buddy-1.14.18.jar": {
+        "sha1": "0081e9b9a20944626e6757b5950676af901c2485",
+        "sha256": "sha256-UhF68WlqU6p3wTE1MHStolzL3y31EfKvM/rWcE+pUQQ="
       }
     }
   },
@@ -15256,27 +15271,27 @@
   },
 
   {
-    "path": "org/antlr/antlr4-master/4.13.1",
+    "path": "org/antlr/antlr4-master/4.13.2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "antlr4-master-4.13.1.pom": {
-        "sha1": "bbbe6ef89c12fbfb3fde78ac5c190adebbfed6ea",
-        "sha256": "sha256-28/JebgFKPwMtFP8to28nSsGA6e+LNzpmrL8aHFGnRg="
+      "antlr4-master-4.13.2.pom": {
+        "sha1": "c16aa4679ed71d485c700238d9b4730dd3d5e82e",
+        "sha256": "sha256-Ct2gJmhYc/ZRNgF4v/xEbO7kgzCBc5466dbo8H6NkCo="
       }
     }
   },
 
   {
-    "path": "org/antlr/antlr4-runtime/4.13.1",
+    "path": "org/antlr/antlr4-runtime/4.13.2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "antlr4-runtime-4.13.1.pom": {
-        "sha1": "4ca08d3d1a1f5cb989858cde922f40acf129e9ac",
-        "sha256": "sha256-GSJrF7+jj5nqImsi6XQg4qjt4JqXQg+xrPGG2a2kZXE="
+      "antlr4-runtime-4.13.2.pom": {
+        "sha1": "d07a9559966ddaa848df4dd2099f15ceaab173ca",
+        "sha256": "sha256-A84HonlsURsMlNwU/YbM3W44KMV5Z60jg94wTg0Runk="
       },
-      "antlr4-runtime-4.13.1.jar": {
-        "sha1": "17125bae1d965624e265ef49552f6465a2bfa307",
-        "sha256": "sha256-VGZdKDjMZkWDQ0aO/FOeRU/JW0aooEsTxqxD/JvmNQU="
+      "antlr4-runtime-4.13.2.jar": {
+        "sha1": "fc3db6d844df652a3d5db31c87fa12757f13691d",
+        "sha256": "sha256-3T6KE6LWab+E+42DTeNc5IdfJxV2mNIGJB7ISIqtyvc="
       }
     }
   },
@@ -15530,6 +15545,17 @@
   },
 
   {
+    "path": "org/apache/apache/33",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "apache-33.pom": {
+        "sha1": "f7b7b5a9e84395f17d7e6a136e5bfc4b9973566d",
+        "sha256": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
+      }
+    }
+  },
+
+  {
     "path": "org/apache/commons/commons-compress/1.8.1",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
@@ -15769,6 +15795,17 @@
       "commons-parent-71.pom": {
         "sha1": "91d35791f5037779fb320d054ed09cb14925dc32",
         "sha256": "sha256-lbe+cPMWrkyiL2+90I3iGC6HzYdKZQ3nw9M4anR6gqM="
+      }
+    }
+  },
+
+  {
+    "path": "org/apache/commons/commons-parent/72",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "commons-parent-72.pom": {
+        "sha1": "cdfbaff82e756be4cb74d3f09b8fbf8f6b06c79d",
+        "sha256": "sha256-Q0Xev8dnsa6saKvdcvxn0YtSHUs5A3KhG2P/DFhrIyA="
       }
     }
   },
@@ -16508,20 +16545,20 @@
   },
 
   {
-    "path": "org/checkerframework/checker-qual/3.45.0",
+    "path": "org/checkerframework/checker-qual/3.46.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "checker-qual-3.45.0.pom": {
-        "sha1": "90e7617dce895b07c6fe15397cca094f7d35a715",
-        "sha256": "sha256-6vn2Le5avMuaKZkVyz1YKpOBUAB4+FeZOO3hH3I2FXQ="
+      "checker-qual-3.46.0.pom": {
+        "sha1": "023fdbd16acb7971828aaa6938b7d2d224e188f0",
+        "sha256": "sha256-p4dUUeMHmg2EH0WWOeaRpSkx+js+dFHYjzBxbvjNiEs="
       },
-      "checker-qual-3.45.0.jar": {
-        "sha1": "f59fc9e26caad509272d2e2ffbaf275cbc0dd9eb",
-        "sha256": "sha256-MD7T1T7EEsVJyE+Iun+0Jd5RyIdspi3fVLJu7EPVtEM="
+      "checker-qual-3.46.0.jar": {
+        "sha1": "829954afc56f1737a1df3ab5aa889de574b97cc4",
+        "sha256": "sha256-S8d6FyJ5MEw/NQRda5yEkngPBH5a2ZGdd0McrynkRAE="
       },
-      "checker-qual-3.45.0.module": {
-        "sha1": "20431fb8b16c7c376df7354b4ae77c3cf36dc7c7",
-        "sha256": "sha256-vY6PlipqhNL39OPF6EnKbP+wmGggEXc2oiqLo33he+I="
+      "checker-qual-3.46.0.module": {
+        "sha1": "d3a39af168be2cc83d9023b723e56f0c51c9e066",
+        "sha256": "sha256-HrKvP0T95kPuHZ9B1Of8hTLqahFKRqgiqX9tji/UWvU="
       }
     }
   },
@@ -16857,27 +16894,27 @@
   },
 
   {
-    "path": "org/easymock/easymock-parent/5.3.0",
+    "path": "org/easymock/easymock-parent/5.4.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "easymock-parent-5.3.0.pom": {
-        "sha1": "cb3dbc3dde07db5aed51fe830d3286337d1617d0",
-        "sha256": "sha256-rbgEijCk2xLHbuG2xXBxah737kpHxnYzUJuFWv6IzYQ="
+      "easymock-parent-5.4.0.pom": {
+        "sha1": "ac49fe5a7d9cfec46d7386f713c5cd5c5afed89f",
+        "sha256": "sha256-sKGUgoX4OZNIqWxgWTXYJVCnVKTDNfw0SfogL74qAnI="
       }
     }
   },
 
   {
-    "path": "org/easymock/easymock/5.3.0",
+    "path": "org/easymock/easymock/5.4.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "easymock-5.3.0.pom": {
-        "sha1": "425f58fb29b86ca6412e9a698e9d82ef32d84c57",
-        "sha256": "sha256-7CsgHpoQXW2uXVjfJE8eDAENPUBMxP/QV7QZ75SQGoU="
+      "easymock-5.4.0.pom": {
+        "sha1": "d566a45d12ee304ab0fba3877ebd93ef64469ea8",
+        "sha256": "sha256-v/kNdi/BrWVB5jCrgeBzJPVflbd5BhE6NKpnqn2HPhk="
       },
-      "easymock-5.3.0.jar": {
-        "sha1": "7bac0b4bbd84f49f9bcd8485281b5e52da081fa4",
-        "sha256": "sha256-31WHJ9p9nYfRGXmyxMZ0gMjvti4uQOEcNScXuYF6fz8="
+      "easymock-5.4.0.jar": {
+        "sha1": "eb56bad81c203765f4a5c74aed28142fb0d79354",
+        "sha256": "sha256-SDUEf+QbVDSRB8EaGEuhIvo8P8cIQHU0ZfdCtJ5+A6M="
       }
     }
   },
@@ -17277,20 +17314,20 @@
   },
 
   {
-    "path": "org/hamcrest/hamcrest-core/3.0-rc1",
+    "path": "org/hamcrest/hamcrest-core/3.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "hamcrest-core-3.0-rc1.pom": {
-        "sha1": "b4531f7e332db9adf6875d6d108788b26ea94c00",
-        "sha256": "sha256-wvfzg1qjfGTIAkKZ95WkWpoVAXkaLhaxZK1T8tqh6f0="
+      "hamcrest-core-3.0.pom": {
+        "sha1": "e419abe63f1e41cb1aa41225f0bb532b2c6e6e1a",
+        "sha256": "sha256-1kyZW1baUn0+fhhmuRkNmL0QuYanfYET7EVQeZ44WqQ="
       },
-      "hamcrest-core-3.0-rc1.jar": {
-        "sha1": "1eff1caea3852bfa392af907b5ad2d08c7ce818d",
-        "sha256": "sha256-gpIUbmwtFqZy0ZvJ9WK4T6bZ9P4/mjHYKfU07fg9fbs="
+      "hamcrest-core-3.0.jar": {
+        "sha1": "254f69f4b0ca22198acfc19fcdd5f96140431c3e",
+        "sha256": "sha256-t4o6gWkvQhzAH8F97ZpF6ftvOUnHEvjsTQHaa4wGvG4="
       },
-      "hamcrest-core-3.0-rc1.module": {
-        "sha1": "9a3cf013361bcafdd05c2f17cdc2459edebd46a5",
-        "sha256": "sha256-Hwn9JWdIE/1jePtplnM8gZkuqbpyQNWEVm+Jkw1YTvU="
+      "hamcrest-core-3.0.module": {
+        "sha1": "796d1cd3d6308a0d7338827644448450dd9b12f0",
+        "sha256": "sha256-gweKVn1bT3j27cznGvQfDnRjmIELze3N/QLiRVe8mmA="
       }
     }
   },
@@ -17322,20 +17359,20 @@
   },
 
   {
-    "path": "org/hamcrest/hamcrest/3.0-rc1",
+    "path": "org/hamcrest/hamcrest/3.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "hamcrest-3.0-rc1.pom": {
-        "sha1": "42a2310ee499db82c55272fa2673ca420bf6bf51",
-        "sha256": "sha256-EzeZrRqcWysG8kW0swHh2DXnoEftQMt84a8hNLBblF4="
+      "hamcrest-3.0.pom": {
+        "sha1": "3c85240a040ddb51dc33d405ef0e075ec68b6796",
+        "sha256": "sha256-SgSmgTO/MkYfR7ilPI7p30zi9JoNrZeUvOhxe+5brDE="
       },
-      "hamcrest-3.0-rc1.jar": {
-        "sha1": "14b0b8ef4b05961db5086455c271786a3ec5c815",
-        "sha256": "sha256-T0y5BrRrhrj071Ej9+oVwjT+w+WgGWUwdhrNptOkK5k="
+      "hamcrest-3.0.jar": {
+        "sha1": "8fd9b78a8e6a6510a078a9e30e9e86a6035cfaf7",
+        "sha256": "sha256-XWa2pKaAdVy27XyxBPp4Ne9kRmdYb/Bzet65d8Oezbw="
       },
-      "hamcrest-3.0-rc1.module": {
-        "sha1": "798ea5bc678a0e450346bc3688d18e998b3cce21",
-        "sha256": "sha256-hTxz0hjDvK1uEcdyDoCmWg/TCDkL0qlgIw6G3HR/Pkw="
+      "hamcrest-3.0.module": {
+        "sha1": "ac51ee99de2e24e2776e9a76e49040b570811dd9",
+        "sha256": "sha256-mhBVNzjTWME+a69Zeb8sGlSQ7uScLcas8xcPzKCSDd4="
       }
     }
   },
@@ -19078,16 +19115,16 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-reflect/2.0.20-Beta2",
+    "path": "org/jetbrains/kotlin/kotlin-reflect/2.0.20-RC2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-reflect-2.0.20-Beta2.pom": {
-        "sha1": "dcba731c793650645246528ced61eaefbfb3d6fb",
-        "sha256": "sha256-oeGGbrRW4hL/svh53GUKNW7oCpPqAGAdcbO2eSZh/VM="
+      "kotlin-reflect-2.0.20-RC2.pom": {
+        "sha1": "9ef4e8b151ce267a9545e53c244c8405c3d5d50a",
+        "sha256": "sha256-jfswws9jGQOdUaQnTpHqCf23tnjI3V4KlrQLo8WC73Y="
       },
-      "kotlin-reflect-2.0.20-Beta2.jar": {
-        "sha1": "c107aab723629eba126d73a256261bc2dd5f6f94",
-        "sha256": "sha256-+AAY6ksSfwuYtxgNP2tx/Unu/Iq43gP6gNHI1hai73g="
+      "kotlin-reflect-2.0.20-RC2.jar": {
+        "sha1": "a0d8fb50a1313394eadc102516275df44af4683a",
+        "sha256": "sha256-RS18FWGiVP3iZXrPISo/9i5I6KqsP8T1UUmG+oiHSYs="
       }
     }
   },
@@ -20665,28 +20702,28 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/2.0.20-Beta2",
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/2.0.20-RC2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-stdlib-2.0.20-Beta2.pom": {
-        "sha1": "072b10781d710062d541929d810c0f5abece834f",
-        "sha256": "sha256-7nhCT2tDwl9IGhtJQUrUf4hoSbtgj+cLdu6cwKsNwRs="
+      "kotlin-stdlib-2.0.20-RC2.pom": {
+        "sha1": "4a354ff4c0ee5051d79b2e32d016706f4bfe1103",
+        "sha256": "sha256-e1nz1Pnv+SgjdDxNqfaO+swpEDqCGkChWDJ27MaweMo="
       },
-      "kotlin-stdlib-2.0.20-Beta2-all.jar": {
-        "sha1": "6b7bb98078d39f9b446e76703a7a3b9ac881ab20",
-        "sha256": "sha256-c2DTXup0f8352l8CNcDXvjyUgDQ9qo3HMU10Uc2LYhM="
+      "kotlin-stdlib-2.0.20-RC2-all.jar": {
+        "sha1": "9bd1e1253e62c42a33a786a0cbe24da0050cb71c",
+        "sha256": "sha256-UP+t6yC00kVqUmWVpPep6FiJaCcVBz5s26Gx2A461Fg="
       },
-      "kotlin-stdlib-2.0.20-Beta2-common.jar": {
-        "sha1": "e20b394b07c3e71fcd241f46159d13cb90fe79a4",
-        "sha256": "sha256-wboFR9YQ07iNrZCwIT8DUrT3w0Qpuu3llUiu0MUiVEY="
+      "kotlin-stdlib-2.0.20-RC2-common.jar": {
+        "sha1": "7484111a8b4551fbe8a50d66de8b36f0af1de252",
+        "sha256": "sha256-5U//s64omzwm42t3TCvW+LojfkiwkioTPlvHSKxPP+o="
       },
-      "kotlin-stdlib-2.0.20-Beta2.jar": {
-        "sha1": "3b5a0c1aa186088d3b4a323f22822c8fff6f73c4",
-        "sha256": "sha256-rFnFiItEt/OSYo338a26XZh/AiBxz97IgmEVolBpzYg="
+      "kotlin-stdlib-2.0.20-RC2.jar": {
+        "sha1": "335ad678a59a3f0b70ebfdf70ed8c46e69b296da",
+        "sha256": "sha256-/BOMxtHeUY3BqOdT1IRJKq7iNaj3cDbE3UPhTVAvQrQ="
       },
-      "kotlin-stdlib-2.0.20-Beta2.module": {
-        "sha1": "2163c5eba25f097c62eddc8f6d54a37398c4f903",
-        "sha256": "sha256-BB6Jv2FfcrLP46MsolVAmCcrt2lWmpM4ycHBtkRM9LI="
+      "kotlin-stdlib-2.0.20-RC2.module": {
+        "sha1": "b7d6822fbfdfaa8198d8f2f7be2ff92a34680d21",
+        "sha256": "sha256-cbU5pKmez8hxqtzG3FU8cKK2fgKx4bKVKezx+aBw5Pk="
       }
     }
   },
@@ -20985,16 +21022,16 @@
   },
 
   {
-    "path": "org/junit/junit-bom/5.11.0-M2",
+    "path": "org/junit/junit-bom/5.11.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "junit-bom-5.11.0-M2.pom": {
-        "sha1": "6c517cddae7893aba5bf9f051c44860a4fc18211",
-        "sha256": "sha256-Sj/8Sk7c/sLLXWGZInBqlAcWF5hXGTn4VN/ac+ThfMg="
+      "junit-bom-5.11.0.pom": {
+        "sha1": "a4a8a67d5348d748a6345d6f1d08846fb2780ed9",
+        "sha256": "sha256-5nRZ1IgkJKxjdPQNscj0ouiJRrNAugcsgL6TKivkZE0="
       },
-      "junit-bom-5.11.0-M2.module": {
-        "sha1": "4546561225def9f7f99c7c1abc3828dec51aad2a",
-        "sha256": "sha256-hkd6vPSQ1soFmqmXPLEI0ipQb0nRpVabsyzGy/Q8LM4="
+      "junit-bom-5.11.0.module": {
+        "sha1": "d0302ab22149450fd7698262515751337f70a3a6",
+        "sha256": "sha256-9+2+Z/IgQnCMQQq8VHQI5cR29An1ViNqEXkiEnSi7S0="
       }
     }
   },

--- a/nix/deps/gradle/deps.list
+++ b/nix/deps/gradle/deps.list
@@ -925,4 +925,5 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0
 com.android.tools.build:gradle:3.5.4
 androidx.annotation:annotation:1.6.0
 androidx.annotation:annotation-jvm:1.6.0
+com.github.Dimezis:BlurView:version-2.0.4
 com.facebook.react:hermes-android:0.73.5

--- a/nix/deps/gradle/deps.list
+++ b/nix/deps/gradle/deps.list
@@ -50,14 +50,14 @@ androidx.core:core:1.9.0
 androidx.cursoradapter:cursoradapter:1.0.0
 androidx.customview:customview:1.0.0
 androidx.databinding:databinding-common:3.2.1
-androidx.databinding:databinding-common:3.5.3
+androidx.databinding:databinding-common:3.5.4
 androidx.databinding:databinding-common:4.1.0
 androidx.databinding:databinding-common:7.0.4
 androidx.databinding:databinding-common:7.2.1
 androidx.databinding:databinding-common:7.3.1
 androidx.databinding:databinding-common:8.1.1
 androidx.databinding:databinding-compiler-common:3.2.1
-androidx.databinding:databinding-compiler-common:3.5.3
+androidx.databinding:databinding-compiler-common:3.5.4
 androidx.databinding:databinding-compiler-common:4.1.0
 androidx.databinding:databinding-compiler-common:7.0.4
 androidx.databinding:databinding-compiler-common:7.2.1
@@ -151,7 +151,6 @@ commons-codec:commons-codec:1.11
 commons-io:commons-io:2.4
 commons-logging:commons-logging:1.1.1
 commons-logging:commons-logging:1.2
-com.adarshr:gradle-test-logger-plugin:2.0.0
 com.adobe.xmp:xmpcore:6.1.11
 com.afollestad.material-dialogs:commons:0.9.6.0
 com.afollestad.material-dialogs:core:0.9.6.0
@@ -160,7 +159,7 @@ com.almworks.sqlite4java:sqlite4java:1.0.392
 com.android.databinding:baseLibrary:1.0-rc5
 com.android.databinding:baseLibrary:3.0.1
 com.android.databinding:baseLibrary:3.2.1
-com.android.databinding:baseLibrary:3.5.3
+com.android.databinding:baseLibrary:3.5.4
 com.android.databinding:baseLibrary:4.1.0
 com.android.databinding:baseLibrary:7.0.4
 com.android.databinding:baseLibrary:7.2.1
@@ -169,7 +168,7 @@ com.android.databinding:baseLibrary:8.1.1
 com.android.databinding:compilerCommon:1.0-rc5
 com.android.databinding:compilerCommon:3.0.1
 com.android.tools.analytics-library:crash:26.2.1
-com.android.tools.analytics-library:crash:26.5.3
+com.android.tools.analytics-library:crash:26.5.4
 com.android.tools.analytics-library:crash:27.1.0
 com.android.tools.analytics-library:crash:30.0.4
 com.android.tools.analytics-library:crash:30.2.1
@@ -177,7 +176,7 @@ com.android.tools.analytics-library:crash:30.3.1
 com.android.tools.analytics-library:crash:31.1.1
 com.android.tools.analytics-library:protos:26.0.1
 com.android.tools.analytics-library:protos:26.2.1
-com.android.tools.analytics-library:protos:26.5.3
+com.android.tools.analytics-library:protos:26.5.4
 com.android.tools.analytics-library:protos:27.1.0
 com.android.tools.analytics-library:protos:30.0.4
 com.android.tools.analytics-library:protos:30.2.1
@@ -185,7 +184,7 @@ com.android.tools.analytics-library:protos:30.3.1
 com.android.tools.analytics-library:protos:31.1.1
 com.android.tools.analytics-library:shared:26.0.1
 com.android.tools.analytics-library:shared:26.2.1
-com.android.tools.analytics-library:shared:26.5.3
+com.android.tools.analytics-library:shared:26.5.4
 com.android.tools.analytics-library:shared:27.1.0
 com.android.tools.analytics-library:shared:30.0.4
 com.android.tools.analytics-library:shared:30.2.1
@@ -193,7 +192,7 @@ com.android.tools.analytics-library:shared:30.3.1
 com.android.tools.analytics-library:shared:31.1.1
 com.android.tools.analytics-library:tracker:26.0.1
 com.android.tools.analytics-library:tracker:26.2.1
-com.android.tools.analytics-library:tracker:26.5.3
+com.android.tools.analytics-library:tracker:26.5.4
 com.android.tools.analytics-library:tracker:27.1.0
 com.android.tools.analytics-library:tracker:30.0.4
 com.android.tools.analytics-library:tracker:30.2.1
@@ -222,14 +221,14 @@ com.android.tools.build:aaptcompiler:7.3.1
 com.android.tools.build:aaptcompiler:8.1.1
 com.android.tools.build:apksig:3.0.1
 com.android.tools.build:apksig:3.2.1
-com.android.tools.build:apksig:3.5.3
+com.android.tools.build:apksig:3.5.4
 com.android.tools.build:apksig:4.1.0
 com.android.tools.build:apksig:7.0.4
 com.android.tools.build:apksig:7.2.1
 com.android.tools.build:apksig:7.3.1
 com.android.tools.build:apksig:8.1.1
 com.android.tools.build:apkzlib:3.2.1
-com.android.tools.build:apkzlib:3.5.3
+com.android.tools.build:apkzlib:3.5.4
 com.android.tools.build:apkzlib:4.1.0
 com.android.tools.build:apkzlib:7.0.4
 com.android.tools.build:apkzlib:7.2.1
@@ -239,7 +238,7 @@ com.android.tools.build:builder-model:1.3.1
 com.android.tools.build:builder-model:1.5.0
 com.android.tools.build:builder-model:3.0.1
 com.android.tools.build:builder-model:3.2.1
-com.android.tools.build:builder-model:3.5.3
+com.android.tools.build:builder-model:3.5.4
 com.android.tools.build:builder-model:4.1.0
 com.android.tools.build:builder-model:7.0.4
 com.android.tools.build:builder-model:7.2.1
@@ -249,7 +248,7 @@ com.android.tools.build:builder-test-api:1.3.1
 com.android.tools.build:builder-test-api:1.5.0
 com.android.tools.build:builder-test-api:3.0.1
 com.android.tools.build:builder-test-api:3.2.1
-com.android.tools.build:builder-test-api:3.5.3
+com.android.tools.build:builder-test-api:3.5.4
 com.android.tools.build:builder-test-api:4.1.0
 com.android.tools.build:builder-test-api:7.0.4
 com.android.tools.build:builder-test-api:7.2.1
@@ -259,7 +258,7 @@ com.android.tools.build:builder:1.3.1
 com.android.tools.build:builder:1.5.0
 com.android.tools.build:builder:3.0.1
 com.android.tools.build:builder:3.2.1
-com.android.tools.build:builder:3.5.3
+com.android.tools.build:builder:3.5.4
 com.android.tools.build:builder:4.1.0
 com.android.tools.build:builder:7.0.4
 com.android.tools.build:builder:7.2.1
@@ -274,7 +273,7 @@ com.android.tools.build:bundletool:1.9.0
 com.android.tools.build:bundletool:1.14.0
 com.android.tools.build:gradle-api:3.0.1
 com.android.tools.build:gradle-api:3.2.1
-com.android.tools.build:gradle-api:3.5.3
+com.android.tools.build:gradle-api:3.5.4
 com.android.tools.build:gradle-api:4.1.0
 com.android.tools.build:gradle-api:7.0.4
 com.android.tools.build:gradle-api:7.2.1
@@ -288,7 +287,7 @@ com.android.tools.build:gradle:1.3.1
 com.android.tools.build:gradle:1.5.0
 com.android.tools.build:gradle:3.0.1
 com.android.tools.build:gradle:3.2.1
-com.android.tools.build:gradle:3.5.3
+com.android.tools.build:gradle:3.5.4
 com.android.tools.build:gradle:4.1.0
 com.android.tools.build:gradle:7.0.4
 com.android.tools.build:gradle:7.2.1
@@ -297,7 +296,7 @@ com.android.tools.build:manifest-merger:24.3.1
 com.android.tools.build:manifest-merger:24.5.0
 com.android.tools.build:manifest-merger:26.0.1
 com.android.tools.build:manifest-merger:26.2.1
-com.android.tools.build:manifest-merger:26.5.3
+com.android.tools.build:manifest-merger:26.5.4
 com.android.tools.build:manifest-merger:27.1.0
 com.android.tools.build:manifest-merger:30.0.4
 com.android.tools.build:manifest-merger:30.2.1
@@ -309,7 +308,7 @@ com.android.tools.ddms:ddmlib:24.3.1
 com.android.tools.ddms:ddmlib:24.5.0
 com.android.tools.ddms:ddmlib:26.0.1
 com.android.tools.ddms:ddmlib:26.2.1
-com.android.tools.ddms:ddmlib:26.5.3
+com.android.tools.ddms:ddmlib:26.5.4
 com.android.tools.ddms:ddmlib:27.1.0
 com.android.tools.ddms:ddmlib:30.0.4
 com.android.tools.ddms:ddmlib:30.2.1
@@ -324,7 +323,7 @@ com.android.tools.layoutlib:layoutlib-api:24.3.1
 com.android.tools.layoutlib:layoutlib-api:24.5.0
 com.android.tools.layoutlib:layoutlib-api:26.0.1
 com.android.tools.layoutlib:layoutlib-api:26.2.1
-com.android.tools.layoutlib:layoutlib-api:26.5.3
+com.android.tools.layoutlib:layoutlib-api:26.5.4
 com.android.tools.layoutlib:layoutlib-api:27.1.0
 com.android.tools.layoutlib:layoutlib-api:30.0.4
 com.android.tools.layoutlib:layoutlib-api:30.2.1
@@ -337,7 +336,7 @@ com.android.tools.lint:lint-checks:24.3.1
 com.android.tools.lint:lint-checks:24.5.0
 com.android.tools.lint:lint-checks:26.0.1
 com.android.tools.lint:lint-gradle-api:26.2.1
-com.android.tools.lint:lint-gradle-api:26.5.3
+com.android.tools.lint:lint-gradle-api:26.5.4
 com.android.tools.lint:lint-gradle-api:27.1.0
 com.android.tools.lint:lint-model:27.1.0
 com.android.tools.lint:lint-model:30.0.4
@@ -378,7 +377,7 @@ com.android.tools:annotations:24.3.1
 com.android.tools:annotations:24.5.0
 com.android.tools:annotations:26.0.1
 com.android.tools:annotations:26.2.1
-com.android.tools:annotations:26.5.3
+com.android.tools:annotations:26.5.4
 com.android.tools:annotations:27.1.0
 com.android.tools:annotations:30.0.4
 com.android.tools:annotations:30.2.1
@@ -388,7 +387,7 @@ com.android.tools:common:24.3.1
 com.android.tools:common:24.5.0
 com.android.tools:common:26.0.1
 com.android.tools:common:26.2.1
-com.android.tools:common:26.5.3
+com.android.tools:common:26.5.4
 com.android.tools:common:27.1.0
 com.android.tools:common:30.0.4
 com.android.tools:common:30.2.1
@@ -398,7 +397,7 @@ com.android.tools:dvlib:24.3.1
 com.android.tools:dvlib:24.5.0
 com.android.tools:dvlib:26.0.1
 com.android.tools:dvlib:26.2.1
-com.android.tools:dvlib:26.5.3
+com.android.tools:dvlib:26.5.4
 com.android.tools:dvlib:27.1.0
 com.android.tools:dvlib:30.0.4
 com.android.tools:dvlib:30.2.1
@@ -406,7 +405,7 @@ com.android.tools:dvlib:30.3.1
 com.android.tools:dvlib:31.1.1
 com.android.tools:repository:26.0.1
 com.android.tools:repository:26.2.1
-com.android.tools:repository:26.5.3
+com.android.tools:repository:26.5.4
 com.android.tools:repository:27.1.0
 com.android.tools:repository:30.0.4
 com.android.tools:repository:30.2.1
@@ -416,7 +415,7 @@ com.android.tools:sdklib:24.3.1
 com.android.tools:sdklib:24.5.0
 com.android.tools:sdklib:26.0.1
 com.android.tools:sdklib:26.2.1
-com.android.tools:sdklib:26.5.3
+com.android.tools:sdklib:26.5.4
 com.android.tools:sdklib:27.1.0
 com.android.tools:sdklib:30.0.4
 com.android.tools:sdklib:30.2.1
@@ -426,7 +425,7 @@ com.android.tools:sdk-common:24.3.1
 com.android.tools:sdk-common:24.5.0
 com.android.tools:sdk-common:26.0.1
 com.android.tools:sdk-common:26.2.1
-com.android.tools:sdk-common:26.5.3
+com.android.tools:sdk-common:26.5.4
 com.android.tools:sdk-common:27.1.0
 com.android.tools:sdk-common:30.0.4
 com.android.tools:sdk-common:30.2.1
@@ -496,7 +495,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
 com.fasterxml.jackson.module:jackson-module-kotlin:2.11.1
 com.fasterxml.woodstox:woodstox-core:6.2.1
-com.github.Dimezis:BlurView:version-2.0.3
+com.github.Dimezis:BlurView:version-2.0.4
 com.github.bumptech.glide:annotations:4.12.0
 com.github.bumptech.glide:compiler:4.12.0
 com.github.bumptech.glide:disklrucache:4.12.0
@@ -734,7 +733,6 @@ org.eclipse.jdt.core.compiler:ecj:4.4.2
 org.eclipse.jdt.core.compiler:ecj:4.6.1
 org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r
 org.eclipse.jgit:org.eclipse.jgit:5.13.1.202206130422-r
-org.fusesource.jansi:jansi:1.18
 org.glassfish.jaxb:jaxb-core:2.2.11
 org.glassfish.jaxb:jaxb-runtime:2.2.11
 org.glassfish.jaxb:jaxb-runtime:2.3.1

--- a/nix/deps/gradle/deps.urls
+++ b/nix/deps/gradle/deps.urls
@@ -68,7 +68,6 @@ https://dl.google.com/dl/android/maven2/androidx/core/core/1.9.0/core-1.9.0.pom
 https://dl.google.com/dl/android/maven2/androidx/cursoradapter/cursoradapter/1.0.0/cursoradapter-1.0.0.pom
 https://dl.google.com/dl/android/maven2/androidx/customview/customview/1.0.0/customview-1.0.0.pom
 https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/3.2.1/databinding-common-3.2.1.pom
-https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/3.5.3/databinding-common-3.5.3.pom
 https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/3.5.4/databinding-common-3.5.4.pom
 https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/4.1.0/databinding-common-4.1.0.pom
 https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/7.0.4/databinding-common-7.0.4.pom
@@ -76,7 +75,6 @@ https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/
 https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/7.3.1/databinding-common-7.3.1.pom
 https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/8.1.1/databinding-common-8.1.1.pom
 https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-compiler-common/3.2.1/databinding-compiler-common-3.2.1.pom
-https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-compiler-common/3.5.3/databinding-compiler-common-3.5.3.pom
 https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-compiler-common/3.5.4/databinding-compiler-common-3.5.4.pom
 https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-compiler-common/4.1.0/databinding-compiler-common-4.1.0.pom
 https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-compiler-common/7.0.4/databinding-compiler-common-7.0.4.pom
@@ -182,7 +180,6 @@ https://dl.google.com/dl/android/maven2/android/arch/lifecycle/common/1.0.0/comm
 https://dl.google.com/dl/android/maven2/android/arch/lifecycle/runtime/1.0.0/runtime-1.0.0.pom
 https://dl.google.com/dl/android/maven2/com/android/databinding/baseLibrary/3.0.1/baseLibrary-3.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/databinding/baseLibrary/3.2.1/baseLibrary-3.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/databinding/baseLibrary/3.5.3/baseLibrary-3.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/databinding/baseLibrary/3.5.4/baseLibrary-3.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/databinding/baseLibrary/4.1.0/baseLibrary-4.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/databinding/baseLibrary/7.0.4/baseLibrary-7.0.4.pom
@@ -216,7 +213,6 @@ https://dl.google.com/dl/android/maven2/com/android/support/support-v4/26.0.2/su
 https://dl.google.com/dl/android/maven2/com/android/support/support-vector-drawable/26.0.2/support-vector-drawable-26.0.2.pom
 https://dl.google.com/dl/android/maven2/com/android/support/support-vector-drawable/27.0.1/support-vector-drawable-27.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/crash/26.2.1/crash-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/crash/26.5.3/crash-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/crash/26.5.4/crash-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/crash/27.1.0/crash-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/crash/30.0.4/crash-30.0.4.pom
@@ -225,7 +221,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/cras
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/crash/31.1.1/crash-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/26.0.1/protos-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/26.2.1/protos-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/26.5.3/protos-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/26.5.4/protos-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/27.1.0/protos-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/30.0.4/protos-30.0.4.pom
@@ -234,7 +229,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/prot
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/31.1.1/protos-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/26.0.1/shared-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/26.2.1/shared-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/26.5.3/shared-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/26.5.4/shared-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/27.1.0/shared-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/30.0.4/shared-30.0.4.pom
@@ -243,7 +237,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shar
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/31.1.1/shared-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/26.0.1/tracker-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/26.2.1/tracker-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/26.5.3/tracker-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/26.5.4/tracker-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/27.1.0/tracker-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/30.0.4/tracker-30.0.4.pom
@@ -252,7 +245,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/trac
 https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/31.1.1/tracker-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/annotations/26.0.1/annotations-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/annotations/26.2.1/annotations-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/annotations/26.5.3/annotations-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/annotations/26.5.4/annotations-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/annotations/27.1.0/annotations-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/annotations/30.0.4/annotations-30.0.4.pom
@@ -277,7 +269,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/build/aaptcompiler/7.3
 https://dl.google.com/dl/android/maven2/com/android/tools/build/aaptcompiler/8.1.1/aaptcompiler-8.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/3.0.1/apksig-3.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/3.2.1/apksig-3.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/3.5.3/apksig-3.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/3.5.4/apksig-3.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/4.1.0/apksig-4.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/7.0.4/apksig-7.0.4.pom
@@ -285,7 +276,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/7.2.1/apk
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/7.3.1/apksig-7.3.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/8.1.1/apksig-8.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/3.2.1/apkzlib-3.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/3.5.3/apkzlib-3.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/3.5.4/apkzlib-3.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/4.1.0/apkzlib-4.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/7.0.4/apkzlib-7.0.4.pom
@@ -294,7 +284,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/7.3.1/ap
 https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/8.1.1/apkzlib-8.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/3.0.1/builder-model-3.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/3.2.1/builder-model-3.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/3.5.3/builder-model-3.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/3.5.4/builder-model-3.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/4.1.0/builder-model-4.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/7.0.4/builder-model-7.0.4.pom
@@ -303,7 +292,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/7.
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/8.1.1/builder-model-8.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/3.0.1/builder-test-api-3.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/3.2.1/builder-test-api-3.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/3.5.3/builder-test-api-3.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/3.5.4/builder-test-api-3.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/4.1.0/builder-test-api-4.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/7.0.4/builder-test-api-7.0.4.pom
@@ -312,7 +300,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/8.1.1/builder-test-api-8.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/3.0.1/builder-3.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/3.2.1/builder-3.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/3.5.3/builder-3.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/3.5.4/builder-3.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/4.1.0/builder-4.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/7.0.4/builder-7.0.4.pom
@@ -328,7 +315,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/build/bundletool/1.9.0
 https://dl.google.com/dl/android/maven2/com/android/tools/build/bundletool/1.14.0/bundletool-1.14.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/3.0.1/gradle-api-3.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/3.2.1/gradle-api-3.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/3.5.3/gradle-api-3.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/3.5.4/gradle-api-3.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/4.1.0/gradle-api-4.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/7.0.4/gradle-api-7.0.4.pom
@@ -339,7 +325,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-core/3.0.
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-settings-api/8.1.1/gradle-settings-api-8.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/3.2.1/gradle-3.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/3.5.3/gradle-3.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/3.5.4/gradle-3.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/4.1.0/gradle-4.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/7.0.4/gradle-7.0.4.pom
@@ -356,7 +341,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/build/jetifier/jetifie
 https://dl.google.com/dl/android/maven2/com/android/tools/build/jetifier/jetifier-processor/1.0.0-beta10/jetifier-processor-1.0.0-beta10.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/26.0.1/manifest-merger-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/26.2.1/manifest-merger-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/26.5.3/manifest-merger-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/26.5.4/manifest-merger-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/27.1.0/manifest-merger-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/30.0.4/manifest-merger-30.0.4.pom
@@ -365,7 +349,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/
 https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/31.1.1/manifest-merger-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/common/26.0.1/common-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/common/26.2.1/common-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/common/26.5.3/common-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/common/26.5.4/common-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/common/27.1.0/common-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/common/30.0.4/common-30.0.4.pom
@@ -374,7 +357,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/common/30.3.1/common-3
 https://dl.google.com/dl/android/maven2/com/android/tools/common/31.1.1/common-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/26.0.1/ddmlib-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/26.2.1/ddmlib-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/26.5.3/ddmlib-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/26.5.4/ddmlib-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/27.1.0/ddmlib-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/30.0.4/ddmlib-30.0.4.pom
@@ -383,7 +365,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/30.3.1/ddm
 https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/31.1.1/ddmlib-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/dvlib/26.0.1/dvlib-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/dvlib/26.2.1/dvlib-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/dvlib/26.5.3/dvlib-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/dvlib/26.5.4/dvlib-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/dvlib/27.1.0/dvlib-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/dvlib/30.0.4/dvlib-30.0.4.pom
@@ -397,7 +378,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/external/org-jetbrains
 https://dl.google.com/dl/android/maven2/com/android/tools/external/org-jetbrains/uast/31.1.1/uast-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/layoutlib/layoutlib-api/26.0.1/layoutlib-api-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/layoutlib/layoutlib-api/26.2.1/layoutlib-api-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/layoutlib/layoutlib-api/26.5.3/layoutlib-api-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/layoutlib/layoutlib-api/26.5.4/layoutlib-api-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/layoutlib/layoutlib-api/27.1.0/layoutlib-api-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/layoutlib/layoutlib-api/30.0.4/layoutlib-api-30.0.4.pom
@@ -409,7 +389,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-api/31.1.1/l
 https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-checks/26.0.1/lint-checks-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-checks/31.1.1/lint-checks-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-gradle-api/26.2.1/lint-gradle-api-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-gradle-api/26.5.3/lint-gradle-api-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-gradle-api/26.5.4/lint-gradle-api-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-gradle-api/27.1.0/lint-gradle-api-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-gradle/31.1.1/lint-gradle-31.1.1.pom
@@ -426,7 +405,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint/31.1.1/lint-
 https://dl.google.com/dl/android/maven2/com/android/tools/play-sdk-proto/31.1.1/play-sdk-proto-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/repository/26.0.1/repository-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/repository/26.2.1/repository-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/repository/26.5.3/repository-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/repository/26.5.4/repository-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/repository/27.1.0/repository-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/repository/30.0.4/repository-30.0.4.pom
@@ -435,7 +413,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/repository/30.3.1/repo
 https://dl.google.com/dl/android/maven2/com/android/tools/repository/31.1.1/repository-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/26.0.1/sdklib-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/26.2.1/sdklib-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/26.5.3/sdklib-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/26.5.4/sdklib-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/27.1.0/sdklib-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/30.0.4/sdklib-30.0.4.pom
@@ -444,7 +421,6 @@ https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/30.3.1/sdklib-3
 https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/31.1.1/sdklib-31.1.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/sdk-common/26.0.1/sdk-common-26.0.1.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/sdk-common/26.2.1/sdk-common-26.2.1.pom
-https://dl.google.com/dl/android/maven2/com/android/tools/sdk-common/26.5.3/sdk-common-26.5.3.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/sdk-common/26.5.4/sdk-common-26.5.4.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/sdk-common/27.1.0/sdk-common-27.1.0.pom
 https://dl.google.com/dl/android/maven2/com/android/tools/sdk-common/30.0.4/sdk-common-30.0.4.pom
@@ -487,7 +463,6 @@ https://dl.google.com/dl/android/maven2/com/google/testing/platform/core-proto/0
 https://dl.google.com/dl/android/maven2/com/google/testing/platform/core-proto/0.0.8-alpha07/core-proto-0.0.8-alpha07.pom
 https://dl.google.com/dl/android/maven2/com/google/testing/platform/core-proto/0.0.8-alpha08/core-proto-0.0.8-alpha08.pom
 https://dl.google.com/dl/android/maven2/com/google/test/platform/core-proto/0.0.2-dev/core-proto-0.0.2-dev.pom
-https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom
 https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.4/BlurView-version-2.0.4.pom
 https://jitpack.io/com/github/status-im/function/0.0.1/function-0.0.1.pom
 https://jitpack.io/com/github/status-im/status-keycard-java/android/3.1.1/android-3.1.1.pom
@@ -495,7 +470,6 @@ https://jitpack.io/com/github/status-im/status-keycard-java/lib/3.1.1/lib-3.1.1.
 https://jitpack.io/com/github/wix-playground/ahbottomnavigation/3.3.0/ahbottomnavigation-3.3.0.pom
 https://jitpack.io/com/github/wix-playground/reflow-animator/1.0.6/reflow-animator-1.0.6.pom
 https://jitpack.io/com/github/yalantis/ucrop/2.2.6-native/ucrop-2.2.6-native.pom
-https://plugins.gradle.org/m2/com/adarshr/gradle-test-logger-plugin/2.0.0/gradle-test-logger-plugin-2.0.0.pom
 https://plugins.gradle.org/m2/org/gradle/toolchains/foojay-resolver-convention/org.gradle.toolchains.foojay-resolver-convention.gradle.plugin/0.5.0/org.gradle.toolchains.foojay-resolver-convention.gradle.plugin-0.5.0.pom
 https://plugins.gradle.org/m2/org/gradle/toolchains/foojay-resolver/0.5.0/foojay-resolver-0.5.0.pom
 https://repo.maven.apache.org/maven2/antlr/antlr/2.7.1/antlr-2.7.1.pom
@@ -1119,9 +1093,6 @@ https://repo.maven.apache.org/maven2/org/eclipse/jgit/org.eclipse.jgit-parent/5.
 https://repo.maven.apache.org/maven2/org/eclipse/jgit/org.eclipse.jgit-parent/5.13.1.202206130422-r/org.eclipse.jgit-parent-5.13.1.202206130422-r.pom
 https://repo.maven.apache.org/maven2/org/eclipse/jgit/org.eclipse.jgit/5.13.0.202109080827-r/org.eclipse.jgit-5.13.0.202109080827-r.pom
 https://repo.maven.apache.org/maven2/org/eclipse/jgit/org.eclipse.jgit/5.13.1.202206130422-r/org.eclipse.jgit-5.13.1.202206130422-r.pom
-https://repo.maven.apache.org/maven2/org/fusesource/fusesource-pom/1.11/fusesource-pom-1.11.pom
-https://repo.maven.apache.org/maven2/org/fusesource/jansi/jansi-project/1.18/jansi-project-1.18.pom
-https://repo.maven.apache.org/maven2/org/fusesource/jansi/jansi/1.18/jansi-1.18.pom
 https://repo.maven.apache.org/maven2/org/glassfish/jaxb/jaxb-bom/2.2.11/jaxb-bom-2.2.11.pom
 https://repo.maven.apache.org/maven2/org/glassfish/jaxb/jaxb-bom/2.3.1/jaxb-bom-2.3.1.pom
 https://repo.maven.apache.org/maven2/org/glassfish/jaxb/jaxb-bom/2.3.2/jaxb-bom-2.3.2.pom

--- a/nix/deps/gradle/deps.urls
+++ b/nix/deps/gradle/deps.urls
@@ -488,6 +488,7 @@ https://dl.google.com/dl/android/maven2/com/google/testing/platform/core-proto/0
 https://dl.google.com/dl/android/maven2/com/google/testing/platform/core-proto/0.0.8-alpha08/core-proto-0.0.8-alpha08.pom
 https://dl.google.com/dl/android/maven2/com/google/test/platform/core-proto/0.0.2-dev/core-proto-0.0.2-dev.pom
 https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom
+https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.4/BlurView-version-2.0.4.pom
 https://jitpack.io/com/github/status-im/function/0.0.1/function-0.0.1.pom
 https://jitpack.io/com/github/status-im/status-keycard-java/android/3.1.1/android-3.1.1.pom
 https://jitpack.io/com/github/status-im/status-keycard-java/lib/3.1.1/lib-3.1.1.pom
@@ -509,7 +510,7 @@ https://repo.maven.apache.org/maven2/commons-io/commons-io/2.4/commons-io-2.4.po
 https://repo.maven.apache.org/maven2/commons-io/commons-io/2.16.1/commons-io-2.16.1.pom
 https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.pom
 https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.pom
-https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.3.3/commons-logging-1.3.3.pom
+https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.3.4/commons-logging-1.3.4.pom
 https://repo.maven.apache.org/maven2/com/adobe/xmp/xmpcore/6.1.11/xmpcore-6.1.11.pom
 https://repo.maven.apache.org/maven2/com/afollestad/material-dialogs/commons/0.9.6.0/commons-0.9.6.0.pom
 https://repo.maven.apache.org/maven2/com/afollestad/material-dialogs/core/0.9.6.0/core-0.9.6.0.pom
@@ -693,7 +694,7 @@ https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotatio
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.10.0/error_prone_annotations-2.10.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.11.0/error_prone_annotations-2.11.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.27.0/error_prone_annotations-2.27.0.pom
-https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.29.2/error_prone_annotations-2.29.2.pom
+https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.30.0/error_prone_annotations-2.30.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.0.18/error_prone_parent-2.0.18.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.2.0/error_prone_parent-2.2.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.3.1/error_prone_parent-2.3.1.pom
@@ -706,7 +707,7 @@ https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.10.0/error_prone_parent-2.10.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.11.0/error_prone_parent-2.11.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.27.0/error_prone_parent-2.27.0.pom
-https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.29.2/error_prone_parent-2.29.2.pom
+https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.30.0/error_prone_parent-2.30.0.pom
 https://repo.maven.apache.org/maven2/com/google/flatbuffers/flatbuffers-java/1.12.0/flatbuffers-java-1.12.0.pom
 https://repo.maven.apache.org/maven2/com/google/google/1/google-1.pom
 https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom
@@ -723,8 +724,8 @@ https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/30.1-jre/guav
 https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/31.0.1-android/guava-parent-31.0.1-android.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/31.0.1-jre/guava-parent-31.0.1-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/31.1-jre/guava-parent-31.1-jre.pom
-https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.2.1-jre/guava-parent-33.2.1-jre.pom
-https://repo.maven.apache.org/maven2/com/google/guava/guava-testlib/33.2.1-jre/guava-testlib-33.2.1-jre.pom
+https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/33.3.0-jre/guava-parent-33.3.0-jre.pom
+https://repo.maven.apache.org/maven2/com/google/guava/guava-testlib/33.3.0-jre/guava-testlib-33.3.0-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/17.0/guava-17.0.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/22.0/guava-22.0.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/23.0/guava-23.0.pom
@@ -737,7 +738,7 @@ https://repo.maven.apache.org/maven2/com/google/guava/guava/30.1-jre/guava-30.1-
 https://repo.maven.apache.org/maven2/com/google/guava/guava/31.0.1-android/guava-31.0.1-android.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/31.1-jre/guava-31.1-jre.pom
-https://repo.maven.apache.org/maven2/com/google/guava/guava/33.2.1-jre/guava-33.2.1-jre.pom
+https://repo.maven.apache.org/maven2/com/google/guava/guava/33.3.0-jre/guava-33.3.0-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/1.0/listenablefuture-1.0.pom
 https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom
 https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom
@@ -751,7 +752,7 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.13.0/pro
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.17.2/protobuf-bom-3.17.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.19.2/protobuf-bom-3.19.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.19.3/protobuf-bom-3.19.3.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/4.28.0-RC1/protobuf-bom-4.28.0-RC1.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/4.28.0-RC2/protobuf-bom-4.28.0-RC2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-javalite/3.17.2/protobuf-javalite-3.17.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-javalite/3.19.2/protobuf-javalite-3.19.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java-util/3.4.0/protobuf-java-util-3.4.0.pom
@@ -768,7 +769,7 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.13.0/pr
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.17.2/protobuf-java-3.17.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.19.2/protobuf-java-3.19.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/3.19.3/protobuf-java-3.19.3.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/4.28.0-RC1/protobuf-java-4.28.0-RC1.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-java/4.28.0-RC2/protobuf-java-4.28.0-RC2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-lite/3.0.1/protobuf-lite-3.0.1.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.0.0/protobuf-parent-3.0.0.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.4.0/protobuf-parent-3.4.0.pom
@@ -779,7 +780,7 @@ https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.13.0/
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.17.2/protobuf-parent-3.17.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.19.2/protobuf-parent-3.19.2.pom
 https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/3.19.3/protobuf-parent-3.19.3.pom
-https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/4.28.0-RC1/protobuf-parent-4.28.0-RC1.pom
+https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-parent/4.28.0-RC2/protobuf-parent-4.28.0-RC2.pom
 https://repo.maven.apache.org/maven2/com/google/truth/truth-parent/1.4.4/truth-parent-1.4.4.pom
 https://repo.maven.apache.org/maven2/com/google/truth/truth/1.4.4/truth-1.4.4.pom
 https://repo.maven.apache.org/maven2/com/google/zxing/core/3.4.1/core-3.4.1.pom
@@ -954,11 +955,11 @@ https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/1.14.15/byte
 https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.11.13/byte-buddy-parent-1.11.13.pom
 https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.11.19/byte-buddy-parent-1.11.19.pom
 https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.14.15/byte-buddy-parent-1.14.15.pom
-https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.14.17/byte-buddy-parent-1.14.17.pom
+https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.14.18/byte-buddy-parent-1.14.18.pom
 https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.11.13/byte-buddy-1.11.13.pom
 https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.11.19/byte-buddy-1.11.19.pom
 https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.14.15/byte-buddy-1.14.15.pom
-https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.14.17/byte-buddy-1.14.17.pom
+https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.14.18/byte-buddy-1.14.18.pom
 https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.6.0/jna-platform-5.6.0.pom
 https://repo.maven.apache.org/maven2/net/java/dev/jna/jna/5.6.0/jna-5.6.0.pom
 https://repo.maven.apache.org/maven2/net/java/jvnet-parent/1/jvnet-parent-1.pom
@@ -982,8 +983,8 @@ https://repo.maven.apache.org/maven2/org/abego/treelayout/org.abego.treelayout.c
 https://repo.maven.apache.org/maven2/org/antlr/ST4/4.0.8/ST4-4.0.8.pom
 https://repo.maven.apache.org/maven2/org/antlr/ST4/4.3.4/ST4-4.3.4.pom
 https://repo.maven.apache.org/maven2/org/antlr/antlr4-master/4.5.3/antlr4-master-4.5.3.pom
-https://repo.maven.apache.org/maven2/org/antlr/antlr4-master/4.13.1/antlr4-master-4.13.1.pom
-https://repo.maven.apache.org/maven2/org/antlr/antlr4-runtime/4.13.1/antlr4-runtime-4.13.1.pom
+https://repo.maven.apache.org/maven2/org/antlr/antlr4-master/4.13.2/antlr4-master-4.13.2.pom
+https://repo.maven.apache.org/maven2/org/antlr/antlr4-runtime/4.13.2/antlr4-runtime-4.13.2.pom
 https://repo.maven.apache.org/maven2/org/antlr/antlr4/4.5.3/antlr4-4.5.3.pom
 https://repo.maven.apache.org/maven2/org/antlr/antlr-master/3.3/antlr-master-3.3.pom
 https://repo.maven.apache.org/maven2/org/antlr/antlr-master/3.5.2/antlr-master-3.5.2.pom
@@ -1004,6 +1005,7 @@ https://repo.maven.apache.org/maven2/org/apache/apache/21/apache-21.pom
 https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom
 https://repo.maven.apache.org/maven2/org/apache/apache/31/apache-31.pom
 https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom
+https://repo.maven.apache.org/maven2/org/apache/apache/33/apache-33.pom
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.8.1/commons-compress-1.8.1.pom
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.12/commons-compress-1.12.pom
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20.pom
@@ -1024,6 +1026,7 @@ https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/48/common
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/52/commons-parent-52.pom
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/69/commons-parent-69.pom
 https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/71/commons-parent-71.pom
+https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/72/commons-parent-72.pom
 https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.1.1/httpclient-4.1.1.pom
 https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.2.6/httpclient-4.2.6.pom
 https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2.pom
@@ -1078,7 +1081,7 @@ https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.8.1/che
 https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.11.1/checker-qual-2.11.1.pom
 https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.5.0/checker-qual-3.5.0.pom
 https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.12.0/checker-qual-3.12.0.pom
-https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.45.0/checker-qual-3.45.0.pom
+https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.46.0/checker-qual-3.46.0.pom
 https://repo.maven.apache.org/maven2/org/codehaus/codehaus-parent/4/codehaus-parent-4.pom
 https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-xml/3.0.9/groovy-xml-3.0.9.pom
 https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-xml/3.0.10/groovy-xml-3.0.10.pom
@@ -1101,8 +1104,8 @@ https://repo.maven.apache.org/maven2/org/codehaus/mojo/mojo-parent/84/mojo-paren
 https://repo.maven.apache.org/maven2/org/codehaus/woodstox/stax2-api/4.2.1/stax2-api-4.2.1.pom
 https://repo.maven.apache.org/maven2/org/easymock/easymockclassextension/3.2/easymockclassextension-3.2.pom
 https://repo.maven.apache.org/maven2/org/easymock/easymock-parent/3.2/easymock-parent-3.2.pom
-https://repo.maven.apache.org/maven2/org/easymock/easymock-parent/5.3.0/easymock-parent-5.3.0.pom
-https://repo.maven.apache.org/maven2/org/easymock/easymock/5.3.0/easymock-5.3.0.pom
+https://repo.maven.apache.org/maven2/org/easymock/easymock-parent/5.4.0/easymock-parent-5.4.0.pom
+https://repo.maven.apache.org/maven2/org/easymock/easymock/5.4.0/easymock-5.4.0.pom
 https://repo.maven.apache.org/maven2/org/eclipse/angus/angus-activation-project/2.0.2/angus-activation-project-2.0.2.pom
 https://repo.maven.apache.org/maven2/org/eclipse/angus/angus-activation/2.0.2/angus-activation-2.0.2.pom
 https://repo.maven.apache.org/maven2/org/eclipse/ee4j/project/1.0.2/project-1.0.2.pom
@@ -1133,10 +1136,10 @@ https://repo.maven.apache.org/maven2/org/glassfish/jaxb/txw2/2.3.1/txw2-2.3.1.po
 https://repo.maven.apache.org/maven2/org/glassfish/jaxb/txw2/2.3.2/txw2-2.3.2.pom
 https://repo.maven.apache.org/maven2/org/glassfish/jaxb/txw2/4.0.5/txw2-4.0.5.pom
 https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom
-https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/3.0-rc1/hamcrest-core-3.0-rc1.pom
+https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/3.0/hamcrest-core-3.0.pom
 https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom
 https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest/2.2/hamcrest-2.2.pom
-https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest/3.0-rc1/hamcrest-3.0-rc1.pom
+https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest/3.0/hamcrest-3.0.pom
 https://repo.maven.apache.org/maven2/org/jacoco/org.jacoco.build/0.7.4.201502262128/org.jacoco.build-0.7.4.201502262128.pom
 https://repo.maven.apache.org/maven2/org/jacoco/org.jacoco.build/0.8.12/org.jacoco.build-0.8.12.pom
 https://repo.maven.apache.org/maven2/org/jacoco/org.jacoco.core/0.7.4.201502262128/org.jacoco.core-0.7.4.201502262128.pom
@@ -1236,7 +1239,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.20/kotlin-reflect-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.7.22/kotlin-reflect-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.8.20-RC2/kotlin-reflect-1.8.20-RC2.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.0.20-Beta2/kotlin-reflect-2.0.20-Beta2.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.0.20-RC2/kotlin-reflect-2.0.20-RC2.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.6.20/kotlin-scripting-common-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.7.22/kotlin-scripting-common-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.8.0/kotlin-scripting-common-1.8.0.pom
@@ -1341,7 +1344,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.8.20-R
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.8.21/kotlin-stdlib-1.8.21.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.0/kotlin-stdlib-1.9.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.21/kotlin-stdlib-1.9.21.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.0.20-Beta2/kotlin-stdlib-2.0.20-Beta2.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.0.20-RC2/kotlin-stdlib-2.0.20-RC2.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/1.7.22/kotlin-tooling-core-1.7.22.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/1.8.0/kotlin-tooling-core-1.8.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/1.9.0/kotlin-tooling-core-1.9.0.pom
@@ -1361,7 +1364,7 @@ https://repo.maven.apache.org/maven2/org/json/json/20180813/json-20180813.pom
 https://repo.maven.apache.org/maven2/org/json/json/20240303/json-20240303.pom
 https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.13.1/jsoup-1.13.1.pom
 https://repo.maven.apache.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.pom
-https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.0-M2/junit-bom-5.11.0-M2.pom
+https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.0/junit-bom-5.11.0.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.7.7/stax-ex-1.7.7.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.8/stax-ex-1.8.pom

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -49,13 +49,6 @@ let
         export ANDROID_SDK_ROOT="${pkgs.androidPkgs.sdk}"
         export ANDROID_NDK_ROOT="${pkgs.androidPkgs.ndk}"
 
-        export STATUS_MOBILE_HOME=$(git rev-parse --show-toplevel)
-        # WARNING: Unpatched Node.js deps allow Gradle to use remote repos.
-        "$STATUS_MOBILE_HOME/nix/scripts/node_modules.sh" ${pkgs.deps.nodejs}
-        function restore_patched_modules() {
-          "$STATUS_MOBILE_HOME/nix/scripts/node_modules.sh" ${pkgs.deps.nodejs-patched}
-        }
-        trap restore_patched_modules EXIT
       '';
     };
 

--- a/patches/build.gradle.patch
+++ b/patches/build.gradle.patch
@@ -1,0 +1,9 @@
+--- /tmp/tmp-status-mobile-215e516b2/tmp.iCGv95VzNg/build.gradle	2024-08-20 19:39:24.147334000 +0530
++++ ./node_modules/@react-native-community/blur/android/build.gradle	2024-08-20 19:39:27.720555147 +0530
+@@ -138,5 +138,5 @@
+   implementation "com.facebook.react:react-native:+"
+   // From node_modules
+ 
+-  implementation 'com.github.Dimezis:BlurView:version-2.0.3'
++  implementation 'com.github.Dimezis:BlurView:version-2.0.4'
+ }


### PR DESCRIPTION
## Summary

This PR patches blur view library to use 
`com.github.Dimezis:BlurView:version-2.0.4` instead of `com.github.Dimezis:BlurView:version-2.0.3`

version 2.0.4 seems more reliable : 
```
> curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.4/BlurView-version-2.0.4.pom | md5sum
bc6f937d2ba82396257f6fc5f5247c0d  -

> curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.4/BlurView-version-2.0.4.pom | md5sum
bc6f937d2ba82396257f6fc5f5247c0d  -

> curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.4/BlurView-version-2.0.4.pom | md5sum
bc6f937d2ba82396257f6fc5f5247c0d  -

> curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.4/BlurView-version-2.0.4.pom | md5sum
bc6f937d2ba82396257f6fc5f5247c0d  -

> curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.4/BlurView-version-2.0.4.pom | md5sum
bc6f937d2ba82396257f6fc5f5247c0d  -

> curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.4/BlurView-version-2.0.4.pom | md5sum
bc6f937d2ba82396257f6fc5f5247c0d  -

> curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.4/BlurView-version-2.0.4.pom | md5sum
bc6f937d2ba82396257f6fc5f5247c0d  -
```

In this PR we also make sure that gradle deps are generated for patched nodejs deps.

## Platforms

- Android

status: ready