### PR TITLE
fix!: cache data related to token price and market data locally for GetWalletToken

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v2.0.0",
-    "commit-sha1": "50338d01d7e3c08661e1b788b828d35b257c6c5a",
-    "src-sha256": "18gvq8hb7isn39ggddsxwrn29ah4p6af6azf9cc0kc7sxmdi0awn"
+    "version": "v2.1.0",
+    "commit-sha1": "23b41ff6505bcb2dae52819df741cd4cdd36e1de",
+    "src-sha256": "16d5zjxazkcyk9c28vdhk1lx0dzs3izx2a1469amdh8bkk36by89"
 }


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

related to: https://github.com/status-im/status-mobile/issues/20975
related status-go pr: https://github.com/status-im/status-go/pull/5832
related status-desktop pr: https://github.com/status-im/status-desktop/pull/16347
and a continuation of [the "balance zero" work group](https://www.notion.so/Working-group-for-0-balances-and-provider-being-down-blocker-7125b05e3a3d4247b09378d3b50120e6?pvs=4)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to resolve some of the issues with the mobile app displaying a balance of zero by updating status-go to cache the related token price and market data.
* Currently the status-go can occasionally be rate-limited when making too many requests from refreshing the wallet home screen. When the requests are rate-limited 

### Testing notes

The main areas that should be affected is the wallet home screen, and technically some changes happened for wallet router, so it would be worth double checking that wallet transactions / estimates are still working.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- wallet home screen
- wallet transactions / router

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile
- Login as a user
- Navigate to the wallet home screen
- Pull to refresh many times quickly (roughly 5 times under 60 seconds)
- View the wallet balance and token balances

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Before Changes

https://github.com/user-attachments/assets/dd7a2fd7-ef9a-4c5b-9620-bdcc59b33592

#### After Changes

https://github.com/user-attachments/assets/54bc1e55-4fe0-48fc-ae0b-553a2243eac9

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

status: ready <!-- Can be ready or wip -->