### PR TITLE
[#21060] Photo preview in mentions

### DIFF
--- a/src/status_im/contexts/shell/activity_center/notification/mentions/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification/mentions/view.cljs
@@ -9,38 +9,45 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn- mention-text [literal]
+(defn- mention-text
+  [literal]
   (let [mention (rf/sub [:messages/resolve-mention literal])]
     [quo/text
      {:style style/mention-text
       :size  :paragraph-1}
      (str "@" mention)]))
 
-(defn- parsed-text->hiccup [{:keys [literal destination] message-type :type}]
+(defn- parsed-text->hiccup
+  [{:keys [literal destination] message-type :type}]
   (case message-type
     "mention" [mention-text literal]
-    "link" destination
+    "link"    destination
     literal))
 
-(defn- message-body [{:keys [container parsed-text]}]
+(defn- message-body
+  [{:keys [container parsed-text]}]
   (into container (map parsed-text->hiccup) parsed-text))
 
-(defn- simple-message [content]
+(defn- simple-message
+  [content]
   (let [parsed-text (get-in content [:content :parsed-text 0 :children])]
-    [message-body {:container   [quo/text
-                                 {:number-of-lines     1
-                                  :style               style/tag-text
-                                  :accessibility-label :activity-message-body
-                                  :size                :paragraph-1}]
-                   :parsed-text parsed-text}]))
+    [message-body
+     {:container   [quo/text
+                    {:number-of-lines     1
+                     :style               style/tag-text
+                     :accessibility-label :activity-message-body
+                     :size                :paragraph-1}]
+      :parsed-text parsed-text}]))
 
-(defn- album-message [content]
+(defn- album-message
+  [content]
   (let [parsed-text (get-in content [0 :parsedText 0 :children])
         images      (map :image content)]
     [quo/activity-logs-photos
      {:photos       images
-      :message-text [message-body {:container   [:<>]
-                                   :parsed-text parsed-text}]}]))
+      :message-text [message-body
+                     {:container   [:<>]
+                      :parsed-text parsed-text}]}]))
 
 (defn- swipeable
   [{:keys [extra-fn]} child]
@@ -56,10 +63,10 @@
   [{:keys [notification extra-fn]}]
   (let [{:keys [author chat-name community-id chat-id message read timestamp
                 album-messages]} notification
-        community-chat?     (not (string/blank? community-id))
-        community-name      (rf/sub [:communities/name community-id])
-        community-logo      (rf/sub [:communities/logo community-id])
-        customization-color (rf/sub [:profile/customization-color])]
+        community-chat?          (not (string/blank? community-id))
+        community-name           (rf/sub [:communities/name community-id])
+        community-logo           (rf/sub [:communities/logo community-id])
+        customization-color      (rf/sub [:profile/customization-color])]
     [swipeable {:extra-fn extra-fn}
      [gesture/touchable-without-feedback
       {:on-press (fn []

--- a/src/status_im/contexts/shell/activity_center/notification/mentions/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification/mentions/view.cljs
@@ -9,25 +9,38 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn- message-body
-  [message]
-  (let [parsed-text          (get-in message [:content :parsed-text])
-        parsed-text-children (:children (first parsed-text))]
-    (into [quo/text
-           {:number-of-lines     1
-            :style               style/tag-text
-            :accessibility-label :activity-message-body
-            :size                :paragraph-1}]
-          (map-indexed (fn [index {:keys [type literal destination]}]
-                         ^{:key index}
-                         (case type
-                           "mention" [quo/text
-                                      {:style style/mention-text
-                                       :size  :paragraph-1}
-                                      (str "@" (rf/sub [:messages/resolve-mention literal]))]
-                           "link"    destination
-                           literal))
-                       parsed-text-children))))
+(defn- mention-text [literal]
+  (let [mention (rf/sub [:messages/resolve-mention literal])]
+    [quo/text
+     {:style style/mention-text
+      :size  :paragraph-1}
+     (str "@" mention)]))
+
+(defn- parsed-text->hiccup [{:keys [literal destination] message-type :type}]
+  (case message-type
+    "mention" [mention-text literal]
+    "link" destination
+    literal))
+
+(defn- message-body [{:keys [container parsed-text]}]
+  (into container (map parsed-text->hiccup) parsed-text))
+
+(defn- simple-message [content]
+  (let [parsed-text (get-in content [:content :parsed-text 0 :children])]
+    [message-body {:container   [quo/text
+                                 {:number-of-lines     1
+                                  :style               style/tag-text
+                                  :accessibility-label :activity-message-body
+                                  :size                :paragraph-1}]
+                   :parsed-text parsed-text}]))
+
+(defn- album-message [content]
+  (let [parsed-text (get-in content [0 :parsedText 0 :children])
+        images      (map :image content)]
+    [quo/activity-logs-photos
+     {:photos       images
+      :message-text [message-body {:container   [:<>]
+                                   :parsed-text parsed-text}]}]))
 
 (defn- swipeable
   [{:keys [extra-fn]} child]
@@ -41,12 +54,12 @@
 
 (defn view
   [{:keys [notification extra-fn]}]
-  (let [{:keys [author chat-name community-id chat-id
-                message read timestamp]} notification
-        community-chat?                  (not (string/blank? community-id))
-        community-name                   (rf/sub [:communities/name community-id])
-        community-logo                   (rf/sub [:communities/logo community-id])
-        customization-color              (rf/sub [:profile/customization-color])]
+  (let [{:keys [author chat-name community-id chat-id message read timestamp
+                album-messages]} notification
+        community-chat?     (not (string/blank? community-id))
+        community-name      (rf/sub [:communities/name community-id])
+        community-logo      (rf/sub [:communities/logo community-id])
+        customization-color (rf/sub [:profile/customization-color])]
     [swipeable {:extra-fn extra-fn}
      [gesture/touchable-without-feedback
       {:on-press (fn []
@@ -74,4 +87,6 @@
                                   :group-name chat-name
                                   :blur?      true
                                   :size       24}])]
-        :message             {:body (message-body message)}}]]]))
+        :message             {:body (if album-messages
+                                      [album-message album-messages]
+                                      [simple-message message])}}]]]))

--- a/src/status_im/contexts/shell/activity_center/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/view.cljs
@@ -31,9 +31,6 @@
                   [notification])
         props    {:notification notification
                   :extra-fn     extra-fn}]
-    ;; Notifications are expensive to render. Without `delay-render` the opening
-    ;; animation of the Activity Center can be clunky and the time to open the
-    ;; AC after pressing the bell icon can be high.
     [rn/view {:style (style/notification-container index)}
      (cond
        (= notification-type types/contact-verification)

--- a/src/status_im/contexts/shell/activity_center/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/view.cljs
@@ -24,7 +24,7 @@
     [utils.re-frame :as rf]))
 
 (defn notification-component
-  [{:keys [type] :as notification} index]
+  [{notification-type :type :as notification} index]
   (let [extra-fn (rn/use-callback
                   (fn []
                     {:notification notification})
@@ -36,23 +36,23 @@
     ;; AC after pressing the bell icon can be high.
     [rn/view {:style (style/notification-container index)}
      (cond
-       (= type types/contact-verification)
+       (= notification-type types/contact-verification)
        [contact-verification/view props]
 
-       (= type types/contact-request)
+       (= notification-type types/contact-request)
        [contact-requests/view props]
 
-       (= type types/mention)
+       (= notification-type types/mention)
        [mentions/view props]
 
-       (= type types/reply)
+       (= notification-type types/reply)
        [reply/view props]
 
-       (= type types/admin)
+       (= notification-type types/admin)
        [admin/view props]
 
-       (some types/membership [type])
-       (condp = type
+       (types/membership notification-type)
+       (condp = notification-type
          types/private-group-chat [membership/view props]
          types/community-request  [community-request/view props]
          types/community-kicked   [community-kicked/view props]


### PR DESCRIPTION
fixes #21060

### Summary

This PR adds support to display image previews in the activity center for mentions.

Demo:

![image](https://github.com/user-attachments/assets/4532013d-3967-4312-b1aa-40bb974475d2)


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

 #### Areas that maybe impacted

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Create a group chat and tag the user `A` in a message containing photos
- Log in as `A` and check the activity center, the notifications should contain the photos shown.

status: ready