### PR TITLE
Strip out eip-3770 prefixes when scan qr

### DIFF
--- a/src/status_im/contexts/shell/qr_reader/view.cljs
+++ b/src/status_im/contexts/shell/qr_reader/view.cljs
@@ -84,7 +84,7 @@
     (load-and-show-profile scanned-text)
 
     (utils-address/supported-address? scanned-text)
-    (when-let [address (utils-address/supported-address->basic-eth-address scanned-text)]
+    (when-let [address (utils-address/supported-address->eth-address scanned-text)]
       (debounce/debounce-and-dispatch [:generic-scanner/scan-success address] 300)
       (debounce/debounce-and-dispatch [:navigate-change-tab :wallet-stack] 300))
 

--- a/src/status_im/contexts/shell/qr_reader/view.cljs
+++ b/src/status_im/contexts/shell/qr_reader/view.cljs
@@ -84,7 +84,7 @@
     (load-and-show-profile scanned-text)
 
     (utils-address/supported-address? scanned-text)
-    (when-let [address (utils-address/supported-address->status-address scanned-text)]
+    (when-let [address (utils-address/supported-address->basic-eth-address scanned-text)]
       (debounce/debounce-and-dispatch [:generic-scanner/scan-success address] 300)
       (debounce/debounce-and-dispatch [:navigate-change-tab :wallet-stack] 300))
 

--- a/src/status_im/contexts/wallet/common/scan_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/scan_account/view.cljs
@@ -15,7 +15,7 @@
       :error-message   (i18n/label :t/oops-this-qr-does-not-contain-an-address)
       :validate-fn     #(utils-address/supported-address? %)
       :on-success-scan (fn [result]
-                         (let [address (utils-address/supported-address->status-address result)]
+                         (let [address (utils-address/supported-address->basic-eth-address result)]
                            (when on-result (on-result address))
                            (debounce/debounce-and-dispatch
                             [:wallet/scan-address-success address]

--- a/src/status_im/contexts/wallet/common/scan_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/scan_account/view.cljs
@@ -15,7 +15,7 @@
       :error-message   (i18n/label :t/oops-this-qr-does-not-contain-an-address)
       :validate-fn     #(utils-address/supported-address? %)
       :on-success-scan (fn [result]
-                         (let [address (utils-address/supported-address->basic-eth-address result)]
+                         (let [address (utils-address/supported-address->eth-address result)]
                            (when on-result (on-result address))
                            (debounce/debounce-and-dispatch
                             [:wallet/scan-address-success address]

--- a/src/utils/address.cljs
+++ b/src/utils/address.cljs
@@ -120,20 +120,20 @@
   [address]
   (re-find regx-address-contains address))
 
-(defn metamask-address->status-address
+(defn metamask-address->basic-eth-address
   [eip-3770-address]
   (extract-address-without-chains-info eip-3770-address))
 
-(defn eip-3770-address->status-address
+(defn eip-3770-address->basic-eth-address
   [eip-3770-address]
   (extract-address-without-chains-info eip-3770-address))
 
-(defn supported-address->status-address
+(defn supported-address->basic-eth-address
   [address]
   (cond
     (eip-3770-address? address)
-    (eip-3770-address->status-address address)
+    (eip-3770-address->basic-eth-address address)
 
     (metamask-address? address)
-    (metamask-address->status-address address)))
+    (metamask-address->basic-eth-addressaddress)))
 

--- a/src/utils/address.cljs
+++ b/src/utils/address.cljs
@@ -120,20 +120,20 @@
   [address]
   (re-find regx-address-contains address))
 
-(defn metamask-address->basic-eth-address
+(defn metamask-address->eth-address
   [eip-3770-address]
   (extract-address-without-chains-info eip-3770-address))
 
-(defn eip-3770-address->basic-eth-address
+(defn eip-3770-address->eth-address
   [eip-3770-address]
   (extract-address-without-chains-info eip-3770-address))
 
-(defn supported-address->basic-eth-address
+(defn supported-address->eth-address
   [address]
   (cond
     (eip-3770-address? address)
-    (eip-3770-address->basic-eth-address address)
+    (eip-3770-address->eth-address address)
 
     (metamask-address? address)
-    (metamask-address->basic-eth-address address)))
+    (metamask-address->eth-address address)))
 

--- a/src/utils/address.cljs
+++ b/src/utils/address.cljs
@@ -101,30 +101,39 @@
 
 (defn eip-3770-address?
   "Checks if address follows EIP-3770 format which is default for Status"
-  [s]
-  (re-find regx-eip-3770-address s))
+  [address]
+  (re-find regx-eip-3770-address address))
 
 (defn supported-address?
   [s]
   (boolean (or (eip-3770-address? s)
                (metamask-address? s))))
 
-(defn metamask-address->status-address
+(defn metamask-address->eip-3770-address
   [metamask-address]
   (when-let [[_ address metamask-network-suffix] (split-metamask-address metamask-address)]
     (if-let [status-network-prefix (eip-155-suffix->eip-3770-prefix metamask-network-suffix)]
       (str status-network-prefix address)
       address)))
 
+(defn extract-address-without-chains-info
+  [address]
+  (re-find regx-address-contains address))
+
+(defn metamask-address->status-address
+  [eip-3770-address]
+  (extract-address-without-chains-info eip-3770-address))
+
+(defn eip-3770-address->status-address
+  [eip-3770-address]
+  (extract-address-without-chains-info eip-3770-address))
+
 (defn supported-address->status-address
   [address]
   (cond
     (eip-3770-address? address)
-    address
+    (eip-3770-address->status-address address)
 
     (metamask-address? address)
     (metamask-address->status-address address)))
 
-(defn extract-address-without-chains-info
-  [address]
-  (re-find regx-address-contains address))

--- a/src/utils/address.cljs
+++ b/src/utils/address.cljs
@@ -135,5 +135,5 @@
     (eip-3770-address->basic-eth-address address)
 
     (metamask-address? address)
-    (metamask-address->basic-eth-addressaddress)))
+    (metamask-address->basic-eth-address address)))
 

--- a/src/utils/address_test.cljs
+++ b/src/utils/address_test.cljs
@@ -152,10 +152,10 @@
     (dorun
      (for [{metamask-address :metamask
             status-address   :status} metamask-to-status]
-       (is (= status-address (utils.address/supported-address->status-address metamask-address))))))
+       (is (= status-address (utils.address/supported-address->basic-eth-address metamask-address))))))
   (testing "Check eip-3770 to status address conversion is valid"
     (dorun
      (for [{eip-3770-address :eip-3770
             status-address   :status} eip-3770-to-status]
-       (is (= status-address (utils.address/supported-address->status-address eip-3770-address)))))))
+       (is (= status-address (utils.address/supported-address->basic-eth-address eip-3770-address)))))))
 

--- a/src/utils/address_test.cljs
+++ b/src/utils/address_test.cljs
@@ -1,6 +1,6 @@
 (ns utils.address-test
   (:require
-    [cljs.test :refer [deftest is run-tests testing]]
+    [cljs.test :refer [deftest is testing]]
     [utils.address]))
 
 (deftest get-shortened-compressed-key-test
@@ -159,5 +159,3 @@
             status-address   :status} eip-3770-to-status]
        (is (= status-address (utils.address/supported-address->status-address eip-3770-address)))))))
 
-
-(run-tests)

--- a/src/utils/address_test.cljs
+++ b/src/utils/address_test.cljs
@@ -152,10 +152,10 @@
     (dorun
      (for [{metamask-address :metamask
             status-address   :status} metamask-to-status]
-       (is (= status-address (utils.address/supported-address->basic-eth-address metamask-address))))))
+       (is (= status-address (utils.address/supported-address->eth-address metamask-address))))))
   (testing "Check eip-3770 to status address conversion is valid"
     (dorun
      (for [{eip-3770-address :eip-3770
             status-address   :status} eip-3770-to-status]
-       (is (= status-address (utils.address/supported-address->basic-eth-address eip-3770-address)))))))
+       (is (= status-address (utils.address/supported-address->eth-address eip-3770-address)))))))
 

--- a/src/utils/address_test.cljs
+++ b/src/utils/address_test.cljs
@@ -1,6 +1,6 @@
 (ns utils.address-test
   (:require
-    [cljs.test :refer [deftest is testing]]
+    [cljs.test :refer [deftest is run-tests testing]]
     [utils.address]))
 
 (deftest get-shortened-compressed-key-test
@@ -46,6 +46,19 @@
    "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0xa"
    "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"])
 
+(def valid-eip-3770-addresses
+  ["0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+   "eth:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+   "eth:arb1:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+   "eth:arb1:oeth:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"])
+
+(def invalid-eip-3770-addresses
+  ["0x+38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+   "eth3:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+   ":eth:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+   "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2:eth"
+   "eth:arb10x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"])
+
 (def invalid-metamask-addresses
   ["ethe:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0x1"
    ":0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0xa4b1"
@@ -54,13 +67,29 @@
    "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd20xa4b1"
    "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2:0xa"])
 
+(def metamask-to-eip-3770
+  [{:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0x1"
+    :eip-3770 "eth:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0xa4b1"
+    :eip-3770 "arb1:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0xa"
+    :eip-3770 "oeth:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+    :eip-3770 "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:metamask "ethe:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0x1" :eip-3770 nil}
+   {:metamask ":0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0xa4b1" :eip-3770 nil}
+   {:metamask "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0xa" :eip-3770 nil}
+   {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0x1d" :eip-3770 nil}
+   {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd20xa4b1" :eip-3770 nil}
+   {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2:0xa" :eip-3770 nil}])
+
 (def metamask-to-status
   [{:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0x1"
-    :status   "eth:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+    :status   "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
    {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0xa4b1"
-    :status   "arb1:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+    :status   "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
    {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0xa"
-    :status   "oeth:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+    :status   "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
    {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
     :status   "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
    {:metamask "ethe:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0x1" :status nil}
@@ -69,6 +98,26 @@
    {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2@0x1d" :status nil}
    {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd20xa4b1" :status nil}
    {:metamask "ethereum:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2:0xa" :status nil}])
+
+(def eip-3770-to-status
+  [{:eip-3770 "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+    :status   "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:eip-3770 "eth:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+    :status   "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:eip-3770 "eth:arb1:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+    :status   "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:eip-3770 "eth:arb1:oeth:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+    :status   "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:status   nil
+    :eip-3770 "0x+38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:status   nil
+    :eip-3770 "eth3:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:status   nil
+    :eip-3770 ":eth:0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}
+   {:status   nil
+    :eip-3770 "0x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2:eth"}
+   {:status   nil
+    :eip-3770 "eth:arb10x38cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"}])
 
 (deftest metamask-address?-test
   (testing "Check valid metamask addresses"
@@ -80,9 +129,35 @@
      (for [address invalid-metamask-addresses]
        (is (not (utils.address/metamask-address? address)))))))
 
-(deftest metamask-address->status-address-test
+(deftest eip-3770-address?-test
+  (testing "Check valid eip-3770 addresses"
+    (dorun
+     (for [address valid-eip-3770-addresses]
+       (is (utils.address/eip-3770-address? address)))))
+  (testing "Check invalid eip-3770 addresses"
+    (dorun
+     (for [address invalid-eip-3770-addresses]
+       (is (not (utils.address/metamask-address? address)))))))
+
+(deftest metamask-address->eip-3770-address-test
+  (testing "Check metamask to status address conversion is valid"
+    (dorun
+     (for [{metamask-address :metamask
+            eip-3770-address :eip-3770} metamask-to-eip-3770]
+       (is (= eip-3770-address (utils.address/metamask-address->eip-3770-address metamask-address)))))))
+
+
+(deftest supported-address->status-address-test
   (testing "Check metamask to status address conversion is valid"
     (dorun
      (for [{metamask-address :metamask
             status-address   :status} metamask-to-status]
-       (is (= status-address (utils.address/metamask-address->status-address metamask-address)))))))
+       (is (= status-address (utils.address/supported-address->status-address metamask-address))))))
+  (testing "Check eip-3770 to status address conversion is valid"
+    (dorun
+     (for [{eip-3770-address :eip-3770
+            status-address   :status} eip-3770-to-status]
+       (is (= status-address (utils.address/supported-address->status-address eip-3770-address)))))))
+
+
+(run-tests)


### PR DESCRIPTION
fixes #21152

### Summary
Qr codes scanned by status app now stripped out of multichain prefixes


### Review notes
Qr scanner related on `utils/address` namespace so all changes happen there.


#### Platforms
- Android
- iOS

#### Areas that maybe impacted

##### Functional
- wallet / transactions


### Steps to test
- Open Status
- Scan any eip-3770 or metamask qr code
- Make sure that scanned address is plain eth address without any prefixes or suffixes

status: ready
