### PR TITLE
chore: remove run-tests from wallet-send event tests

### DIFF
--- a/src/status_im/contexts/wallet/send/events_test.cljs
+++ b/src/status_im/contexts/wallet/send/events_test.cljs
@@ -1,6 +1,6 @@
 (ns status-im.contexts.wallet.send.events-test
   (:require
-    [cljs.test :refer-macros [is testing run-tests]]
+    [cljs.test :refer-macros [is testing]]
     matcher-combinators.test
     [re-frame.db :as rf-db]
     [status-im.contexts.wallet.common.utils.networks :as network-utils]
@@ -710,5 +710,3 @@
                                 :stack-id       stack-id
                                 :start-flow?    start-flow?
                                 :netork-details network-details}])))))))
-
-(run-tests)


### PR DESCRIPTION
### Summary

* This PR removes an unneeded `(run-tests)` expression that can emit false failures in CI and running unit tests locally

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- CI

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
