### PR TITLE
Update Sign in flow on Profiles list screen

### DIFF
--- a/src/status_im/contexts/profile/profiles/view.cljs
+++ b/src/status_im/contexts/profile/profiles/view.cljs
@@ -5,7 +5,6 @@
     [react-native.core :as rn]
     [react-native.reanimated :as reanimated]
     [react-native.safe-area :as safe-area]
-    [status-im.common.check-before-syncing.view :as check-before-syncing]
     [status-im.common.confirmation-drawer.view :as confirmation-drawer]
     [status-im.common.metrics-confirmation-modal.view :as metrics-modal]
     [status-im.common.standard-authentication.core :as standard-authentication]
@@ -44,32 +43,32 @@
                                               :linear
                                               50))
 
-(defn- show-check-before-syncing
+(defn- navigate-to-new-to-status
   []
-  (rf/dispatch
-   [:show-bottom-sheet
-    {:content (fn [] [check-before-syncing/view
-                      {:on-submit
-                       #(debounce/throttle-and-dispatch
-                         [:open-modal :screen/onboarding.sign-in]
-                         1000)}])
-     :shell?  true}]))
+  (when @push-animation-fn-atom
+    (@push-animation-fn-atom))
+  (debounce/throttle-and-dispatch
+   [:open-modal :screen/onboarding.new-to-status]
+   1000))
+
+(defn- navigate-to-sync-or-recover-profile
+  []
+  (when @push-animation-fn-atom
+    (@push-animation-fn-atom))
+  (debounce/throttle-and-dispatch
+   [:open-modal :screen/onboarding.sync-or-recover-profile]
+   1000))
 
 (defn new-account-options
   []
   [quo/action-drawer
    [[{:icon                :i/profile
       :label               (i18n/label :t/create-new-profile)
-      :on-press            (fn []
-                             (when @push-animation-fn-atom
-                               (@push-animation-fn-atom))
-                             (debounce/throttle-and-dispatch
-                              [:open-modal :screen/onboarding.new-to-status]
-                              1000))
+      :on-press            navigate-to-new-to-status
       :accessibility-label :create-new-profile}
      {:icon                :i/multi-profile
-      :label               (i18n/label :t/add-existing-status-profile)
-      :on-press            show-check-before-syncing
+      :label               (i18n/label :t/sync-or-recover-profile)
+      :on-press            navigate-to-sync-or-recover-profile
       :accessibility-label :multi-profile}]]])
 
 (defn show-new-account-options

--- a/translations/en.json
+++ b/translations/en.json
@@ -53,7 +53,6 @@
   "add-bootnode": "Add bootnode",
   "add-contact": "Add contact",
   "add-custom-token": "Add custom token",
-  "add-existing-status-profile": "Add existing Status profile",
   "add-favourite": "Add favourite",
   "add-mailserver": "Add Status node",
   "add-me-to-your-contacts": "Please add me to your contacts",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -48,7 +48,6 @@
     "add-bootnode": "Bootnodeを追加",
     "add-contact": "連絡先を追加",
     "add-custom-token": "カスタムトークンを追加",
-    "add-existing-status-profile": "既存のStatusプロフィールを追加する",
     "add-favourite": "お気に入りに追加する",
     "add-mailserver": "Statusノードを追加",
     "add-me-to-your-contacts": "連絡先に追加してください",


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20628

### Summary
The 'Sync' or 'Recover Profile' screen will now be shown instead of directly opening the syncing sheet. This adds another layer, which may not be ideal. However, this change is necessary to [simplify](https://github.com/status-im/status-mobile/pull/21090/files#diff-d6d12a107e3ffe116d992ea055af107e6b7c68f5f3084958999d739b01f15dfe) navigation for implementing the [seed phrase fallback flow](https://github.com/status-im/status-mobile/issues/20628)."

### Testing note:
Please make sure navigation/flow of account creation/recovery are not broken.

status: ready