### PR TITLE
[#21335] feat: add dApp analytics

### DIFF
--- a/src/status_im/contexts/centralized_metrics/events.cljs
+++ b/src/status_im/contexts/centralized_metrics/events.cljs
@@ -46,6 +46,14 @@
                                          (get-in db [:profile/login :key-uid])]))
               :shell?   true}]]]})))
 
-(rf/reg-event-fx :centralized-metrics/track-event
- "Track an event, :centralized-metrics/track-event event-name {:kebab_case_key value}"
- (fn [_ _] {}))
+(rf/reg-fx :effects.centralized-metrics/track
+ (fn [event]
+   (native-module/add-centralized-metric event)))
+
+(rf/reg-event-fx
+ :centralized-metrics/track
+ (fn [{:keys [db]} [event-name data]]
+   (let [event-id (keyword (name event-name))]
+     (when (push-event? db)
+       {:fx [[:effects.centralized-metrics/track
+              (tracking/key-value-event event-id data)]]}))))

--- a/src/status_im/contexts/centralized_metrics/events.cljs
+++ b/src/status_im/contexts/centralized_metrics/events.cljs
@@ -53,7 +53,7 @@
 (rf/reg-event-fx
  :centralized-metrics/track
  (fn [{:keys [db]} [event-name data]]
-   (let [event-id (keyword (name event-name))]
+   (let [event-id (name event-name)]
      (when (push-event? db)
        {:fx [[:effects.centralized-metrics/track
               (tracking/key-value-event event-id data)]]}))))

--- a/src/status_im/contexts/centralized_metrics/events.cljs
+++ b/src/status_im/contexts/centralized_metrics/events.cljs
@@ -45,3 +45,7 @@
                           #(rf/dispatch [:profile.login/login-with-biometric-if-available
                                          (get-in db [:profile/login :key-uid])]))
               :shell?   true}]]]})))
+
+(rf/reg-event-fx :centralized-metrics/track-event
+ "Track an event, :centralized-metrics/track-event event-name {:kebab_case_key value}"
+ (fn [_ _] {}))

--- a/src/status_im/contexts/centralized_metrics/tracking.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking.cljs
@@ -4,20 +4,20 @@
     [react-native.platform :as platform]))
 
 (defn key-value-event
-  [event-name val-key value]
+  [event-name event-value]
   {:metric
    {:eventName  event-name
     :platform   platform/os
     :appVersion build/app-short-version
-    :eventValue {val-key value}}})
+    :eventValue event-value}})
 
 (defn user-journey-event
   [action]
-  (key-value-event "user-journey" :action action))
+  (key-value-event "user-journey" {:action action}))
 
 (defn navigation-event
   [view-id]
-  (key-value-event "navigation" :viewId view-id))
+  (key-value-event "navigation" {:viewId view-id}))
 
 (def ^:const app-started-event "app-started")
 
@@ -51,15 +51,18 @@
     (navigation-event (name view-id))))
 
 (defn tracked-event
-  [[event-name second-parameter]]
+  [[event-name second-parameter extra-data]]
   (case event-name
     :profile/get-profiles-overview-success
     (user-journey-event app-started-event)
 
     :centralized-metrics/toggle-centralized-metrics
-    (key-value-event "events.metrics-enabled" :enabled second-parameter)
+    (key-value-event "events.metrics-enabled" {:enabled second-parameter})
 
     :set-view-id
     (track-view-id-event second-parameter)
+
+    :centralized-metrics/track-event
+    (key-value-event second-parameter extra-data)
 
     nil))

--- a/src/status_im/contexts/centralized_metrics/tracking.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking.cljs
@@ -51,7 +51,7 @@
     (navigation-event (name view-id))))
 
 (defn tracked-event
-  [[event-name second-parameter extra-data]]
+  [[event-name second-parameter]]
   (case event-name
     :profile/get-profiles-overview-success
     (user-journey-event app-started-event)
@@ -61,8 +61,5 @@
 
     :set-view-id
     (track-view-id-event second-parameter)
-
-    :centralized-metrics/track-event
-    (key-value-event second-parameter extra-data)
 
     nil))

--- a/src/status_im/contexts/centralized_metrics/tracking_test.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking_test.cljs
@@ -18,7 +18,7 @@
                        :platform   platform-os
                        :appVersion app-version
                        :eventValue {val-key value}}}]
-      (is (= expected (tracking/key-value-event event-name val-key value))))))
+      (is (= expected (tracking/key-value-event event-name {val-key value}))))))
 
 (deftest user-journey-event-test
   (testing "creates correct user journey event"

--- a/src/status_im/contexts/wallet/connected_dapps/view.cljs
+++ b/src/status_im/contexts/wallet/connected_dapps/view.cljs
@@ -20,6 +20,7 @@
   (rf/dispatch
    [:wallet-connect/disconnect-dapp
     {:topic      topic
+     :name       name
      :on-success (fn []
                    (rf/dispatch [:toasts/upsert
                                  {:id   :dapp-disconnect-success

--- a/src/status_im/contexts/wallet/connected_dapps/view.cljs
+++ b/src/status_im/contexts/wallet/connected_dapps/view.cljs
@@ -20,7 +20,6 @@
   (rf/dispatch
    [:wallet-connect/disconnect-dapp
     {:topic      topic
-     :name       name
      :on-success (fn []
                    (rf/dispatch [:toasts/upsert
                                  {:id   :dapp-disconnect-success

--- a/src/status_im/contexts/wallet/wallet_connect/events/effects.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/effects.cljs
@@ -142,10 +142,10 @@
            :reason      reason})
          (promesa/then (fn []
                          (log/debug "Wallet Connect session proposal rejected")
-                         (partial rf/call-continuation on-success)))
+                         (rf/call-continuation on-success)))
          (promesa/catch (fn []
                           (log/error "Wallet Connect unable to reject session proposal")
-                          (partial rf/call-continuation on-error)))))))
+                          (rf/call-continuation on-error)))))))
 
 (rf/reg-fx
  :effects.wallet-connect/get-sessions

--- a/src/status_im/contexts/wallet/wallet_connect/events/effects.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/effects.cljs
@@ -73,8 +73,8 @@
            (signing/eth-sign password address data)
 
            (signing/personal-sign password address data))
-         (promesa/then on-success)
-         (promesa/catch on-error)))))
+         (promesa/then (partial rf/call-continuation on-success))
+         (promesa/catch (partial rf/call-continuation on-error))))))
 
 (rf/reg-fx
  :effects.wallet-connect/prepare-transaction
@@ -93,8 +93,8 @@
                                       tx-hash
                                       tx-args
                                       chain-id)
-       (promesa/then on-success)
-       (promesa/catch on-error))))
+       (promesa/then (partial rf/call-continuation on-success))
+       (promesa/catch (partial rf/call-continuation on-error)))))
 
 (rf/reg-fx
  :effects.wallet-connect/send-transaction
@@ -104,8 +104,8 @@
                                       tx-hash
                                       tx-args
                                       chain-id)
-       (promesa/then on-success)
-       (promesa/catch on-error))))
+       (promesa/then (partial rf/call-continuation on-success))
+       (promesa/catch (partial rf/call-continuation on-error)))))
 
 (rf/reg-fx
  :effects.wallet-connect/sign-typed-data
@@ -115,8 +115,8 @@
                         data
                         chain-id
                         version)
-       (promesa/then on-success)
-       (promesa/catch on-error))))
+       (promesa/then (partial rf/call-continuation on-success))
+       (promesa/catch (partial rf/call-continuation on-error)))))
 
 (rf/reg-fx
  :effects.wallet-connect/respond-session-request

--- a/src/status_im/contexts/wallet/wallet_connect/events/effects.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/effects.cljs
@@ -8,7 +8,6 @@
     [status-im.contexts.wallet.wallet-connect.utils.signing :as signing]
     [status-im.contexts.wallet.wallet-connect.utils.transactions :as transactions]
     [status-im.contexts.wallet.wallet-connect.utils.typed-data :as typed-data]
-    [taoensso.timbre :as log]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
@@ -140,12 +139,8 @@
           {:web3-wallet web3-wallet
            :id          id
            :reason      reason})
-         (promesa/then (fn []
-                         (log/debug "Wallet Connect session proposal rejected")
-                         (rf/call-continuation on-success)))
-         (promesa/catch (fn []
-                          (log/error "Wallet Connect unable to reject session proposal")
-                          (rf/call-continuation on-error)))))))
+         (promesa/then on-success)
+         (promesa/catch on-error)))))
 
 (rf/reg-fx
  :effects.wallet-connect/get-sessions

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
@@ -148,11 +148,8 @@
            [:dispatch [:wallet-connect/redirect-to-dapp (data-store/get-dapp-redirect-url session)]]
            [:dispatch
             [:centralized-metrics/track :metric/dapp-session
-             {:action :approved
-              :result :success}]]
-           [:dispatch
-            [:centralized-metrics/track :metric/dapp-connected
-             {:total_connected_dapps total-connected-dapps}]]]})))
+             {:action                :approved
+              :total_connected_dapps total-connected-dapps}]]]})))
 
 (rf/reg-event-fx :wallet-connect/approve-session-error
  (fn [_ [error]]
@@ -163,7 +160,7 @@
          [:dispatch
           [:centralized-metrics/track :metric/dapp-session
            {:action :approved
-            :result :fail}]]]}))
+            :error  (aget error "code")}]]]}))
 
 (rf/reg-event-fx
  :wallet-connect/reject-session-proposal
@@ -178,10 +175,9 @@
                :proposal    (or proposal request)
                :on-success  [:centralized-metrics/track :metric/dapp-session
                              {:networks networks
-                              :action   (if rejected? :rejected :not_supported)
-                              :result   :success}]
+                              :action   (if rejected? :rejected :not_supported)}]
                :on-error    [:centralized-metrics/track :metric/dapp-session
                              {:networks networks
                               :action   (if rejected? :rejected :not_supported)
-                              :result   :fail}]}])
+                              :error    true}]}])
            [:dispatch [:wallet-connect/reset-current-session-proposal]]]})))

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
@@ -168,7 +168,9 @@
      {:fx (if-not response-sent?
             [[:effects.wallet-connect/reject-session-proposal
               {:web3-wallet web3-wallet
-               :proposal    (or proposal request)}]
+               :proposal    (or proposal request)
+               :on-success  #(log/info "Wallet Connect session proposal rejected")
+               :on-error    #(log/error "Wallet Connect unable to reject session proposal")}]
              [:dispatch
               [:centralized-metrics/track :metric/dapp-session-proposal
                {:action   (if rejected? :rejected :not_supported)

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
@@ -141,7 +141,7 @@
        {:fx [[:dispatch [:wallet-connect/no-internet-toast]]]}))))
 
 (rf/reg-event-fx :wallet-connect/approve-session-success
- (fn [{:keys [db]} [session proposal]]
+ (fn [{:keys [db]} [proposal session]]
    (let [networks              (data-store/get-networks-from-proposal db proposal)
          total-connected-dapps (-> db
                                    :wallet-connect/sessions
@@ -161,7 +161,7 @@
               :total_connected_dapps total-connected-dapps}]]]})))
 
 (rf/reg-event-fx :wallet-connect/approve-session-error
- (fn [{:keys [db]} [error proposal]]
+ (fn [{:keys [db]} [proposal error]]
    (let [networks (data-store/get-networks-from-proposal db proposal)]
      (log/error "Wallet Connect session approval failed"
                 {:error error

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
@@ -135,34 +135,72 @@
                  :proposal-request current-proposal
                  :session-networks session-networks
                  :address          current-address
-                 :on-success       #(rf/dispatch [:wallet-connect/approve-session-success %])
-                 :on-fail          #(rf/dispatch [:wallet-connect/approve-session-error %])}])
+                 :on-success       #(rf/dispatch [:wallet-connect/approve-session-success %
+                                                  current-proposal])
+                 :on-fail          #(rf/dispatch [:wallet-connect/approve-session-error %
+                                                  current-proposal])}])
              [:dispatch [:dismiss-modal :screen/wallet.wallet-connect-session-proposal]]]}
        {:fx [[:dispatch [:wallet-connect/no-internet-toast]]]}))))
 
 (rf/reg-event-fx :wallet-connect/approve-session-success
- (fn [_ [session]]
-   (log/info "Wallet Connect session approved")
-   {:fx [[:dispatch [:wallet-connect/on-new-session session]]
-         [:dispatch [:wallet-connect/reset-current-session-proposal]]
-         [:dispatch [:wallet-connect/redirect-to-dapp (data-store/get-dapp-redirect-url session)]]]}))
+ (fn [{:keys [db]} [session proposal]]
+   (let [[dapp-name networks]  (data-store/get-dapp-name-and-networks db proposal)
+         total-connected-dapps (-> db
+                                   :wallet-connect/sessions
+                                   count
+                                   inc)]
+     (log/info "Wallet Connect session approved")
+     {:fx [[:dispatch [:wallet-connect/on-new-session session]]
+           [:dispatch [:wallet-connect/reset-current-session-proposal]]
+           [:dispatch [:wallet-connect/redirect-to-dapp (data-store/get-dapp-redirect-url session)]]
+           [:dispatch
+            [:centralized-metrics/track-event "dapp-session"
+             {:dapp_name dapp-name
+              :networks  networks
+              :action    :approved
+              :result    :success}]]
+           [:dispatch
+            [:centralized-metrics/track-event "dapp-connected"
+             {:dapp_name             dapp-name
+              :networks              networks
+              :total_connected_dapps total-connected-dapps}]]]})))
 
 (rf/reg-event-fx :wallet-connect/approve-session-error
- (fn [_ [error]]
-   (log/error "Wallet Connect session approval failed"
-              {:error error
-               :event :wallet-connect/approve-session})
-   {:fx [[:dispatch [:wallet-connect/reset-current-session-proposal]]]}))
+ (fn [{:keys [db]} [error proposal]]
+   (let [[dapp-name networks] (data-store/get-dapp-name-and-networks db proposal)]
+     (log/error "Wallet Connect session approval failed"
+                {:error error
+                 :event :wallet-connect/approve-session})
+     {:fx [[:dispatch [:wallet-connect/reset-current-session-proposal]]
+           [:dispatch
+            [:centralized-metrics/track-event "dapp-session"
+             {:dapp_name dapp-name
+              :networks  networks
+              :action    :approved
+              :result    :fail}]]]})))
 
 (rf/reg-event-fx
  :wallet-connect/reject-session-proposal
  (fn [{:keys [db]} [proposal]]
    (let [web3-wallet                      (get db :wallet-connect/web3-wallet)
-         {:keys [request response-sent?]} (:wallet-connect/current-proposal db)]
+         {:keys [request response-sent?]} (:wallet-connect/current-proposal db)
+         [dapp-name networks]             (data-store/get-dapp-name-and-networks db proposal)]
      {:fx [(when-not response-sent?
              [:effects.wallet-connect/reject-session-proposal
               {:web3-wallet web3-wallet
                :proposal    (or proposal request)
-               :on-success  #(log/info "Wallet Connect session proposal rejected")
-               :on-error    #(log/error "Wallet Connect unable to reject session proposal")}])
+               :on-success  (fn []
+                              (log/info "Wallet Connect session proposal rejected")
+                              (rf/dispatch [:centralized-metrics/track-event "dapp-session"
+                                            {:dapp_name dapp-name
+                                             :networks  networks
+                                             :action    :rejected
+                                             :result    :success}]))
+               :on-error    (fn []
+                              (log/error "Wallet Connect unable to reject session proposal")
+                              (rf/dispatch [:centralized-metrics/track-event "dapp-session"
+                                            {:dapp_name dapp-name
+                                             :networks  networks
+                                             :action    :rejected
+                                             :result    :fail}]))}])
            [:dispatch [:wallet-connect/reset-current-session-proposal]]]})))

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_responses.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_responses.cljs
@@ -104,6 +104,7 @@
            [:dispatch
             [:centralized-metrics/track :metric/dapp-sign
              {:network network
+              :action  :approved
               :result  :success}]]]})))
 
 (rf/reg-event-fx
@@ -127,6 +128,7 @@
            [:dispatch
             [:centralized-metrics/track :metric/dapp-sign
              {:network network
+              :action  :approved
               :result  :fail}]]]})))
 
 (rf/reg-event-fx
@@ -141,6 +143,7 @@
            [:dispatch
             [:centralized-metrics/track :metric/dapp-send
              {:network network
+              :action  :approved
               :result  :fail}]]]})))
 
 (rf/reg-event-fx :wallet-connect/respond-send-transaction-success
@@ -149,6 +152,7 @@
      {:fx [[:dispatch
             [:centralized-metrics/track :metric/dapp-send
              {:network network
+              :action  :approved
               :result  :success}]]
            [:dispatch [:wallet-connect/finish-session-request result]]]})))
 

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_responses.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_responses.cljs
@@ -184,14 +184,15 @@
  (fn [{:keys [db]}]
    (let [{:keys [response-sent? event]} (get db :wallet-connect/current-request)
          method                         (data-store/get-request-method event)]
-     {:fx (if-not response-sent?
-            [[:dispatch
-              [:centralized-metrics/track :metric/dapp-session-response
-               {:method   method
-                :approved false}]]
-             [:dispatch
-              [:wallet-connect/send-response
-               {:request event
-                :error   (wallet-connect/get-sdk-error
-                          constants/wallet-connect-user-rejected-error-key)}]]]
-            [[:dispatch [:wallet-connect/reset-current-request]]])})))
+     {:fx (concat
+           (when-not response-sent?
+             [[:dispatch
+               [:centralized-metrics/track :metric/dapp-session-response
+                {:method   method
+                 :approved false}]]
+              [:dispatch
+               [:wallet-connect/send-response
+                {:request event
+                 :error   (wallet-connect/get-sdk-error
+                           constants/wallet-connect-user-rejected-error-key)}]]])
+           [[:dispatch [:wallet-connect/reset-current-request]]])})))

--- a/src/status_im/contexts/wallet/wallet_connect/events/sessions.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/sessions.cljs
@@ -18,7 +18,7 @@
 
 (rf/reg-event-fx
  :wallet-connect/disconnect-dapp
- (fn [{:keys [db]} [{:keys [topic name on-success on-fail]}]]
+ (fn [{:keys [db]} [{:keys [topic on-success on-fail]}]]
    (let [web3-wallet    (get db :wallet-connect/web3-wallet)
          network-status (:network/status db)]
      (log/info "Disconnecting dApp session" topic)
@@ -27,17 +27,15 @@
               {:web3-wallet web3-wallet
                :topic       topic
                :on-fail     (fn []
-                              (rf/dispatch [:centralized-metrics/track-event "dapp-disconnected"
-                                            {:dapp_name name
-                                             :result    :fail}])
+                              (rf/dispatch [:centralized-metrics/track :metric/dapp-disconnected
+                                            {:result :fail}])
                               (when on-fail
                                 (on-fail)))
                :on-success  (fn []
                               (log/info "Successfully disconnected dApp session" topic)
                               (rf/dispatch [:wallet-connect/delete-session topic])
-                              (rf/dispatch [:centralized-metrics/track-event "dapp-disconnected"
-                                            {:dapp_name name
-                                             :result    :success}])
+                              (rf/dispatch [:centralized-metrics/track :metric/dapp-disconnected
+                                            {:result :success}])
                               (when on-success
                                 (on-success)))}]]}
        {:fx [[:dispatch [:wallet-connect/no-internet-toast]]]}))))

--- a/src/status_im/contexts/wallet/wallet_connect/events/sessions.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/sessions.cljs
@@ -32,9 +32,8 @@
                :on-success  (fn []
                               (log/info "Successfully disconnected dApp session" topic)
                               (rf/dispatch [:wallet-connect/delete-session topic])
-                              (rf/dispatch [:dispatch
-                                            [:centralized-metrics/track
-                                             :metric/dapp-session-disconnected]])
+                              (rf/dispatch [:centralized-metrics/track
+                                            :metric/dapp-session-disconnected])
                               (when on-success
                                 (on-success)))}]]}
        {:fx [[:dispatch [:wallet-connect/no-internet-toast]]]}))))

--- a/src/status_im/contexts/wallet/wallet_connect/events/sessions.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/sessions.cljs
@@ -27,15 +27,14 @@
               {:web3-wallet web3-wallet
                :topic       topic
                :on-fail     (fn []
-                              (rf/dispatch [:centralized-metrics/track :metric/dapp-disconnected
-                                            {:result :fail}])
                               (when on-fail
                                 (on-fail)))
                :on-success  (fn []
                               (log/info "Successfully disconnected dApp session" topic)
                               (rf/dispatch [:wallet-connect/delete-session topic])
-                              (rf/dispatch [:centralized-metrics/track :metric/dapp-disconnected
-                                            {:result :success}])
+                              (rf/dispatch [:dispatch
+                                            [:centralized-metrics/track
+                                             :metric/dapp-session-disconnected]])
                               (when on-success
                                 (on-success)))}]]}
        {:fx [[:dispatch [:wallet-connect/no-internet-toast]]]}))))

--- a/src/status_im/contexts/wallet/wallet_connect/events/sessions.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/sessions.cljs
@@ -14,7 +14,10 @@
             [{:method     "wallet_disconnectWalletConnectSession"
               :params     [topic]
               :on-success [:wallet-connect/delete-session topic]
-              :on-error   #(log/info "Wallet Connect session persistence failed" %)}]]]})))
+              :on-error   #(log/info "Wallet Connect session persistence failed" %)}]]
+           [:dispatch
+            [:centralized-metrics/track
+             :metric/dapp-session-disconnected]]]})))
 
 (rf/reg-event-fx
  :wallet-connect/disconnect-dapp

--- a/src/status_im/contexts/wallet/wallet_connect/modals/common/footer/view.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/modals/common/footer/view.cljs
@@ -18,6 +18,7 @@
   [{:keys [warning-label slide-button-text error-state]} & children]
   (let [{:keys [customization-color]} (rf/sub [:wallet-connect/current-request-account-details])
         offline?                      (rf/sub [:network/offline?])
+        view-id                       (rf/sub [:view-id])
         theme                         (quo.theme/use-theme)]
     [:<>
      (when (or offline? error-state)
@@ -32,8 +33,13 @@
                                           :not-enough-assets
                                           :t/not-enough-assets-for-transaction)))
          :button-text     (i18n/label :t/add-eth)
-         :on-button-press #(rf/dispatch [:show-bottom-sheet
-                                         {:content buy-token/view}])}])
+         :on-button-press (rn/use-callback (fn []
+                                             (rf/dispatch [:centralized-metrics/track
+                                                           :metric/button-press
+                                                           {:key     :add_eth
+                                                            :view_id view-id}])
+                                             (rf/dispatch [:show-bottom-sheet
+                                                           {:content buy-token/view}])))}])
      [rn/view {:style style/content-container}
       (into [rn/view
              {:style style/data-items-container}]

--- a/src/status_im/contexts/wallet/wallet_connect/modals/common/footer/view.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/modals/common/footer/view.cljs
@@ -18,7 +18,6 @@
   [{:keys [warning-label slide-button-text error-state]} & children]
   (let [{:keys [customization-color]} (rf/sub [:wallet-connect/current-request-account-details])
         offline?                      (rf/sub [:network/offline?])
-        view-id                       (rf/sub [:view-id])
         theme                         (quo.theme/use-theme)]
     [:<>
      (when (or offline? error-state)
@@ -35,9 +34,7 @@
          :button-text     (i18n/label :t/add-eth)
          :on-button-press (rn/use-callback (fn []
                                              (rf/dispatch [:centralized-metrics/track
-                                                           :metric/button-press
-                                                           {:key     :add_eth
-                                                            :view_id view-id}])
+                                                           :metric/dapp-buy-eth])
                                              (rf/dispatch [:show-bottom-sheet
                                                            {:content buy-token/view}])))}])
      [rn/view {:style style/content-container}

--- a/src/status_im/contexts/wallet/wallet_connect/utils/data_store.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/utils/data_store.cljs
@@ -74,24 +74,9 @@
       get-db-current-request-event
       get-request-params))
 
-(defn get-network-from-request
+(defn get-total-connected-dapps
   [db]
   (-> db
-      get-db-current-request-event
-      (get-in [:params :chainId])))
-
-(defn get-networks-from-proposal
-  "Find networks from current proposal as a string of comma separated values"
-  [db & [proposal]]
-  (let [current-proposal (get-in db [:wallet-connect/current-proposal :request])]
-    (cond
-      current-proposal
-      (->> (get-in db [:wallet-connect/current-proposal :session-networks])
-           vec
-           (string/join ","))
-
-      proposal
-      (->> (or (get-in proposal [:params :requiredNamespaces :eip155 :chains])
-               (get-in proposal [:requiredNamespaces :eip155 :chains]))
-           vec
-           (string/join ",")))))
+      :wallet-connect/sessions
+      count
+      inc))

--- a/src/status_im/contexts/wallet/wallet_connect/utils/data_store.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/utils/data_store.cljs
@@ -73,3 +73,48 @@
   (-> db
       get-db-current-request-event
       get-request-params))
+
+(defn- find-networks
+  [current-request current-proposal request db]
+  (cond
+    current-request
+    (get-in current-request [:params :chainId])
+
+    current-proposal
+    (->> (get-in db [:wallet-connect/current-proposal :session-networks])
+         vec
+         (string/join ","))
+
+    request
+    (->> (or (get-in request [:params :requiredNamespaces :eip155 :chains])
+             (get-in request [:requiredNamespaces :eip155 :chains]))
+         vec
+         (string/join ","))
+
+    :else
+    []))
+
+(defn- find-url
+  [current-request current-proposal request]
+  (cond
+    current-request
+    (get-in current-request [:verifyContext :verified :origin])
+
+    current-proposal
+    (get-in current-proposal [:params :proposer :metadata :url])
+
+    request
+    (or (get-in request [:params :proposer :metadata :url])
+        (get-in request [:peer :metadata :url]))
+
+    :else
+    nil))
+
+(defn get-dapp-name-and-networks
+  [db & [request]]
+  (let [current-request  (get-in db [:wallet-connect/current-request :event])
+        current-proposal (get-in db [:wallet-connect/current-proposal :request])
+        session-networks (find-networks current-request current-proposal request db)
+        dapp-url         (find-url current-request current-proposal request)
+        dapp-name        (compute-dapp-name nil dapp-url)]
+    [dapp-name session-networks]))

--- a/src/status_im/contexts/wallet/wallet_connect/utils/data_store_test.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/utils/data_store_test.cljs
@@ -25,3 +25,26 @@
   (testing "returns nil if no redirect URL is found"
     (let [session {:peer {:metadata {}}}]
       (is (nil? (sut/get-dapp-redirect-url session))))))
+
+(deftest get-network-from-request-test
+  (testing "returns the correct chainId from the request"
+    (let [db {:wallet-connect/current-request {:event {:params {:chainId "eip155:1"}}}}]
+      (is (= "eip155:1" (sut/get-network-from-request db)))))
+
+  (testing "returns nil if chainId is not present in the request"
+    (let [db {:wallet-connect/current-request {:event {:params {}}}}]
+      (is (nil? (sut/get-network-from-request db))))))
+
+(deftest get-networks-from-proposal-test
+  (testing "returns session-networks as a comma-separated string when current-proposal exists"
+    (let [db {:wallet-connect/current-proposal {:request          {}
+                                                :session-networks ["eip155:1" "eip155:137"]}}]
+      (is (= "eip155:1,eip155:137" (sut/get-networks-from-proposal db)))))
+
+  (testing "returns required namespaces from proposal when proposal is provided"
+    (let [proposal {:params {:requiredNamespaces {:eip155 {:chains ["eip155:1" "eip155:10"]}}}}]
+      (is (= "eip155:1,eip155:10" (sut/get-networks-from-proposal nil proposal)))))
+
+  (testing "returns nil if no session-networks or requiredNamespaces are found"
+    (let [db {}]
+      (is (= nil (sut/get-networks-from-proposal db))))))

--- a/src/status_im/contexts/wallet/wallet_connect/utils/data_store_test.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/utils/data_store_test.cljs
@@ -26,25 +26,16 @@
     (let [session {:peer {:metadata {}}}]
       (is (nil? (sut/get-dapp-redirect-url session))))))
 
-(deftest get-network-from-request-test
-  (testing "returns the correct chainId from the request"
-    (let [db {:wallet-connect/current-request {:event {:params {:chainId "eip155:1"}}}}]
-      (is (= "eip155:1" (sut/get-network-from-request db)))))
+(deftest get-total-connected-dapps-test
+  (testing "returns the total number of connected dApps plus 1"
+    (let [db {:wallet-connect/sessions [{:url "https://dapp1.com"}
+                                        {:url "https://dapp2.com"}]}]
+      (is (= 3 (sut/get-total-connected-dapps db)))))
 
-  (testing "returns nil if chainId is not present in the request"
-    (let [db {:wallet-connect/current-request {:event {:params {}}}}]
-      (is (nil? (sut/get-network-from-request db))))))
+  (testing "returns 1 when there are no connected dApps"
+    (let [db {:wallet-connect/sessions []}]
+      (is (= 1 (sut/get-total-connected-dapps db)))))
 
-(deftest get-networks-from-proposal-test
-  (testing "returns session-networks as a comma-separated string when current-proposal exists"
-    (let [db {:wallet-connect/current-proposal {:request          {}
-                                                :session-networks ["eip155:1" "eip155:137"]}}]
-      (is (= "eip155:1,eip155:137" (sut/get-networks-from-proposal db)))))
-
-  (testing "returns required namespaces from proposal when proposal is provided"
-    (let [proposal {:params {:requiredNamespaces {:eip155 {:chains ["eip155:1" "eip155:10"]}}}}]
-      (is (= "eip155:1,eip155:10" (sut/get-networks-from-proposal nil proposal)))))
-
-  (testing "returns nil if no session-networks or requiredNamespaces are found"
-    (let [db {}]
-      (is (= nil (sut/get-networks-from-proposal db))))))
+  (testing "handles nil sessions correctly"
+    (let [db {:wallet-connect/sessions nil}]
+      (is (= 1 (sut/get-total-connected-dapps db))))))


### PR DESCRIPTION
fixes #21335

### Summary

Integrate analytic for dApp events, another approach to have a separate tracking event.   

### Result Events 
https://www.notion.so/Event-Tracking-Specification-Mobile-11a8f96fb65c8032a05efcebea3a1ce6?pvs=4#11a8f96fb65c800896eafd13c746c62b

status: ready

