### PR TITLE
fix(wallet)_: Error on sending ERC1155 collectible

### DIFF
--- a/src/status_im/common/controlled_input/utils.cljs
+++ b/src/status_im/common/controlled_input/utils.cljs
@@ -16,6 +16,10 @@
 
 (defn numeric-value
   [state]
+  (or (parse-double (input-value state)) 0))
+
+(defn value-bn
+  [state]
   (money/bignumber (input-value state)))
 
 (defn input-error
@@ -28,27 +32,31 @@
 
 (defn upper-limit
   [state]
+  (:upper-limit state))
+
+(defn upper-limit-bn
+  [state]
   (money/bignumber (:upper-limit state)))
 
 (defn lower-limit
+  [state]
+  (:lower-limit state))
+
+(defn lower-limit-bn
   [state]
   (money/bignumber (:lower-limit state)))
 
 (defn upper-limit-exceeded?
   [state]
-  (let [num-value (numeric-value state)]
-    (and
-     (upper-limit state)
-     (when (money/bignumber? num-value)
-       (money/greater-than (numeric-value state) (upper-limit state))))))
+  (and (upper-limit state)
+       (when (money/bignumber? (value-bn state))
+         (money/greater-than (value-bn state) (upper-limit-bn state)))))
 
 (defn- lower-limit-exceeded?
   [state]
-  (let [num-value (numeric-value state)]
-    (and
-     (lower-limit state)
-     (when (money/bignumber? num-value)
-       (money/less-than (numeric-value state) (lower-limit state))))))
+  (and (lower-limit state)
+       (when (money/bignumber? (value-bn state))
+         (money/less-than (value-bn state) (lower-limit-bn state)))))
 
 (defn- recheck-errorness
   [state]
@@ -81,11 +89,11 @@
 
 (defn increase
   [state]
-  (set-input-value state (str (money/add (numeric-value state) 1))))
+  (set-input-value state (str (money/add (value-bn state) 1))))
 
 (defn decrease
   [state]
-  (set-input-value state (str (money/add (numeric-value state) -1))))
+  (set-input-value state (str (money/add (value-bn state) -1))))
 
 (def ^:private not-digits-or-dot-pattern
   #"[^0-9+\.]")
@@ -122,10 +130,12 @@
     state))
 
 (defn delete-last
-  [state]
-  (let [value     (input-value state)
-        new-value (subs value 0 (dec (count value)))]
-    (set-input-value state new-value)))
+  ([state]
+   (delete-last state ""))
+  ([state default-value]
+   (let [value     (input-value state)
+         new-value (subs value 0 (dec (count value)))]
+     (set-input-value state (if (string/blank? new-value) default-value new-value)))))
 
 (defn delete-all
   [state]
@@ -133,7 +143,7 @@
 
 (defn empty-value?
   [state]
-  (string/blank? (:value state)))
+  (or (string/blank? (:value state)) (<= (numeric-value state) 0)))
 
 (defn- fiat->crypto
   [value conversion-rate]

--- a/src/status_im/common/controlled_input/utils.cljs
+++ b/src/status_im/common/controlled_input/utils.cljs
@@ -14,7 +14,7 @@
   [state]
   (:value state))
 
-(defn numeric-value
+(defn value-numeric
   [state]
   (or (parse-double (input-value state)) 0))
 
@@ -70,7 +70,7 @@
       (assoc :value value)
       recheck-errorness))
 
-(defn set-numeric-value
+(defn set-value-numeric
   [state value]
   (set-input-value state (str value)))
 
@@ -143,7 +143,7 @@
 
 (defn empty-value?
   [state]
-  (or (string/blank? (:value state)) (<= (numeric-value state) 0)))
+  (or (string/blank? (:value state)) (<= (value-numeric state) 0)))
 
 (defn- fiat->crypto
   [value conversion-rate]

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -262,8 +262,8 @@
                                                             (string/upper-case
                                                              constants/mainnet-short-name))
                                                        (money/equal-to
-                                                        (controlled-input/numeric-value input-state)
-                                                        (controlled-input/upper-limit input-state))
+                                                        (controlled-input/value-bn input-state)
+                                                        (controlled-input/upper-limit-bn input-state))
                                                        (money/equal-to (:total-balance
                                                                         owned-eth-token)
                                                                        0)))
@@ -338,10 +338,10 @@
                                      {:limit (if crypto-currency?
                                                (utils/prettify-crypto-balance
                                                 (or (clj->js token-symbol) "")
-                                                (controlled-input/upper-limit input-state)
+                                                (controlled-input/upper-limit-bn input-state)
                                                 conversion-rate)
                                                (utils/prettify-balance currency-symbol
-                                                                       (controlled-input/upper-limit
+                                                                       (controlled-input/upper-limit-bn
                                                                         input-state)))})
                           :status   (when (controlled-input/input-error input-state) :error)}]}]
      [routes/view

--- a/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
@@ -11,25 +11,26 @@
 
 (defn view
   []
-  (let [on-close              (rn/use-callback
-                               #(rf/dispatch [:wallet/collectible-amount-navigate-back]))
-        send-transaction-data (rf/sub [:wallet/wallet-send])
-        collectible           (:collectible send-transaction-data)
-        balance               (utils/collectible-balance collectible)
-        [value set-value]     (rn/use-state (-> controlled-input/init-state
-                                                (controlled-input/set-numeric-value 1)
-                                                (controlled-input/set-lower-limit 1)))
-        preview-uri           (get-in collectible [:preview-url :uri])
-        incorrect-value?      (controlled-input/input-error value)
-        increase-value        (rn/use-callback #(set-value controlled-input/increase))
-        decrease-value        (rn/use-callback #(set-value controlled-input/decrease))
-        delete-character      (rn/use-callback #(set-value controlled-input/delete-last))
-        add-character         (rn/use-callback
-                               (fn [c]
-                                 (set-value #(controlled-input/add-character % c))))]
+  (let [on-close                      (rn/use-callback
+                                       #(rf/dispatch [:wallet/collectible-amount-navigate-back]))
+        send-transaction-data         (rf/sub [:wallet/wallet-send])
+        collectible                   (:collectible send-transaction-data)
+        balance                       (utils/collectible-balance collectible)
+        [input-state set-input-state] (rn/use-state (-> controlled-input/init-state
+                                                        (controlled-input/set-numeric-value 1)
+                                                        (controlled-input/set-lower-limit 1)))
+        preview-uri                   (get-in collectible [:preview-url :uri])
+        incorrect-value?              (controlled-input/input-error input-state)
+        increase-value                (rn/use-callback #(set-input-state controlled-input/increase))
+        decrease-value                (rn/use-callback #(set-input-state controlled-input/decrease))
+        delete-character              (rn/use-callback
+                                       (fn [] (set-input-state #(controlled-input/delete-last % "1"))))
+        add-character                 (rn/use-callback
+                                       (fn [c]
+                                         (set-input-state #(controlled-input/add-character % c))))]
     (rn/use-effect
      (fn []
-       (set-value #(controlled-input/set-upper-limit % balance)))
+       (set-input-state #(controlled-input/set-upper-limit % balance)))
      [balance])
     [rn/view
      [account-switcher/view
@@ -47,9 +48,9 @@
        :status          (if incorrect-value? :error :default)
        :container-style style/network-tags-container}]
      [quo/amount-input
-      {:max-value       (controlled-input/upper-limit value)
-       :min-value       (controlled-input/lower-limit value)
-       :value           (controlled-input/numeric-value value)
+      {:max-value       (controlled-input/upper-limit input-state)
+       :min-value       (controlled-input/lower-limit input-state)
+       :value           (controlled-input/numeric-value input-state)
        :on-inc-press    increase-value
        :on-dec-press    decrease-value
        :container-style style/amount-input-container
@@ -59,7 +60,7 @@
        :button-one-props {:on-press  #(rf/dispatch
                                        [:wallet/set-collectible-amount-to-send
                                         {:stack-id :screen/wallet.select-collectible-amount
-                                         :amount   (controlled-input/numeric-value value)}])
+                                         :amount   (controlled-input/numeric-value input-state)}])
                           :disabled? incorrect-value?}
        :button-one-label (i18n/label :t/confirm)}]
      [quo/numbered-keyboard

--- a/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
@@ -17,7 +17,7 @@
         collectible                   (:collectible send-transaction-data)
         balance                       (utils/collectible-balance collectible)
         [input-state set-input-state] (rn/use-state (-> controlled-input/init-state
-                                                        (controlled-input/set-numeric-value 1)
+                                                        (controlled-input/set-value-numeric 1)
                                                         (controlled-input/set-lower-limit 1)))
         preview-uri                   (get-in collectible [:preview-url :uri])
         incorrect-value?              (controlled-input/input-error input-state)
@@ -50,7 +50,7 @@
      [quo/amount-input
       {:max-value       (controlled-input/upper-limit input-state)
        :min-value       (controlled-input/lower-limit input-state)
-       :value           (controlled-input/numeric-value input-state)
+       :value           (controlled-input/value-numeric input-state)
        :on-inc-press    increase-value
        :on-dec-press    decrease-value
        :container-style style/amount-input-container
@@ -60,7 +60,7 @@
        :button-one-props {:on-press  #(rf/dispatch
                                        [:wallet/set-collectible-amount-to-send
                                         {:stack-id :screen/wallet.select-collectible-amount
-                                         :amount   (controlled-input/numeric-value input-state)}])
+                                         :amount   (controlled-input/value-numeric input-state)}])
                           :disabled? incorrect-value?}
        :button-one-label (i18n/label :t/confirm)}]
      [quo/numbered-keyboard

--- a/src/status_im/contexts/wallet/swap/setup_swap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/setup_swap/view.cljs
@@ -74,7 +74,7 @@
         approval-amount-required         (rf/sub [:wallet/swap-proposal-approval-amount-required])
         currency-symbol                  (rf/sub [:profile/currency-symbol])
         approval-transaction-status      (rf/sub [:wallet/swap-approval-transaction-status])
-        pay-input-num-value              (controlled-input/numeric-value input-state)
+        pay-input-num-value              (controlled-input/value-numeric input-state)
         pay-input-amount                 (controlled-input/input-value input-state)
         pay-token-symbol                 (:symbol asset-to-pay)
         pay-token-decimals               (:decimals asset-to-pay)
@@ -231,7 +231,7 @@
         network                                     (rf/sub [:wallet/swap-network])
         pay-input-amount                            (controlled-input/input-value pay-input-state)
         pay-token-decimals                          (:decimals asset-to-pay)
-        pay-input-num-value                         (controlled-input/numeric-value pay-input-state)
+        pay-input-num-value                         (controlled-input/value-numeric pay-input-state)
         pay-token-balance-selected-chain            (get-in asset-to-pay
                                                             [:balances-per-chain
                                                              (:chain-id network) :balance]


### PR DESCRIPTION
fixes #21183

### Summary

This PR:
- fixes crash while sending an ERC115 collectible
- fixes routes are fetched if we enter 0 in the input

### Platforms

- Android
- iOS

### Steps to test

#### Prerequisites: A profile with tokens and ERC1155 collectibles

- Open Status
- Navigate to the wallet tab
- Try sending an ERC1155 collectible
- Verify no error is encountered
- Navigate to send token (ETH/ERC20) by picking any
- Enter 0 in the input field
- Verify the routes are not fetched

status: ready
