### PR TITLE
ci: use default IPFS Gateway URL

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 import groovy.json.JsonBuilder
 

--- a/ci/Jenkinsfile.e2e-nightly
+++ b/ci/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.9'
+library 'status-jenkins-lib@v1.9.10'
 
 pipeline {
   agent {


### PR DESCRIPTION
## Summary

This PR removes the config for setting IPFS Gateway URL.
The default in status-go is `https://ipfs.status.im/` which works well.

fixes : https://github.com/status-im/status-mobile/issues/20958

## Testing notes
Please test stickers in PR builds and in release builds.

## Additional notes
This PR should only be merged after https://github.com/status-im/status-jenkins-lib/pull/98 is merged and a tagged version is present in this PR.

## Platforms
- Android
- iOS

status: ready
