### PR TITLE
nix: add preBuild phase for generating files

### DIFF
--- a/nix/status-go/library/default.nix
+++ b/nix/status-go/library/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, meta, source, buildGoPackage }:
+{ lib, stdenv, meta, source, buildGoPackage,
+  go-bindata, mockgen, protoc-gen-go, protobuf3_20 }:
 
 buildGoPackage {
   pname = source.repo;
@@ -6,6 +7,10 @@ buildGoPackage {
 
   inherit meta;
   inherit (source) src goPackagePath;
+
+  nativeBuildInputs = [
+    go-bindata mockgen protoc-gen-go protobuf3_20
+  ];
 
   phases = ["unpackPhase" "configurePhase" "buildPhase"];
 
@@ -22,6 +27,7 @@ buildGoPackage {
   preBuild = ''
     pushd go/src/$goPackagePath
     go run cmd/library/*.go > $NIX_BUILD_TOP/main.go
+    make generate SHELL=$SHELL GO111MODULE=on GO_GENERATE_CMD='go generate'
     popd
   '';
 

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v2.3.0",
-    "commit-sha1": "effde33d493ff52b66c8013067c9aa6444d84473",
-    "src-sha256": "1rd0mczdkvjm9pbmza234v1jy1bvqh3ni2xck1l42ha4sld2aqjl"
+    "version": "develop",
+    "commit-sha1": "ba37c32c07d1b05a94d1c7f7cb1b38fb82730f7b",
+    "src-sha256": "1f1bbw70iircicda9w0hch56hxr7p1vvzkrk58v8p5sq23xzdf6y"
 }


### PR DESCRIPTION
## Summary

This PR adds a `preBuild` phase to for `status-go` builds to generate files that are no longer committed into the repo.

## Testing notes
Please smoke test android & iOS.

## Platforms
- Android
- iOS

fixes: https://github.com/status-im/status-go/issues/5919

status: ready
