### PR TITLE
fix(wallet-settings)_: Icon color in missing keypair section

### DIFF
--- a/src/quo/components/list_items/missing_keypair/view.cljs
+++ b/src/quo/components/list_items/missing_keypair/view.cljs
@@ -28,7 +28,6 @@
                   :seed :i/seed
                   :key  :i/password
                   nil)
-       :color   :neutral
        :blur?   true
        :border? true}]
      [rn/view


### PR DESCRIPTION
### Summary

This PR fixes the icon color in the missing keypair section

[Design Link](https://www.figma.com/design/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?node-id=29987-52375&t=JVa1Y1XilKgtdIji-1)

| Figma | Bug | Fix |
| --- | --- | --- | 
|  <img width="250" src="https://github.com/user-attachments/assets/97b1b650-c8a4-4238-b6af-54e2efc338bd" /> | <img width="250" src="https://github.com/user-attachments/assets/e66de4e0-b9a7-4a1b-a811-64bc156a10b8" />  | <img width="250" src="https://github.com/user-attachments/assets/ce712d17-b51f-42ea-bd96-6d4f299742a8" /> |


### Testing notes

Manual QA can be skipped as it's just a line change

### Platforms

- Android
- iOS

### Steps to test 

##### Prerequisite: A profile with one or more missing key pair

- Open Status
- Navigate to `Profile > Wallet > Key pair and accounts`
- Verify the icon is blur variant

status: ready
