### PR TITLE
chore: Skip flaky audio-player component tests

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/content/audio/component_spec.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/audio/component_spec.cljs
@@ -26,7 +26,7 @@
     (h/render [audio-message/audio-message message context])
     (h/is-truthy (h/get-by-label-text :audio-message-container)))
 
-  (h/test "press play calls audio/toggle-playpause-player"
+  (h/test-skip "press play calls audio/toggle-playpause-player"
     (with-redefs [audio/toggle-playpause-player     (js/jest.fn)
                   audio/new-player                  (fn [_ _ _] {})
                   audio/prepare-player              (fn [_ on-success _] (on-success))


### PR DESCRIPTION
### Summary

* This PR attempts to skip the component tests related to testing the rendering and playback of the audio-message component. At the moment, the tests appear to be flaky, so we're disabling them temporarily until we can fix them.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Non-functional

- Test coverage

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
