### PR TITLE
fix: calendar component specs to avoid duplicate day entries

### DIFF
--- a/src/quo/components/calendar/calendar/component_spec.cljs
+++ b/src/quo/components/calendar/calendar/component_spec.cljs
@@ -23,10 +23,7 @@
         {:start-date nil
          :end-date   nil
          :on-change  on-change}])
-      (h/fire-event :press
-                    (-> (str (time/day start-date))
-                        (h/query-all-by-text)
-                        first))
+      (h/fire-event :press (h/query-first-by-text (str (time/day start-date))))
       (h/was-called-with on-change {:start-date start-date :end-date nil})))
 
   (h/test "should call on-change with start and end date on second click"
@@ -34,10 +31,7 @@
       (h/render
        [calendar/view
         {:start-date start-date :end-date nil :on-change on-change}])
-      (h/fire-event :press
-                    (-> (str (time/day end-date))
-                        (h/query-all-by-text)
-                        first))
+      (h/fire-event :press (h/query-first-by-text (str (time/day end-date))))
       (h/was-called-with on-change {:start-date start-date :end-date end-date})))
 
   (h/test "should reset the dates on third click"
@@ -47,10 +41,7 @@
         {:start-date start-date
          :end-date   end-date
          :on-change  on-change}])
-      (h/fire-event :press
-                    (-> (str (time/day start-date))
-                        (h/query-all-by-text)
-                        first))
+      (h/fire-event :press (h/query-first-by-text (str (time/day start-date))))
       (h/was-called-with on-change {:start-date start-date :end-date nil})))
 
   (h/test "should reset dates when start date is clicked again"
@@ -60,10 +51,7 @@
         {:start-date start-date
          :end-date   nil
          :on-change  on-change}])
-      (h/fire-event :press
-                    (-> (str (time/day start-date))
-                        (h/query-all-by-text)
-                        first))
+      (h/fire-event :press (h/query-first-by-text (str (time/day start-date))))
       (h/was-called-with on-change {:start-date nil :end-date nil})))
 
   (h/test "should assign start and end date correctly when upper range selected first"
@@ -73,8 +61,5 @@
         {:start-date end-date
          :end-date   nil
          :on-change  on-change}])
-      (h/fire-event :press
-                    (-> (str (time/day start-date))
-                        (h/query-all-by-text)
-                        first))
+      (h/fire-event :press (h/query-first-by-text (str (time/day start-date))))
       (h/was-called-with on-change {:start-date start-date :end-date end-date}))))

--- a/src/quo/components/calendar/calendar/component_spec.cljs
+++ b/src/quo/components/calendar/calendar/component_spec.cljs
@@ -23,7 +23,10 @@
         {:start-date nil
          :end-date   nil
          :on-change  on-change}])
-      (h/fire-event :press (h/query-by-text (str (time/day start-date))))
+      (h/fire-event :press
+                    (-> (str (time/day start-date))
+                        (h/query-all-by-text)
+                        first))
       (h/was-called-with on-change {:start-date start-date :end-date nil})))
 
   (h/test "should call on-change with start and end date on second click"
@@ -31,7 +34,10 @@
       (h/render
        [calendar/view
         {:start-date start-date :end-date nil :on-change on-change}])
-      (h/fire-event :press (h/query-by-text (str (time/day end-date))))
+      (h/fire-event :press
+                    (-> (str (time/day end-date))
+                        (h/query-all-by-text)
+                        first))
       (h/was-called-with on-change {:start-date start-date :end-date end-date})))
 
   (h/test "should reset the dates on third click"
@@ -41,7 +47,10 @@
         {:start-date start-date
          :end-date   end-date
          :on-change  on-change}])
-      (h/fire-event :press (h/query-by-text (str (time/day start-date))))
+      (h/fire-event :press
+                    (-> (str (time/day start-date))
+                        (h/query-all-by-text)
+                        first))
       (h/was-called-with on-change {:start-date start-date :end-date nil})))
 
   (h/test "should reset dates when start date is clicked again"
@@ -51,7 +60,10 @@
         {:start-date start-date
          :end-date   nil
          :on-change  on-change}])
-      (h/fire-event :press (h/query-by-text (str (time/day start-date))))
+      (h/fire-event :press
+                    (-> (str (time/day start-date))
+                        (h/query-all-by-text)
+                        first))
       (h/was-called-with on-change {:start-date nil :end-date nil})))
 
   (h/test "should assign start and end date correctly when upper range selected first"
@@ -61,5 +73,8 @@
         {:start-date end-date
          :end-date   nil
          :on-change  on-change}])
-      (h/fire-event :press (h/query-by-text (str (time/day start-date))))
+      (h/fire-event :press
+                    (-> (str (time/day start-date))
+                        (h/query-all-by-text)
+                        first))
       (h/was-called-with on-change {:start-date start-date :end-date end-date}))))

--- a/src/quo/components/calendar/calendar/component_spec.cljs
+++ b/src/quo/components/calendar/calendar/component_spec.cljs
@@ -4,7 +4,7 @@
     [quo.components.calendar.calendar.view :as calendar]
     [test-helpers.component :as h]))
 
-(def start-date (time/date-time (time/year (time/now)) (time/month (time/now)) 5))
+(def start-date (time/date-time (time/year (time/now)) (time/month (time/now)) 8))
 (def end-date (time/date-time (time/plus start-date (time/days 2))))
 
 (h/describe "calendar component"

--- a/src/test_helpers/component.cljs
+++ b/src/test_helpers/component.cljs
@@ -101,6 +101,7 @@
 (def get-by-text (with-node-or-screen :get-by-text))
 (def query-all-by-text (with-node-or-screen :query-all-by-text))
 (def query-by-text (with-node-or-screen :query-by-text))
+(def query-first-by-text (comp first query-all-by-text))
 
 (def get-all-by-label-text (with-node-or-screen :get-all-by-label-text))
 (def get-by-label-text (with-node-or-screen :get-by-label-text))


### PR DESCRIPTION
### Summary

* This PR attempts to resolve the CI issue related to the calendar component specs finding duplicate day entries.

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Non-functional

- Component Specs

status: ready <!-- Can be ready or wip -->