### PR TITLE
[#20909] fix: dapp wrong network refusal

### DIFF
--- a/src/status_im/contexts/wallet/wallet_connect/core.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/core.cljs
@@ -52,9 +52,7 @@
   [proposal]
   (let [metadata (get-in proposal [:params :proposer :metadata])
         origin   (get-in proposal [:verifyContext :verified :origin])]
-    (if metadata
-      metadata
-      {:url origin})))
+    (or metadata {:url origin})))
 
 (defn get-current-request-dapp
   [request sessions]

--- a/src/status_im/contexts/wallet/wallet_connect/core.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/core.cljs
@@ -50,7 +50,11 @@
 
 (defn get-session-dapp-metadata
   [proposal]
-  (get-in proposal [:params :proposer :metadata]))
+  (let [metadata (get-in proposal [:params :proposer :metadata])
+        origin   (get-in proposal [:verifyContext :verified :origin])]
+    (if metadata
+      metadata
+      {:url origin})))
 
 (defn get-current-request-dapp
   [request sessions]

--- a/src/status_im/contexts/wallet/wallet_connect/events.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events.cljs
@@ -109,9 +109,12 @@
    (if (wallet-connect-core/event-should-be-handled? db event)
      {:fx [[:dispatch [:wallet-connect/process-session-request event]]]}
      {:fx [[:dispatch
+            [:wallet-connect/show-session-networks-unsupported-toast event]]
+           [:dispatch
             [:wallet-connect/send-response
-             {:error (wallet-connect/get-sdk-error
-                      constants/wallet-connect-user-rejected-chains-error-key)}]]]})))
+             {:request event
+              :error   (wallet-connect/get-sdk-error
+                        constants/wallet-connect-user-rejected-chains-error-key)}]]]})))
 
 (rf/reg-event-fx
  :wallet-connect/on-session-delete

--- a/src/status_im/contexts/wallet/wallet_connect/responding_events.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/responding_events.cljs
@@ -115,8 +115,9 @@
 
 (rf/reg-event-fx
  :wallet-connect/send-response
- (fn [{:keys [db]} [{:keys [result error]}]]
-   (when-let [{:keys [id topic] :as event} (get-in db [:wallet-connect/current-request :event])]
+ (fn [{:keys [db]} [{:keys [request result error]}]]
+   (when-let [{:keys [id topic] :as event} (or request
+                                               (get-in db [:wallet-connect/current-request :event]))]
      (let [method      (wallet-connect-core/get-request-method event)
            web3-wallet (get db :wallet-connect/web3-wallet)]
        {:db (assoc-in db [:wallet-connect/current-request :response-sent?] true)


### PR DESCRIPTION
fixes #20909
fixes #20910
### Summary

No error is shown when signing the event when user's network differs from event network


#### Areas that maybe impacted

- Dapps communication when network differ


### Steps to test

- Connect to https://react-app.walletconnect.com/ using testnetwork (Sepolia)
- Disable testmode and login the app
- Trigger personal_sign event
- Observe the result

### Before and after screenshots comparison
#### Before
Dapp was stuck in pending request modal and no notification in the app
![image](https://github.com/user-attachments/assets/8c72361d-27d9-4cc2-8116-7763c1165700)

#### After 

<img width="1481" alt="Screenshot 2024-08-23 at 18 48 24" src="https://github.com/user-attachments/assets/9d5e310e-80ac-4394-9376-ffe1a3c740b4">
<img width="390px" alt="Screenshot 2024-08-23 at 18 48 24" src="https://github.com/user-attachments/assets/7e0f405c-ddea-4621-900f-22a1de2793b2">


status: ready
