### PR TITLE
fix(chats): Navigation after opening a profile link

### DIFF
--- a/src/status_im/contexts/chat/events.cljs
+++ b/src/status_im/contexts/chat/events.cljs
@@ -212,6 +212,11 @@
             #(when (group-chat? cofx chat-id)
                (loading/load-chat % chat-id))))
 
+(rf/reg-event-fx
+ :chat/clear-current-chat-id
+ (fn [{:keys [db]}]
+   {:db (dissoc db :current-chat-id)}))
+
 (rf/defn pop-to-root-and-navigate-to-chat
   {:events [:chat/pop-to-root-and-navigate-to-chat]}
   [cofx chat-id animation]

--- a/src/status_im/contexts/chat/messenger/messages/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/view.cljs
@@ -57,6 +57,7 @@
                                 chat-screen-layout-calculations-complete?}]
     (when *screen-loaded?*
       (rn/use-mount #(reset! *screen-loaded?* true)))
+    (rn/use-unmount #(rf/dispatch [:chat/clear-current-chat-id]))
     (when-not (if *screen-loaded?* @*screen-loaded?* screen-loaded?)
       (reanimated/set-shared-value chat-screen-layout-calculations-complete? false)
       (reanimated/set-shared-value distance-from-list-top 0)

--- a/src/status_im/contexts/chat/messenger/messages/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/view.cljs
@@ -57,7 +57,7 @@
                                 chat-screen-layout-calculations-complete?}]
     (when *screen-loaded?*
       (rn/use-mount #(reset! *screen-loaded?* true)))
-    (rn/use-unmount #(rf/dispatch [:chat/clear-current-chat-id]))
+    (rn/use-unmount #(rf/dispatch [:chat/close]))
     (when-not (if *screen-loaded?* @*screen-loaded?* screen-loaded?)
       (reanimated/set-shared-value chat-screen-layout-calculations-complete? false)
       (reanimated/set-shared-value distance-from-list-top 0)


### PR DESCRIPTION
fixes #21065

### Summary

The bug solved here is a side effect of the solution introduced in:
- https://github.com/status-im/status-mobile/pull/20326

It skips the navigation to a chat if the app is already in a chat. The problem arises when we navigate to a profile via a link because the app doesn't properly forget we are in a chat.

This PR removes the key `:current-chat-id` when the chat screen is unmounted, by doing this, we are always able to navigate to a chat.

### Review notes
@Parveshdhull Given https://github.com/status-im/status-mobile/pull/20326#pullrequestreview-2098208131 seems you know better about the solution implemented. Is this PR going in the right way? I tested it and seems to work, but I'd like to get your POV.

Seems the real solution for these issues is about actually fixing
- https://github.com/status-im/status-mobile/issues/20313. 

wdyt?

## Testing notes for QA

Due to the solution, we should test that the chat screen is always shown on every navigation interaction in both directions back and forth.

#### Platforms

- Android
- iOS


### Steps to test

Please check the issue to reproduce the error and check it's not happening again. Additionally, please test navigation interactions related to the chat screen are not affected.

status: ready