### PR TITLE
Fix: app upgrade issues in wallet

### DIFF
--- a/src/status_im/contexts/wallet/sheets/account_options/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/account_options/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.wallet.sheets.account-options.view
-  (:require [oops.core :as oops]
+  (:require [clojure.string :as string]
+            [oops.core :as oops]
             [quo.core :as quo]
             [quo.foundations.colors :as colors]
             quo.theme
@@ -33,6 +34,7 @@
   [{:keys [theme show-account-selector? options-height]}]
   (let [{:keys [name color emoji address watch-only?
                 default-account?]} (rf/sub [:wallet/current-viewing-account])
+        {:keys [derived-from]}     (rf/sub [:wallet/current-viewing-account-keypair])
         network-preference-details (rf/sub [:wallet/network-preference-details])
         multichain-address         (utils/get-multichain-address
                                     network-preference-details
@@ -89,7 +91,7 @@
                                  #(rf/dispatch [:wallet/share-account
                                                 {:title share-title :content multichain-address}])
                                  600))}
-        (when-not default-account?
+        (when-not (or default-account? (string/blank? derived-from))
           {:add-divider?        (not show-account-selector?)
            :icon                :i/delete
            :accessibility-label :remove-account

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -210,7 +210,7 @@
  :wallet/fully-operable-keypairs-list
  :<- [:wallet/keypairs-list]
  (fn [keypairs]
-   (filter #(= :fully (:lowest-operability %)) keypairs)))
+   (filter #(and (= :fully (:lowest-operability %)) (not-empty (:derived-from %))) keypairs)))
 
 (rf/reg-sub
  :wallet/keypair-names


### PR DESCRIPTION
fixes #21103

### Summary

This PR:
 - hides keypairs with empty origin in selection while creating an account
 - hides remove account button for accounts with empty origin

#### Platforms

- Android
- iOS

### Steps to test

- Install V1
- Import new account using private key / seed phrase
- Upgrade to V2
- Verify you can not create a derived account based on the key imported pair
- Verify you can not remove the imported account

status: ready 
