### PR TITLE
nix: use multiple nixpkgs sources

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -51,7 +51,6 @@ in {
   };
 
   # Package version adjustments
-  gradle = super.gradle_8.override { java = super.openjdk17_headless; };
   nodejs = super.nodejs_20;
   ruby = super.ruby_3_1;
   yarn = super.yarn.override { nodejs = super.nodejs_20; };

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -6,8 +6,16 @@ let
   # For testing local version of nixpkgs
   #nixpkgsSrc = (import <nixpkgs> { }).lib.cleanSource "/home/jakubgs/work/nixpkgs";
 
-  # We use a commit from the unstable channel of nixpkgs for gradle 8.8
+  # We follow release 24-05 of nixpkgs
+  # https://github.com/NixOS/nixpkgs/releases/tag/24.05
   nixpkgsSrc = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/df27247e6f3e636c119e2610bf12d38b5e98cc79.tar.gz";
+    sha256 = "sha256:0zynbk52khdfhg4qfv26h3r5156xff5p0cga2cin7b07i7lqminh";
+  };
+
+  # FIXME: remove this additional source when nixpkgs includes gradle 8.8 in stable channel
+  # We use a commit from the unstable channel of nixpkgs for gradle 8.8
+  gradleNixpkgsSrc = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/48d567fc7b299de90f70a48e4263e31f690ba03e.tar.gz";
     sha256 = "sha256:0zynbk52khdfhg4qfv26h3r5156xff5p0cga2cin7b07i7lqminh";
   };
@@ -20,6 +28,14 @@ let
 
   # Override some packages and utilities
   pkgsOverlay = import ./overlay.nix;
+
+  # FIXME: remove this additional source when nixpkgs includes gradle 8.8 in stable channel
+  gradleOverlay = final: prev: {
+    gradle = (import gradleNixpkgsSrc {
+      inherit (prev) system;
+      config = defaultConfig // config;
+    }).gradle_8.override { java = prev.openjdk17_headless; };
+  };
 
   # Fix for lack of Android SDK for M1 Macs.
   systemOverride = let
@@ -35,5 +51,5 @@ in
   (import nixpkgsSrc) {
     config = defaultConfig // config;
     system = systemOverride;
-    overlays = [ pkgsOverlay ];
+    overlays = [ pkgsOverlay gradleOverlay ];
   }


### PR DESCRIPTION
## Summary

In this PR we specify multiple `nixpkgs` sources.

We use the stable channel for all our packages and we use the unstable channel only for `gradle 8.8`

A side effect might be longer wait times when running the android shell ( only the 1st time ).

## Platforms
- Android
- iOS

status: ready
