### PR TITLE
feat: integrate max slippage drawer

### DIFF
--- a/src/quo/components/settings/data_item/view.cljs
+++ b/src/quo/components/settings/data_item/view.cljs
@@ -148,7 +148,7 @@
                      colors/neutral-50)]
     [rn/pressable
      {:accessibility-label :data-item
-      :disabled            (not right-icon)
+      :disabled            (nil? on-press)
       :on-press            on-press
       :style               (merge (style/container {:size        size
                                                     :card?       card?

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -591,6 +591,7 @@
 (def ^:const slippages [0.1 0.5 1])
 (def ^:const default-slippage 0.5)
 (def ^:const max-recommended-slippage 5)
+(def ^:const max-slippage 30)
 (def ^:const max-slippage-decimal-places 2)
 (def ^:const swap-provider-paraswap
   {:name                     :paraswap

--- a/src/status_im/contexts/wallet/swap/setup_swap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/setup_swap/view.cljs
@@ -12,6 +12,7 @@
             [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
             [status-im.contexts.wallet.common.utils :as utils]
             [status-im.contexts.wallet.sheets.buy-token.view :as buy-token]
+            [status-im.contexts.wallet.sheets.slippage-settings.view :as slippage-settings]
             [status-im.contexts.wallet.swap.setup-swap.style :as style]
             [status-im.contexts.wallet.swap.utils :as swap-utils]
             [utils.debounce :as debounce]
@@ -39,7 +40,7 @@
                   {:clean-approval-transaction? clean-approval-transaction?}])))
 
 (defn- data-item
-  [{:keys [title subtitle size subtitle-icon subtitle-color loading?]}]
+  [{:keys [title subtitle size subtitle-icon subtitle-color on-press loading?]}]
   [quo/data-item
    {:container-style style/detail-item
     :blur?           false
@@ -50,7 +51,8 @@
     :subtitle        subtitle
     :size            size
     :icon            subtitle-icon
-    :subtitle-color  subtitle-color}])
+    :subtitle-color  subtitle-color
+    :on-press        on-press}])
 
 (defn- transaction-details
   []
@@ -72,9 +74,11 @@
                                                    theme)))]
      [data-item
       {:title         (i18n/label :t/max-slippage)
-       :subtitle      max-slippage
+       :subtitle      (str max-slippage "%")
        :subtitle-icon :i/edit
-       :size          :small}]]))
+       :size          :small
+       :on-press      #(rf/dispatch [:show-bottom-sheet
+                                     {:content slippage-settings/view}])}]]))
 
 (defn- pay-token-input
   [{:keys [input-state on-max-press on-input-focus on-token-press on-approve-press input-focused?]}]

--- a/translations/en.json
+++ b/translations/en.json
@@ -2320,6 +2320,7 @@
   "slide-to-sign": "Slide to sign",
   "slide-to-swap": "Slide to swap",
   "slippage": "Slippage",
+  "slippage-cant-be-more-than-30": "Slippage can't be more than 30",
   "slippage-may-be-higher-than-necessary": "Slippage may be higher than necessary",
   "slippage-settings": "Slippage settings",
   "slippage-settings-description": "Your transaction will revert if the price changes more than the slippage percentage",


### PR DESCRIPTION
fixes #21296

### Summary

This PR integrates Max Slippage drawer into the setup swap screen.

https://github.com/user-attachments/assets/1059cdd1-fb32-4fc0-8a69-b05629336c98

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Login
- Go to wallet
- Select an account
- Select Swap option
- Select a token on Select asset to pay screen
- Enter an amount
- Tap on Max slippage to edit Max Slippage
- Verify it is working as expected

status: ready