### PR TITLE
fix(swap): approval tx of amounts with lots decimals

### DIFF
--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -391,7 +391,7 @@
         approval-amount-required           (:approval-amount-required route)
         approval-amount-required-sanitized (-> approval-amount-required
                                                (utils.hex/normalize-hex)
-                                               (native-module/hex-to-number))
+                                               (money/from-hex))
         approval-contract-address          (:approval-contract-address route)
         data                               (native-module/encode-function-call
                                             constants/contract-function-signature-erc20-approve

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -151,6 +151,12 @@
   [^js bn]
   (str "0x" (to-string bn 16)))
 
+(defn from-hex
+  [hex-str]
+  (try
+    (new BigNumber hex-str 16)
+    (catch :default _ nil)))
+
 (defn wei->str
   ([unit n display-unit]
    (str (to-fixed (wei-> unit n)) " " display-unit))

--- a/src/utils/money_test.cljs
+++ b/src/utils/money_test.cljs
@@ -83,3 +83,10 @@
    1000001   "1M"
    10000000  "10M"
    100000000 "100M"))
+
+(deftest from-hex-test
+  (is (= (money/bignumber "2840425681744351250") (money/from-hex "276b381bbb44d012")))
+  (is (= (money/bignumber "0") (money/from-hex "0")))
+  (is (= (money/bignumber "255") (money/from-hex "ff")))
+  (is (= (money/bignumber "4294967295") (money/from-hex "ffffffff")))
+  (is (= (money/bignumber "12345678901234567890") (money/from-hex "ab54a98ceb1f0ad2"))))


### PR DESCRIPTION
fixes #21325 

### Summary

This PR fixes a rounding issue when converting hex numbers with lots of decimals, causing issues in some swap transactions (check issue for more context).

Tested these changes locally and were able to execute both approval and swap transactions without any issues:

https://optimistic.etherscan.io/tx/0x8c028e3dde799d43cfb589ae9360120ec54548f48e37fdf0f39d3eedc2f27feb
https://optimistic.etherscan.io/tx/0xd4e82302434dcaa96591c079835c4d08131ed92998d4bfe162224c229b4670ce

#### Platforms

- Android
- iOS

##### Functional

- wallet / transactions

### Steps to test

1. Restore a user with a token that has 18 decimal places.
2. Go to the swap page.
3. Tap the "max" value.
4. Approve the max value.
5. Verify the approval amount was correct on the blockchain explorer
6. Try to confirm the transaction.
7. Verify the transaction is executed correctly

status: ready