### PR TITLE
feat_: retry dns discovery on failure

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v2.3.0",
-    "commit-sha1": "effde33d493ff52b66c8013067c9aa6444d84473",
-    "src-sha256": "1rd0mczdkvjm9pbmza234v1jy1bvqh3ni2xck1l42ha4sld2aqjl"
+    "version": "292309c335d4f27911a691fa6de60cdb5da8ce01",
+    "commit-sha1": "292309c335d4f27911a691fa6de60cdb5da8ce01",
+    "src-sha256": "0kybmy30v0l5sj97fykrqv15z2vn0ij4rbwwm3p3nhmcqf58zc93"
 }


### PR DESCRIPTION
Might fix https://github.com/status-im/status-mobile/issues/21371

Requires: 
- https://github.com/status-im/status-go/pull/5785

This PR adds a retry mechanism for dns discovery URLs that fail to be retrieved by periodically attempting to resolve the URL with a backoff period that will increase up to 1m.

This PR is very simple to test: we should disconnect the internet and login. Once logged in, reconnect to the internet. The retry mechanism will attempt to retrieve the values from the DNS Discovery URL, and peer discovery should happen again.
