### PR TITLE
feat(swap): remove feature flag

### DIFF
--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -60,10 +60,9 @@
          :bridge-action    (fn []
                              (rf/dispatch [:wallet/clean-send-data])
                              (rf/dispatch [:wallet/start-bridge]))
-         :swap-action      (when (ff/enabled? ::ff/wallet.swap)
-                             (fn []
-                               (rf/dispatch [:wallet.tokens/get-token-list])
-                               (rf/dispatch [:open-modal :screen/wallet.swap-select-asset-to-pay])))
+         :swap-action      (fn []
+                             (rf/dispatch [:wallet.tokens/get-token-list])
+                             (rf/dispatch [:open-modal :screen/wallet.swap-select-asset-to-pay]))
          :bridge-disabled? testnet-mode?
          :swap-disabled?   testnet-mode?}])
      [quo/tabs

--- a/src/status_im/contexts/wallet/common/token_value/view.cljs
+++ b/src/status_im/contexts/wallet/common/token_value/view.cljs
@@ -102,8 +102,7 @@
                  (when (seq token-owners)
                    (action-send params entry-point))
                  (action-receive selected-account)
-                 (when (ff/enabled? ::ff/wallet.swap)
-                   (action-swap params))
+                 (action-swap params)
                  (when (seq token-owners)
                    (action-bridge (assoc params
                                          :bridge-disabled?

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -345,8 +345,7 @@
                            :Prod
                            data-store/rpc->network)
                      data)}]
-     {:fx [(when (ff/enabled? ::ff/wallet.swap)
-             [:dispatch [:wallet.tokens/get-token-list]])]
+     {:fx [[:dispatch [:wallet.tokens/get-token-list]]]
       :db (assoc-in db [:wallet :networks] network-data)})))
 
 (rf/reg-event-fx

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -31,7 +31,6 @@
    ::wallet.import-private-key          (enabled-in-env? :FLAG_IMPORT_PRIVATE_KEY_ENABLED)
    ::wallet.long-press-watch-only-asset (enabled-in-env? :FLAG_LONG_PRESS_WATCH_ONLY_ASSET_ENABLED)
    ::wallet.saved-addresses             (enabled-in-env? :WALLET_SAVED_ADDRESSES)
-   ::wallet.swap                        (enabled-in-env? :FLAG_SWAP_ENABLED)
    ::wallet.wallet-connect              (enabled-in-env? :FLAG_WALLET_CONNECT_ENABLED)
    ::wallet.custom-network-amounts      (enabled-in-env? :FLAG_WALLET_CUSTOM_NETWORK_AMOUNTS_ENABLED)})
 


### PR DESCRIPTION
fixes #21362

### Summary

This PR removes the swap feature flag and makes the feature always available

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Login
- Verify Swap feature is always available without the need of enabling a feature flag

status: ready