### PR TITLE
[#21117] More privacy policy links

### DIFF
--- a/src/status_im/common/metrics_confirmation_modal/style.cljs
+++ b/src/status_im/common/metrics_confirmation_modal/style.cljs
@@ -4,7 +4,7 @@
   {:margin-top        11
    :margin-horizontal 20
    :gap               21
-   :margin-bottom     15})
+   :margin-bottom     8})
 
 (def item-text
   {:margin-top  10
@@ -12,3 +12,9 @@
 
 (def info-text
   {:margin-top -5})
+
+(def privacy-policy
+  {:margin-top        4
+   :margin-horizontal 20
+   :margin-bottom     20
+   :align-items       :center})

--- a/src/status_im/common/metrics_confirmation_modal/view.cljs
+++ b/src/status_im/common/metrics_confirmation_modal/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.common.metrics-confirmation-modal.view
   (:require
     [quo.core :as quo]
+    [quo.foundations.colors :as colors]
     [quo.theme]
     [react-native.core :as rn]
     [status-im.common.metrics-confirmation-modal.style :as style]
@@ -52,14 +53,36 @@
   (toggle-metrics false)
   (hide-bottom-sheet))
 
+(declare view)
+
 (defn- on-privacy-policy-press
-  []
+  [settings?]
   (rf/dispatch
    [:show-bottom-sheet
-    {:content (fn []
-                [quo.theme/provider :dark
-                 [privacy/privacy-statement]])
-     :shell?  true}]))
+    {:content  (fn []
+                 [quo.theme/provider :dark
+                  [privacy/privacy-statement]])
+     :on-close (fn []
+                 (rf/dispatch [:show-bottom-sheet
+                               {:content (fn []
+                                           [quo.theme/provider :dark
+                                            [view {:settings? settings?}]])
+                                :shell?  true}]))
+     :shell?   true}]))
+
+(defn- privacy-policy-text
+  [settings?]
+  [rn/view {:style style/privacy-policy}
+   [quo/text
+    [quo/text
+     {:style {:color colors/white-opa-50}
+      :size  :paragraph-2}
+     (i18n/label :t/more-details-in-privacy-policy-1)]
+    [quo/text
+     {:size     :paragraph-2
+      :weight   :bold
+      :on-press #(on-privacy-policy-press settings?)}
+     (i18n/label :t/more-details-in-privacy-policy-2)]]])
 
 (defn view
   [{:keys [settings?]}]
@@ -79,22 +102,18 @@
       [quo/text
        {:size  :paragraph-2
         :style style/info-text}
-       (i18n/label :t/usage-data-shared-from-all-profiles)
-       (i18n/label :t/more-details-in-privacy-policy-1)
-       [quo/text
-        {:size     :paragraph-2
-         :weight   :bold
-         :on-press on-privacy-policy-press}
-        (i18n/label :t/more-details-in-privacy-policy-2)]]
+       (i18n/label :t/usage-data-shared-from-all-profiles)]
       [quo/text
        {:size  :paragraph-2
         :style style/info-text}
+       (i18n/label :t/usage-data-shared-from-all-profiles)
        (i18n/label :t/sharing-usage-data-can-be-turned-off)])]
    [quo/bottom-actions
     {:actions          :two-actions
      :blur?            true
      :button-one-label (i18n/label :t/share-usage-data)
      :button-one-props {:on-press on-share-usage}
-     :button-two-label (i18n/label (if settings? :t/do-not-share :t/not-now))
+     :button-two-label (i18n/label :t/not-now)
      :button-two-props {:type     :grey
-                        :on-press on-do-not-share}}]])
+                        :on-press on-do-not-share}}]
+   [privacy-policy-text settings?]])

--- a/src/status_im/contexts/onboarding/intro/style.cljs
+++ b/src/status_im/contexts/onboarding/intro/style.cljs
@@ -10,7 +10,7 @@
   {:flex           1
    :flex-direction :row
    :flex-wrap      :wrap
-   :align-self     :center})
+   :align-self     :flex-start})
 
 (def terms-privacy-container
   {:gap                8


### PR DESCRIPTION
fixes #21117

### Summary

This PR adds the provacy policy links to  the metrics modal (a.k.a. Help us improve Status).

This is the new behavior of the bottom sheet and it's being applied to all places where it's being used:

https://github.com/user-attachments/assets/e602dca2-91a7-4cd1-bc99-1addd9f9384f

### Review notes
Please check the flows specified in the issue description. The "Upgrade flow" doesn't exist.


#### Platforms

- Android
- iOS

status: ready