### PR TITLE
fixes Not visible status bar on light theme

### DIFF
--- a/src/legacy/status_im/multiaccounts/logout/core.cljs
+++ b/src/legacy/status_im/multiaccounts/logout/core.cljs
@@ -30,7 +30,7 @@
   [{:keys [db] :as cofx} {:keys [auth-method logout?]}]
   (let [key-uid (get-in db [:profile/profile :key-uid])]
     (rf/merge cofx
-              {:dispatch                               [:init-root :progress]
+              {:dispatch                               [:update-theme-and-init-root :progress]
                :effects.shell/reset-state              nil
                :hide-popover                           nil
                ::logout                                nil

--- a/src/status_im/contexts/onboarding/events.cljs
+++ b/src/status_im/contexts/onboarding/events.cljs
@@ -91,7 +91,7 @@
     (merge
      {:db (assoc db :profile/profiles-overview multiaccounts)}
      (when-not (seq multiaccounts)
-       {:dispatch [:init-root :screen/onboarding.intro]}))))
+       {:dispatch [:update-theme-and-init-root :screen/onboarding.intro]}))))
 
 (rf/defn password-set
   {:events [:onboarding/password-set]}

--- a/src/status_im/contexts/onboarding/welcome/view.cljs
+++ b/src/status_im/contexts/onboarding/welcome/view.cljs
@@ -45,7 +45,7 @@
           :colors [colors/neutral-100-opa-0 colors/neutral-100-opa-80]}])
       [quo/button
        {:on-press            (fn []
-                               (rf/dispatch [:init-root :shell-stack])
+                               (rf/dispatch [:update-theme-and-init-root :shell-stack])
                                (rf/dispatch [:profile/show-testnet-mode-banner-if-enabled])
                                (rf/dispatch [:universal-links/process-stored-event]))
         :type                :primary

--- a/src/status_im/contexts/preview/quo/common.cljs
+++ b/src/status_im/contexts/preview/quo/common.cljs
@@ -25,4 +25,4 @@
                      (rf/dispatch [:navigate-back])
                      (do
                        (rf/dispatch [:theme/switch {:theme :dark}])
-                       (rf/dispatch [:init-root root])))}]))
+                       (rf/dispatch [:update-theme-and-init-root root])))}]))

--- a/src/status_im/contexts/profile/events.cljs
+++ b/src/status_im/contexts/profile/events.cljs
@@ -53,7 +53,7 @@
                     (assoc :profile/profiles-overview profiles)
                     (update :profile/login #(select-profile % key-uid)))
                 db-with-settings)
-          :fx [[:dispatch [:init-root :screen/profile.profiles]]
+          :fx [[:dispatch [:update-theme-and-init-root :screen/profile.profiles]]
                (when (and key-uid userConfirmed)
                  [:effects.biometric/check-if-available
                   {:key-uid    key-uid
@@ -61,7 +61,7 @@
                                  (rf/dispatch [:profile.login/check-biometric-success key-uid
                                                auth-method]))}])]})
        {:db db-with-settings
-        :fx [[:dispatch [:init-root :screen/onboarding.intro]]]}))))
+        :fx [[:dispatch [:update-theme-and-init-root :screen/onboarding.intro]]]}))))
 
 (rf/reg-event-fx
  :profile/update-setting-from-backup

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -73,13 +73,13 @@
 
                 (cond
                   pairing-completed?
-                  [[:dispatch [:init-root :screen/onboarding.syncing-results]]]
+                  [[:dispatch [:update-theme-and-init-root :screen/onboarding.syncing-results]]]
 
                   (get db :onboarding/new-account?)
                   [[:dispatch [:onboarding/finalize-setup]]]
 
                   :else
-                  [[:dispatch [:init-root :shell-stack]]
+                  [[:dispatch [:update-theme-and-init-root :shell-stack]]
                    [:dispatch [:profile/show-testnet-mode-banner-if-enabled]]]))})))
 
 ;; login phase 2: we want to load and show chats faster, so we split login into 2 phases
@@ -185,7 +185,7 @@
      {:db (-> db
               (assoc-in [:profile/login :password] password)
               (assoc-in [:profile/login :processing] true))
-      :fx [[:dispatch [:init-root :progress]]
+      :fx [[:dispatch [:update-theme-and-init-root :progress]]
            [:effects.profile/login
             [(get-in db [:profile/login :key-uid])
              (security/safe-unmask-data password)]]]})))

--- a/src/status_im/navigation/core.cljs
+++ b/src/status_im/navigation/core.cljs
@@ -29,7 +29,7 @@
      (re-frame/dispatch [:bottom-sheet-hidden])
      (when @state/root-id
        (reset! theme/device-theme (rn/get-color-scheme))
-       (re-frame/dispatch [:init-root @state/root-id])
+       (re-frame/dispatch [:update-theme-and-init-root @state/root-id])
        (re-frame/dispatch [:chat/check-last-chat])
        (re-frame/dispatch [:alert-banners/restore-alert-banners]))
      (rn/hide-splash-screen)))

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -74,7 +74,6 @@
    (let [[status-bar-theme] (get-status-nav-color root-id theme)
          root               (get (roots/roots status-bar-theme) root-id)]
      (dismiss-all-modals)
-     (rf/dispatch [:theme/switch {:view-id root-id}])
      (reset! state/root-id (or (get-in root [:root :stack :id]) root-id))
      (navigation/set-root root)
      (state/navigation-state-reset [{:id   root-id

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -70,6 +70,7 @@
     (assoc :dispatch [:chat/close (:current-chat-id db)])))
 
 (rf/defn init-root
+  "WARNING: Use `:update-theme-and-init-root` instead. `:init-root` should not be used directly."
   {:events [:init-root]}
   [{:keys [db]} root-id]
   {:set-root [root-id (:theme db)]})

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -74,6 +74,12 @@
   [{:keys [db]} root-id]
   {:set-root [root-id (:theme db)]})
 
+(rf/defn update-theme-and-init-root
+  {:events [:update-theme-and-init-root]}
+  [_ root-id]
+  {:fx [[:dispatch [:theme/switch {:view-id root-id}]]
+        [:dispatch [:init-root root-id]]]})
+
 (rf/defn change-tab
   {:events [:navigate-change-tab]}
   [{:keys [db]} stack-id]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21101

### Summary
The issue occurred because we updated the theme value after setting the root (not before), which caused the root to be initialized with the old theme value.

PR only addresses bug fixing because its urgent. Other improvements related to naming and doc-string are done in https://github.com/status-im/status-mobile/pull/21107

status: ready