### PR TITLE
fix public chat deletion and name display issues post-migration

### DIFF
--- a/src/status_im/common/confirmation_drawer/view.cljs
+++ b/src/status_im/common/confirmation_drawer/view.cljs
@@ -5,6 +5,7 @@
     [react-native.core :as rn]
     [reagent.core :as reagent]
     [status-im.common.confirmation-drawer.style :as style]
+    [status-im.constants :as constants]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -35,11 +36,12 @@
            close-button-text]}]
   (let [extra-action-selected? (reagent/atom false)]
     (fn []
-      (let [{:keys [group-chat chat-id public-key color
+      (let [{:keys [group-chat chat-id public-key color chat-type
                     profile-picture name]} context
             id                             (or chat-id public-key)
             theme                          (quo.theme/use-theme)
-            [primary-name _]               (when-not group-chat
+            [primary-name _]               (when-not (or group-chat
+                                                         (= chat-type constants/public-chat-type))
                                              (rf/sub [:contacts/contact-two-names-by-identity id]))
             display-name                   (cond
                                              (= primary-name "Unknown")

--- a/src/status_im/common/home/actions/view.cljs
+++ b/src/status_im/common/home/actions/view.cljs
@@ -398,10 +398,11 @@
           :chevron?            false}))
 
 (defn destructive-actions
-  [{:keys [group-chat] :as item} inside-chat?]
+  [{:keys [group-chat chat-type] :as item} inside-chat?]
   [(when (not group-chat)
-     (close-chat-entry item inside-chat? (not group-chat)))
-   (clear-history-entry item group-chat)
+     (close-chat-entry item inside-chat? (not= chat-type constants/public-chat-type)))
+   (when-not (= chat-type constants/public-chat-type)
+     (clear-history-entry item group-chat))
    (when group-chat
      (leave-group-entry item nil))])
 
@@ -438,6 +439,11 @@
     (notification-actions item inside-chat? true)
     (destructive-actions item inside-chat?)]])
 
+(defn public-chat-actions
+  [item inside-chat?]
+  [quo/action-drawer
+   [(destructive-actions item inside-chat?)]])
+
 (defn private-group-chat-actions
   [item inside-chat?]
   [quo/action-drawer
@@ -473,6 +479,8 @@
      [one-to-one-actions chat inside-chat?]
      constants/private-group-chat-type
      [private-group-chat-actions chat inside-chat?]
+     constants/public-chat-type
+     [public-chat-actions chat inside-chat?]
      constants/community-chat-type
      [communities-chat-actions/actions chat inside-chat? hide-show-members?]
      nil))

--- a/src/status_im/contexts/chat/events.cljs
+++ b/src/status_im/contexts/chat/events.cljs
@@ -33,8 +33,8 @@
    (multi-user-chat? (get-chat cofx chat-id))))
 
 (defn public-chat?
-  ([chat]
-   (:public? chat))
+  ([{:keys [chat-type]}]
+   (= chat-type constants/public-chat-type))
   ([cofx chat-id]
    (public-chat? (get-chat cofx chat-id))))
 
@@ -52,7 +52,7 @@
 (defn group-chat?
   ([chat]
    (and (multi-user-chat? chat)
-        (not (public-chat? chat))))
+        (not (:public? chat))))
   ([cofx chat-id]
    (group-chat? (get-chat cofx chat-id))))
 

--- a/src/status_im/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im/contexts/chat/home/chat_list_item/view.cljs
@@ -237,11 +237,17 @@
 
 (defn chat-item
   [{:keys [chat-id group-chat color name last-message timestamp muted image
-           unviewed-messages-count]
+           chat-type unviewed-messages-count]
     :as   item}]
   (let [[primary-name secondary-name]
-        (if group-chat
+        (cond
+          group-chat
           [name ""]
+
+          (= chat-type constants/public-chat-type)
+          [(str "#" name) ""]
+
+          :else
           (rf/sub [:contacts/contact-two-names-by-identity chat-id]))
         {:keys [ens-verified added?] :as contact} (when-not group-chat
                                                     (rf/sub [:contacts/contact-by-address chat-id]))

--- a/src/status_im/contexts/chat/messenger/messages/contact_requests/bottom_drawer/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/contact_requests/bottom_drawer/view.cljs
@@ -12,10 +12,13 @@
 (defn view
   [{:keys [contact-id]}]
   (let [customization-color       (rf/sub [:profile/customization-color])
-        [primary-name _]          (rf/sub [:contacts/contact-two-names-by-identity contact-id])
         {:keys [contact-request-state
-                community-id]}    (rf/sub [:chats/current-chat-chat-view])
+                community-id
+                chat-name]}       (rf/sub [:chats/current-chat-chat-view])
         chat-type                 (rf/sub [:chats/chat-type])
+        [primary-name _]          (if (= chat-type :public-chat)
+                                    [(str "#" chat-name) ""]
+                                    (rf/sub [:contacts/contact-two-names-by-identity contact-id]))
         community-chat?           (= chat-type :community-chat)
         joined                    (when community-chat?
                                     (rf/sub [:communities/community-joined community-id]))

--- a/src/status_im/subs/chats.cljs
+++ b/src/status_im/subs/chats.cljs
@@ -125,7 +125,8 @@
  :<- [:contacts/blocked-set]
  :<- [:contacts/contacts-raw]
  :<- [:chat/inputs]
- (fn [[{:keys [group-chat chat-id] :as current-chat} my-public-key community blocked-users-set contacts
+ (fn [[{:keys [group-chat chat-id chat-name name] :as current-chat} my-public-key community
+       blocked-users-set contacts
        inputs]]
    (when current-chat
      (cond-> current-chat
@@ -139,6 +140,9 @@
             (group-chats.db/member? my-public-key current-chat))
        (assoc :able-to-send-message? true
               :member?               true)
+
+       (not chat-name)
+       (assoc :chat-name name)
 
        (not group-chat)
        (assoc
@@ -164,6 +168,7 @@
    (condp apply [current-chat]
      chat.events/community-chat? :community-chat
      chat.events/group-chat?     :group-chat
+     chat.events/public-chat?    :public-chat
      :chat)))
 
 (re-frame/reg-sub


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21153

### Summary

https://github.com/status-im/status-mobile/issues/21153#issuecomment-2383352227
> Acceptance criteria for this issue:
> 
> chat is shown like #name in the list instead of {"e.....th"}
> can remove it via options
> Optional:
> header and message "Add {...} to contacts" in chat view

Fixed the first two and partially the last. It will still show as 'Add chat name to contacts' for public chats.

### Video

https://github.com/user-attachments/assets/0f914545-9913-4f64-a423-b9540a698e75


### Testing Note:
Please let me know if you need assistance while testing.

status: ready