### PR TITLE
Fixed amounts for multiple collectibles

### DIFF
--- a/src/status_im/contexts/wallet/collectible/tabs/overview/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/tabs/overview/view.cljs
@@ -63,7 +63,9 @@
 
 (defn view
   [collectible]
-  (let [owner-account (rf/sub [:wallet/collectible-details-owner collectible])
+  (let [owner-address (or (rf/sub [:wallet/current-viewing-account-address])
+                          (-> collectible :ownership first :address))
+        owner-account (rf/sub [:wallet-connect/account-details-by-address owner-address])
         traits        (-> collectible :collectible-data :traits)]
     [:<>
      [info

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -157,12 +157,10 @@
             set-title-ref                  (rn/use-callback #(reset! title-ref %))
             animation-shared-element-id    (rf/sub [:animation-shared-element-id])
             collectible                    (rf/sub [:wallet/collectible-details])
-            collectible-owner              (rf/sub [:wallet/collectible-details-owner collectible])
+            collectible-owner              (rf/sub [:wallet/current-viewing-account])
             aspect-ratio                   (rf/sub [:wallet/collectible-aspect-ratio])
             gradient-color                 (rf/sub [:wallet/collectible-gradient-color])
-            total-owned                    (rf/sub [:wallet/total-owned-collectible
-                                                    (:ownership collectible)
-                                                    (:address collectible-owner)])
+            total-owned                    (:total-owned collectible)
             {:keys [id
                     preview-url
                     collection-data

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -45,7 +45,7 @@
       :collectible-name     (:name collectible-data)
       :supported-file?      (utils/supported-file? (:animation-media-type collectible-data))
       :gradient-color-index gradient-color
-      :counter              (utils/collectible-owned-counter total-owned)
+      :counter              total-owned
       :container-style      style/collectible-container
       :on-press             on-press-fn
       :on-long-press        on-long-press-fn}]))

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -45,7 +45,7 @@
       :collectible-name     (:name collectible-data)
       :supported-file?      (utils/supported-file? (:animation-media-type collectible-data))
       :gradient-color-index gradient-color
-      :counter              total-owned
+      :counter              (utils/collectible-owned-counter total-owned)
       :container-style      style/collectible-container
       :on-press             on-press-fn
       :on-long-press        on-long-press-fn}]))

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -284,7 +284,7 @@
 
                               collectible
                               (str (:name collection-data) " #" collectible-id))
-         owner-address      (-> collectible :ownership first :address)
+         owner-address      (-> db :wallet :current-viewing-account-address)
          collectible-tx     (-> db
                                 (update-in [:wallet :ui :send] dissoc :token)
                                 (assoc-in [:wallet :ui :send :collectible] collectible)

--- a/src/status_im/contexts/wallet/send/select_asset/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_asset/view.cljs
@@ -30,14 +30,15 @@
   (let [collectibles      (rf/sub [:wallet/current-viewing-account-collectibles-filtered search-text])
         search-performed? (not (string/blank? search-text))]
     [collectibles-tab/view
-     {:collectibles         collectibles
-      :filtered?            search-performed?
-      :on-end-reached       #(rf/dispatch [:wallet/request-collectibles-for-current-viewing-account])
-      :on-collectible-press (fn [{:keys [collectible]}]
-                              (rf/dispatch [:wallet/set-collectible-to-send
-                                            {:collectible    collectible
-                                             :current-screen :screen/wallet.select-asset
-                                             :entry-point    :account-send-button}]))}]))
+     {:collectibles            collectibles
+      :current-account-address (rf/sub [:wallet/current-viewing-account-address])
+      :filtered?               search-performed?
+      :on-end-reached          #(rf/dispatch [:wallet/request-collectibles-for-current-viewing-account])
+      :on-collectible-press    (fn [{:keys [collectible]}]
+                                 (rf/dispatch [:wallet/set-collectible-to-send
+                                               {:collectible    collectible
+                                                :current-screen :screen/wallet.select-asset
+                                                :entry-point    :account-send-button}]))}]))
 
 (defn- tab-view
   [search-text selected-tab on-change-text]

--- a/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
@@ -15,7 +15,9 @@
                                        #(rf/dispatch [:wallet/collectible-amount-navigate-back]))
         send-transaction-data         (rf/sub [:wallet/wallet-send])
         collectible                   (:collectible send-transaction-data)
-        balance                       (utils/collectible-balance collectible)
+        sender-address                (rf/sub [:wallet/current-viewing-account-address])
+        balance                       (rf/sub [:wallet/total-owned-collectible (:ownership collectible)
+                                               sender-address])
         [input-state set-input-state] (rn/use-state (-> controlled-input/init-state
                                                         (controlled-input/set-value-numeric 1)
                                                         (controlled-input/set-lower-limit 1)))

--- a/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
@@ -7,6 +7,7 @@
     [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im.contexts.wallet.send.select-collectible-amount.style :as style]
     [utils.i18n :as i18n]
+    [utils.money :as money]
     [utils.re-frame :as rf]))
 
 (defn view

--- a/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_collectible_amount/view.cljs
@@ -7,7 +7,6 @@
     [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im.contexts.wallet.send.select-collectible-amount.style :as style]
     [utils.i18n :as i18n]
-    [utils.money :as money]
     [utils.re-frame :as rf]))
 
 (defn view

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -1,7 +1,8 @@
 (ns status-im.subs.wallet.collectibles
   (:require
     [clojure.string :as string]
-    [re-frame.core :as re-frame]))
+    [re-frame.core :as re-frame]
+    [utils.collection]))
 
 (defn- filter-collectibles-in-chains
   [collectibles chain-ids]
@@ -69,7 +70,7 @@
      (->> all-collectibles
           (apply interleave)
           (remove nil?)
-          distinct
+          (utils.collection/distinct-by :id)
           (add-collectibles-preview-url)))))
 
 (re-frame/reg-sub

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -128,9 +128,7 @@
  :wallet/total-owned-collectible
  :<- [:wallet/accounts-without-watched-accounts]
  (fn [accounts [_ ownership address]]
-   (let [addresses (if address
-                     #{address}
-                     (set (map :address accounts)))]
+   (let [addresses (set (or address (map :address accounts)))]
      (reduce (fn [acc item]
                (if (contains? addresses (:address item))
                  (+ acc (js/parseInt (:balance item)))

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -128,7 +128,9 @@
  :wallet/total-owned-collectible
  :<- [:wallet/accounts-without-watched-accounts]
  (fn [accounts [_ ownership address]]
-   (let [addresses (set (or address (map :address accounts)))]
+   (let [addresses (if address
+                     #{address}
+                     (set (map :address accounts)))]
      (reduce (fn [acc item]
                (if (contains? addresses (:address item))
                  (+ acc (js/parseInt (:balance item)))


### PR DESCRIPTION
fixes #20728

### Summary

Fixed issues with displaying multiple collectibles when they belong to different accounts


Uploading Simulator Screen Recording - iPhone 13 - 2024-09-09 at 17.10.12.mp4…



### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->




##### Functional


- wallet / transactions



### Steps to test
- The user has 2 wallet addresses
- Send multi collectible form "Address 1" to "Address 2"
- Check the result within the wallet main page

**Expected result:**
The collectible is not doubled on the wallet main page; On the wallet main page the counf of collectible = total count of all collectibles on all available accounts


status: ready 

