### PR TITLE
[#21270] - Collectibles stuck in loading for watch only accounts

### DIFF
--- a/src/quo/components/profile/collectible_list_item/view.cljs
+++ b/src/quo/components/profile/collectible_list_item/view.cljs
@@ -160,12 +160,13 @@
                                        :on-load-end   set-image-loaded
                                        :theme         theme
                                        :label         (i18n/label :t/unsupported-file)}]
-        (not (:image-loaded? state)) [loading-image
+        (or (not (:image-loaded? state))
+            loading?)                [loading-image
                                       {:loader-opacity       loader-opacity
                                        :theme                theme
                                        :gradient-color-index gradient-color-index}])
 
-      (when supported-file?
+      (when (and supported-file? (not loading?))
         [reanimated/view {:style (style/supported-file image-opacity)}
          [rn/image
           {:style         style/image

--- a/src/quo/components/profile/collectible_list_item/view.cljs
+++ b/src/quo/components/profile/collectible_list_item/view.cljs
@@ -150,21 +150,21 @@
     [rn/view {:style (style/card-view-container theme)}
      [rn/view {:style {:aspect-ratio 1}}
       (cond
-        (:image-error? state)        [fallback-view
-                                      {:image-opacity image-opacity
-                                       :on-load-end   set-image-loaded
-                                       :theme         theme
-                                       :label         (i18n/label :t/cant-fetch-info)}]
-        (not supported-file?)        [fallback-view
-                                      {:image-opacity image-opacity
-                                       :on-load-end   set-image-loaded
-                                       :theme         theme
-                                       :label         (i18n/label :t/unsupported-file)}]
+        (:image-error? state) [fallback-view
+                               {:image-opacity image-opacity
+                                :on-load-end   set-image-loaded
+                                :theme         theme
+                                :label         (i18n/label :t/cant-fetch-info)}]
+        (not supported-file?) [fallback-view
+                               {:image-opacity image-opacity
+                                :on-load-end   set-image-loaded
+                                :theme         theme
+                                :label         (i18n/label :t/unsupported-file)}]
         (or (not (:image-loaded? state))
-            loading?)                [loading-image
-                                      {:loader-opacity       loader-opacity
-                                       :theme                theme
-                                       :gradient-color-index gradient-color-index}])
+            loading?)         [loading-image
+                               {:loader-opacity       loader-opacity
+                                :theme                theme
+                                :gradient-color-index gradient-color-index}])
 
       (when (and supported-file? (not loading?))
         [reanimated/view {:style (style/supported-file image-opacity)}

--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -28,7 +28,8 @@
 (defn- collectibles-tab
   []
   (let [updating?               (rf/sub [:wallet/current-viewing-account-collectibles-updating?])
-        collectible-list        (rf/sub [:wallet/current-viewing-account-collectibles-in-selected-networks])
+        collectible-list        (rf/sub
+                                 [:wallet/current-viewing-account-collectibles-in-selected-networks])
         current-account-address (rf/sub [:wallet/current-viewing-account-address])]
     [collectibles/view
      {:loading?                  updating?

--- a/src/status_im/contexts/wallet/account/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/account/tabs/view.cljs
@@ -28,8 +28,7 @@
 (defn- collectibles-tab
   []
   (let [updating?               (rf/sub [:wallet/current-viewing-account-collectibles-updating?])
-        collectible-list        (rf/sub
-                                 [:wallet/current-viewing-account-collectibles-in-selected-networks])
+        collectible-list        (rf/sub [:wallet/current-viewing-account-collectibles-in-selected-networks])
         current-account-address (rf/sub [:wallet/current-viewing-account-address])]
     [collectibles/view
      {:loading?                  updating?


### PR DESCRIPTION
fixes #21270

## Summary

This PR fixes the exception thrown on Android when a loading collectible is pressed.

**:warning:  ATM I can't test on iOS, I really appreaciate QA help testing that the loading state and collectible behavior hasn't changed on iOS :warning:**

## :warning:  Important note

Although this PR solves the exception, the root issue (collectibles are stuck in a loading state) happen sometimes.

It was reported in:
- https://github.com/status-im/status-mobile/issues/18613  

And we tried to solve it in:
- https://github.com/status-im/status-mobile/pull/20961

But it's still reproducible (waited for more than a minute, and actually after 15mins they never loaded):

https://github.com/user-attachments/assets/5a4559e7-edd4-4ef4-bfba-e65c67620981

## What is this PR doing then?

This PR:
:white_check_mark:  Fixes the loading collectible state on Android (it only worked on iOS)
:white_check_mark:  When the user presses a loading collectible, it won't throw any error/exception.


### Review notes

I'll reopen the root issue.

#### Platforms

- Android
- iOS

### Steps to test

[Android]
- Open Status in a fresh install
- Create a new Status profile
- Disable test networks (if they were enabled)
- Add a watched address, you can pick any of the addresses listed in this issue, e.g. `0x00000000219ab540356cbb839cbe05303d7705fa`
- Switch to the collectibles tab
- If they are stuck in a loading state, you can press them and no exception will be thrown.

[iOS]
- Make sure the collectibles are still stuck in a loading state and nothing is broken (pressing, opening a collectible, scrolling).

status: ready