### PR TITLE
Keycard - Allow user to migrate existing Profile [Part 2]

### DIFF
--- a/src/status_im/contexts/keycard/events.cljs
+++ b/src/status_im/contexts/keycard/events.cljs
@@ -72,22 +72,21 @@
 
 (rf/reg-event-fx :keycard/on-get-application-info-success
  (fn [{:keys [db]} [application-info {:keys [key-uid on-success-fx]}]]
-   (let [error (keycard.utils/validate-application-info key-uid application-info)]
-     (if error
-       (case error
-         :keycard/error.not-keycard
-         {:fx [[:dispatch [:keycard/disconnect]]
-               [:dispatch [:open-modal :screen/keycard.not-keycard]]]}
-         :keycard/error.keycard-blank
-         {:fx [[:dispatch [:keycard/disconnect]]
-               [:dispatch [:open-modal :screen/keycard.empty]]]}
-         {:db (assoc-in db [:keycard :application-info-error] error)
-          :fx [[:dispatch [:keycard/disconnect]]
-               [:dispatch [:open-modal :screen/keycard.error]]]})
-       {:db (-> db
-                (assoc-in [:keycard :application-info] application-info)
-                (assoc-in [:keycard :pin :status] :verifying))
-        :fx on-success-fx}))))
+   (if-let [error (keycard.utils/validate-application-info key-uid application-info)]
+     (case error
+       :keycard/error.not-keycard
+       {:fx [[:dispatch [:keycard/disconnect]]
+             [:dispatch [:open-modal :screen/keycard.not-keycard]]]}
+       :keycard/error.keycard-blank
+       {:fx [[:dispatch [:keycard/disconnect]]
+             [:dispatch [:open-modal :screen/keycard.empty]]]}
+       {:db (assoc-in db [:keycard :application-info-error] error)
+        :fx [[:dispatch [:keycard/disconnect]]
+             [:dispatch [:open-modal :screen/keycard.error]]]})
+     {:db (-> db
+              (assoc-in [:keycard :application-info] application-info)
+              (assoc-in [:keycard :pin :status] :verifying))
+      :fx on-success-fx})))
 
 (rf/reg-event-fx :keycard/get-application-info
  (fn [_ [{:keys [on-success on-failure]}]]

--- a/src/status_im/contexts/keycard/sheets/migrate/view.cljs
+++ b/src/status_im/contexts/keycard/sheets/migrate/view.cljs
@@ -6,9 +6,10 @@
 
 (defn view
   []
-  (let [profile-name        (rf/sub [:profile/name])
-        profile-picture     (rf/sub [:profile/image])
-        customization-color (rf/sub [:profile/customization-color])]
+  (let [profile-name               (rf/sub [:profile/name])
+        profile-picture            (rf/sub [:profile/image])
+        customization-color        (rf/sub [:profile/customization-color])
+        recovery-phrase-backed-up? (rf/sub [:profile/recovery-phrase-backed-up?])]
     [:<>
      [quo/drawer-top
       {:type                :context-tag
@@ -27,7 +28,13 @@
      [quo/bottom-actions
       {:actions          :two-actions
        :button-one-label (i18n/label :t/continue)
-       :button-one-props {:on-press #()}
+       :button-one-props {:on-press #(if recovery-phrase-backed-up?
+                                       (rf/dispatch [:open-modal :screen/use-recovery-phrase
+                                                     {:on-success (fn [{:keys [key-uid phrase
+                                                                               on-error]}])}])
+                                       (rf/dispatch [:open-modal :screen/backup-recovery-phrase
+                                                     {:on-success (fn [{:keys [masked-seed-phrase
+                                                                               random-phrase]}])}]))}
        :button-two-label (i18n/label :t/cancel)
        :button-two-props {:type     :grey
                           :on-press #(rf/dispatch [:hide-bottom-sheet])}}]]))

--- a/src/status_im/contexts/keycard/sheets/migrate/view.cljs
+++ b/src/status_im/contexts/keycard/sheets/migrate/view.cljs
@@ -30,11 +30,9 @@
        :button-one-label (i18n/label :t/continue)
        :button-one-props {:on-press #(if recovery-phrase-backed-up?
                                        (rf/dispatch [:open-modal :screen/use-recovery-phrase
-                                                     {:on-success (fn [{:keys [key-uid phrase
-                                                                               on-error]}])}])
+                                                     {:on-success (fn [])}])
                                        (rf/dispatch [:open-modal :screen/backup-recovery-phrase
-                                                     {:on-success (fn [{:keys [masked-seed-phrase
-                                                                               random-phrase]}])}]))}
+                                                     {:on-success (fn [])}]))}
        :button-two-label (i18n/label :t/cancel)
        :button-two-props {:type     :grey
                           :on-press #(rf/dispatch [:hide-bottom-sheet])}}]]))

--- a/src/status_im/contexts/onboarding/events.cljs
+++ b/src/status_im/contexts/onboarding/events.cljs
@@ -131,15 +131,6 @@
                  [:open-modal :screen/onboarding.enable-biometrics]
                  [:open-modal :screen/onboarding.enable-notifications])}))
 
-(rf/defn seed-phrase-entered
-  {:events [:onboarding/seed-phrase-entered]}
-  [_ seed-phrase on-error]
-  {:multiaccount/validate-mnemonic [seed-phrase
-                                    (fn [mnemonic key-uid]
-                                      (re-frame/dispatch [:onboarding/seed-phrase-validated
-                                                          mnemonic key-uid]))
-                                    on-error]})
-
 (rf/defn seed-phrase-validated
   {:events [:onboarding/seed-phrase-validated]}
   [{:keys [db]} seed-phrase key-uid]

--- a/src/status_im/contexts/profile/backup_recovery_phrase/style.cljs
+++ b/src/status_im/contexts/profile/backup_recovery_phrase/style.cljs
@@ -1,4 +1,4 @@
-(ns status-im.contexts.wallet.add-account.create-account.new-keypair.backup-recovery-phrase.style
+(ns status-im.contexts.profile.backup-recovery-phrase.style
   (:require
     [quo.foundations.colors :as colors]
     [react-native.platform :as platform]))

--- a/src/status_im/contexts/profile/backup_recovery_phrase/view.cljs
+++ b/src/status_im/contexts/profile/backup_recovery_phrase/view.cljs
@@ -1,4 +1,4 @@
-(ns status-im.contexts.wallet.add-account.create-account.new-keypair.backup-recovery-phrase.view
+(ns status-im.contexts.profile.backup-recovery-phrase.view
   (:require
     [clojure.string :as string]
     [native-module.core :as native-module]
@@ -6,8 +6,7 @@
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [reagent.core :as reagent]
-    [status-im.contexts.wallet.add-account.create-account.new-keypair.backup-recovery-phrase.style :as
-     style]
+    [status-im.contexts.profile.backup-recovery-phrase.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
@@ -45,20 +44,20 @@
 
 (defn view
   []
-  (let [step-labels         [:t/backup-step-1 :t/backup-step-2 :t/backup-step-3
-                             :t/backup-step-4]
-        checked?            (reagent/atom
-                             {:0 false
-                              :1 false
-                              :2 false
-                              :3 false})
-        revealed?           (reagent/atom false)
-        customization-color (rf/sub [:profile/customization-color])
-        seed-phrase         (reagent/atom [])
-        random-phrase       (reagent/atom [])]
+  (let [step-labels          [:t/backup-step-1 :t/backup-step-2 :t/backup-step-3
+                              :t/backup-step-4]
+        checked?             (reagent/atom
+                              {:0 false
+                               :1 false
+                               :2 false
+                               :3 false})
+        revealed?            (reagent/atom false)
+        customization-color  (rf/sub [:profile/customization-color])
+        {:keys [on-success]} (rf/sub [:get-screen-params])
+        seed-phrase          (reagent/atom [])
+        random-phrase        (reagent/atom [])]
     (fn []
       (let [theme (quo.theme/use-theme)]
-
         (rn/use-mount
          (fn []
            (native-module/get-random-mnemonic #(reset! seed-phrase (string/split % #"\s")))
@@ -107,10 +106,10 @@
               :button-one-label (i18n/label :t/i-have-written)
               :button-one-props {:disabled?           (some false? (vals @checked?))
                                  :customization-color customization-color
-                                 :on-press            #(rf/dispatch [:wallet/store-new-seed-phrase
-                                                                     {:seed-phrase   (security/mask-data
-                                                                                      @seed-phrase)
-                                                                      :random-phrase @random-phrase}])}}]
+                                 :on-press            #(on-success {:masked-seed-phrase
+                                                                    (security/mask-data
+                                                                     @seed-phrase)
+                                                                    :random-phrase @random-phrase})}}]
             [quo/text
              {:size  :paragraph-2
               :style (style/description-text theme)}

--- a/src/status_im/contexts/profile/recover/effects.cljs
+++ b/src/status_im/contexts/profile/recover/effects.cljs
@@ -1,9 +1,31 @@
 (ns status-im.contexts.profile.recover.effects
   (:require
     [native-module.core :as native-module]
-    [utils.re-frame :as rf]))
+    [promesa.core :as promesa]
+    [utils.re-frame :as rf]
+    [utils.security.core :as security]
+    [utils.transforms :as transforms]))
 
 (rf/reg-fx :effects.profile/restore-and-login
  (fn [request]
    ;;"node.login" signal will be triggered as a callback
    (native-module/restore-account-and-login request)))
+
+(defn validate-mnemonic
+  [mnemonic]
+  (-> mnemonic
+      (security/safe-unmask-data)
+      (native-module/validate-mnemonic)
+      (promesa/then (fn [result]
+                      (let [{:keys [keyUID]} (transforms/json->clj result)]
+                        {:key-uid keyUID})))))
+
+(rf/reg-fx :effects.profile/validate-recovery-phrase
+ (fn [[mnemonic on-success on-error]]
+   (-> (validate-mnemonic mnemonic)
+       (promesa/then (fn [{:keys [key-uid]}]
+                       (when (fn? on-success)
+                         (on-success mnemonic key-uid))))
+       (promesa/catch (fn [error]
+                        (when (and error (fn? on-error))
+                          (on-error error)))))))

--- a/src/status_im/contexts/profile/recover/events.cljs
+++ b/src/status_im/contexts/profile/recover/events.cljs
@@ -24,3 +24,7 @@
             :imagePath          (profile.config/strip-file-prefix image-path)
             :customizationColor (or color constants/profile-default-color)
             :fetchBackup        true)}))
+
+(rf/reg-event-fx :profile.recover/validate-recovery-phrase
+ (fn [_ [phrase {:keys [on-success on-error]}]]
+   {:effects.profile/validate-recovery-phrase [phrase on-success on-error]}))

--- a/src/status_im/contexts/profile/settings/view.cljs
+++ b/src/status_im/contexts/profile/settings/view.cljs
@@ -49,13 +49,14 @@
 
 (defn view
   []
-  (let [theme               (quo.theme/use-theme)
-        insets              (safe-area/get-insets)
-        customization-color (rf/sub [:profile/customization-color])
-        scroll-y            (reanimated/use-shared-value 0)
-        profile             (rf/sub [:profile/profile])
-        full-name           (profile.utils/displayed-name profile)
-        on-scroll           (rn/use-callback #(scroll-handler % scroll-y))]
+  (let [theme                      (quo.theme/use-theme)
+        insets                     (safe-area/get-insets)
+        customization-color        (rf/sub [:profile/customization-color])
+        scroll-y                   (reanimated/use-shared-value 0)
+        profile                    (rf/sub [:profile/profile])
+        recovery-phrase-backed-up? (rf/sub [:profile/recovery-phrase-backed-up?])
+        full-name                  (profile.utils/displayed-name profile)
+        on-scroll                  (rn/use-callback #(scroll-handler % scroll-y))]
     [quo/overlay {:type :shell}
      [rn/view
       {:style (style/navigation-wrapper {:customization-color customization-color
@@ -79,7 +80,7 @@
                                                                      profile)}}])}]}]]
      [rn/flat-list
       {:header                          [settings.header/view {:scroll-y scroll-y}]
-       :data                            (settings.items/items (boolean (seq (:mnemonic profile))))
+       :data                            (settings.items/items (not recovery-phrase-backed-up?))
        :shows-vertical-scroll-indicator false
        :render-fn                       settings-category-view
        :get-item-layout                 get-item-layout

--- a/src/status_im/contexts/settings/wallet/events.cljs
+++ b/src/status_im/contexts/settings/wallet/events.cljs
@@ -160,7 +160,7 @@
 
 (defn wallet-validate-seed-phrase
   [_ [seed-phrase on-success on-error]]
-  {:fx [[:multiaccount/validate-mnemonic [seed-phrase on-success on-error]]]})
+  {:fx [[:effects.profile/validate-recovery-phrase [seed-phrase on-success on-error]]]})
 
 (rf/reg-event-fx :wallet/validate-seed-phrase wallet-validate-seed-phrase)
 

--- a/src/status_im/contexts/settings/wallet/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/events_test.cljs
@@ -101,7 +101,7 @@
         seed-phrase-masked (security/mask-data "seed phrase")
         on-success         #(prn "success")
         on-error           #(prn "error")
-        expected           {:fx [[:multiaccount/validate-mnemonic
+        expected           {:fx [[:effects.profile/validate-recovery-phrase
                                   [seed-phrase-masked on-success on-error]]]}]
     (is (= expected
            (sut/wallet-validate-seed-phrase

--- a/src/status_im/contexts/wallet/add_account/create_account/events.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/events.cljs
@@ -61,16 +61,6 @@
 
 (rf/reg-event-fx :wallet/seed-phrase-validated seed-phrase-validated)
 
-(defn seed-phrase-entered
-  [_ [seed-phrase on-error]]
-  {:fx [[:multiaccount/validate-mnemonic
-         [seed-phrase
-          (fn [mnemonic key-uid]
-            (rf/dispatch [:wallet/seed-phrase-validated mnemonic key-uid on-error]))
-          on-error]]]})
-
-(rf/reg-event-fx :wallet/seed-phrase-entered seed-phrase-entered)
-
 (defn store-account-generated-with-mnemonic
   [{:keys [db]} [{:keys [new-account-data keypair-name]}]]
   (let [new-account (update new-account-data :mnemonic security/mask-data)]

--- a/src/status_im/contexts/wallet/add_account/create_account/select_keypair/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/select_keypair/view.cljs
@@ -16,13 +16,21 @@
    [[{:icon                :i/add
       :accessibility-label :generate-new-keypair
       :label               (i18n/label :t/generate-new-keypair)
-      :on-press            #(rf/dispatch [:navigate-to :screen/wallet.backup-recovery-phrase])}
+      :on-press            #(rf/dispatch [:navigate-to :screen/backup-recovery-phrase
+                                          {:on-success (fn [{:keys [masked-seed-phrase random-phrase]}]
+                                                         (rf/dispatch [:wallet/store-new-seed-phrase
+                                                                       {:seed-phrase masked-seed-phrase
+                                                                        :random-phrase
+                                                                        random-phrase}]))}])}
      {:icon                :i/seed
       :accessibility-label :import-using-phrase
       :label               (i18n/label :t/import-using-phrase)
       :add-divider?        true
-      :on-press            #(rf/dispatch [:navigate-to :screen/wallet.enter-seed-phrase
-                                          {:recovering-keypair? true}])}
+      :on-press            (fn []
+                             (rf/dispatch [:navigate-to :screen/use-recovery-phrase
+                                           {:on-success (fn [{:keys [key-uid phrase on-error]}]
+                                                          (rf/dispatch [:wallet/seed-phrase-validated
+                                                                        phrase key-uid on-error]))}]))}
      (when (ff/enabled? ::ff/wallet.import-private-key)
        {:icon                :i/key
         :accessibility-label :import-private-key

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -47,6 +47,7 @@
     [status-im.contexts.preview.quo.component-preview.view :as component-preview]
     [status-im.contexts.preview.quo.main :as quo.preview]
     [status-im.contexts.preview.status-im.main :as status-im-preview]
+    [status-im.contexts.profile.backup-recovery-phrase.view :as backup-recovery-phrase]
     [status-im.contexts.profile.contact.share.view :as share-contact]
     [status-im.contexts.profile.contact.view :as contact-profile]
     [status-im.contexts.profile.edit.accent-colour.view :as edit-accent-colour]
@@ -107,8 +108,6 @@
      wallet-import-private-key]
     [status-im.contexts.wallet.add-account.create-account.key-pair-name.view :as
      wallet-key-pair-name]
-    [status-im.contexts.wallet.add-account.create-account.new-keypair.backup-recovery-phrase.view :as
-     wallet-backup-recovery-phrase]
     [status-im.contexts.wallet.add-account.create-account.new-keypair.confirm-backup.view :as
      wallet-confirm-backup]
     [status-im.contexts.wallet.add-account.create-account.select-keypair.view :as wallet-select-keypair]
@@ -476,9 +475,9 @@
      :options   {:insets {:top? true}}
      :component wallet-create-account/view}
 
-    {:name      :screen/wallet.backup-recovery-phrase
+    {:name      :screen/backup-recovery-phrase
      :options   {:insets {:top? true :bottom? true}}
-     :component wallet-backup-recovery-phrase/view}
+     :component backup-recovery-phrase/view}
 
     {:name      :screen/wallet.confirm-backup
      :options   {:insets {:top? true :bottom? true}}
@@ -488,7 +487,7 @@
      :options   {:insets {:top? true}}
      :component wallet-key-pair-name/view}
 
-    {:name      :screen/wallet.enter-seed-phrase
+    {:name      :screen/use-recovery-phrase
      :component enter-seed-phrase/view}
 
     {:name      :screen/wallet.share-address

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -345,6 +345,12 @@
  (fn [{:keys [processing]}]
    processing))
 
+(re-frame/reg-sub
+ :profile/recovery-phrase-backed-up?
+ :<- [:profile/profile]
+ (fn [profile]
+   (not (boolean (seq (:mnemonic profile))))))
+
 ;; LINK PREVIEW
 ;; ========================================================================================================
 


### PR DESCRIPTION
fixes #21366
fixes #21367

This PR makes two screens used by onboarding and wallet more general, so they could be used anywhere in the app

`:screen/wallet.backup-recovery-phrase` is now more general `:screen/backup-recovery-phrase`
and
`:screen/wallet.enter-seed-phrase` is `:screen/use-recovery-phrase`

`:screen/use-recovery-phrase` is still not perfect, because it was implemented for onboarding and is still used there, but the onboarding code is a nightmare, and should be completely refactored later

QA: we need to make sure `backup-recovery-phrase` works fine in wallet still, and `use-recovery-phrase` work on onboarding and in wallet

in this PR we still don't test keycard, thank you