### PR TITLE
Fix/async call for mention suggestion

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "f859b58c3896523b2fb9a09b3e5c1cedb04f959b",
-    "commit-sha1": "f859b58c3896523b2fb9a09b3e5c1cedb04f959b",
-    "src-sha256": "009nd47aajng5k7wrcqv5zvvzniaswqi706fpkbbjhqziympi1s1"
+    "version": "fix/issue-relate-to-mobile-pr-16330-2",
+    "commit-sha1": "b2c2e40737a333874c27f77e8675fc2d71e299ff",
+    "src-sha256": "1xjwlvcfc93cliwnq64kx39c4l67c7dfdk8hmhlmixqg9d6pmclh"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "fix/issue-relate-to-mobile-pr-16330-2",
-    "commit-sha1": "b2c2e40737a333874c27f77e8675fc2d71e299ff",
-    "src-sha256": "1xjwlvcfc93cliwnq64kx39c4l67c7dfdk8hmhlmixqg9d6pmclh"
+    "version": "6e5a32c02215f36509b21645a32361fca85b10f7",
+    "commit-sha1": "6e5a32c02215f36509b21645a32361fca85b10f7",
+    "src-sha256": "0wp0a7xp7vw64kkiyrpkswb37dfabj1al4a4nrb71iyfrcyrzscl"
 }


### PR DESCRIPTION
### Summary

This PR addresses an issue with asynchronous calls in the mention functionality. The main changes include:

1. Enhanced mention result handling:
   - Added `call-id` and `call-time` to track individual calls
   - Updated the `transfer-mention-result` function to include these new fields

2. Improved `on-change-text` event:
   - Introduced a `call-id` to uniquely identify each call
   - Added the current timestamp to the RPC call parameters

3. Refined `on-change-text-success` event:
   - Implemented a check to ensure the response matches the most recent call
   - Added response time logging for performance monitoring
   - Only update the app state if the response is for the latest call

These changes aim to resolve race conditions and ensure that the UI always reflects the most recent user input when dealing with mentions. The addition of call tracking and response time logging will help with future performance optimizations.

Relate status-go [PR](https://github.com/status-im/status-go/pull/3806)

### Testing notes
mention suggestion should work as before

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->