### PR TITLE
feat: use 1 content-topic for all chats within a community (not to merge)

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v8.1.0",
-    "commit-sha1": "df1c8788e42784ba3b8ed3e7c5bd3ea530028410",
-    "src-sha256": "1yxcswrj7p1m96lx795vbqlgjlmpkgzaw7l8f2k4ni3d7vmlklnw"
+    "version": "a8951fd5e737aa782c5f003b5a067ee02a69562c",
+    "commit-sha1": "a8951fd5e737aa782c5f003b5a067ee02a69562c",
+    "src-sha256": "02v0d8dalsrv44w1h7502pd5ni2098lhvkv4nk8pj4dl489qanmv"
 }


### PR DESCRIPTION
### Summary

This PR is mainly to dogfood underlying changes made in status-go.

Reference PR https://github.com/status-im/status-go/pull/5864 which has details.

This PR uses single content-topic for all community chats to send messages. It still receives messages on all existing content-topics used by previous versions in order to maintain compatibility.

Details of the discussion are available https://forum.vac.dev/t/status-communities-review-and-proposed-usage-of-waku-content-topics/335/29

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->
Community chats and control flows 

##### Functional


- public chats
- all community chats and control flows (channel creation, updation, deletion, permissions change, user add, user kick etc)
- new account

### Steps to test
- This PR would require complete testing of communities in relay and light modes.
- It would also require to be tested for compacibility with older version of the code.
- Best to check all admin functions as well using this new code
- We also need to validate if community admin is using older code and a member is using new code there are no incompatibilites.
- All chats and community flows such as add member, remove member, add channel, delete channel, change permissions to channels etc

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
