### PR TITLE
fix_: Blank screen on input pages when navigating back with keyboard open

### DIFF
--- a/src/status_im/common/floating_button_page/view.cljs
+++ b/src/status_im/common/floating_button_page/view.cljs
@@ -61,7 +61,7 @@
 (defn view
   [{:keys [header footer customization-color footer-container-padding header-container-style
            content-container-style gradient-cover? keyboard-should-persist-taps shell-overlay?
-           blur-options content-avoid-keyboard?]
+           blur-options content-avoid-keyboard? automatically-adjust-keyboard-insets]
     :or   {footer-container-padding (safe-area/get-top)}}
    & children]
   (reagent/with-let [scroll-view-ref              (atom nil)
@@ -123,7 +123,7 @@
            :scroll-event-throttle                64
            :content-container-style              {:flex-grow 1}
            :always-bounce-vertical               @keyboard-did-show?
-           :automatically-adjust-keyboard-insets true
+           :automatically-adjust-keyboard-insets automatically-adjust-keyboard-insets
            :shows-vertical-scroll-indicator      false
            :keyboard-should-persist-taps         keyboard-should-persist-taps}
           (into [rn/view

--- a/src/status_im/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im/contexts/onboarding/create_password/view.cljs
@@ -193,6 +193,7 @@
      {:header [page-nav]
       :keyboard-should-persist-taps :handled
       :content-avoid-keyboard? true
+      :automatically-adjust-keyboard-insets true
       :blur-options
       {:blur-amount        34
        :blur-radius        20


### PR DESCRIPTION
fixes #21092
fixes #20983

### Summary

This PR fixes the blank screen shown on pages with inputs when navigating back to that screen with the keyboard open.

https://github.com/user-attachments/assets/f3f98cd0-0d8d-48ae-b13c-3af97a651c0d

### Review notes

The issue is due to the floating-button page, which has a prop `automatically-adjust-keyboard-insets` that adds insets to the content in IOS. This prop was introduced to the floating button page directly in PR https://github.com/status-im/status-mobile/pull/20645 for the create password screen in onboarding. This PR safely makes the prop to be controlled by the screen/parent. 

#### Platforms

- iOS

### Steps to test

- Open Status
- Navigate to `Profile > Wallet > Saved addresses > +`
- Tap on scan (`[-]`) and try to scan a address
- Verify the address is shown in the input field and that the screen is not blank

status: ready
