### PR TITLE
fix(wallet):  client should pass a list with "Symbol" and without "ChainID-" to status-go

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -566,6 +566,7 @@
 (def ^:const bridge-name-erc-1155-transfer "ERC1155Transfer")
 (def ^:const bridge-name-hop "Hop")
 (def ^:const bridge-name-paraswap "Paraswap")
+(def ^:const bridge-name-celer "CBridge")
 
 (def ^:const bridge-assets #{"ETH" "USDT" "USDC" "DAI"})
 

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -495,9 +495,7 @@
                     :TokenIDTo          token-id-to
                     :SlippagePercentage slippage-percentage))
 
-      (not (or (= bridge-name constants/bridge-name-erc-721-transfer)
-               (= bridge-name constants/bridge-name-transfer)
-               (= bridge-name constants/bridge-name-hop)))
+      (= bridge-name constants/bridge-name-celer)
       (assoc :CbridgeTx
              (assoc tx-data
                     :ChainID   to-chain-id

--- a/src/status_im/contexts/wallet/tokens/events.cljs
+++ b/src/status_im/contexts/wallet/tokens/events.cljs
@@ -50,8 +50,10 @@
                           data)
         symbols   (->> tokens
                        :by-symbol
-                       keys
-                       (remove utils.address/address?))]
+                       vals
+                       (map :symbol)
+                       set
+                       vec)]
     {:fx [[:effects.wallet.tokens/fetch-market-values
            {:symbols    symbols
             :currency   constants/profile-default-currency


### PR DESCRIPTION
__(!) it's a draft__ 

> So, the mobile client seems to be calling wallet_fetchPrices, wallet_fetchMarketValues and wallet_fetchTokenDetails with a list of "ChainID-Symbol", where it should just be "Symbol". We'll need a mobile dev to look at this.

https://github.com/status-im/status-mobile/pull/21445#issuecomment-2419891362
