### PR TITLE
fix: change verbiage from privacy statement to privacy policy

### DIFF
--- a/src/status_im/contexts/onboarding/intro/view.cljs
+++ b/src/status_im/contexts/onboarding/intro/view.cljs
@@ -53,7 +53,7 @@
                                  :style    style/highlighted-text
                                  :size     :paragraph-2
                                  :weight   :medium}
-                                (i18n/label :t/intro-privacy-statement)]]]
+                                (i18n/label :t/intro-privacy-policy)]]]
        :button-one-label     (i18n/label :t/sync-or-recover-profile)
        :button-one-props     {:type                :dark-grey
                               :disabled?           (not terms-accepted?)

--- a/translations/en.json
+++ b/translations/en.json
@@ -1174,6 +1174,7 @@
   "instruction-after-qr-generated": "On your other device, navigate to the Syncing screen and select “Scan sync”",
   "insufficient-balance-to-cover-fee": "not enough balance to cover transaction fee",
   "intro-message1": "Welcome to Status!\nTap this message to set your password and get started.",
+  "intro-privacy-policy": "Privacy Policy",
   "intro-privacy-policy-note1": "Status does not collect or profit from your personal data. By continuing, you agree with the ",
   "intro-privacy-policy-note2": "privacy policy",
   "intro-privacy-statement": "Privacy Statement",


### PR DESCRIPTION
### Summary

* This PR changes the verbiage for the onboarding checkbox to say "Privacy Policy" instead of "Privacy Statement".

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Onboarding

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status without any profiles

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### After Changes

<img width="520" alt="Screenshot 2024-08-26 at 13 17 23" src="https://github.com/user-attachments/assets/205c3af6-ee61-4cd2-990c-bf7da64234db">

status: ready <!-- Can be ready or wip -->