### PR TITLE
[#21439] fix: close swap flow after confirmation

### DIFF
--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -541,7 +541,8 @@
      :component wallet-swap-select-asset-to-pay/view}
 
     {:name      :screen/wallet.setup-swap
-     :options   {:insets {:bottom? true}}
+     :options   {:modalPresentationStyle :overCurrentContext
+                 :insets                 {:bottom? true}}
      :component wallet-swap-setup-swap/view}
 
     {:name      :screen/wallet.swap-propasal


### PR DESCRIPTION
fixes #21439

### Summary

Swap confirmation page remains open after transaction confirmation if swap flow starts from asset long tapping

#### Areas that maybe impacted

- Swap flow

### Steps to test

1. Recover user with available assets to be swapped
2. Go to wallet main page or open any wallet account
3. Long tap the asset -> swap
4. Perform swap transaction


### Result

https://github.com/user-attachments/assets/703e6009-5f46-4ca8-a816-a8a60d24ccb6


status: ready 

