### PR TITLE
[#21354] Exception when navigating back from route generation

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -158,16 +158,14 @@
         active-screen?                            (= view-id current-screen-id)
         bottom                                    (safe-area/get-bottom)
         [crypto-currency? set-crypto-currency]    (rn/use-state initial-crypto-currency?)
-        on-navigate-back                          on-navigate-back
         handle-on-confirm                         (fn [amount]
                                                     (rf/dispatch [:wallet/set-token-amount-to-send
                                                                   {:amount   amount
                                                                    :stack-id current-screen-id}]))
         {fiat-currency :currency}                 (rf/sub [:profile/profile])
-        {token-symbol :symbol
+        {token-symbol   :symbol
          token-networks :networks
-         :as
-         token}                                   (rf/sub [:wallet/wallet-send-token])
+         :as            token}                    (rf/sub [:wallet/wallet-send-token])
         send-from-locked-amounts                  (rf/sub [:wallet/wallet-send-from-locked-amounts])
         {:keys [total-balance]
          :as   token-by-symbol}                   (rf/sub [:wallet/token-by-symbol
@@ -196,10 +194,8 @@
                                                     (utils/cut-crypto-decimals-to-fit-usd-cents
                                                      token-balance
                                                      usd-conversion-rate)
-                                                    (-> (money/crypto->fiat
-                                                         token-balance
-                                                         conversion-rate)
-                                                        utils/cut-fiat-balance-to-two-decimals))
+                                                    (utils/cut-fiat-balance-to-two-decimals
+                                                     (money/crypto->fiat token-balance conversion-rate)))
         input-value                               (controlled-input/input-value input-state)
         valid-input?                              (not (or (controlled-input/empty-value? input-state)
                                                            (controlled-input/input-error input-state)))
@@ -389,7 +385,8 @@
        :button-one-label (if should-try-again?
                            (i18n/label :t/try-again)
                            button-one-label)
-       :button-one-props (merge (when-not should-try-again? button-one-props)
+       :button-one-props (merge (when-not should-try-again?
+                                  button-one-props)
                                 {:disabled? (or loading-routes?
                                                 (and (not should-try-again?) confirm-disabled?))
                                  :on-press  (cond

--- a/src/status_im/contexts/wallet/send/send_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/send_amount/view.cljs
@@ -10,8 +10,7 @@
   [input-amount/view
    {:current-screen-id      :screen/wallet.send-input-amount
     :button-one-label       (i18n/label :t/review-send)
-    :enabled-from-chain-ids (rf/sub
-                             [:wallet/wallet-send-enabled-from-chain-ids])
+    :enabled-from-chain-ids (rf/sub [:wallet/wallet-send-enabled-from-chain-ids])
     :from-enabled-networks  (rf/sub [:wallet/wallet-send-enabled-networks])
     :on-navigate-back       (fn []
                               (rf/dispatch-sync [:wallet/stop-and-clean-suggested-routes])

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -239,9 +239,12 @@
 
 (defn crypto->fiat
   [crypto fiat-price]
-  (when-let [^js bn (bignumber crypto)]
-    (-> (.times bn ^js (bignumber fiat-price))
-        (with-precision 2))))
+  (let [^js crypto-bn     (bignumber crypto)
+        ^js fiat-price-bn (bignumber fiat-price)]
+    (when (and crypto-bn fiat-price-bn)
+      (-> crypto-bn
+          (.times fiat-price-bn)
+          (with-precision 2)))))
 
 (defn sufficient-funds?
   [^js amount ^js balance]


### PR DESCRIPTION
fixes #21354 

### Summary

This PR solves the exception when fastly navigating back once the routes arrive. 

The problem happened because the `conversion-rate` used to calculate the `fiat->crypto` value (calculated in the view ns :warning:), was `nil` when navigating back.

Video of the issue solved:

https://github.com/user-attachments/assets/28b2f853-8d03-4ebc-90f0-99b56ab26579


### Review notes

The component `status-im.contexts.wallet.send.input-amount.view/view` needs a refactor, there a lot of calculations made in the view and the `let` bindings to understand the logic of it is giant.

#### Platforms

- Android
- iOS

### Steps to test

Please follow the video in the issue description and check is no longer reproducible.

status: ready