### PR TITLE
fix hidden community appears on "Opened" Tab

### DIFF
--- a/src/status_im/contexts/communities/events_test.cljs
+++ b/src/status_im/contexts/communities/events_test.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.communities.events-test
   (:require [cljs.test :refer [deftest is testing]]
+            [legacy.status-im.data-store.communities :as data-store.communities]
             matcher-combinators.test
             [status-im.contexts.chat.messenger.messages.link-preview.events :as link-preview.events]
             [status-im.contexts.communities.events :as events]))
@@ -51,7 +52,7 @@
                      [:dispatch [:chat.ui/spectate-community community-id]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
-                       {:id community-id}]]]}
+                       (data-store.communities/<-rpc #js {"id" community-id})]]]}
                (events/community-fetched cofx arg))))))
     (testing "given a joined community"
       (let [cofx {:db {:communities/fetching-communities {community-id true}}}
@@ -62,7 +63,7 @@
                      [:dispatch [:chat.ui/spectate-community community-id]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
-                       {:id community-id}]]]}
+                       (data-store.communities/<-rpc #js {"id" community-id})]]]}
                (events/community-fetched cofx arg))))))
     (testing "given a token-gated community"
       (let [cofx {:db {:communities/fetching-communities {community-id true}}}
@@ -73,7 +74,7 @@
                      [:dispatch [:chat.ui/spectate-community community-id]]
                      [:dispatch
                       [:chat.ui/cache-link-preview-data "community-link+community-id"
-                       {:id community-id}]]]}
+                       (data-store.communities/<-rpc #js {"id" community-id})]]]}
                (events/community-fetched cofx arg))))))
     (testing "given nil community"
       (testing "do nothing"

--- a/src/utils/transforms.cljs
+++ b/src/utils/transforms.cljs
@@ -18,7 +18,7 @@
 (defn <-js-map
   "Shallowly transforms JS Object keys/values with `key-fn`/`val-fn`.
 
-  Returns nil if `m` is not an instance of `js/Object`.
+  Returns m if `m` is not an instance of `js/Object`.
 
   Implementation taken from `js->clj`, but with the ability to customize how
   keys and/or values are transformed in one loop.
@@ -33,7 +33,8 @@
   ([^js m]
    (<-js-map m nil))
   ([^js m {:keys [key-fn val-fn]}]
-   (when (identical? (type m) js/Object)
+   (assert (or (nil? m) (identical? (type m) js/Object) (map? m)))
+   (if (identical? (type m) js/Object)
      (persistent!
       (reduce (fn [r k]
                 (let [v       (oops/oget+ m k)
@@ -41,7 +42,8 @@
                       new-val (if val-fn (val-fn k v) v)]
                   (assoc! r new-key new-val)))
               (transient {})
-              (js-keys m))))))
+              (js-keys m)))
+     m)))
 
 (defn js-stringify
   [js-object spaces]

--- a/src/utils/transforms_test.cljs
+++ b/src/utils/transforms_test.cljs
@@ -13,7 +13,7 @@
     (are [expected m]
      (is (equals-as-json expected (sut/<-js-map m)))
      nil               nil
-     nil               #js []
+     {:a 1}            {:a 1}
      #js {}            #js {}
      #js {"a" 1 "b" 2} #js {"a" 1 "b" 2}))
 


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21169

### Summary

When the community is fetched, we were calling the [handle-community](https://github.com/status-im/status-mobile/blob/337ec963b7fc8934da09f600b249567f3f177c3c/src/status_im/contexts/communities/events.cljs#L21) event with a Clojure object instead of a JavaScript object. The [<-js-map](https://github.com/status-im/status-mobile/blob/337ec963b7fc8934da09f600b249567f3f177c3c/src/utils/transforms.cljs#L21) function returns `nil` because it expects a JavaScript object, resulting in a community with a `nil` id.

**Note:** To address this issue for the future, I considered changing [<-js-map](https://github.com/status-im/status-mobile/blob/337ec963b7fc8934da09f600b249567f3f177c3c/src/utils/transforms.cljs#L21) to return the Clojure object itself instead of `nil`. However, in this particular case, this change would not have been beneficial because the [rename-communities-keys](https://github.com/status-im/status-mobile/blob/337ec963b7fc8934da09f600b249567f3f177c3c/src/legacy/status_im/data_store/communities.cljs#L58) function also expects JavaScript keys. Therefore, I did not modify the function, considering potential consequences. Still, please let me know if you think we should return the Clojure object instead of `nil`.

status: ready