### PR TITLE
feat(swap): switch pay/receive assets

### DIFF
--- a/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
@@ -212,7 +212,7 @@
 (defn- slide-button
   []
   (let [loading-swap-proposal? (rf/sub [:wallet/swap-loading-swap-proposal?])
-        swap-proposal          (rf/sub [:wallet/swap-proposal])
+        swap-proposal          (rf/sub [:wallet/swap-proposal-without-fees])
         account                (rf/sub [:wallet/current-viewing-account])
         on-auth-success        (rn/use-callback #(rf/dispatch
                                                   [:wallet/swap-transaction

--- a/src/status_im/contexts/wallet/swap/swap_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/swap/swap_confirmation/view.cljs
@@ -157,12 +157,13 @@
 (defn- slide-button
   []
   (let [loading-swap-proposal? (rf/sub [:wallet/swap-loading-swap-proposal?])
-        swap-proposal          (rf/sub [:wallet/swap-proposal])
+        swap-proposal          (rf/sub [:wallet/swap-proposal-without-fees])
         account                (rf/sub [:wallet/current-viewing-account])
         account-color          (:color account)
-        on-auth-success        (rn/use-callback #(rf/dispatch
-                                                  [:wallet/swap-transaction
-                                                   (security/safe-unmask-data %)]))]
+        on-auth-success        (rn/use-callback (fn [data]
+                                                  (rf/dispatch [:wallet/stop-get-swap-proposal])
+                                                  (rf/dispatch [:wallet/swap-transaction
+                                                                (security/safe-unmask-data data)])))]
     [standard-auth/slide-button
      {:size                :size-48
       :track-text          (i18n/label :t/slide-to-swap)

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -44,15 +44,18 @@
 
 (defn greater-than-or-equals
   [^js bn1 ^js bn2]
-  (.greaterThanOrEqualTo bn1 bn2))
+  (when (bignumber? bn1)
+    (.greaterThanOrEqualTo bn1 bn2)))
 
 (defn greater-than
   [bn1 bn2]
-  (.greaterThan ^js bn1 bn2))
+  (when (bignumber? bn1)
+    (.greaterThan ^js bn1 bn2)))
 
 (defn less-than
   [bn1 bn2]
-  (.lessThan ^js bn1 bn2))
+  (when (bignumber? bn1)
+    (.lessThan ^js bn1 bn2)))
 
 (defn equal-to
   [n1 n2]

--- a/src/utils/number.cljs
+++ b/src/utils/number.cljs
@@ -1,5 +1,8 @@
 (ns utils.number
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [native-module.core :as native-module]
+            [utils.hex :as utils.hex]
+            [utils.money :as utils.money]))
 
 (defn naive-round
   "Quickly and naively round number `n` up to `decimal-places`.
@@ -61,3 +64,16 @@
              (str "." (string/replace decimals #"0+$" ""))
              "")
            ""))))
+
+(defn hex->whole
+  [num decimals]
+  (-> num
+      utils.hex/normalize-hex
+      native-module/hex-to-number
+      (convert-to-whole-number decimals)))
+
+(defn to-fixed
+  [num decimals]
+  (-> num
+      (utils.money/to-fixed decimals)
+      remove-trailing-zeroes))


### PR DESCRIPTION
fixes #20339 

### Summary

This PR adds functionality to the switch button in Setup Swap screen to flip between pay and receive assets. We are replicating same behavior as Desktop as for now we don't support editing the receive field.
- If there is a valid proposal shown to the user, we switch both token and receive amount
- If there is not a swap proposal shown to the user, we keep the same amount in the pay input and just switch the tokens

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Login
- Go to wallet
- Select an account
- Select Swap option
- Select a token on Select asset to pay screen
- Enter a valid amount
- Wait for swap proposal to appear
- Tap on the Switch button that is in the middle of pay and receive inputs
- Verify the tokens are flipped correctly

status: ready