### PR TITLE
fix Error when creating an account on e2e build

### DIFF
--- a/src/status_im/contexts/onboarding/events.cljs
+++ b/src/status_im/contexts/onboarding/events.cljs
@@ -67,6 +67,28 @@
  (fn [_ [error]]
    {:dispatch [:biometric/show-message (ex-cause error)]}))
 
+;; Navigate to next screen once onboarding animation and account creation both are complete
+;; Note: If account creation fails, user will get stuck on loading screen
+;; TODO: Show error screen in case account creation/restoration fails
+(rf/reg-event-fx :onboarding/account-creation-complete
+ (fn [{:keys [db]} [opts]]
+   (let [loading-animation-complete? (or (:loading-animation-complete? opts)
+                                         (:onboarding/loading-animation-complete? db))
+         loading-screen              (or (:loading-screen opts) (:onboarding/loading-screen db))
+         login-signal-received?      (or (:login-signal-received? opts)
+                                         (:onboarding/login-signal-received? db))]
+     (if (and loading-animation-complete? login-signal-received?)
+       {:db (-> db
+                (dissoc :onboarding/loading-screen)
+                (dissoc :onboarding/loading-animation-complete?)
+                (dissoc :onboarding/login-signal-received?))
+        :fx [[:dispatch
+              [:navigate-to-within-stack [:screen/onboarding.enable-notifications loading-screen]]]]}
+       {:db (-> db
+                (assoc :onboarding/loading-screen loading-screen)
+                (assoc :onboarding/loading-animation-complete? loading-animation-complete?)
+                (assoc :onboarding/login-signal-received? login-signal-received?))}))))
+
 (rf/defn create-account-and-login
   {:events [:onboarding/create-account-and-login]}
   [{:keys [db] :as cofx}]
@@ -88,9 +110,9 @@
                                 (when-not syncing-account-recovered?
                                   [:dispatch [:syncing/clear-syncing-installation-id]])]
                :dispatch-later [{:ms       constants/onboarding-generating-keys-animation-duration-ms
-                                 :dispatch [:navigate-to-within-stack
-                                            [:screen/onboarding.enable-notifications
-                                             loading-screen]]}]
+                                 :dispatch [:onboarding/account-creation-complete
+                                            {:loading-animation-complete? true
+                                             :loading-screen              loading-screen}]}]
                :db             (-> db
                                    (dissoc :profile/login)
                                    (dissoc :auth-method)

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -83,7 +83,8 @@
                   [[:dispatch [:update-theme-and-init-root :screen/onboarding.syncing-results]]]
 
                   (get db :onboarding/new-account?)
-                  [[:dispatch [:onboarding/finalize-setup]]]
+                  [[:dispatch [:onboarding/finalize-setup]]
+                   [:dispatch [:onboarding/account-creation-complete {:login-signal-received? true}]]]
 
                   :else
                   [[:dispatch [:update-theme-and-init-root :shell-stack]]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20806

### Summary
Navigate to next screen once onboarding animation and account creation both are complete.

Note: If account creation fails, user will get stuck on loading screen.

### Testing
Needs to adjust tests as per https://github.com/status-im/status-mobile/pull/21471

status: ready