### PR TITLE
[#20803] fix: dapp session proposal reject

### DIFF
--- a/src/status_im/contexts/wallet/wallet_connect/responding_events.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/responding_events.cljs
@@ -168,11 +168,11 @@
  :wallet-connect/reject-session-proposal
  (fn [{:keys [db]} [proposal]]
    (let [web3-wallet                      (get db :wallet-connect/web3-wallet)
-         {:keys [request response-sent?]} (or proposal (:wallet-connect/current-proposal db))]
+         {:keys [request response-sent?]} (:wallet-connect/current-proposal db)]
      {:fx [(when-not response-sent?
              [:effects.wallet-connect/reject-session-proposal
               {:web3-wallet web3-wallet
-               :proposal    request
+               :proposal    (or proposal request)
                :on-success  #(log/info "Wallet Connect session proposal rejected")
                :on-error    #(log/error "Wallet Connect unable to reject session proposal")}])
            [:dispatch [:wallet-connect/reset-current-session-proposal]]]})))


### PR DESCRIPTION
fixes #20803

### Summary

I couldn’t reproduce the issue reported in #20803, but I did notice that it doesn’t send the reject event to the dapp, so I went ahead and fixed that part. The correct toast message already appears if the network is not supported.

#### Areas that maybe impacted

- Reject dapp pair request


### Steps to test

- Enable testmode in Status app
- https://rarible.com/connect remains on Mainnet
- Generate wallet connect QR
- Scan QR - tap connect


### Result


https://github.com/user-attachments/assets/7b1c7100-fd4f-4941-968b-1a95a0c80db5

<img src="https://github.com/user-attachments/assets/5c096490-cf26-4763-8d87-c8411d7bc393" width="390px"/>


status: ready

