### PR TITLE
Added metrics for collectibles

### DIFF
--- a/src/status_im/contexts/centralized_metrics/events.cljs
+++ b/src/status_im/contexts/centralized_metrics/events.cljs
@@ -14,7 +14,7 @@
 
 (defn centralized-metrics-interceptor
   [context]
-  (when-let [event (tracking/tracked-event (interceptor/get-coeffect context :event))]
+  (when-let [event (tracking/metrics-event (interceptor/get-coeffect context :event))]
     (log/debug "tracking event" event)
     (when (push-event? (interceptor/get-coeffect context :db))
       (native-module/add-centralized-metric event)))

--- a/src/status_im/contexts/centralized_metrics/events_test.cljs
+++ b/src/status_im/contexts/centralized_metrics/events_test.cljs
@@ -15,7 +15,7 @@
 
 (deftest centralized-metrics-interceptor-test
   (testing "processes context correctly"
-    (with-redefs [tracking/tracked-event (fn [_] {:metric "mocked-event"})
+    (with-redefs [tracking/metrics-event (fn [_] {:metric "mocked-event"})
                   events/push-event?     (fn [_] true)]
       (let [context {:coeffects {:event [:some-event]
                                  :db    {:centralized-metrics/enabled? true}}}]

--- a/src/status_im/contexts/centralized_metrics/tracking.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking.cljs
@@ -43,23 +43,38 @@
     :screen/onboarding.syncing-progress
     :screen/onboarding.syncing-progress-intro
     :screen/onboarding.syncing-results
-    :screen/onboarding.welcome})
+    :screen/onboarding.welcome
+
+    ;; Collectibles
+    :screen/wallet.collectible})
 
 (defn track-view-id-event
   [view-id]
   (when (contains? view-ids-to-track view-id)
     (navigation-event (name view-id))))
 
-(defn tracked-event
-  [[event-name second-parameter]]
-  (case event-name
+(defn navigated-to-collectibles-tab-event
+  [location]
+  (key-value-event "navigated-to-collectibles-tab" {:location location}))
+
+(defn metrics-event
+  [[rf-event-name rf-event-parameter]]
+  (case rf-event-name
     :profile/get-profiles-overview-success
     (user-journey-event app-started-event)
 
     :centralized-metrics/toggle-centralized-metrics
-    (key-value-event "events.metrics-enabled" {:enabled second-parameter})
+    (key-value-event "events.metrics-enabled" {:enabled rf-event-parameter})
 
     :set-view-id
-    (track-view-id-event second-parameter)
+    (track-view-id-event rf-event-parameter)
+
+    :wallet/select-account-tab
+    (when (= rf-event-parameter :collectibles)
+      (navigated-to-collectibles-tab-event :account))
+
+    :wallet/select-home-tab
+    (when (= rf-event-parameter :collectibles)
+      (navigated-to-collectibles-tab-event :home))
 
     nil))

--- a/src/status_im/contexts/centralized_metrics/tracking_test.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking_test.cljs
@@ -63,17 +63,17 @@
              :platform   platform-os
              :appVersion app-version
              :eventValue {:action tracking/app-started-event}}}
-           (tracking/tracked-event [:profile/get-profiles-overview-success])))
+           (tracking/metrics-event [:profile/get-profiles-overview-success])))
     (is (= {:metric
             {:eventName  "events.metrics-enabled"
              :platform   platform-os
              :appVersion app-version
              :eventValue {:enabled true}}}
-           (tracking/tracked-event [:centralized-metrics/toggle-centralized-metrics true])))
+           (tracking/metrics-event [:centralized-metrics/toggle-centralized-metrics true])))
     (is (= {:metric
             {:eventName  "navigation"
              :platform   platform-os
              :appVersion app-version
              :eventValue {:viewId "wallet-stack"}}}
-           (tracking/tracked-event [:set-view-id :wallet-stack])))
-    (is (nil? (tracking/tracked-event [:unknown-event])))))
+           (tracking/metrics-event [:set-view-id :wallet-stack])))
+    (is (nil? (tracking/metrics-event [:unknown-event])))))

--- a/src/status_im/contexts/wallet/db.cljs
+++ b/src/status_im/contexts/wallet/db.cljs
@@ -10,4 +10,5 @@
         ;; Note: we set it to nil by default to differentiate when the user logs
         ;; in and the device is offline, versus re-fetching when offline and
         ;; tokens already exist in the app-db.
-        :tokens-loading nil}})
+        :tokens-loading nil
+        :active-tab     :assets}})

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -59,6 +59,10 @@
  (fn [{:keys [db]} [tab]]
    {:db (assoc-in db [:wallet :ui :account-page :active-tab] tab)}))
 
+(rf/reg-event-fx :wallet/select-home-tab
+ (fn [{:keys [db]} [tab]]
+   {:db (assoc-in db [:wallet :ui :active-tab] tab)}))
+
 (rf/reg-event-fx :wallet/clear-account-tab
  (fn [{:keys [db]}]
    {:db (assoc-in db [:wallet :ui :account-page :active-tab] nil)}))

--- a/src/status_im/contexts/wallet/home/view.cljs
+++ b/src/status_im/contexts/wallet/home/view.cljs
@@ -41,6 +41,8 @@
    (when (ff/enabled? ::ff/wallet.home-activity)
      {:id :activity :label (i18n/label :t/activity) :accessibility-label :activity-tab})])
 
+(defn- change-tab [id] (rf/dispatch [:wallet/select-home-tab id]))
+
 (defn- render-cards
   [cards ref]
   [rn/flat-list
@@ -64,15 +66,15 @@
 
 (defn view
   []
-  (let [[selected-tab set-selected-tab] (rn/use-state (:id (first tabs-data)))
-        account-list-ref                (rn/use-ref-atom nil)
-        tokens-loading?                 (rf/sub [:wallet/home-tokens-loading?])
-        networks                        (rf/sub [:wallet/selected-network-details])
-        account-cards-data              (rf/sub [:wallet/account-cards-data])
-        cards                           (conj account-cards-data (new-account-card-data))
-        [init-loaded? set-init-loaded]  (rn/use-state false)
-        {:keys [formatted-balance]}     (rf/sub [:wallet/aggregated-token-values-and-balance])
-        theme                           (quo.theme/use-theme)]
+  (let [selected-tab                   (rf/sub [:wallet/home-tab])
+        account-list-ref               (rn/use-ref-atom nil)
+        tokens-loading?                (rf/sub [:wallet/home-tokens-loading?])
+        networks                       (rf/sub [:wallet/selected-network-details])
+        account-cards-data             (rf/sub [:wallet/account-cards-data])
+        cards                          (conj account-cards-data (new-account-card-data))
+        [init-loaded? set-init-loaded] (rn/use-state false)
+        {:keys [formatted-balance]}    (rf/sub [:wallet/aggregated-token-values-and-balance])
+        theme                          (quo.theme/use-theme)]
     (rn/use-effect (fn []
                      (when (and @account-list-ref (pos? (count cards)))
                        (.scrollToOffset ^js @account-list-ref
@@ -104,7 +106,7 @@
                                  (when (ff/enabled? ::ff/wallet.graph)
                                    [quo/wallet-graph {:time-frame :empty}])
                                  [render-cards cards account-list-ref]
-                                 [render-tabs tabs-data set-selected-tab selected-tab]]
+                                 [render-tabs tabs-data change-tab selected-tab]]
        :content-container-style style/list-container
        :sticky-header-indices   [0]
        :data                    []

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -592,6 +592,12 @@
    (get-in ui [:account-page :active-tab])))
 
 (rf/reg-sub
+ :wallet/home-tab
+ :<- [:wallet/ui]
+ (fn [ui]
+   (:active-tab ui)))
+
+(rf/reg-sub
  :wallet/aggregated-tokens
  :<- [:wallet/accounts-without-watched-accounts]
  (fn [accounts]


### PR DESCRIPTION
fixes #21279

### Summary

Added tracking for events:
- user navigated collectibles tab (from wallet home or account)
- user navigated collectible details
- user fetched collectibles, ~~we track the number of collectibles fetched~~ according to the [comment](https://github.com/status-im/status-mobile/pull/21280#issuecomment-2428997090) decided not to implement number tracking in this PR

### Review notes


#### Platforms
- Android
- iOS

#### Areas that maybe impacted

##### Functional
- wallet / transactions


status: ready
