### PR TITLE
fixes for building universal APK

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -211,7 +211,7 @@ android {
             reset()
             enable getEnvOrConfig('ANDROID_ABI_SPLIT').toBoolean()
             include getEnvOrConfig('ANDROID_ABI_INCLUDE').split(";")
-            universalApk false
+            universalApk getEnvOrConfig('ORG_GRADLE_PROJECT_universalApk').toBoolean()
         }
     }
     signingConfigs {

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 import groovy.json.JsonBuilder
 

--- a/ci/Jenkinsfile.e2e-nightly
+++ b/ci/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.8'
+library 'status-jenkins-lib@v1.9.9'
 
 pipeline {
   agent {

--- a/nix/mobile/android/build.nix
+++ b/nix/mobile/android/build.nix
@@ -23,6 +23,7 @@
   # Android architectures to build for
   # Used to detect end-to-end builds
   androidAbiInclude ? lib.getEnvWithDefault "ANDROID_ABI_INCLUDE" "arm64-v8a",
+  universalApk ? lib.getEnvWithDefault "ORG_GRADLE_PROJECT_universalApk" "false"
 }:
 
 let
@@ -89,6 +90,7 @@ in stdenv.mkDerivation rec {
   ORG_GRADLE_PROJECT_commitHash = commitHash;
   ORG_GRADLE_PROJECT_buildUrl = buildUrl;
   ORG_GRADLE_PROJECT_hermesEnabled = hermesEnabled;
+  ORG_GRADLE_PROJECT_universalApk = universalApk;
 
   # Fix for ERR_OSSL_EVP_UNSUPPORTED error.
   NODE_OPTIONS = "--openssl-legacy-provider";


### PR DESCRIPTION
## Summary

In my previous PR -> https://github.com/status-im/status-mobile/pull/21163 I had attempted to build universalAPK only for release builds but had missed out on these changes.

This PR ensures `universalApk` value of `gradle` config is properly set.
This PR also points to my branch in `status-jenkins-lib` which modifies the APK size restrictions.
Its not `110 MB` for Universal APKs and `70 MB` for Individual Architecture APKs

## Platforms
- Android

status: ready
