### PR TITLE
fix Lost the syncing state in fallback recovery, when first enter the seed phrase for the wrong account

### DIFF
--- a/src/status_im/contexts/onboarding/create_or_sync_profile/view.cljs
+++ b/src/status_im/contexts/onboarding/create_or_sync_profile/view.cljs
@@ -23,6 +23,7 @@
 
 (defn- navigate-to-sign-in-by-syncing
   []
+  (rf/dispatch [:syncing/clear-syncing-fallback-flow])
   (debounce/throttle-and-dispatch
    [:onboarding/navigate-to-sign-in-by-syncing]
    1000))
@@ -37,6 +38,7 @@
 
 (defn- navigate-to-sign-in-by-seed-phrase
   [create-profile?]
+  (rf/dispatch [:syncing/clear-syncing-fallback-flow])
   (rf/dispatch [:onboarding/navigate-to-sign-in-by-seed-phrase
                 (if create-profile?
                   :screen/onboarding.new-to-status

--- a/src/status_im/contexts/onboarding/syncing/progress/view.cljs
+++ b/src/status_im/contexts/onboarding/syncing/progress/view.cljs
@@ -28,6 +28,7 @@
 
 (defn- navigate-to-enter-seed-phrase
   []
+  (rf/dispatch [:syncing/set-syncing-fallback-flow])
   (debounce/debounce-and-dispatch
    [:onboarding/navigate-to-sign-in-by-seed-phrase :screen/onboarding.sync-or-recover-profile]
    500))

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -142,7 +142,7 @@
                            (rf/dispatch [:chats-list/load-success result])
                            (rf/dispatch [:communities/get-user-requests-to-join])
                            (rf/dispatch [:profile.login/get-chats-callback]))}]
-           (when (:syncing/installation-id db)
+           (when (and (:syncing/fallback-flow? db) (:syncing/installation-id db))
              [:dispatch [:pairing/finish-seed-phrase-fallback-syncing]])
            (when-not new-account?
              [:dispatch [:universal-links/process-stored-event]])]})))

--- a/src/status_im/contexts/syncing/events.cljs
+++ b/src/status_im/contexts/syncing/events.cljs
@@ -39,11 +39,6 @@
                     {:type :negative
                      :text error}]))))
 
-(rf/defn initiate-pairing-process
-  {:events [:syncing/initiate-pairing-process]}
-  [{:keys [db]}]
-  {:db (assoc db :syncing/pairing-process-initiated? true)})
-
 (rf/defn set-syncing-installation-id
   {:events [:syncing/set-syncing-installation-id]}
   [{:keys [db]} installation-id key-uid]
@@ -51,15 +46,26 @@
               :syncing/key-uid         key-uid
               :syncing/installation-id installation-id)})
 
-(defn clear-syncing-data
+(defn clear-syncing-installation-id
   [{:keys [db]}]
   {:db (dissoc
         db
         :syncing/key-uid
-        :syncing/installation-id
-        :syncing/pairing-process-initiated?)})
+        :syncing/installation-id)})
 
-(re-frame/reg-event-fx :syncing/clear-syncing-data clear-syncing-data)
+(re-frame/reg-event-fx :syncing/clear-syncing-installation-id clear-syncing-installation-id)
+
+(defn set-syncing-fallback-flow
+  [{:keys [db]}]
+  {:db (assoc db :syncing/fallback-flow? true)})
+
+(re-frame/reg-event-fx :syncing/set-syncing-fallback-flow set-syncing-fallback-flow)
+
+(defn clear-syncing-fallback-flow
+  [{:keys [db]}]
+  {:db (dissoc db :syncing/fallback-flow?)})
+
+(re-frame/reg-event-fx :syncing/clear-syncing-fallback-flow clear-syncing-fallback-flow)
 
 (rf/defn preflight-outbound-check-for-local-pairing
   {:events [:syncing/preflight-outbound-check]}
@@ -95,7 +101,6 @@
                             (when (sync-utils/valid-connection-string? response)
                               (on-valid-connection-string response)
                               (rf/dispatch [:syncing/update-role constants/local-pairing-role-sender])
-                              (rf/dispatch [:syncing/initiate-pairing-process])
                               (rf/dispatch [:hide-bottom-sheet])))]
     (when-not (and error (string/blank? error))
       (let [key-uid    (get-in db [:profile/profile :key-uid])


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21258

status: ready