### PR TITLE
fix(wallet)_: token supported networks

### DIFF
--- a/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
@@ -15,7 +15,7 @@
 
 (defn- bridge-token-component
   []
-  (fn [{:keys [chain-id network-name]} {:keys [networks] :as token}]
+  (fn [{:keys [chain-id network-name]} {:keys [supported-networks] :as token}]
     (let [network                     (rf/sub [:wallet/network-details-by-chain-id chain-id])
           currency                    (rf/sub [:profile/currency])
           currency-symbol             (rf/sub [:profile/currency-symbol])
@@ -28,7 +28,8 @@
           fiat-formatted              (utils/get-standard-fiat-format crypto-value
                                                                       currency-symbol
                                                                       fiat-value)
-          token-available-on-network? (network-utils/token-available-on-network? networks chain-id)]
+          token-available-on-network? (network-utils/token-available-on-network? supported-networks
+                                                                                 chain-id)]
       [quo/network-list
        {:label         (name network-name)
         :network-image (quo.resources/get-network (:network-name network))
@@ -49,7 +50,10 @@
         mainnet          (first network-details)
         layer-2-networks (rest network-details)
         account-token    (some #(when (= token-symbol (:symbol %)) %) tokens)
-        account-token    (when account-token (assoc account-token :networks (:networks token)))
+        account-token    (when account-token
+                           (assoc account-token
+                                  :networks           (:networks token)
+                                  :supported-networks (:supported-networks token)))
         bridge-to-title  (i18n/label :t/bridge-to
                                      {:name (string/upper-case (str token-symbol))})]
 

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -522,9 +522,10 @@
   [tokens networks chain-ids]
   (map (fn [token]
          (assoc token
-                :networks          (network-utils/network-list token networks)
-                :available-balance (calculate-total-token-balance token)
-                :total-balance     (calculate-total-token-balance token chain-ids)))
+                :networks           (network-utils/network-list-with-positive-balance token networks)
+                :supported-networks (network-utils/network-list token networks)
+                :available-balance  (calculate-total-token-balance token)
+                :total-balance      (calculate-total-token-balance token chain-ids)))
        tokens))
 
 (defn estimated-time-format

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -190,17 +190,21 @@
    ;; `token` is a map extracted from the sender, but in the wallet home page we don't know the
    ;; sender yet, so we only provide the `token-symbol`, later in
    ;; `:wallet/select-from-account` the `token` key will be set.
-   (let [{:keys [networks]}  token
-         receiver-networks   (get-in db [:wallet :ui :send :receiver-networks])
-         token-networks-ids  (map :chain-id networks)
-         unsupported-token?  (not-any? (set receiver-networks) token-networks-ids)
-         unique-owner        (when (= (count owners) 1)
-                               (first owners))
-         unique-owner-tokens (get-in db [:wallet :accounts unique-owner :tokens])
-         token-data          (or token
-                                 (when (and token-symbol unique-owner)
-                                   (some #(when (= (:symbol %) token-symbol) %)
-                                         unique-owner-tokens)))]
+   (let [{:keys [networks]}     token
+         receiver-networks      (get-in db [:wallet :ui :send :receiver-networks])
+         token-networks-ids     (map :chain-id networks)
+         unsupported-token?     (not-any? (set receiver-networks) token-networks-ids)
+         unique-owner           (when (= (count owners) 1)
+                                  (first owners))
+         unique-owner-tokens    (get-in db [:wallet :accounts unique-owner :tokens])
+         token-data             (or token
+                                    (when (and token-symbol unique-owner)
+                                      (some #(when (= (:symbol %) token-symbol) %)
+                                            unique-owner-tokens)))
+         test-networks-enabled? (get-in db [:profile/profile :test-networks-enabled?])
+         network-details        (-> (get-in db
+                                            [:wallet :networks (if test-networks-enabled? :test :prod)])
+                                    (network-utils/sorted-networks-with-details))]
      (when (or token-data token-symbol)
        {:db (cond-> db
               :always      (update-in [:wallet :ui :send]
@@ -211,7 +215,11 @@
               token-symbol (assoc-in [:wallet :ui :send :token-symbol] token-symbol)
               token-data   (update-in [:wallet :ui :send]
                                       #(assoc %
-                                              :token              token-data
+                                              :token              (assoc token-data
+                                                                         :supported-networks
+                                                                         (network-utils/network-list
+                                                                          token-data
+                                                                          network-details))
                                               :token-display-name (:symbol token-data)))
               unique-owner (assoc-in [:wallet :current-viewing-account-address] unique-owner)
               entry-point  (assoc-in [:wallet :ui :send :entry-point] entry-point))

--- a/src/status_im/contexts/wallet/send/events_test.cljs
+++ b/src/status_im/contexts/wallet/send/events_test.cljs
@@ -79,11 +79,14 @@
 (h/deftest-event :wallet/edit-token-to-send
   [event-id dispatch]
   (let [token-symbol      "ETH"
-        token             {:symbol   "ETH"
-                           :name     "Ether"
-                           :networks #{{:chain-id 421614}
-                                       {:chain-id 11155420}
-                                       {:chain-id 11155111}}}
+        token             {:symbol             "ETH"
+                           :name               "Ether"
+                           :networks           #{{:chain-id 421614}
+                                                 {:chain-id 11155420}
+                                                 {:chain-id 11155111}}
+                           :supported-networks #{{:chain-id 421614}
+                                                 {:chain-id 11155420}
+                                                 {:chain-id 11155111}}}
         receiver-networks [421614 11155420]]
     (testing "can be called with :token"
       (let [initial-db  {:wallet {:ui {:send {:receiver-networks receiver-networks

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -27,7 +27,7 @@
              receiver-preferred-networks              (rf/sub
                                                        [:wallet/wallet-send-receiver-preferred-networks])
              {token-symbol   :symbol
-              token-networks :networks}               (rf/sub [:wallet/wallet-send-token])
+              token-networks :supported-networks}     (rf/sub [:wallet/wallet-send-token])
              token-chain-ids-set                      (set (mapv #(:chain-id %) token-networks))
              [selected-receiver-networks
               set-selected-receiver-networks]         (rn/use-state receiver-networks)

--- a/src/status_im/contexts/wallet/swap/utils.cljs
+++ b/src/status_im/contexts/wallet/swap/utils.cljs
@@ -65,7 +65,11 @@
                       :tokens
                       (filter #(= token-symbol (:symbol %)))
                       first)]
-    (assoc token :networks (network-utils/network-list token networks))))
+    (assoc token
+           :networks
+           (network-utils/network-list-with-positive-balance
+            token
+            networks))))
 
 (defn select-default-asset-to-receive
   "Selects an asset to receive if it was not provided explicitly.

--- a/src/status_im/contexts/wallet/tokens/events_test.cljs
+++ b/src/status_im/contexts/wallet/tokens/events_test.cljs
@@ -47,10 +47,10 @@
        (match?
         (:db (tokens.events/store-token-list cofx [{:data data}]))
         {:wallet {:networks {:prod [{:chain-id 1}]}
-                  :tokens   {:sources    [{:name         "native"
-                                           :source       "native"
-                                           :version      "1.0.0"
-                                           :tokens-count 2}]
+                  :tokens   {:sources [{:name         "native"
+                                        :source       "native"
+                                        :version      "1.0.0"
+                                        :tokens-count 2}]
                              :by-address '({:address      "0x0000000000000000000000000000000000000000"
                                             :decimals     18
                                             :key          "1-0x0000000000000000000000000000000000000000"
@@ -73,28 +73,29 @@
                                             :verified?    true
                                             :chain-id     1
                                             :image        nil})
-                             :by-symbol  '({:address      "0x0000000000000000000000000000000000000000"
-                                            :decimals     18
-                                            :key          "1-ETH"
-                                            :community-id nil
-                                            :symbol       "ETH"
-                                            :sources      ["native"]
-                                            :name         "Ether"
-                                            :type         :erc20
-                                            :verified?    true
-                                            :chain-id     1
-                                            :image        nil}
-                                           {:address      "0x0000000000000000000000000000000000000001"
-                                            :decimals     18
-                                            :key          "1-SNT"
-                                            :community-id nil
-                                            :symbol       "SNT"
-                                            :sources      ["native"]
-                                            :name         "Status Network Token"
-                                            :type         :erc20
-                                            :verified?    true
-                                            :chain-id     1
-                                            :image        nil})}
+                             :by-symbol '({:address      "0x0000000000000000000000000000000000000000"
+                                           :decimals     18
+                                           :key          "1-ETH"
+                                           :community-id nil
+                                           :symbol       "ETH"
+                                           :sources      ["native"]
+                                           :name         "Ether"
+                                           :type         :erc20
+                                           :verified?    true
+                                           :chain-id     1
+                                           :image        nil}
+                                          {:address      "0x0000000000000000000000000000000000000001"
+                                           :decimals     18
+                                           :key          "1-SNT"
+                                           :community-id nil
+                                           :symbol       "SNT"
+                                           :sources      ["native"]
+                                           :name         "Status Network Token"
+                                           :type         :erc20
+                                           :verified?    true
+                                           :chain-id     1
+                                           :image        nil})
+                             :supported-chains-by-symbol {"ETH" #{1} "SNT" #{1}}}
                   :ui       {:loading {:token-list    false
                                        :market-values true
                                        :details       true
@@ -109,12 +110,13 @@
                       :db
                       :wallet
                       :tokens)
-                  {:sources    [{:name         "native"
-                                 :source       "native"
-                                 :version      "1.0.0"
-                                 :tokens-count 2}]
-                   :by-address nil
-                   :by-symbol  nil}))))
+                  {:sources                    [{:name         "native"
+                                                 :source       "native"
+                                                 :version      "1.0.0"
+                                                 :tokens-count 2}]
+                   :by-address                 nil
+                   :by-symbol                  nil
+                   :supported-chains-by-symbol {}}))))
   (testing "response contains two lists"
     (let [cofx {:db {:wallet {:networks {:prod [{:chain-id 1}]}}}}
           data [{:name    "native"
@@ -131,80 +133,81 @@
             :db
             :wallet
             :tokens)
-        {:sources    [{:name         "native"
-                       :source       "native"
-                       :version      "1.0.0"
-                       :tokens-count 2}
-                      {:name         "second"
-                       :source       "second"
-                       :version      "1.0.0"
-                       :tokens-count 2}]
-         :by-address '({:address      "0x0000000000000000000000000000000000000000"
-                        :decimals     18
-                        :key          "1-0x0000000000000000000000000000000000000000"
-                        :community-id nil
-                        :symbol       "ETH"
-                        :sources      ["native"]
-                        :name         "Ether"
-                        :type         :erc20
-                        :verified?    true
-                        :chain-id     1
-                        :image        nil}
-                       {:address      "0x0000000000000000000000000000000000000001"
-                        :decimals     18
-                        :key          "1-0x0000000000000000000000000000000000000001"
-                        :community-id nil
-                        :symbol       "SNT"
-                        :sources      ["native" "second"]
-                        :name         "Status Network Token"
-                        :type         :erc20
-                        :verified?    true
-                        :chain-id     1
-                        :image        nil}
-                       {:address      "0x0000000000000000000000000000000000000002"
-                        :decimals     18
-                        :key          "1-0x0000000000000000000000000000000000000002"
-                        :community-id nil
-                        :symbol       "ANOTHER1"
-                        :sources      ["second"]
-                        :name         "Another Token 1"
-                        :type         :erc20
-                        :verified?    false
-                        :chain-id     1
-                        :image        nil})
-         :by-symbol  '({:address      "0x0000000000000000000000000000000000000000"
-                        :decimals     18
-                        :key          "1-ETH"
-                        :community-id nil
-                        :symbol       "ETH"
-                        :sources      ["native"]
-                        :name         "Ether"
-                        :type         :erc20
-                        :verified?    true
-                        :chain-id     1
-                        :image        nil}
-                       {:address      "0x0000000000000000000000000000000000000001"
-                        :decimals     18
-                        :key          "1-SNT"
-                        :community-id nil
-                        :symbol       "SNT"
-                        :sources      ["native" "second"]
-                        :name         "Status Network Token"
-                        :type         :erc20
-                        :verified?    true
-                        :chain-id     1
-                        :image        nil}
-                       {:address      "0x0000000000000000000000000000000000000002"
-                        :decimals     18
-                        :key          "1-ANOTHER1"
-                        :community-id nil
-                        :symbol       "ANOTHER1"
-                        :sources      ["second"]
-                        :name         "Another Token 1"
-                        :type         :erc20
-                        :verified?    false
-                        :chain-id     1
-                        :image        nil})}))))
+        {:sources                    [{:name         "native"
+                                       :source       "native"
+                                       :version      "1.0.0"
+                                       :tokens-count 2}
+                                      {:name         "second"
+                                       :source       "second"
+                                       :version      "1.0.0"
+                                       :tokens-count 2}]
+         :by-address                 '({:address      "0x0000000000000000000000000000000000000000"
+                                        :decimals     18
+                                        :key          "1-0x0000000000000000000000000000000000000000"
+                                        :community-id nil
+                                        :symbol       "ETH"
+                                        :sources      ["native"]
+                                        :name         "Ether"
+                                        :type         :erc20
+                                        :verified?    true
+                                        :chain-id     1
+                                        :image        nil}
+                                       {:address      "0x0000000000000000000000000000000000000001"
+                                        :decimals     18
+                                        :key          "1-0x0000000000000000000000000000000000000001"
+                                        :community-id nil
+                                        :symbol       "SNT"
+                                        :sources      ["native" "second"]
+                                        :name         "Status Network Token"
+                                        :type         :erc20
+                                        :verified?    true
+                                        :chain-id     1
+                                        :image        nil}
+                                       {:address      "0x0000000000000000000000000000000000000002"
+                                        :decimals     18
+                                        :key          "1-0x0000000000000000000000000000000000000002"
+                                        :community-id nil
+                                        :symbol       "ANOTHER1"
+                                        :sources      ["second"]
+                                        :name         "Another Token 1"
+                                        :type         :erc20
+                                        :verified?    false
+                                        :chain-id     1
+                                        :image        nil})
+         :by-symbol                  '({:address      "0x0000000000000000000000000000000000000000"
+                                        :decimals     18
+                                        :key          "1-ETH"
+                                        :community-id nil
+                                        :symbol       "ETH"
+                                        :sources      ["native"]
+                                        :name         "Ether"
+                                        :type         :erc20
+                                        :verified?    true
+                                        :chain-id     1
+                                        :image        nil}
+                                       {:address      "0x0000000000000000000000000000000000000001"
+                                        :decimals     18
+                                        :key          "1-SNT"
+                                        :community-id nil
+                                        :symbol       "SNT"
+                                        :sources      ["native" "second"]
+                                        :name         "Status Network Token"
+                                        :type         :erc20
+                                        :verified?    true
+                                        :chain-id     1
+                                        :image        nil}
+                                       {:address      "0x0000000000000000000000000000000000000002"
+                                        :decimals     18
+                                        :key          "1-ANOTHER1"
+                                        :community-id nil
+                                        :symbol       "ANOTHER1"
+                                        :sources      ["second"]
+                                        :name         "Another Token 1"
+                                        :type         :erc20
+                                        :verified?    false
+                                        :chain-id     1
+                                        :image        nil})
+         :supported-chains-by-symbol {"ETH" #{1} "SNT" #{1} "ANOTHER1" #{1}}}))))
   (testing "second list contains a token that replaces the one that was added before"
     (let [cofx {:db {:wallet {:networks {:prod [{:chain-id 1}]}}}}
           data [{:name    "native"
@@ -221,55 +224,56 @@
             :db
             :wallet
             :tokens)
-        {:sources    [{:name         "native"
-                       :source       "native"
-                       :version      "1.0.0"
-                       :tokens-count 2}
-                      {:name         "second"
-                       :source       "second"
-                       :version      "1.0.0"
-                       :tokens-count 1}]
-         :by-address '({:address      "0x0000000000000000000000000000000000000000"
-                        :decimals     18
-                        :key          "1-0x0000000000000000000000000000000000000000"
-                        :community-id nil
-                        :symbol       "ANOTHER1"
-                        :sources      ["native" "second"]
-                        :name         "Another Token 2"
-                        :type         :erc20
-                        :verified?    false
-                        :chain-id     1
-                        :image        nil}
-                       {:address      "0x0000000000000000000000000000000000000002"
-                        :decimals     18
-                        :key          "1-0x0000000000000000000000000000000000000002"
-                        :community-id nil
-                        :symbol       "ANOTHER1"
-                        :sources      ["native"]
-                        :name         "Another Token 1"
-                        :type         :erc20
-                        :verified?    false
-                        :chain-id     1
-                        :image        nil})
-         :by-symbol  '({:address      "0x0000000000000000000000000000000000000000"
-                        :decimals     18
-                        :key          "1-ETH"
-                        :community-id nil
-                        :symbol       "ETH"
-                        :sources      ["native"]
-                        :name         "Ether"
-                        :type         :erc20
-                        :verified?    true
-                        :chain-id     1
-                        :image        nil}
-                       {:address      "0x0000000000000000000000000000000000000000"
-                        :decimals     18
-                        :key          "1-ANOTHER1"
-                        :community-id nil
-                        :symbol       "ANOTHER1"
-                        :sources      ["native" "second"]
-                        :name         "Another Token 2"
-                        :type         :erc20
-                        :verified?    false
-                        :chain-id     1
-                        :image        nil})})))))
+        {:sources                    [{:name         "native"
+                                       :source       "native"
+                                       :version      "1.0.0"
+                                       :tokens-count 2}
+                                      {:name         "second"
+                                       :source       "second"
+                                       :version      "1.0.0"
+                                       :tokens-count 1}]
+         :by-address                 '({:address      "0x0000000000000000000000000000000000000000"
+                                        :decimals     18
+                                        :key          "1-0x0000000000000000000000000000000000000000"
+                                        :community-id nil
+                                        :symbol       "ANOTHER1"
+                                        :sources      ["native" "second"]
+                                        :name         "Another Token 2"
+                                        :type         :erc20
+                                        :verified?    false
+                                        :chain-id     1
+                                        :image        nil}
+                                       {:address      "0x0000000000000000000000000000000000000002"
+                                        :decimals     18
+                                        :key          "1-0x0000000000000000000000000000000000000002"
+                                        :community-id nil
+                                        :symbol       "ANOTHER1"
+                                        :sources      ["native"]
+                                        :name         "Another Token 1"
+                                        :type         :erc20
+                                        :verified?    false
+                                        :chain-id     1
+                                        :image        nil})
+         :by-symbol                  '({:address      "0x0000000000000000000000000000000000000000"
+                                        :decimals     18
+                                        :key          "1-ETH"
+                                        :community-id nil
+                                        :symbol       "ETH"
+                                        :sources      ["native"]
+                                        :name         "Ether"
+                                        :type         :erc20
+                                        :verified?    true
+                                        :chain-id     1
+                                        :image        nil}
+                                       {:address      "0x0000000000000000000000000000000000000000"
+                                        :decimals     18
+                                        :key          "1-ANOTHER1"
+                                        :community-id nil
+                                        :symbol       "ANOTHER1"
+                                        :sources      ["native" "second"]
+                                        :name         "Another Token 2"
+                                        :type         :erc20
+                                        :verified?    false
+                                        :chain-id     1
+                                        :image        nil})
+         :supported-chains-by-symbol {"ETH" #{1} "ANOTHER1" #{1}}})))))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -144,11 +144,12 @@
                                        (remove disabled-from-chain-ids?)
                                        set)]
      (some-> token
-             (assoc :networks          (network-utils/network-list token networks)
-                    :available-balance (utils/calculate-total-token-balance token)
-                    :total-balance     (utils/calculate-total-token-balance
-                                        token
-                                        enabled-from-chain-ids))))))
+             (assoc :networks           (network-utils/network-list-with-positive-balance token networks)
+                    :supported-networks (network-utils/network-list token networks)
+                    :available-balance  (utils/calculate-total-token-balance token)
+                    :total-balance      (utils/calculate-total-token-balance
+                                         token
+                                         enabled-from-chain-ids))))))
 
 (rf/reg-sub
  :wallet/wallet-send-token-symbol
@@ -459,6 +460,7 @@
                                                    networks)
                                                   chain-ids
                                                   (filter #(some #{(:chain-id %)} chain-ids)))
+                                      :supported-networks (network-utils/network-list token networks)
                                       :available-balance (utils/calculate-total-token-balance token)
                                       :total-balance (utils/calculate-total-token-balance
                                                       token


### PR DESCRIPTION
fixes #20988

### Summary

This PR fixes the networks/chains supported by the token based on the token list fetched from status-go instead of relying on the `balance-per-chain` map as status-go returns balance for chains only if there is a positive balance.

### Platforms

- Android
- iOS

### Areas that may be impacted

#### Functional

- wallet/transactions

### Steps to test

##### Prerequisites: A wallet account with a token balance on one network 

- Open Status
- Navigate to `Wallet > Account > Bridge`
- Verify the supported networks by each token is displayed below each token
- Upon selecting a token, verify the token supported networks are selectable even if there is no balance on that network/chain
- Navigate to `Wallet > Account > Send`
- Verify the tokens are displayed correctly with networks supported by the token
- Navigate to the routes generation page and verify `Not available` text is not shown on the receiver side
- Verify the transaction can be performed

status: ready 
