### PR TITLE
[#21212] - Fix not joined options for token gated communities

### DIFF
--- a/src/status_im/contexts/communities/actions/community_options/component_spec.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/component_spec.cljs
@@ -8,7 +8,8 @@
 
   (h/test "joined options - Non token Gated"
     (h/setup-subs {:communities/my-pending-request-to-join nil
-                   :communities/community                  {:joined true}})
+                   :communities/community                  {:joined true}
+                   :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
     (h/is-truthy (h/get-by-translation-text :t/view-members))
     (h/is-truthy (h/get-by-translation-text :t/view-community-rules))
@@ -23,7 +24,8 @@
   (h/test "joined options - Token Gated"
     (h/setup-subs {:communities/my-pending-request-to-join nil
                    :communities/community                  {:joined            true
-                                                            :role-permissions? true}})
+                                                            :role-permissions? true}
+                   :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
     (h/is-truthy (h/get-by-translation-text :t/view-members))
     (h/is-truthy (h/get-by-translation-text :t/view-community-rules))
@@ -38,7 +40,8 @@
 
   (h/test "admin options - Non token Gated"
     (h/setup-subs {:communities/my-pending-request-to-join nil
-                   :communities/community                  {:admin true}})
+                   :communities/community                  {:admin true}
+                   :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
     (h/is-truthy (h/get-by-translation-text :t/view-members))
     (h/is-truthy (h/get-by-translation-text :t/view-community-rules))
@@ -52,7 +55,8 @@
   (h/test "admin options - Token Gated"
     (h/setup-subs {:communities/my-pending-request-to-join nil
                    :communities/community                  {:admin             true
-                                                            :role-permissions? true}})
+                                                            :role-permissions? true}
+                   :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
     (h/is-truthy (h/get-by-translation-text :t/view-members))
     (h/is-truthy (h/get-by-translation-text :t/view-community-rules))
@@ -65,7 +69,8 @@
 
   (h/test "request sent options - Non token Gated"
     (h/setup-subs {:communities/my-pending-request-to-join "mock-id"
-                   :communities/community                  {}})
+                   :communities/community                  {}
+                   :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
     (h/is-truthy (h/get-by-translation-text :t/view-members))
     (h/is-truthy (h/get-by-translation-text :t/view-community-rules))
@@ -76,7 +81,8 @@
 
   (h/test "request sent options - Token Gated"
     (h/setup-subs {:communities/my-pending-request-to-join "mock-id"
-                   :communities/community                  {:role-permissions? true}})
+                   :communities/community                  {:role-permissions? true}
+                   :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
     (h/is-truthy (h/get-by-translation-text :t/invite-people-from-contacts))
     ;(h/is-truthy (h/get-by-translation-text :t/view-token-gating))
@@ -86,7 +92,8 @@
 
   (h/test "banned options - Non token Gated"
     (h/setup-subs {:communities/my-pending-request-to-join nil
-                   :communities/community                  {:banList true}})
+                   :communities/community                  {:banList true}
+                   :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
     (h/is-truthy (h/get-by-translation-text :t/view-members))
     (h/is-truthy (h/get-by-translation-text :t/view-community-rules))
@@ -97,7 +104,8 @@
   (h/test "banned options - Token Gated"
     (h/setup-subs {:communities/my-pending-request-to-join nil
                    :communities/community                  {:banList           100
-                                                            :role-permissions? true}})
+                                                            :role-permissions? true}
+                   :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
     (h/is-truthy (h/get-by-translation-text :t/invite-people-from-contacts))
     ;(h/is-truthy (h/get-by-translation-text :t/view-token-gating))
@@ -107,7 +115,8 @@
   (h/test "banned options - Token Gated"
     (h/setup-subs {:communities/my-pending-request-to-join nil
                    :communities/community                  {:banList           100
-                                                            :role-permissions? true}})
+                                                            :role-permissions? true}
+                   :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
     (h/is-truthy (h/get-by-translation-text :t/invite-people-from-contacts))
     ;(h/is-truthy (h/get-by-translation-text :t/view-token-gating))
@@ -118,6 +127,7 @@
     (h/setup-subs {:communities/my-pending-request-to-join nil
                    :communities/community                  {:joined            true
                                                             :muted             true
-                                                            :role-permissions? true}})
+                                                            :role-permissions? true}
+                   :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
     (h/is-truthy (h/get-by-translation-text :t/unmute-community))))

--- a/src/status_im/contexts/communities/actions/community_options/view.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/view.cljs
@@ -56,7 +56,7 @@
 
 (defn mark-as-read
   [id]
-  {:icon                :i/up-to-date
+  {:icon                :i/mark-as-read
    :accessibility-label :mark-as-read
    :label               (i18n/label :t/mark-as-read)
    :on-press            #(hide-sheet-and-dispatch [:chat.ui/mark-all-read-in-community-pressed id])})
@@ -137,13 +137,11 @@
 
 (defn not-joined-options
   [id token-gated? intro-message]
-  [[(when-not token-gated? (view-members id))
-    (when-not token-gated? (view-rules id intro-message))
-    (mark-as-read id)
-    (invite-contacts id)
-    (when token-gated? (view-token-gating id))
-    (show-qr id)
-    (share-community id)]])
+  (let [common   [(show-qr id) (share-community id)]
+        specific (if token-gated?
+                   [(invite-contacts id) (view-token-gating id)]
+                   [(view-members id) (view-rules id intro-message) (invite-contacts id)])]
+    [(concat specific common)]))
 
 (defn join-request-sent-options
   [id token-gated? request-id intro-message]

--- a/src/status_im/contexts/communities/actions/community_options/view.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/view.cljs
@@ -186,17 +186,22 @@
 
 (defn get-context-drawers
   [{:keys [id]}]
-  (let [{:keys [role-permissions? ;; Used to check token gating for a community
-                admin joined muted banList muted-till color
-                intro-message]}  (rf/sub [:communities/community id])
-        request-id               (rf/sub [:communities/my-pending-request-to-join id])
-        test-networks-enabled?   (rf/sub [:profile/test-networks-enabled?])]
+  (let [{:keys [role-permissions? admin joined
+                muted banList muted-till color
+                intro-message]} (rf/sub [:communities/community id])
+        request-id              (rf/sub [:communities/my-pending-request-to-join id])
+        test-networks?          (rf/sub [:profile/test-networks-enabled?])]
     (cond
-      admin      (owner-options id role-permissions? muted muted-till intro-message)
-      joined     (joined-options id role-permissions? muted muted-till color intro-message)
-      request-id (join-request-sent-options id role-permissions? request-id intro-message test-networks-enabled?)
-      banList    (banned-options id role-permissions? intro-message test-networks-enabled?)
-      :else      (not-joined-options id role-permissions? intro-message test-networks-enabled?))))
+      admin
+      (owner-options id role-permissions? muted muted-till intro-message)
+      joined
+      (joined-options id role-permissions? muted muted-till color intro-message)
+      request-id
+      (join-request-sent-options id role-permissions? request-id intro-message test-networks?)
+      banList
+      (banned-options id role-permissions? intro-message test-networks?)
+      :else
+      (not-joined-options id role-permissions? intro-message test-networks?))))
 
 (defn community-options-bottom-sheet
   [id]


### PR DESCRIPTION
fixes #21212

### Summary

This PR fixes a the options shown for token gated communities when the user isn't joined.

Options are now correct:
<img src="https://github.com/user-attachments/assets/50503c8e-ffe7-4b12-b954-508ec6be4948" height="550">

Additionally, changes the  "Mark as read" icon, we were using:

![Screenshot from 2024-09-10 17-03-36](https://github.com/user-attachments/assets/771e211a-84c2-44f7-bcb9-af62a277c2b1)

Now (as in figma):

![Screenshot from 2024-09-10 17-03-46](https://github.com/user-attachments/assets/21ec0d53-f00e-4073-af26-681605b83456)


#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Create a new profile and visit a token gated communitiy, you can use this one:

https://status.app/c/G1EAAMTyFm0fBflGtiFYF5IgNAQzPiCADTgBCjTjlZ_tpjItNSiTKjz7Bvw2VF7r7XG_tFRcPsgFyoCnHC2MDzF5Bw==#zQ3shsQJt1uYuzLvQ1mpcDHSUnEYTV5wMmtzkoqER8kezGqAE

- Click on the 3 dots button and check the modal

status: ready