### PR TITLE
☝️Point Go to 5807

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "refs/pull/5807/head",
-    "commit-sha1": "refs/pull/5807/head",
+    "version": "0506f56c2e0594f3c8316be81ea22b1be65ae1bb",
+    "commit-sha1": "0506f56c2e0594f3c8316be81ea22b1be65ae1bb",
     "src-sha256": "1w5vln7bf8s9ss3mlh4469lcimq2yrp0qvijbvx1hd99571gc0md"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "f859b58c3896523b2fb9a09b3e5c1cedb04f959b",
-    "commit-sha1": "f859b58c3896523b2fb9a09b3e5c1cedb04f959b",
-    "src-sha256": "009nd47aajng5k7wrcqv5zvvzniaswqi706fpkbbjhqziympi1s1"
+    "version": "refs/pull/5807/head",
+    "commit-sha1": "refs/pull/5807/head",
+    "src-sha256": "1w5vln7bf8s9ss3mlh4469lcimq2yrp0qvijbvx1hd99571gc0md"
 }


### PR DESCRIPTION
# Description
This PR is a placeholder to test changes made to Status Go in this PR -> https://github.com/status-im/status-go/pull/5807

# Testing notes
There are notes on changes about the fix on Desktop client, we need to check the paths outlined there
https://github.com/status-im/status-desktop/pull/16330

# Known issues
There were 6 regressions introduced in the last PR that improved the router. We are not sure if it was Status Go changes or client issues, but they issues still exist, and might be reflected while testing this PR. 

If you face one of the 6 issues referred in [this PR](https://github.com/status-im/status-mobile/pull/21235), just refer to the existing issue. If there are new issues, we can follow the process as usual and ask Desktop to fix the problems in that PR itself.

# Time sensitivity
Since this is a cross team issue, it's important to be mindful of time. The last time, the router cleanup issues were dragged for sometime (which is my fault as I couldn't pick up and delegate them). Let's try better this time.

