### PR TITLE
fix_: delay in fetching the currencies list

### DIFF
--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -62,6 +62,9 @@
                  ;; loading chats and communities. This globally helps alleviate
                  ;; stuttering immediately after login.
                  [:dispatch-later [{:ms 500 :dispatch [:wallet/initialize]}]]
+                 ;; Fetching the currencies along with wallet initialization as
+                 ;; we rely on it for displaying currency symbol
+                 [:dispatch-later [{:ms 500 :dispatch [:settings/get-currencies]}]]
 
                  [:logs/set-level log-level]
 
@@ -95,7 +98,6 @@
            [:dispatch-later [{:ms 1500 :dispatch [:profile.login/non-critical-initialization]}]]
            [:dispatch [:network/check-expensive-connection]]
            [:profile.settings/get-profile-picture key-uid]
-           [:settings/get-currencies]
            (when (ff/enabled? ::ff/wallet.wallet-connect)
              [:dispatch [:wallet-connect/init]])
            (when (ff/enabled? ::ff/wallet.swap)

--- a/src/status_im/contexts/settings/language_and_currency/events.cljs
+++ b/src/status_im/contexts/settings/language_and_currency/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.settings.language-and-currency.events
-  (:require [status-im.common.json-rpc.events :as json-rpc]
-            [status-im.contexts.settings.language-and-currency.data-store :as data-store]
+  (:require [status-im.contexts.settings.language-and-currency.data-store :as data-store]
             [utils.collection]
             [utils.re-frame :as rf]))
 
@@ -11,8 +10,9 @@
                  :currencies
                  (utils.collection/index-by :id all-currencies))})))
 
-(rf/reg-fx :settings/get-currencies
+(rf/reg-event-fx :settings/get-currencies
  (fn []
-   (json-rpc/call {:method     "appgeneral_getCurrencies"
-                   :on-success [:settings/get-currencies-success]
-                   :on-error   [:log-rpc-error {:event :settings/get-currencies}]})))
+   {:fx [[:json-rpc/call
+          [{:method     "appgeneral_getCurrencies"
+            :on-success [:settings/get-currencies-success]
+            :on-error   [:log-rpc-error {:event :settings/get-currencies}]}]]]}))


### PR DESCRIPTION
fixes #21190

### Summary

This PR fixes the delay in showing the currency symbol in the wallet.

The root cause is explained in the actual issue: https://github.com/status-im/status-mobile/issues/21190#issuecomment-2338314375

Moving the RPC call to Phase 1 along with wallet initialisation helps us to improve the wallet UX (by skipping the waiting to start the messenger) and it doesn't cost much as it barely takes ~0.23 ms including processing of response and saving it in the app-db.

### Platforms

- Android
- iOS

### Steps to test

#### Prerequisite: A user joined a big community with a large number of members and channels (eg: Status Community)

- Open Status
- Log into your profile
- Navigate to the Wallet tab
- Verify the currency symbol is displayed with the fiat value

status: ready 
