### PR TITLE
Add syncing notification to System Tab

### DIFF
--- a/src/status_im/contexts/shell/activity_center/notification_types.cljs
+++ b/src/status_im/contexts/shell/activity_center/notification_types.cljs
@@ -28,7 +28,8 @@
 
 ;; TODO: Replace with correct enum values once status-go implements them.
 (def ^:const tx 66612)
-(def ^:const system 66614)
+(def ^:const system
+  #{new-installation-received new-installation-created})
 
 (def ^:const membership
   "Membership is like a logical group of notifications with different types, i.e.


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21288

### Summary
Installation-related notification doesn't have their own tab. In the meeting with Alisher and QA, we agreed that for the time being show them in the System tab.
More information in the https://github.com/status-im/status-mobile/pull/21090#issuecomment-2346471515 and in Issue [description](https://github.com/status-im/status-mobile/issues/21288).


status: ready