### PR TITLE
[#20593] fix: show name of saved address in sending flow

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -6,24 +6,21 @@
     [react-native.platform :as platform]
     [status-im.constants :as constants]
     [status-im.contexts.settings.wallet.saved-addresses.sheets.remove-address.view :as remove-address]
-    [status-im.contexts.wallet.common.utils :as utils]
-    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
 (defn view
-  [{:keys [name full-address chain-short-names address] :as opts}]
-  (let [[_ splitted-address]           (network-utils/split-network-full-address address)
-        open-send-flow                 (rn/use-callback
+  [{:keys [name full-address chain-short-names address customization-color] :as opts}]
+  (let [open-send-flow                 (rn/use-callback
                                         (fn []
                                           (rf/dispatch [:hide-bottom-sheet])
                                           (rf/dispatch [:pop-to-root :shell-stack])
                                           (js/setTimeout #(rf/dispatch [:wallet/select-send-address
                                                                         {:address full-address
                                                                          :recipient
-                                                                         {:label
-                                                                          (utils/get-shortened-address
-                                                                           splitted-address)
+                                                                         {:label name
+                                                                          :customization-color
+                                                                          customization-color
                                                                           :recipient-type :saved-address}
                                                                          :stack-id :wallet-select-address
                                                                          :start-flow? true}])


### PR DESCRIPTION
fixes #20593

### Summary

The name of the saved address is not shown on the confirmation page.

#### Areas that maybe impacted

- Sending flow from saved addresses bottom sheet

### Steps to test

1. Go to wallet settings -> select 'Saved Addresses' -> select any saved address.
2. Tap 'Send to ' option.
3. Go to the send flow.
4. Check the confirmation page.


### Result

https://github.com/user-attachments/assets/4beb1cd9-b918-4ea1-987d-63370085d3c6



status: ready