### PR TITLE
fix(wallet)_: Activity tab is selected on navigating back from the swap flow

### DIFF
--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -204,12 +204,6 @@
  (fn [{:keys [db]}]
    {:db (update-in db [:wallet :ui] dissoc :swap)}))
 
-(rf/reg-event-fx
- :wallet/on-swap-done
- (fn [_]
-   {:fx [[:dispatch [:wallet/select-account-tab :activity]]
-         [:dispatch [:wallet/clean-swap]]]}))
-
 (rf/reg-event-fx :wallet/swap-transaction
  (fn [{:keys [db]} [sha3-pwd]]
    (let [wallet-address         (get-in db
@@ -299,6 +293,7 @@
                                                          :screen/wallet.swap-set-spending-cap
                                                          :screen/wallet.swap-confirmation)])
                                          (when-not approval-required?
+                                           (rf/dispatch [:wallet/select-account-tab :activity])
                                            (debounce/debounce-and-dispatch
                                             [:toasts/upsert
                                              {:id   :swap-transaction-pending

--- a/src/status_im/contexts/wallet/swap/setup_swap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/setup_swap/view.cljs
@@ -156,7 +156,7 @@
                                               :valid-input?                valid-pay-input?
                                               :clean-approval-transaction? true}))
                                           [pay-input-amount])]
-    (rn/use-unmount #(rf/dispatch [:wallet/on-swap-done]))
+    (rn/use-unmount #(rf/dispatch [:wallet/clean-swap]))
     (rn/use-effect
      (fn []
        (request-fetch-swap-proposal))


### PR DESCRIPTION
fixes #21464

### Summary

This PR fixes activity tab is selected when navigating back from the swap flow

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the Wallet tab
- Open an account
- Navigate to the swap flow by tapping on the Swap button
- Return to the account page
- Verify the activity tab is not selected

status: ready
