### PR TITLE
fix: ensure clean-up state after send transaction confirmation

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -43,23 +43,19 @@
                                          :token-decimals token-decimals
                                          :native-token?  native-token?
                                          :receiver?      false})
-         from-network-values-for-ui    (send-utils/network-values-for-ui
-                                        from-network-amounts-by-chain)
          to-network-amounts-by-chain   (send-utils/network-amounts-by-chain
                                         {:route          chosen-route
                                          :token-decimals token-decimals
                                          :native-token?  native-token?
                                          :receiver?      true})
-         to-network-values-for-ui      (send-utils/network-values-for-ui
-                                        to-network-amounts-by-chain)
          sender-possible-chain-ids     (map :chain-id sender-network-values)
          sender-network-values         (if routes-available?
                                          (send-utils/network-amounts
                                           {:network-values
                                            (if (= tx-type :tx/bridge)
-                                             from-network-values-for-ui
+                                             from-network-amounts-by-chain
                                              (send-utils/add-zero-values-to-network-values
-                                              from-network-values-for-ui
+                                              from-network-amounts-by-chain
                                               sender-possible-chain-ids))
                                            :disabled-chain-ids disabled-from-chain-ids
                                            :receiver-networks receiver-networks
@@ -71,7 +67,7 @@
                                           sender-network-values))
          receiver-network-values       (if routes-available?
                                          (send-utils/network-amounts
-                                          {:network-values     to-network-values-for-ui
+                                          {:network-values     to-network-amounts-by-chain
                                            :disabled-chain-ids disabled-from-chain-ids
                                            :receiver-networks  receiver-networks
                                            :token-networks-ids token-networks-ids
@@ -91,8 +87,8 @@
                      assoc
                      :suggested-routes          suggested-routes-data
                      :route                     chosen-route
-                     :from-values-by-chain      from-network-values-for-ui
-                     :to-values-by-chain        to-network-values-for-ui
+                     :from-values-by-chain      from-network-amounts-by-chain
+                     :to-values-by-chain        to-network-amounts-by-chain
                      :sender-network-values     sender-network-values
                      :receiver-network-values   receiver-network-values
                      :network-links             network-links

--- a/src/status_im/contexts/wallet/send/send_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/send_amount/view.cljs
@@ -2,11 +2,13 @@
   (:require
     [quo.theme]
     [status-im.contexts.wallet.send.input-amount.view :as input-amount]
+    [status-im.setup.hot-reload :as hot-reload]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
 (defn view
   []
+  (hot-reload/use-safe-unmount #(rf/dispatch [:wallet/stop-get-suggested-routes]))
   [input-amount/view
    {:current-screen-id      :screen/wallet.send-input-amount
     :button-one-label       (i18n/label :t/review-send)

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -9,6 +9,7 @@
     [status-im.common.standard-authentication.core :as standard-auth]
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.send.transaction-confirmation.style :as style]
+    [status-im.contexts.wallet.send.utils :as send-utils]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
@@ -142,7 +143,7 @@
      [quo/summary-info
       {:type          summary-info-type
        :networks?     true
-       :values        network-values
+       :values        (send-utils/network-values-for-ui network-values)
        :account-props (cond-> account-props
                         (and account-to? (not bridge-tx?))
                         (assoc

--- a/src/status_im/contexts/wallet/swap/swap_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/swap/swap_confirmation/view.cljs
@@ -7,6 +7,7 @@
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.common.standard-authentication.core :as standard-auth]
     [status-im.constants :as constants]
+    [status-im.contexts.wallet.send.utils :as send-utils]
     [status-im.contexts.wallet.swap.swap-confirmation.style :as style]
     [utils.address :as address-utils]
     [utils.i18n :as i18n]
@@ -76,7 +77,7 @@
      [quo/summary-info
       {:type        :token
        :networks?   true
-       :values      network-values
+       :values      (send-utils/network-values-for-ui network-values)
        :token-props {:token   token-symbol
                      :label   (str amount " " token-symbol)
                      :address (address-utils/get-shortened-compressed-key token-address)

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -42,27 +42,35 @@
   [x]
   (instance? BigNumber x))
 
+(defn ->bignumber
+  [n]
+  (if (bignumber? n) n (bignumber n)))
+
+(defn ->bignumbers
+  [& nums]
+  (let [bignums (map ->bignumber nums)]
+    (when (every? bignumber? bignums)
+      bignums)))
+
 (defn greater-than-or-equals
-  [^js bn1 ^js bn2]
-  (when (bignumber? bn1)
+  [^js n1 ^js n2]
+  (when-let [[^js bn1 ^js bn2] (->bignumbers n1 n2)]
     (.greaterThanOrEqualTo bn1 bn2)))
 
 (defn greater-than
-  [bn1 bn2]
-  (when (bignumber? bn1)
+  [n1 n2]
+  (when-let [[^js bn1 ^js bn2] (->bignumbers n1 n2)]
     (.greaterThan ^js bn1 bn2)))
 
 (defn less-than
-  [bn1 bn2]
-  (when (bignumber? bn1)
+  [n1 n2]
+  (when-let [[^js bn1 ^js bn2] (->bignumbers n1 n2)]
     (.lessThan ^js bn1 bn2)))
 
 (defn equal-to
   [n1 n2]
-  (boolean
-   (when-let [^js bn1 (if (bignumber? n1) n1 (bignumber n1))]
-     (when-let [^js bn2 (if (bignumber? n2) n2 (bignumber n2))]
-       (.eq ^js bn1 bn2)))))
+  (when-let [[^js bn1 ^js bn2] (->bignumbers n1 n2)]
+    (.eq ^js bn1 bn2)))
 
 (extend-type BigNumber
  IEquiv
@@ -81,8 +89,9 @@
        :else                     0)))
 
 (defn sub
-  [bn1 bn2]
-  (.sub ^js bn1 bn2))
+  [n1 n2]
+  (when-let [[^js bn1 ^js bn2] (->bignumbers n1 n2)]
+    (.sub ^js bn1 bn2)))
 
 (defn valid?
   [^js bn]
@@ -127,7 +136,7 @@
 
 (defn to-number
   [^js bn]
-  (when bn
+  (when (bignumber? bn)
     (.toNumber bn)))
 
 (defn to-string
@@ -160,7 +169,7 @@
 
 (defn ether->wei
   [^js bn]
-  (when bn
+  (when (bignumber? bn)
     (.times bn ^js (bignumber 1e18))))
 
 (defn token->unit
@@ -230,7 +239,7 @@
 (defn sufficient-funds?
   [^js amount ^js balance]
   (when (and amount balance)
-    (.greaterThanOrEqualTo balance amount)))
+    (greater-than-or-equals balance amount)))
 
 (defn fiat-amount-value
   [amount-str from to prices]
@@ -277,7 +286,7 @@
 
 (defn absolute-value
   [bn]
-  (when bn
+  (when (bignumber? bn)
     (.absoluteValue ^js bn)))
 
 (defn format-amount

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -60,7 +60,9 @@
 (defn equal-to
   [n1 n2]
   (when-let [^js bn1 (bignumber n1)]
-    (.eq ^js bn1 n2)))
+    (try
+      (.eq ^js bn1 n2)
+      (catch :default _ false))))
 
 (extend-type BigNumber
  IEquiv

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -59,10 +59,10 @@
 
 (defn equal-to
   [n1 n2]
-  (when-let [^js bn1 (bignumber n1)]
-    (try
-      (.eq ^js bn1 n2)
-      (catch :default _ false))))
+  (boolean
+   (when-let [^js bn1 (if (bignumber? n1) n1 (bignumber n1))]
+     (when-let [^js bn2 (if (bignumber? n2) n2 (bignumber n2))]
+       (.eq ^js bn1 bn2)))))
 
 (extend-type BigNumber
  IEquiv

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -47,10 +47,11 @@
   (if (bignumber? n) n (bignumber n)))
 
 (defn ->bignumbers
-  [& nums]
-  (let [bignums (map ->bignumber nums)]
-    (when (every? bignumber? bignums)
-      bignums)))
+  [n1 n2]
+  (when-let [bn1 (->bignumber n1)]
+    (when-let [bn2 (->bignumber n2)]
+      (when (and (bignumber? bn1) (bignumber? bn2))
+        [bn1 bn2]))))
 
 (defn greater-than-or-equals
   [^js n1 ^js n2]


### PR DESCRIPTION
partially fixes https://github.com/status-im/status-mobile/issues/21251

### Summary

* This PR attempts to resolve some issues that have been occurring after sending a transaction.
  * BigNumber errors for `"<0.01"`
    * It seems we're storing this string `"<0.01"` for some wallet ui state, but that state can be accidentally used with BigNumber calculations, which can exceptions.
    * Here's where we inject this string into the ui state: https://github.com/status-im/status-mobile/blob/69664322b8ea01a87e7762c24dcace3c6f917991/src/status_im/contexts/wallet/send/utils.cljs#L67
    * And here's where we are referencing that value: https://github.com/status-im/status-mobile/blob/2f3d3fc7f90bfddc12d8a21bf6202e5af4c5dcb6/src/quo/components/wallet/summary_info/view.cljs#L33-L40
  * Suggest Routes being received after the send transaction is already confirmed
    * It seems like we weren't configuring the wallet send screen to finish requesting the suggested routes data after the user has confirmed the transaction. And as we would continue to receive more suggested route results, the calculations would run with the existing wallet ui state, and that would eventually do some BigNumber comparisons with the string `"<0.01"` which would cause things to throw.
* Ideally, we would refactor the code in a way that avoids saving `"<0.01"` into the database, perhaps we can save an separate keyword like `:less-than-something` to indicate the same thing. Maybe this would avoid potential number comparison issues in the future.

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- wallet / transactions

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Login as user with funds
- Navigate to wallet home screen
- Open account with funds
- Press the "send" button to start a transaction
- Choose an account for receiving the transaction
- Input an amount of funds below `0.01`, like `0.001`
- Review and Confirm the transaction

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

<!-- (PRs will only be accepted if squashed into single commit.)
| Figma (if available) | iOS (if available)    | Android (if available)
| --- | --- | --- |
| Please embed Image/Video here of the before and after.  | Please embed Image/Video here of the before and after.  | Please embed Image/Video here of the before and after. |
 -->
 
 #### Before Changes
 
https://github.com/user-attachments/assets/3fff742e-0e1d-45f3-9096-7e9c4bb76384

#### After Changes

https://github.com/user-attachments/assets/d1e4b91c-f640-49cd-a476-aa4329104b1d

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
