### PR TITLE
fix(wallet)_: Stop route calculation

### DIFF
--- a/src/status_im/contexts/wallet/bridge/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/input_amount/view.cljs
@@ -3,13 +3,11 @@
     [react-native.core :as rn]
     [status-im.contexts.wallet.bridge.input-amount.style :as style]
     [status-im.contexts.wallet.send.input-amount.view :as input-amount]
-    [status-im.setup.hot-reload :as hot-reload]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
 (defn view
   []
-  (hot-reload/use-safe-unmount #(rf/dispatch [:wallet/stop-get-suggested-routes]))
   [rn/view {:style style/bridge-send-wrapper}
    [input-amount/view
     {:current-screen-id      :screen/wallet.bridge-input-amount
@@ -23,5 +21,6 @@
                                              {:amount   amount
                                               :stack-id :screen/wallet.bridge-input-amount}]))
      :on-navigate-back       (fn []
+                               (rf/dispatch-sync [:wallet/stop-and-clean-suggested-routes])
                                (rf/dispatch [:wallet/clean-disabled-from-networks])
                                (rf/dispatch [:wallet/clean-send-amount]))}]])

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -335,8 +335,7 @@
                      :text (i18n/label :t/at-least-one-network-must-be-activated)}]))))
 
 (defn view
-  [{:keys [token theme valid-input? request-fetch-routes
-           lock-fetch-routes? on-press-to-network current-screen-id
+  [{:keys [token theme valid-input? request-fetch-routes on-press-to-network current-screen-id
            token-not-supported-in-receiver-networks? send-amount-in-crypto]}]
   (let [token-symbol (:symbol token)
         nav-current-screen-id (rf/sub [:view-id])
@@ -359,8 +358,7 @@
     (rn/use-effect
      (fn []
        (when (and active-screen?
-                  (> (count token-available-networks-for-suggested-routes) 0)
-                  (not lock-fetch-routes?))
+                  (> (count token-available-networks-for-suggested-routes) 0))
          (request-fetch-routes 2000)))
      [send-amount-in-crypto valid-input?])
     (rn/use-effect

--- a/src/status_im/contexts/wallet/send/send_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/send_amount/view.cljs
@@ -2,13 +2,11 @@
   (:require
     [quo.theme]
     [status-im.contexts.wallet.send.input-amount.view :as input-amount]
-    [status-im.setup.hot-reload :as hot-reload]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
 (defn view
   []
-  (hot-reload/use-safe-unmount #(rf/dispatch [:wallet/stop-get-suggested-routes]))
   [input-amount/view
    {:current-screen-id      :screen/wallet.send-input-amount
     :button-one-label       (i18n/label :t/review-send)
@@ -16,6 +14,7 @@
                              [:wallet/wallet-send-enabled-from-chain-ids])
     :from-enabled-networks  (rf/sub [:wallet/wallet-send-enabled-networks])
     :on-navigate-back       (fn []
+                              (rf/dispatch-sync [:wallet/stop-and-clean-suggested-routes])
                               (rf/dispatch [:wallet/clean-disabled-from-networks])
                               (rf/dispatch [:wallet/clean-from-locked-amounts])
                               (rf/dispatch [:wallet/clean-send-amount]))}])

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -94,10 +94,15 @@
    :optimism 2
    :arbitrum 3})
 
+(defn safe-add-type-edit
+  [network-values]
+  (if (or (empty? network-values) (some #(= (:type %) :edit) network-values))
+    network-values
+    (conj network-values {:type :edit})))
 
 (defn reset-loading-network-amounts-to-zero
   [network-amounts]
-  (map
+  (mapv
    (fn [network-amount]
      (cond-> network-amount
        (= (:type network-amount) :loading)
@@ -177,7 +182,7 @@
       (and receiver?
            routes-found?
            (not= tx-type :tx/bridge))
-      (conj {:type :edit}))))
+      safe-add-type-edit)))
 
 (defn loading-network-amounts
   [{:keys [valid-networks disabled-chain-ids receiver-networks token-networks-ids tx-type receiver?]}]


### PR DESCRIPTION
fixes #21249
fixes #21043
fixes #21251
fixes #21250
fixes #21254

### Summary

This PR 
- stops route calculation when the user
  - changes from account
  - changes the send (input) amount
  - goes back from the routes calculation page
  - after the transaction is successfully submitted
  - goes back from tx confirmation page for collectibles
- Prevents the keyboard being dismissed while entering the password on the transaction confirmation page
- Fixes multiple edit tiles/boxes added to receiver routes

### Review notes

Most of the regression bugs introduced in https://github.com/status-im/status-mobile/pull/21235 were due to a constant route signal, which was not stopped when the user moved away from the send flow. Additionally, The routes need to be stopped after a transaction is made, as we use the `createMultiTransaction` RPC which doesn't stop it (this is stopped in newer transaction RPCs/flows). 


### Testing notes

This PR fixes only the above-mentioned issues and if any bugs are discovered, please help us verify against the latest develop 🙏 . This PR aims to stabilize the send flows.

### Platforms

- Android
- iOS

### Steps to test

##### Prerequisites: A profile (wallet account) with multiple assets (tokens/collectibles) across different networks

- Open Status
- Navigate to Wallet tab > Send
- Select a token and enter a value which is available in all three networks
- Verify the edit tile/box is shown only once
- Change the from account and verify the inputs and routes are cleaned up
- Change the token and verify the input and routes are cleaned up
- Go back from the routes calculation page or tx confirmation page and verify no errors are thrown
- Select any token/collectible to send 
- Verify the password can be entered without the keyboard being dismissed
- Verify the transaction is made successfully and no errors are thrown after that while the user is in the wallet tab 

status: ready
