### PR TITLE
feat: autorefresh swap proposal

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -608,3 +608,4 @@
 (def ^:const transaction-status-failed "Failed")
 
 (def ^:const min-token-decimals-to-display 6)
+(def ^:const swap-proposal-refresh-interval-ms 15000)

--- a/src/status_im/subs/bottom_sheet.cljs
+++ b/src/status_im/subs/bottom_sheet.cljs
@@ -1,0 +1,8 @@
+(ns status-im.subs.bottom-sheet
+  (:require
+    [re-frame.core :as re-frame]))
+
+(re-frame/reg-sub
+ :bottom-sheet-sheets
+ :<- [:bottom-sheet]
+ :-> :sheets)

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -4,6 +4,7 @@
     status-im.subs.activity-center
     status-im.subs.alert-banner
     status-im.subs.biometrics
+    status-im.subs.bottom-sheet
     status-im.subs.chats
     status-im.subs.communities
     status-im.subs.community.account-selection

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -79,11 +79,6 @@
  :-> :max-slippage)
 
 (rf/reg-sub
- :wallet/swap-loading-fees?
- :<- [:wallet/swap]
- :-> :loading-fees?)
-
-(rf/reg-sub
  :wallet/swap-approval-transaction-id
  :<- [:wallet/swap]
  :-> :approval-transaction-id)
@@ -157,9 +152,10 @@
  :wallet/swap-proposal-provider
  :<- [:wallet/swap-proposal]
  (fn [swap-proposal]
-   (let [bridge-name  (:bridge-name swap-proposal)
-         provider-key (keyword (string/lower-case bridge-name))]
-     (get constants/swap-providers provider-key))))
+   (when swap-proposal
+     (let [bridge-name  (:bridge-name swap-proposal)
+           provider-key (keyword (string/lower-case bridge-name))]
+       (get constants/swap-providers provider-key)))))
 
 (rf/reg-sub
  :wallet/swap-proposal-approval-required

--- a/src/status_im/subs/wallet/swap_test.cljs
+++ b/src/status_im/subs/wallet/swap_test.cljs
@@ -141,7 +141,6 @@
                                               :eip-1559-enabled       true
                                               :l-1-gas-fee            "0"}}
    :error-response "Error"
-   :loading-fees? false
    :loading-swap-proposal? false
    :max-slippage 0.5})
 
@@ -217,14 +216,6 @@
       [:wallet :ui :swap]
       swap-data)
     (is (match? 0.5 (rf/sub [sub-name])))))
-
-(h/deftest-sub :wallet/swap-loading-fees?
-  [sub-name]
-  (testing "Return if swap is loading fees"
-    (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
-      swap-data)
-    (is (false? (rf/sub [sub-name])))))
 
 (h/deftest-sub :wallet/swap-loading-swap-proposal?
   [sub-name]


### PR DESCRIPTION
fixes #20341

### Summary

This PR implements autorefreshing swap proposal after 15 seconds

https://github.com/user-attachments/assets/578de384-d67e-476d-9a3a-709ac32c6af0

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in with a user with some funds
- Go to Wallet
- Go to account
- Tap on Swap button
- Select asset to pay
- Enter an amount and wait for a swap proposal to be fetched
- Verify that every 15 seconds swap proposal is refetched
- Also this should impact set spending cap screen and swap confirmation screen

status: ready