### PR TITLE
chore: dispatch open-url event instead of calling function directly

### DIFF
--- a/src/status_im/contexts/wallet/sheets/account_origin/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/account_origin/view.cljs
@@ -5,7 +5,8 @@
     [react-native.core :as rn]
     [status-im.constants :as const]
     [status-im.contexts.wallet.sheets.account-origin.style :as style]
-    [utils.i18n :as i18n]))
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (defn- header
   [text]
@@ -41,5 +42,5 @@
      :size            24
      :icon-left       :i/info
      :container-style style/action-container
-     :on-press        #(rn/open-url const/create-account-link)}
+     :on-press        #(rf/dispatch [:open-url const/create-account-link])}
     (i18n/label :t/read-more)]])

--- a/src/status_im/contexts/wallet/sheets/buy_token/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/buy_token/view.cljs
@@ -9,7 +9,8 @@
 (defn- crypto-on-ramp-item
   [{:keys [name description fees logo-url site-url recurrent-site-url]} _ _ {:keys [tab]}]
   (let [open-url (rn/use-callback (fn []
-                                    (rn/open-url (if (= tab :recurrent) recurrent-site-url site-url)))
+                                    (rf/dispatch [:open-url
+                                                  (if (= tab :recurrent) recurrent-site-url site-url)]))
                                   [site-url recurrent-site-url tab])]
     [quo/settings-item
      {:title             name

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_responses.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_responses.cljs
@@ -148,7 +148,7 @@
                                :sessionJson
                                transforms/json->clj
                                data-store/get-dapp-redirect-url))]
-     {:fx [[:open-url redirect-url]]})))
+     {:fx [[:effects/open-url redirect-url]]})))
 
 (rf/reg-event-fx
  :wallet-connect/dismiss-request-modal

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_responses_test.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_responses_test.cljs
@@ -23,5 +23,5 @@
                   data-store/get-dapp-redirect-url
                   (fn [_] "native://redirect-url")]
 
-      (is (match? {:fx [[:open-url "native://redirect-url"]]}
+      (is (match? {:fx [[:effects/open-url "native://redirect-url"]]}
                   (dispatch [event-id]))))))

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -148,10 +148,10 @@
 
 (rf/reg-event-fx :open-url
  (fn [_ [url]]
-   {:fx [[:open-url url]]}))
+   {:fx [[:effects/open-url url]]}))
 
 (rf/reg-fx
- :open-url
+ :effects/open-url
  (fn [url]
    (when (not (string/blank? url))
      (.openURL ^js react/linking (url/normalize-url url)))))

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -146,6 +146,10 @@
 
 (rf/reg-event-fx :open-share open-share)
 
+(rf/reg-event-fx :open-url
+ (fn [_ [url]]
+   {:fx [[:open-url url]]}))
+
 (rf/reg-fx
  :open-url
  (fn [url]


### PR DESCRIPTION
fixes #20377 
follow-up pr: https://github.com/status-im/status-mobile/pull/20752

### Summary

* This PR attempts to replace usage of `rn/open-url` (for opening links) to `rf/dispatch` with the `:open-url` event
  * This PR also defines the `:open-url` Re-Frame event

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Opening links from the buy crypto bottom-sheet
- Opening the read-more link when creating an account

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- The steps to verify the behaviour of these changes are captured in the screen recordings below
- Though this steps assume that the user has opened the Status mobile app and has an account with a balance greater than 0.

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### After Changes

##### Opening links from the buy crypto bottom-sheet

https://github.com/user-attachments/assets/0004c22d-e2ea-456a-a376-dd6ed1352e2d

##### Opening the read-more link from the account creation info

https://github.com/user-attachments/assets/75257102-00a0-4e47-a0b1-3f0e5c39fcf2


status: ready <!-- Can be ready or wip -->