### PR TITLE
Testing different go changes required for release 2.31

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "806b2587dbbc6730129bab84689559895c3dcaf2",
-    "commit-sha1": "806b2587dbbc6730129bab84689559895c3dcaf2",
-    "src-sha256": "0hg0f444nllbyympmhxyrli70bxb8wmyhajp5qxqr4f15z4l47r5"
+    "version": "5a19cc2a6ebc23d5dd8fcac2530a2897b0443e42",
+    "commit-sha1": "5a19cc2a6ebc23d5dd8fcac2530a2897b0443e42",
+    "src-sha256": "0x910lkg3f78fd9psm8mxw6hl9dfjy5nmkm0nz62h1z3zhc6ijx6"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "remove-goerli",
-    "commit-sha1": "0c7a580110bd7d59570087498bc3e70519566e0e",
-    "src-sha256": "13g2kc4cnmzn329dlvy2a7lw8wm5mss3bg6qxx7iqprkkyivcvr8"
+    "version": "806b2587dbbc6730129bab84689559895c3dcaf2",
+    "commit-sha1": "806b2587dbbc6730129bab84689559895c3dcaf2",
+    "src-sha256": "0hg0f444nllbyympmhxyrli70bxb8wmyhajp5qxqr4f15z4l47r5"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v3.2.0",
-    "commit-sha1": "3f613a9281f470a91b5080d35d22e55847ac276e",
-    "src-sha256": "1ghxxlmz0swq6dwabx84m23ikbs1bkzwfgqm4sp7hrnglm7bvikc"
+    "version": "remove-goerli",
+    "commit-sha1": "0c7a580110bd7d59570087498bc3e70519566e0e",
+    "src-sha256": "13g2kc4cnmzn329dlvy2a7lw8wm5mss3bg6qxx7iqprkkyivcvr8"
 }


### PR DESCRIPTION
PR is created to test `806b2587dbbc6730129bab84689559895c3dcaf2` commit which includes following changes:

https://github.com/status-im/status-go/pull/5950
https://github.com/status-im/status-go/pull/5924
https://github.com/status-im/status-go/pull/5941
https://github.com/status-im/status-go/pull/5945

-o-

Bumped to status-go commit `5a19cc2a6ebc23d5dd8fcac2530a2897b0443e42`

to include https://github.com/status-im/status-go/pull/5957 as well