### PR TITLE
fix!: prevent community notifications from being removed after last message is deleted

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.184.52",
-    "commit-sha1": "81cfce709e8d123eb1956b87f8e0f19dc47c122c",
-    "src-sha256": "0hna30ms4ccxmi20l5v36y84pva1s4jjkqg11whwmdjgw75d0fan"
+    "version": "v0.184.53",
+    "commit-sha1": "f7d9d036a000e920a8f4041697888f9777f7818c",
+    "src-sha256": "0ja2g046dys8lf2m4y3lzr5vm7v219z8mf5a1ah7clv93x016cd4"
 }


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/17052
status-go PR https://github.com/status-im/status-go/pull/5789
replaces this PR: https://github.com/status-im/status-mobile/pull/20744

### Summary

* This PR attempts to fix an issue with community notifications disappearing for users after another user has deleted the last message in the community chat.
  * More context on the fix and related issue can be found in the status-go PR: https://github.com/status-im/status-go/pull/5789

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Community Chats
- Activity Center
- Notifications for new OneToOne chats
- Notifications for new Private Group chats

### Steps to test

More context about the steps to reproduce can be found this issue #17052 

> 1. `User_A` and `User_B` are both in the same community.
> 2. `User_A` sends several replies or mentions to `User_B`.
> 3. `User_A` sends one more message and then deletes it using the 'delete for everyone' option.
> 4. `User_B` checks the AC.
> 

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before Changes

https://github.com/user-attachments/assets/ad5a0519-0a82-41f2-922b-43a6b43a8ab5

#### After Changes

https://github.com/user-attachments/assets/fe0cde08-1513-4b32-b945-9e6278af3efd

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [X] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

status: ready