### PR TITLE
chore: take status-go fixes for push notifications that is already in 2.30

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v2.0.0",
-    "commit-sha1": "50338d01d7e3c08661e1b788b828d35b257c6c5a",
-    "src-sha256": "18gvq8hb7isn39ggddsxwrn29ah4p6af6azf9cc0kc7sxmdi0awn"
+    "version": "1cdfcd6bd7b0b7c68a008fee406f81067a21b910",
+    "commit-sha1": "1cdfcd6bd7b0b7c68a008fee406f81067a21b910",
+    "src-sha256": "19hdli07skhcmjrd7xm2q1d7qylsln6w9id2y5x64bnf0saz3g95"
 }


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Taking in fix for push notifications not being delivered from underlying status-go/go-waku https://github.com/status-im/status-go/pull/5861

fixes #21120 for develop branch

### Summary

[comment]: # push notifications were not being received and this has been solved by making a work-around of reducing filter subscription batch timer to 300msecs. But this fix was not properly propagated into the develop branch as the code was moved around and refactored. 

Note that underlying status-go PR also has some other fixes. 1 of them is only for relay and hence should not affect the mobile client. 

### Testing notes
Please verify push notifications issue that was being faced as part of linked issue.

cc @pavloburykh @churik 

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- mailservers

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
- Test receiving of messages in 1:1, group chats and communities
- Test push notifications


status: ready 

- push notifications and filter subscriptions

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
