### PR TITLE
feat: disable swap and bridge options on testnet mode

### DIFF
--- a/src/quo/components/buttons/wallet_ctas/style.cljs
+++ b/src/quo/components/buttons/wallet_ctas/style.cljs
@@ -1,4 +1,5 @@
-(ns quo.components.buttons.wallet-ctas.style)
+(ns quo.components.buttons.wallet-ctas.style
+  (:require [quo.foundations.colors :as colors]))
 
 (def inner-container
   {:flex-direction  :row
@@ -10,3 +11,9 @@
    :width            77.75
    :justify-content  :center
    :align-items      :center})
+
+(defn action-button-text
+  [theme disabled?]
+  (cond-> {:margin-top 4
+           :color      (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)}
+    disabled? (assoc :opacity 0.5)))

--- a/src/quo/components/buttons/wallet_ctas/view.cljs
+++ b/src/quo/components/buttons/wallet_ctas/view.cljs
@@ -3,28 +3,28 @@
     [quo.components.buttons.wallet-button.view :as wallet-button]
     [quo.components.buttons.wallet-ctas.style :as style]
     [quo.components.markdown.text :as text]
-    [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [utils.i18n :as i18n]))
 
 
 (defn action-button
-  [{:keys [icon text on-press theme accessibility-label]}]
+  [{:keys [icon text on-press theme accessibility-label disabled?]}]
   [rn/view
    {:style               style/button-container
     :accessibility-label accessibility-label}
    [wallet-button/view
-    {:icon     icon
-     :on-press on-press}]
+    {:icon      icon
+     :disabled? disabled?
+     :on-press  on-press}]
    [text/text
     {:weight :medium
      :size   :paragraph-2
-     :style  {:margin-top 4
-              :color      (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)}} text]])
+     :style  (style/action-button-text theme disabled?)} text]])
 
 (defn view
-  [{:keys [buy-action send-action receive-action bridge-action swap-action container-style]}]
+  [{:keys [buy-action send-action receive-action bridge-action swap-action bridge-disabled?
+           swap-disabled? container-style]}]
   (let [theme (quo.theme/use-theme)]
     [rn/view {:style container-style}
      [rn/view {:style style/inner-container}
@@ -52,10 +52,12 @@
           :text                (i18n/label :t/swap)
           :on-press            swap-action
           :theme               theme
+          :disabled?           swap-disabled?
           :accessibility-label :swap}])
       [action-button
        {:icon                :i/bridge
         :text                (i18n/label :t/bridge)
         :on-press            bridge-action
         :theme               theme
+        :disabled?           bridge-disabled?
         :accessibility-label :bridge}]]]))

--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -26,7 +26,8 @@
   (let [selected-tab          (or (rf/sub [:wallet/account-tab]) first-tab-id)
         {:keys [name color formatted-balance
                 watch-only?]} (rf/sub [:wallet/current-viewing-account])
-        customization-color   (rf/sub [:profile/customization-color])]
+        customization-color   (rf/sub [:profile/customization-color])
+        testnet-mode?         (rf/sub [:profile/test-networks-enabled?])]
     (hot-reload/use-safe-unmount (fn []
                                    (rf/dispatch [:wallet/close-account-page])
                                    (rf/dispatch [:wallet/clean-current-viewing-account])))
@@ -46,23 +47,25 @@
        [quo/wallet-graph {:time-frame :empty}])
      (when (not watch-only?)
        [quo/wallet-ctas
-        {:container-style style/cta-buttons
-         :send-action     (fn []
-                            (rf/dispatch [:wallet/clean-send-data])
-                            (rf/dispatch [:wallet/wizard-navigate-forward
-                                          {:start-flow? true
-                                           :flow-id     :wallet-send-flow}]))
-         :receive-action  #(rf/dispatch [:open-modal :screen/wallet.share-address
-                                         {:status :receive}])
-         :buy-action      #(rf/dispatch [:show-bottom-sheet
-                                         {:content buy-token/view}])
-         :bridge-action   (fn []
-                            (rf/dispatch [:wallet/clean-send-data])
-                            (rf/dispatch [:wallet/start-bridge]))
-         :swap-action     (when (ff/enabled? ::ff/wallet.swap)
-                            (fn []
-                              (rf/dispatch [:wallet.tokens/get-token-list])
-                              (rf/dispatch [:open-modal :screen/wallet.swap-select-asset-to-pay])))}])
+        {:container-style  style/cta-buttons
+         :send-action      (fn []
+                             (rf/dispatch [:wallet/clean-send-data])
+                             (rf/dispatch [:wallet/wizard-navigate-forward
+                                           {:start-flow? true
+                                            :flow-id     :wallet-send-flow}]))
+         :receive-action   #(rf/dispatch [:open-modal :screen/wallet.share-address
+                                          {:status :receive}])
+         :buy-action       #(rf/dispatch [:show-bottom-sheet
+                                          {:content buy-token/view}])
+         :bridge-action    (fn []
+                             (rf/dispatch [:wallet/clean-send-data])
+                             (rf/dispatch [:wallet/start-bridge]))
+         :swap-action      (when (ff/enabled? ::ff/wallet.swap)
+                             (fn []
+                               (rf/dispatch [:wallet.tokens/get-token-list])
+                               (rf/dispatch [:open-modal :screen/wallet.swap-select-asset-to-pay])))
+         :bridge-disabled? testnet-mode?
+         :swap-disabled?   testnet-mode?}])
      [quo/tabs
       {:style            style/tabs
        :size             32

--- a/src/status_im/contexts/wallet/common/token_value/view.cljs
+++ b/src/status_im/contexts/wallet/common/token_value/view.cljs
@@ -37,20 +37,21 @@
                           #(rf/dispatch [:open-modal :screen/share-shell {:initial-tab :wallet}]))})
 
 (defn- action-bridge
-  [{:keys [bridge-disabled?] :as params}]
+  [{:keys [bridge-disabled? testnet-mode?] :as params}]
   {:icon                :i/bridge
    :accessibility-label :bridge
    :label               (i18n/label :t/bridge)
-   :disabled?           bridge-disabled?
+   :disabled?           (or testnet-mode? bridge-disabled?)
    :on-press            (fn []
                           (rf/dispatch [:hide-bottom-sheet])
                           (rf/dispatch [:wallet/bridge-select-token params]))})
 
 (defn- action-swap
-  [{:keys [token token-symbol]}]
+  [{:keys [token token-symbol testnet-mode?]}]
   {:icon                :i/swap
    :accessibility-label :swap
    :label               (i18n/label :t/swap)
+   :disabled?           testnet-mode?
    :on-press            (fn []
                           (rf/dispatch [:hide-bottom-sheet])
                           (rf/dispatch [:wallet.swap/start
@@ -79,8 +80,10 @@
                                          {:query token-symbol}]))
         selected-account (rf/sub [:wallet/current-viewing-account-address])
         token-owners     (rf/sub [:wallet/operable-addresses-with-token-symbol token-symbol])
-        params           (cond-> {:start-flow? true
-                                  :owners      token-owners}
+        testnet-mode?    (rf/sub [:profile/test-networks-enabled?])
+        params           (cond-> {:start-flow?   true
+                                  :owners        token-owners
+                                  :testnet-mode? testnet-mode?}
                            selected-account
                            (assoc :token        token-data
                                   :stack-id     :screen/wallet.accounts


### PR DESCRIPTION
fixes #21342 

### Summary

This PR disables swap and bridge options when the user is in testnet mode

![](https://github.com/user-attachments/assets/26c800cf-3edb-4136-93b0-b1a65a342f26)
![](https://github.com/user-attachments/assets/871a1b76-e555-4f4a-b017-5b760c44de2b)

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Go to wallet
- Verify either Swap and Bridge options are accessible when the user is in testnet mode

status: ready