### PR TITLE
nix: fix sha256 of nixpkgs release 24-05

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -10,7 +10,7 @@ let
   # https://github.com/NixOS/nixpkgs/releases/tag/24.05
   nixpkgsSrc = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/df27247e6f3e636c119e2610bf12d38b5e98cc79.tar.gz";
-    sha256 = "sha256:0zynbk52khdfhg4qfv26h3r5156xff5p0cga2cin7b07i7lqminh";
+    sha256 = "sha256:0bbvimk7xb7akrx106mmsiwf9nzxnssisqmqffla03zz51d0kz2n";
   };
 
   # FIXME: remove this additional source when nixpkgs includes gradle 8.8 in stable channel


### PR DESCRIPTION
## Summary

Pavlo reported : 

```
(mypython) Pavlos-MBP:status-mobile pavloburykh$ make shell
Configuring Nix shell for target 'default'...
warning: ignoring untrusted substituter 'https://nix-cache.status.im/'
error: hash mismatch in file downloaded from 'https://github.com/NixOS/nixpkgs/archive/df27247e6f3e636c119e2610bf12d38b5e98cc79.tar.gz':
         specified: sha256:0zynbk52khdfhg4qfv26h3r5156xff5p0cga2cin7b07i7lqminh
         got:       sha256:0bbvimk7xb7akrx106mmsiwf9nzxnssisqmqffla03zz51d0kz2n
(use '--show-trace' to show detailed location information)
make: *** [shell] Error 102
```
Which indicates mismatch of hashes. This change was introduced in https://github.com/status-im/status-mobile/pull/21374
Why this was not caught sooner or in the PR? 
Because I just copy pasted the nix hash and cache was used, Hence it was not caught back then.

## Platforms
- Android
- iOS

status: ready
