### PR TITLE
chore: fix status-go script

### DIFF
--- a/scripts/update-status-go.sh
+++ b/scripts/update-status-go.sh
@@ -29,7 +29,7 @@ identify_git_sha() {
     STATUS_GO_MATCHING_REFS=$(git ls-remote ${REPO_URL} ${1})
 
     # It's possible that there's both a branch and a tag matching the given version
-    STATUS_GO_TAG_SHA1=$(echo "${STATUS_GO_MATCHING_REFS}" | grep 'refs/tags' | cut -f1)
+    STATUS_GO_TAG_SHA1=$(echo "${STATUS_GO_MATCHING_REFS}" | grep "refs/tags/${1}" | cut -f1)
     STATUS_GO_BRANCH_SHA1=$(echo "${STATUS_GO_MATCHING_REFS}" | grep 'refs/heads' | cut -f1)
 
     # Prefer tag over branch if both are found


### PR DESCRIPTION
## Summary

This PR fixes the script that generates status-go version.
We recently saw that this script broke when generating sha1 for v1.0.0

```
[nix-shell:~/code/status-im/PR/status-mobile/scripts]$ ./update-status-go.sh v1.0.0
path is '/nix/store/pjwd4ipzg86jvkw2rrbq1ms9kzmhgi2a-status-go-archive.zip'
URL:     https://github.com/status-im/status-go/commit/392ec7ae8ed2c9699607439627b65efef9e5fde2
10635d555ff6498ce26b10be7a82d2c49ca674cb
8069b8cd82416a961dd0a3408e880da065d41eed
90d8268bcad11268c4fe3bf78d208d2ca161245b
164e1fcfb1a9a6149bd47d6bfccc17a6085f10dd
efe2689df29586981ebcac398de473d6b7586bfd
024f30f0b9cf0b95abbaffa692ad9bd126b80afe
SHA-1:   392ec7ae8ed2c9699607439627b65efef9e5fde2
10635d555ff6498ce26b10be7a82d2c49ca674cb
8069b8cd82416a961dd0a3408e880da065d41eed
90d8268bcad11268c4fe3bf78d208d2ca161245b
164e1fcfb1a9a6149bd47d6bfccc17a6085f10dd
efe2689df29586981ebcac398de473d6b7586bfd
024f30f0b9cf0b95abbaffa692ad9bd126b80afe
SHA-256: 009nd47aajng5k7wrcqv5zvvzniaswqi706fpkbbjhqziympi1s1
```

status: ready
