### PR TITLE
fix_: crash on viewing dynamic file type collectibles

### DIFF
--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -15,7 +15,6 @@
 
 (def supported-collectible-types
   #{"image/jpeg"
-    "image/gif"
     "image/bmp"
     "image/png"
     "image/webp"

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -40,7 +40,8 @@
     [quo/collectible-list-item
      {:type                 :card
       :image-src            (:uri preview-url)
-      :avatar-image-src     (:image-url collection-data)
+      :avatar-image-src     (when (utils/supported-file? (:image-url collection-data))
+                              (:image-url collection-data))
       :collectible-name     (:name collectible-data)
       :supported-file?      (utils/supported-file? (:animation-media-type collectible-data))
       :gradient-color-index gradient-color


### PR DESCRIPTION
fixes #20466

### Summary

This PR removes the support for GIF file types for the collectibles.

### Review notes

The crash is due to bloated memory consumption due to dynamic file types (such as GIF) in the list that result in low FPS.

It’s consumed so much memory. The average RAM consumption was 1.2 GB (60 FPS), if the collectables were static images. If it’s a GIF, it goes up to 2.5 GB (8 FPS). 

Until we find a solid solution to handle the dynamic data types, we drop the support for GIFs and support only static images/file types.

### Platforms

- Android
- iOS

### Steps to test

#### Prerequisite: A profile with a lot of collectibles (GIFs)

- Open Status
- Log into your account
- Navigate to the Wallet tab and then collectibles
- Verify unsupported file is displayed for GIF-type collectibles
- Verify that the scrolling through the list doesn't crash the app

status: ready 

