### PR TITLE
fix(swap): display very small numbers max values, fix scientific notation, display long number & handle decimal mismatch

### DIFF
--- a/src/quo/components/wallet/swap_input/style.cljs
+++ b/src/quo/components/wallet/swap_input/style.cljs
@@ -75,3 +75,16 @@
 
 (def fiat-amount
   {:color colors/neutral-50})
+
+(def gradient-common
+  {:width    64
+   :position :absolute
+   :top      0
+   :bottom   0
+   :z-index  1})
+
+(def gradient-start
+  (assoc gradient-common :left 0))
+
+(def gradient-end
+  (assoc gradient-common :right 0))

--- a/src/quo/components/wallet/swap_input/view.cljs
+++ b/src/quo/components/wallet/swap_input/view.cljs
@@ -11,6 +11,7 @@
             [quo.foundations.colors :as colors]
             quo.theme
             [react-native.core :as rn]
+            [react-native.linear-gradient :as linear-gradient]
             [schema.core :as schema]))
 
 (def ?schema
@@ -18,6 +19,7 @@
    [:catn
     [:props
      [:map {:closed true}
+      [:get-ref {:optional true} [:maybe fn?]]
       [:type {:optional true} [:maybe [:enum :pay :receive]]]
       [:status {:optional true} [:maybe [:enum :default :typing :disabled :loading]]]
       [:token {:optional true} [:maybe :string]]
@@ -42,26 +44,65 @@
       [:container-style {:optional true} [:maybe :map]]]]]
    :any])
 
+(def icon-size 32)
+(def container-padding (* 2 (:padding (style/row-1 false))))
+(def max-cursor-position 5)
+
 (defn view-internal
   [{:keys [type status token value fiat-value show-approval-label? error? network-tag-props
            approval-label-props default-value auto-focus? input-disabled? enable-swap?
-           currency-symbol on-change-text show-keyboard?
+           currency-symbol on-change-text show-keyboard? get-ref
            container-style on-swap-press on-token-press on-max-press on-input-focus]}]
-  (let [theme             (quo.theme/use-theme)
-        pay?              (= type :pay)
-        disabled?         (= status :disabled)
-        loading?          (= status :loading)
-        typing?           (= status :typing)
-        controlled-input? (some? value)
-        input-ref         (rn/use-ref-atom nil)
-        set-input-ref     (rn/use-callback (fn [ref] (reset! input-ref ref)) [])
-        focus-input       (rn/use-callback (fn []
-                                             (some-> @input-ref
-                                                     (oops/ocall "focus")))
-                                           [input-ref])]
+  (let [theme                        (quo.theme/use-theme)
+        pay?                         (= type :pay)
+        disabled?                    (= status :disabled)
+        loading?                     (= status :loading)
+        typing?                      (= status :typing)
+        controlled-input?            (some? value)
+        [container-width
+         set-container-width]        (rn/use-state)
+        [overflow?
+         set-overflow?]              (rn/use-state false)
+        [cursor-close-to-start?
+         set-cursor-close-to-start?] (rn/use-state false)
+        [label-width
+         set-label-width]            (rn/use-state 0)
+        input-ref                    (rn/use-ref-atom nil)
+        set-input-ref                (rn/use-callback (fn [ref]
+                                                        (reset! input-ref ref)
+                                                        (when get-ref (get-ref ref)))
+                                                      [])
+        focus-input                  (rn/use-callback (fn []
+                                                        (some-> @input-ref
+                                                                (oops/ocall "focus")))
+                                                      [input-ref])
+        on-layout-container          (rn/use-callback
+                                      (fn [e]
+                                        (let [width (oops/oget e "nativeEvent.layout.width")]
+                                          (set-container-width width))))
+        on-layout-text-input         (rn/use-callback
+                                      (fn [e]
+                                        (let [width     (oops/oget e "nativeEvent.layout.width")
+                                              max-width (- container-width
+                                                           icon-size
+                                                           container-padding
+                                                           (* label-width 2))]
+                                          (set-overflow? (> width max-width))))
+                                      [container-width label-width])
+        on-layout-label              (rn/use-callback
+                                      (fn [e]
+                                        (let [width (oops/oget e "nativeEvent.layout.width")]
+                                          (set-label-width width))))
+        on-selection-change          (rn/use-callback
+                                      (fn [e]
+                                        (let [selection-start (oops/oget e
+                                                                         "nativeEvent.selection.start")]
+                                          (set-cursor-close-to-start?
+                                           (< selection-start max-cursor-position)))))]
     [rn/view
      {:style               container-style
-      :accessibility-label :swap-input}
+      :accessibility-label :swap-input
+      :on-layout           on-layout-container}
      [rn/view {:style (style/content typing? theme)}
       [rn/view
        {:style (style/row-1 loading?)}
@@ -75,25 +116,43 @@
           [rn/pressable
            {:style    style/input-container
             :on-press focus-input}
-           [rn/text-input
-            (cond-> {:ref                      set-input-ref
-                     :style                    (style/input disabled? error? theme)
-                     :placeholder-text-color   (colors/theme-colors colors/neutral-40
-                                                                    colors/neutral-50
-                                                                    theme)
-                     :keyboard-type            :numeric
-                     :editable                 (not input-disabled?)
-                     :auto-focus               auto-focus?
-                     :on-focus                 on-input-focus
-                     :on-change-text           on-change-text
-                     :show-soft-input-on-focus show-keyboard?
-                     :default-value            default-value
-                     :placeholder              "0"}
-              controlled-input? (assoc :value value))]
+           [rn/view {:style {:flex-shrink 1}}
+            (when (and overflow? typing? (not cursor-close-to-start?))
+              [linear-gradient/linear-gradient
+               {:start  {:x 0 :y 0}
+                :end    {:x 1 :y 0}
+                :colors [(colors/theme-colors colors/white colors/neutral-100 theme)
+                         (colors/theme-colors colors/white-opa-10 colors/neutral-100-opa-10 theme)]
+                :style  style/gradient-start}])
+            (when (and overflow? disabled?)
+              [linear-gradient/linear-gradient
+               {:start  {:x 0 :y 0}
+                :end    {:x 1 :y 0}
+                :colors [(colors/theme-colors colors/white-opa-10 colors/neutral-100-opa-10 theme)
+                         (colors/theme-colors colors/white colors/neutral-100 theme)]
+                :style  style/gradient-end}])
+            [rn/text-input
+             (cond-> {:ref                      set-input-ref
+                      :style                    (style/input disabled? error? theme)
+                      :placeholder-text-color   (colors/theme-colors colors/neutral-40
+                                                                     colors/neutral-50
+                                                                     theme)
+                      :keyboard-type            :numeric
+                      :editable                 (not input-disabled?)
+                      :auto-focus               auto-focus?
+                      :on-focus                 on-input-focus
+                      :on-change-text           on-change-text
+                      :on-layout                on-layout-text-input
+                      :on-selection-change      on-selection-change
+                      :show-soft-input-on-focus show-keyboard?
+                      :default-value            default-value
+                      :placeholder              "0"}
+               controlled-input? (assoc :value value))]]
            [text/text
-            {:size   :paragraph-2
-             :weight :semi-bold
-             :style  (style/token-symbol theme)}
+            {:size      :paragraph-2
+             :weight    :semi-bold
+             :style     (style/token-symbol theme)
+             :on-layout on-layout-label}
             token]]
           (when (and pay? enable-swap?)
             [buttons/button

--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -14,7 +14,7 @@
             [utils.number :as number]))
 
 (rf/reg-event-fx :wallet.swap/start
- (fn [{:keys [db]} [{:keys [network open-new-screen?] :as data}]]
+ (fn [{:keys [db]} [{:keys [network asset-to-receive open-new-screen?] :as data}]]
    (let [{:keys [wallet]}       db
          test-networks-enabled? (get-in db [:profile/profile :test-networks-enabled?])
          account                (swap-utils/wallet-account wallet)
@@ -25,12 +25,6 @@
                                     :account                account
                                     :test-networks-enabled? test-networks-enabled?
                                     :token-symbol           (get-in data [:asset-to-pay :symbol])}))
-         asset-to-receive       (or (:asset-to-receive data)
-                                    (swap-utils/select-default-asset-to-receive
-                                     {:wallet                 wallet
-                                      :account                account
-                                      :test-networks-enabled? test-networks-enabled?
-                                      :asset-to-pay           asset-to-pay}))
          network'               (or network
                                     (swap-utils/select-network asset-to-pay))]
      {:db (-> db
@@ -137,8 +131,6 @@
                                       :amount                 amount
                                       :amount-hex             amount-in-hex
                                       :loading-swap-proposal? true)
-                                     :always
-                                     (dissoc :error-response)
                                      clean-approval-transaction?
                                      (dissoc :approval-transaction-id :approved-amount :swap-proposal)))
         :json-rpc/call [{:method   "wallet_getSuggestedRoutesAsync"

--- a/src/status_im/contexts/wallet/swap/select_asset_to_pay/view.cljs
+++ b/src/status_im/contexts/wallet/swap/select_asset_to_pay/view.cljs
@@ -20,10 +20,15 @@
 
 (defn- assets-view
   [search-text on-change-text]
-  (let [on-token-press (fn [token]
-                         (rf/dispatch [:wallet.swap/start
-                                       {:asset-to-pay     token
-                                        :open-new-screen? false}]))]
+  (let [snt-token      (rf/sub [:wallet/token-by-symbol "SNT"])
+        eth-token      (rf/sub [:wallet/token-by-symbol "ETH"])
+        on-token-press (fn [token]
+                         (let [pay-token-symbol (:symbol token)
+                               asset-to-receive (if (= pay-token-symbol "SNT") eth-token snt-token)]
+                           (rf/dispatch [:wallet.swap/start
+                                         {:asset-to-pay     token
+                                          :asset-to-receive asset-to-receive
+                                          :open-new-screen? false}])))]
     [:<>
      [search-input search-text on-change-text]
      [asset-list/view

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -492,7 +492,7 @@
 
 (rf/reg-sub
  :wallet/token-by-symbol
- :<- [:wallet/current-viewing-account]
+ :<- [:wallet/current-viewing-account-or-default]
  :<- [:wallet/network-details]
  (fn [[{:keys [tokens]} networks] [_ token-symbol chain-ids]]
    (->> (utils/tokens-with-balance tokens networks chain-ids)

--- a/src/utils/number_test.cljs
+++ b/src/utils/number_test.cljs
@@ -5,23 +5,23 @@
 
 (deftest convert-to-whole-number-test
   (testing "correctly converts fractional amounts to whole numbers"
-    (is (= 123.45 (utils.number/convert-to-whole-number 12345 2)))
-    (is (= 1.2345 (utils.number/convert-to-whole-number 12345 4)))
-    (is (= 12345.0 (utils.number/convert-to-whole-number 1234500 2)))
-    (is (= 0.123 (utils.number/convert-to-whole-number 123 3)))
-    (is (= 1000.0 (utils.number/convert-to-whole-number 1000000 3))))
+    (is (= "123.45" (utils.number/convert-to-whole-number 12345 2)))
+    (is (= "1.2345" (utils.number/convert-to-whole-number 12345 4)))
+    (is (= "12345" (utils.number/convert-to-whole-number 1234500 2)))
+    (is (= "0.123" (utils.number/convert-to-whole-number 123 3)))
+    (is (= "1000" (utils.number/convert-to-whole-number 1000000 3))))
 
   (testing "handles zero decimals"
-    (is (= 12345 (utils.number/convert-to-whole-number 12345 0))))
+    (is (= "12345" (utils.number/convert-to-whole-number 12345 0))))
 
   (testing "handles negative amounts"
-    (is (= -123.45 (utils.number/convert-to-whole-number -12345 2)))
-    (is (= -1.2345 (utils.number/convert-to-whole-number -12345 4)))
-    (is (= -0.123 (utils.number/convert-to-whole-number -123 3))))
+    (is (= "-123.45" (utils.number/convert-to-whole-number -12345 2)))
+    (is (= "-1.2345" (utils.number/convert-to-whole-number -12345 4)))
+    (is (= "-0.123" (utils.number/convert-to-whole-number -123 3))))
 
   (testing "handles zero amount"
-    (is (= 0 (utils.number/convert-to-whole-number 0 2)))
-    (is (= 0 (utils.number/convert-to-whole-number 0 0)))))
+    (is (= "0" (utils.number/convert-to-whole-number 0 2)))
+    (is (= "0" (utils.number/convert-to-whole-number 0 0)))))
 
 (deftest parse-int-test
   (testing "defaults to zero"
@@ -50,3 +50,36 @@
     (is (= 6 (utils.number/parse-float "6")))
     (is (= 6.99 (utils.number/parse-float "6.99" 0)))
     (is (= -6.9 (utils.number/parse-float "-6.9" 0)))))
+
+(deftest small-number-threshold-test
+  (testing "correctly generates threshold strings based on decimal count"
+    (is (= "<0.1" (utils.number/small-number-threshold 1)))
+    (is (= "<0.01" (utils.number/small-number-threshold 2)))
+    (is (= "<0.001" (utils.number/small-number-threshold 3)))
+    (is (= "<0.000001" (utils.number/small-number-threshold 6)))
+    (is (= "<0.0000000001" (utils.number/small-number-threshold 10)))
+    (is (= "<0.000000000000000001" (utils.number/small-number-threshold 18)))
+    (is (= "<0.000000000000000000001" (utils.number/small-number-threshold 21))))
+
+  (testing "handles edge cases for decimal count"
+    (is (= "0" (utils.number/small-number-threshold 0)))
+    (is (= "0" (utils.number/small-number-threshold -1)))))
+
+(deftest valid-decimal-count?-test
+  (testing "valid decimal count check for numbers with varying decimals"
+    (is (true? (utils.number/valid-decimal-count? 123 2)))
+    (is (true? (utils.number/valid-decimal-count? 123 0)))
+
+    (is (true? (utils.number/valid-decimal-count? 123.45 2)))
+    (is (true? (utils.number/valid-decimal-count? 123.4 2)))
+    (is (true? (utils.number/valid-decimal-count? 123.456 3)))
+
+    (is (false? (utils.number/valid-decimal-count? 123.456 2)))
+    (is (false? (utils.number/valid-decimal-count? 123.456789 4)))
+
+    (is (true? (utils.number/valid-decimal-count? 123.0 1)))
+    (is (true? (utils.number/valid-decimal-count? -123.45 2)))
+    (is (false? (utils.number/valid-decimal-count? -123.4567 3)))
+
+    (is (true? (utils.number/valid-decimal-count? 1234567890.12 2)))
+    (is (false? (utils.number/valid-decimal-count? 1234567890.12345 3)))))


### PR DESCRIPTION
fixes #21348
fixes #21347
fixes #21331
fixes #21330
fixes #21405

### Summary

This PR fixes a couple of bugs in the Swap flow:
1. Remaining decimals token shown in Scientific Notation on swap page if max label is tapped
2. Long numbers in swap receive field not properly displayed
3. Default token in the receiving field of swap is not SNT
4. Handling decimal mismatch when switching tokens with different decimal support

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

#### Issue 1
- Open Status
- Restore a user with a token that has a very small remaining decimal value (e.g., 0.000000000262783357 DAI).
- Go to swaps
- Select that token in the select asset to pay screen
- Tap "Max" value
- Verify the value is not in scientific notation

#### Issue 2
- Open Status
- Log in
- Go to swaps
- Select some 18 decimals token in the receiving value
- Enter some values
- Verify the values are displayed properly with gradients in the beginning of the input (pay token) and in the end pf the input (receive token)

[NOTE] There's an Android bug in our current version of React Native (0.73) that prevents us to position the text input at the start of it (https://github.com/facebook/react-native/issues/44171), thus will have to follow-up on this once we update to 0.74+ where this seems to be fixed (https://github.com/reactwg/react-native-releases/issues/283)

#### Issue 3 
- Open Status
- Login
- Go to swaps
- Select an asset
- Verify the default asset to receive is SNT

#### Issue 4 
- Open Status
- Login
- Go to swaps
- Select a token with 18 decimal support (like DAI) in the asset to pay field
- Change the token to one with 6 decimal support (like USDC)
- Verify the input is cleared when decimals of the current value and thew new selected token don't match

status: ready