### PR TITLE
[#21308] Increase hit area for selectors

### DIFF
--- a/src/quo/components/selectors/selectors/view.cljs
+++ b/src/quo/components/selectors/selectors/view.cljs
@@ -32,7 +32,8 @@
     [rn/pressable
      (when-not disabled?
        {:on-press                on-press
-        :allow-multiple-presses? true})
+        :allow-multiple-presses? true
+        :hit-slop                12})
      [rn/view
       {:style                             outer-styles
        :needs-offscreen-alpha-compositing true

--- a/src/status_im/contexts/onboarding/common/background/view.cljs
+++ b/src/status_im/contexts/onboarding/common/background/view.cljs
@@ -58,7 +58,7 @@
       (reset! shell.state/screen-height height)
       (async-storage/set-item! :screen-height height))))
 
-(defn f-view
+(defn view
   [dark-overlay?]
   (let [view-id      (rf/sub [:view-id])
         animate?     (not dark-overlay?)
@@ -94,5 +94,3 @@
          :blur-radius   (if platform/android? 25 10)
          :blur-type     :transparent
          :overlay-color :transparent}])]))
-
-(defn view [dark-overlay?] [:f> f-view dark-overlay?])


### PR DESCRIPTION
fixes #21308 

### Summary

This PR increases the hit area for all selectors in the app [to 32dp](https://discord.com/channels/1210237582470807632/1274068685266489434/1289025038057734164).

This change affects the entire app.

Demo on onboarding:

https://github.com/user-attachments/assets/f70ffac3-5531-4a81-b4ad-5ca6ef3fa163


### Testing notes
Please test the app and make sure the selectors are easier to press now.

#### Platforms

- Android
- iOS

status: ready