### PR TITLE
add optional BIP39Passphrase parameter on account recovery

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/Utils.kt
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/Utils.kt
@@ -124,6 +124,11 @@ class Utils(private val reactContext: ReactApplicationContext) : ReactContextBas
         executeRunnableStatusGoMethod({ Statusgo.validateMnemonic(seed) }, callback)
     }
 
+    @ReactMethod
+    fun validateMnemonicWithPassphrase(seed: String, passphrase: String, callback: Callback) {
+        executeRunnableStatusGoMethod({ Statusgo.validateMnemonicWithPassphrase(seed, passphrase) }, callback)
+    }
+
     fun is24Hour(): Boolean {
         return android.text.format.DateFormat.is24HourFormat(reactContext.applicationContext)
     }

--- a/modules/react-native-status/ios/RCTStatus/Utils.m
+++ b/modules/react-native-status/ios/RCTStatus/Utils.m
@@ -116,6 +116,16 @@ RCT_EXPORT_METHOD(validateMnemonic:(NSString *)seed
     callback(@[result]);
 }
 
+RCT_EXPORT_METHOD(validateMnemonicWithPassphrase:(NSString *)seed
+    passphrase:(NSString *)passphrase
+    callback:(RCTResponseSenderBlock)callback) {
+    #if DEBUG
+        NSLog(@"validateMnemonicWithPassphrase() method called");
+    #endif
+    NSString *result = StatusgoValidateMnemonicWithPassphrase(seed, passphrase);
+    callback(@[result]);
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(checkAddressChecksum:(NSString *)address) {
     return StatusgoCheckAddressChecksum(address);
 }

--- a/modules/react-native-status/nodejs/status.cpp
+++ b/modules/react-native-status/nodejs/status.cpp
@@ -942,6 +942,46 @@ void _ValidateMnemonic(const FunctionCallbackInfo<Value>& args) {
 
 }
 
+void _ValidateMnemonicWithPassphrase(const FunctionCallbackInfo<Value>& args) {
+	Isolate* isolate = args.GetIsolate();
+        Local<Context> context = isolate->GetCurrentContext();
+
+	if (args.Length() != 2) {
+		// Throw an Error that is passed back to JavaScript
+		isolate->ThrowException(Exception::TypeError(
+			String::NewFromUtf8Literal(isolate, "Wrong number of arguments for ValidateMnemonicWithPassphrase")));
+		return;
+	}
+
+	// Check the argument types
+
+	if (!args[0]->IsString()) {
+		isolate->ThrowException(Exception::TypeError(
+			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'mnemonic'")));
+		return;
+	}
+
+	if (!args[1]->IsString()) {
+		isolate->ThrowException(Exception::TypeError(
+			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'passphrase'")));
+		return;
+	}
+
+	String::Utf8Value arg0Obj(isolate, args[0]->ToString(context).ToLocalChecked());
+	char *arg0 = *arg0Obj;
+
+	String::Utf8Value arg1Obj(isolate, args[1]->ToString(context).ToLocalChecked());
+	char *arg1 = *arg1Obj;
+
+	// Call exported Go function, which returns a C string
+	char *c = ValidateMnemonicWithPassphrase(arg0, arg1);
+
+	Local<String> ret = String::NewFromUtf8(isolate, c).ToLocalChecked();
+	args.GetReturnValue().Set(ret);
+	delete c;
+
+}
+
 void _MultiformatSerializePublicKey(const FunctionCallbackInfo<Value>& args) {
 	Isolate* isolate = args.GetIsolate();
         Local<Context> context = isolate->GetCurrentContext();
@@ -2016,6 +2056,7 @@ void init(Local<Object> exports) {
 	NODE_SET_METHOD(exports, "saveAccountAndLogin", _SaveAccountAndLogin);
 	NODE_SET_METHOD(exports, "createAccountAndLogin", _CreateAccountAndLogin);
 	NODE_SET_METHOD(exports, "validateMnemonic", _ValidateMnemonic);
+  NODE_SET_METHOD(exports, "validateMnemonicWithPassphrase", _ValidateMnemonicWithPassphrase);
 	NODE_SET_METHOD(exports, "multiformatSerializePublicKey", _MultiformatSerializePublicKey);
 	NODE_SET_METHOD(exports, "saveAccountAndLoginWithKeycard", _SaveAccountAndLoginWithKeycard);
 	NODE_SET_METHOD(exports, "loginWithKeycard", _LoginWithKeycard);

--- a/src/native_module/core.cljs
+++ b/src/native_module/core.cljs
@@ -460,6 +460,14 @@
    (log/debug "[native-module] validate-mnemonic")
    (.validateMnemonic ^js (utils) mnemonic callback)))
 
+(defn validate-mnemonic-with-passphrase
+  "Validate that a mnemonic conforms to BIP39 dictionary/checksum standards and return key-uid"
+  ([mnemonic passphrase]
+   (native-utils/promisify-native-module-call validate-mnemonic-with-passphrase mnemonic passphrase))
+  ([mnemonic passphrase callback]
+   (log/debug "[native-module] validate-mnemonic-with-passphrase")
+   (.validateMnemonicWithPassphrase ^js (utils) mnemonic passphrase callback)))
+
 (defn validate-connection-string
   [connection-string]
   (log/debug "[native-module] validate-connection-string")

--- a/src/status_im/contexts/profile/recover/events.cljs
+++ b/src/status_im/contexts/profile/recover/events.cljs
@@ -8,7 +8,7 @@
 
 (rf/defn recover-profile-and-login
   {:events [:profile.recover/recover-and-login]}
-  [{:keys [db]} {:keys [display-name password image-path color seed-phrase]}]
+  [{:keys [db]} {:keys [display-name password image-path color seed-phrase BIP39Passphrase]}]
   (let [login-sha3-password (native-module/sha3 (security/safe-unmask-data password))]
     {:db
      (-> db
@@ -19,6 +19,7 @@
      (merge (profile.config/create)
             {:displayName        display-name
              :mnemonic           (security/safe-unmask-data seed-phrase)
+             :BIP39Passphrase    (security/safe-unmask-data BIP39Passphrase)
              :password           login-sha3-password
              :imagePath          (profile.config/strip-file-prefix image-path)
              :customizationColor color

--- a/src/tests/test_utils.cljs
+++ b/src/tests/test_utils.cljs
@@ -107,6 +107,8 @@
     (fn [address] (.checkAddressChecksum native-status address))
     :validateMnemonic
     (fn [json callback] (callback (.validateMnemonic native-status json)))
+    :validateMnemonicWithPassphrase
+    (fn [json callback] (callback (.validateMnemonicWithpassphrase native-status json)))
     :isAddress
     (fn [address] (.isAddress native-status address))}))
 

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -1,9 +1,9 @@
 {
     "_comment": "THIS SHOULD NOT BE EDITED BY HAND.",
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
-    "owner": "status-im",
+    "owner": "rasom",
     "repo": "status-go",
-    "version": "v0.186.0",
-    "commit-sha1": "b866640dc56471846f530e907d50a1df6df13ae0",
-    "src-sha256": "0sw8z4f4f87k01qnpp8sk7sam4bkk77nn7pd5iggqchbmpzr6638"
+    "version": "bip39-passphrase",
+    "commit-sha1": "3dbc87d5a39afa35b26968c8567171911d710232",
+    "src-sha256": "1w596bsjhsmj7bg7xanzichry3vsg8k9j0zz86kclcj5a8j4185k"
 }


### PR DESCRIPTION
https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed

This change allows to add passphrase on account recovery via mnemonic. The input is hidden by default (to not affect existing design and flow), but if screen's header is pressed for more than 7 seconds the input is shown (similar to old Status mobile version). I know nobody uses it exept me apparently, but there is little no harm in having it in the app.

It also can be on wallet account addition.

depends on https://github.com/status-im/status-go/pull/5833