### PR TITLE
fix: priority queue panic

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.184.52",
-    "commit-sha1": "81cfce709e8d123eb1956b87f8e0f19dc47c122c",
-    "src-sha256": "0hna30ms4ccxmi20l5v36y84pva1s4jjkqg11whwmdjgw75d0fan"
+    "version": "83f9ec909286cbebe1f68437aa51489922f59315",
+    "commit-sha1": "83f9ec909286cbebe1f68437aa51489922f59315",
+    "src-sha256": "0v6ad2cbmzmwdcpnlbw7maljir22939lbj5bk6agnxhfpacad490"
 }


### PR DESCRIPTION
Fixes: https://github.com/status-im/status-mobile/issues/21174
Requires: https://github.com/status-im/status-go/pull/5799

This makes the message priority queue safe for being accessed concurrently.