### PR TITLE
fix(swap): refetch swap proposal when switching account

### DIFF
--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -192,6 +192,18 @@
       (number/small-number-threshold display-decimals)
       (str amount-fixed-decimals))))
 
+(defn token-balance-display-for-network
+  "Formats a token balance for a specific chain and rounds it to a specified number of decimals.
+  If the balance is less than the smallest representable value based on rounding decimals, 
+  a threshold value is displayed instead."
+  [token chain-id rounding-decimals]
+  (let [token-decimals   (:decimals token)
+        display-decimals (min token-decimals rounding-decimals)]
+    (-> (get-in token [:balances-per-chain chain-id :raw-balance] 0)
+        (number/convert-to-whole-number token-decimals)
+        money/bignumber
+        (sanitized-token-amount-to-display display-decimals))))
+
 (defn calculate-balance-from-tokens
   [{:keys [currency tokens chain-ids]}]
   (->> tokens

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -195,3 +195,77 @@
     (is (= (utils/sanitized-token-amount-to-display 0.00000123 6) "0.000001"))
     (is (= (utils/sanitized-token-amount-to-display nil 2) "0"))
     (is (= (utils/sanitized-token-amount-to-display "invalid" 2) "0"))))
+
+(deftest token-balance-display-for-network-test
+  (testing "Standard balance with rounding decimals"
+    (let [token             {:decimals           18
+                             :balances-per-chain {1 {:raw-balance "1000000000000000000"}}}
+          chain-id          1
+          rounding-decimals 2
+          expected          "1"]
+      (is (= (utils/token-balance-display-for-network token chain-id rounding-decimals)
+             expected))))
+
+  (testing "Balance with more decimals than specified rounding"
+    (let [token             {:decimals           18
+                             :balances-per-chain {1 {:raw-balance "123456789000000000"}}}
+          chain-id          1
+          rounding-decimals 3
+          expected          "0.123"]
+      (is (= (utils/token-balance-display-for-network token chain-id rounding-decimals)
+             expected))))
+
+  (testing "Very small balance displayed as threshold (<0.000001)"
+    (let [token             {:decimals           18
+                             :balances-per-chain {1 {:raw-balance "1"}}}
+          chain-id          1
+          rounding-decimals 6
+          expected          "<0.000001"]
+      (is (= (utils/token-balance-display-for-network token chain-id rounding-decimals)
+             expected))))
+
+  (testing
+    "Very small balance displayed without threshold when token decimals are equal than reounding decimals"
+    (let [token             {:decimals           18
+                             :balances-per-chain {1 {:raw-balance "1"}}}
+          chain-id          1
+          rounding-decimals 18
+          expected          "0.000000000000000001"]
+      (is (= (utils/token-balance-display-for-network token chain-id rounding-decimals)
+             expected))))
+
+  (testing
+    "Very small balance displayed without threshold when token decimals are lower than reounding decimals"
+    (let [token             {:decimals           18
+                             :balances-per-chain {1 {:raw-balance "1"}}}
+          chain-id          1
+          rounding-decimals 21
+          expected          "0.000000000000000001"]
+      (is (= (utils/token-balance-display-for-network token chain-id rounding-decimals)
+             expected))))
+
+  (testing "Zero balance displayed correctly"
+    (let [token             {:decimals           18
+                             :balances-per-chain {1 {:raw-balance "0"}}}
+          chain-id          1
+          rounding-decimals 2
+          expected          "0"]
+      (is (= (utils/token-balance-display-for-network token chain-id rounding-decimals)
+             expected))))
+
+  (testing "Balance with trailing zeroes removed"
+    (let [token             {:decimals           8
+                             :balances-per-chain {1 {:raw-balance "123400000"}}}
+          chain-id          1
+          rounding-decimals 6
+          expected          "1.234"]
+      (is (= (utils/token-balance-display-for-network token chain-id rounding-decimals)
+             expected))))
+
+  (testing "Balance when chain data is missing"
+    (let [token             {:decimals 18}
+          chain-id          1
+          rounding-decimals 2
+          expected          "0"]
+      (is (= (utils/token-balance-display-for-network token chain-id rounding-decimals)
+             expected)))))

--- a/src/status_im/contexts/wallet/sheets/select_account/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/select_account/view.cljs
@@ -2,10 +2,12 @@
   (:require [quo.core :as quo]
             quo.theme
             [react-native.gesture :as gesture]
-            [status-im.contexts.wallet.common.utils :as wallet.utils]
+            [status-im.contexts.wallet.common.utils :as utils]
             [status-im.contexts.wallet.sheets.select-account.style :as style]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
+
+(def ^:private rounding-decimals 4)
 
 (defn list-item
   [{:keys [account selected-account-address]}]
@@ -25,12 +27,14 @@
         token                          (->> tokens
                                             (filter #(= (:symbol %) asset-symbol))
                                             first)
-        token-balance                  (get-in token [:balances-per-chain (:chain-id network) :balance])]
+        chain-id                       (:chain-id network)
+        token-balance-display          (utils/token-balance-display-for-network token
+                                                                                chain-id
+                                                                                rounding-decimals)]
     [quo/account-item
      {:type                (if (= address selected-account-address) :default :tag)
       :token-props         {:symbol asset-symbol
-                            :value  (wallet.utils/cut-fiat-balance (or (js/parseFloat token-balance) 0)
-                                                                   4)}
+                            :value  token-balance-display}
       :account-props       (assoc account :customization-color color)
       :customization-color color
       :state               (if (= address selected-account-address) :selected :default)

--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -247,13 +247,12 @@
 
 (rf/reg-event-fx
  :wallet/clean-swap-proposal
- (fn [{:keys [db]} [{:keys [clean-approval-transaction?]}]]
-   (let [keys-to-dissoc (cond-> [:amount
-                                 :amount-hex
-                                 :last-request-uuid
+ (fn [{:keys [db]} [{:keys [clean-amounts? clean-approval-transaction?]}]]
+   (let [keys-to-dissoc (cond-> [:last-request-uuid
                                  :swap-proposal
                                  :error-response
                                  :loading-swap-proposal?]
+                          clean-amounts?              (conj :amount :amount-hex)
                           clean-approval-transaction? (conj :approval-transaction-id :approved-amount))]
      {:db (apply update-in db [:wallet :ui :swap] dissoc keys-to-dissoc)
       :fx [[:dispatch [:wallet/stop-get-swap-proposal]]]})))


### PR DESCRIPTION
fixes #21441

### Summary

This PR fixes swap proposal not recalculated when switching accounts, leading to bug as the linked one because of wrong balance data

#### Demo:
https://github.com/user-attachments/assets/db38bc4e-9087-4393-a44f-30097a7d16f6

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

1. Recover a user with two accounts:
   - `Account 1` has an approved ERC-20 token.
   - `Account 2` has an unapproved ERC-20 token and fewer assets than `Account 1`.
2. Go to the swap page using `Account 1`.
3. Enter a valid value that is sufficient for `Account 1` but insufficient for `Account 2`.
4. Switch to `Account 2`.
5. Verify swap proposal is refetched or error state is shown in the amount entered is higher than the switched account balance

status: ready