### PR TITLE
fix: take lightclient bad peer logic from waku

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v7.0.0",
-    "commit-sha1": "84493728d9ac41553297e8084943c1429cdfe59a",
-    "src-sha256": "11dwdlk9svmc6f8wmya43fis9jfigvh5idxpiwmia9gkad1zal6y"
+    "version": "8acd48240bfeacd119bb4a41985f52be5ef00038",
+    "commit-sha1": "8acd48240bfeacd119bb4a41985f52be5ef00038",
+    "src-sha256": "0hn350bxs14gnm39dg9x588142nj7n79k313487y659yk1142ksx"
 }


### PR DESCRIPTION
### Summary
changes mentioned in  https://github.com/waku-org/go-waku/pull/1241
A simple logic to delete bad peers based on dial failures so that they don't get reused. this may help stabilize filter subscriptions faster. 

..### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
network switch
startup of app
bringing to foreground

##### Functional

- 1-1 chats
- public chats
- group chats


### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
