### PR TITLE
Swap: use correct fee on spending cap screen

### DIFF
--- a/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
@@ -25,9 +25,8 @@
                                        {:currency currency
                                         :balance  balance
                                         :token    token})
-          fiat-formatted              (utils/get-standard-fiat-format crypto-value
-                                                                      currency-symbol
-                                                                      fiat-value)
+          fiat-formatted              (utils/fiat-formatted-for-ui currency-symbol
+                                                                   fiat-value)
           token-available-on-network? (network-utils/token-available-on-network? supported-networks
                                                                                  chain-id)]
       [quo/network-list

--- a/src/status_im/contexts/wallet/common/asset_list/view.cljs
+++ b/src/status_im/contexts/wallet/common/asset_list/view.cljs
@@ -18,7 +18,7 @@
                            :balance  total-balance
                            :token    token})
         crypto-formatted (utils/get-standard-crypto-format token total-balance)
-        fiat-formatted   (utils/get-standard-fiat-format crypto-formatted currency-symbol fiat-value)]
+        fiat-formatted   (utils/fiat-formatted-for-ui currency-symbol fiat-value)]
     [quo/token-network
      {:token       token-symbol
       :label       token-name

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -251,9 +251,9 @@
       (str $ address))
     address))
 
-(defn get-standard-fiat-format
-  [crypto-value currency-symbol fiat-value]
-  (if (string/includes? crypto-value "<")
+(defn fiat-formatted-for-ui
+  [currency-symbol fiat-value]
+  (if (money/less-than fiat-value 0.01)
     (str "<" currency-symbol "0.01")
     (prettify-balance currency-symbol fiat-value)))
 
@@ -281,9 +281,8 @@
         formatted-token-price             (prettify-balance currency-symbol price)
         percentage-change                 (prettify-percentage-change change-pct-24hour)
         crypto-value                      (get-standard-crypto-format token balance)
-        fiat-value                        (get-standard-fiat-format crypto-value
-                                                                    currency-symbol
-                                                                    fiat-unformatted-value)]
+        fiat-value                        (fiat-formatted-for-ui currency-symbol
+                                                                 fiat-unformatted-value)]
     {:token               (:symbol token)
      :token-name          (:name token)
      :state               :default

--- a/src/status_im/contexts/wallet/sheets/select_asset/asset_list/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/select_asset/asset_list/view.cljs
@@ -20,7 +20,7 @@
                            :balance  total-balance
                            :token    token})
         crypto-formatted (utils/get-standard-crypto-format token total-balance)
-        fiat-formatted   (utils/get-standard-fiat-format crypto-formatted currency-symbol fiat-value)]
+        fiat-formatted   (utils/fiat-formatted-for-ui currency-symbol fiat-value)]
     [rn/view {:style {:padding-horizontal 8}}
      [quo/token-network
       {:token       token-symbol

--- a/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
@@ -7,6 +7,7 @@
     [status-im.common.events-helper :as events-helper]
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.common.standard-authentication.core :as standard-auth]
+    [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.common.utils.external-links :as external-links]
     [status-im.contexts.wallet.swap.set-spending-cap.style :as style]
     [utils.address :as address-utils]
@@ -184,10 +185,14 @@
 
 (defn- transaction-details
   []
-  (let [network                (rf/sub [:wallet/swap-network])
-        approval-fees          (rf/sub [:wallet/approval-gas-fees-formatted])
-        loading-swap-proposal? (rf/sub [:wallet/swap-loading-swap-proposal?])
-        estimated-time         (rf/sub [:wallet/swap-proposal-estimated-time])]
+  (let [network                 (rf/sub [:wallet/swap-network])
+        approval-fees           (rf/sub [:wallet/approval-gas-fees])
+        currency-symbol         (rf/sub [:profile/currency-symbol])
+        approval-fees-formatted (utils/fiat-formatted-for-ui
+                                 currency-symbol
+                                 approval-fees)
+        loading-swap-proposal?  (rf/sub [:wallet/swap-loading-swap-proposal?])
+        estimated-time          (rf/sub [:wallet/swap-proposal-estimated-time])]
     [rn/view {:style style/details-container}
      [:<>
       [data-item
@@ -196,7 +201,9 @@
         :network-image (:source network)}]
       [data-item
        {:title    (i18n/label :t/max-fees)
-        :subtitle (if (and estimated-time approval-fees) approval-fees (i18n/label :t/unknown))
+        :subtitle (if (and estimated-time approval-fees-formatted)
+                    approval-fees-formatted
+                    (i18n/label :t/unknown))
         :loading? loading-swap-proposal?
         :size     :small}]
       [data-item

--- a/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
@@ -7,7 +7,6 @@
     [status-im.common.events-helper :as events-helper]
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.common.standard-authentication.core :as standard-auth]
-    [status-im.constants :as constants]
     [status-im.contexts.wallet.common.utils.external-links :as external-links]
     [status-im.contexts.wallet.swap.set-spending-cap.style :as style]
     [utils.address :as address-utils]

--- a/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
@@ -186,8 +186,7 @@
 (defn- transaction-details
   []
   (let [network                (rf/sub [:wallet/swap-network])
-        max-fees               (rf/sub [:wallet/wallet-swap-proposal-fee-fiat-formatted
-                                        constants/token-for-fees-symbol])
+        approval-fees          (rf/sub [:wallet/approval-gas-fees-formatted])
         loading-swap-proposal? (rf/sub [:wallet/swap-loading-swap-proposal?])
         estimated-time         (rf/sub [:wallet/swap-proposal-estimated-time])]
     [rn/view {:style style/details-container}
@@ -198,7 +197,7 @@
         :network-image (:source network)}]
       [data-item
        {:title    (i18n/label :t/max-fees)
-        :subtitle (if (and estimated-time max-fees) max-fees (i18n/label :t/unknown))
+        :subtitle (if (and estimated-time approval-fees) approval-fees (i18n/label :t/unknown))
         :loading? loading-swap-proposal?
         :size     :small}]
       [data-item

--- a/src/status_im/contexts/wallet/swap/setup_swap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/setup_swap/view.cljs
@@ -65,15 +65,24 @@
 (defn- transaction-details
   []
   (let [theme                  (quo.theme/use-theme)
-        max-fees               (rf/sub [:wallet/wallet-swap-proposal-fee-fiat-formatted
+        swap-proposal-fee      (rf/sub [:wallet/wallet-swap-proposal-fee-fiat
                                         constants/token-for-fees-symbol])
+        approval-gas-fee       (rf/sub [:wallet/approval-gas-fees])
         max-slippage           (rf/sub [:wallet/swap-max-slippage])
         loading-swap-proposal? (rf/sub [:wallet/swap-loading-swap-proposal?])
+        currency-symbol        (rf/sub [:profile/currency-symbol])
+        approval-required      (rf/sub [:wallet/swap-proposal-approval-required])
+        max-fee                (if approval-required
+                                 (money/add approval-gas-fee swap-proposal-fee)
+                                 swap-proposal-fee)
+        max-fee-formatted      (utils/fiat-formatted-for-ui
+                                currency-symbol
+                                max-fee)
         error-response         (rf/sub [:wallet/swap-error-response])]
     [rn/view {:style style/details-container}
      [data-item
       (cond-> {:title    (i18n/label :t/max-fees)
-               :subtitle max-fees
+               :subtitle max-fee-formatted
                :loading? loading-swap-proposal?
                :size     :small}
         error-response (assoc :subtitle-color

--- a/src/status_im/contexts/wallet/swap/setup_swap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/setup_swap/view.cljs
@@ -71,8 +71,9 @@
         max-slippage           (rf/sub [:wallet/swap-max-slippage])
         loading-swap-proposal? (rf/sub [:wallet/swap-loading-swap-proposal?])
         currency-symbol        (rf/sub [:profile/currency-symbol])
-        approval-required      (rf/sub [:wallet/swap-proposal-approval-required])
-        max-fee                (if approval-required
+        approval-required?     (rf/sub [:wallet/swap-proposal-approval-required])
+        approval-status        (rf/sub [:wallet/swap-approval-transaction-status])
+        max-fee                (if (and approval-required? (not= approval-status :confirmed))
                                  (money/add approval-gas-fee swap-proposal-fee)
                                  swap-proposal-fee)
         max-fee-formatted      (utils/fiat-formatted-for-ui

--- a/src/status_im/contexts/wallet/swap/swap_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/swap/swap_confirmation/view.cljs
@@ -7,6 +7,7 @@
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.common.standard-authentication.core :as standard-auth]
     [status-im.constants :as constants]
+    [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.send.utils :as send-utils]
     [status-im.contexts.wallet.swap.swap-confirmation.style :as style]
     [utils.address :as address-utils]
@@ -137,8 +138,12 @@
 
 (defn- transaction-details
   []
-  (let [max-fees               (rf/sub [:wallet/wallet-swap-proposal-fee-fiat-formatted
+  (let [max-fees               (rf/sub [:wallet/wallet-swap-proposal-fee-fiat
                                         constants/token-for-fees-symbol])
+        currency-symbol        (rf/sub [:profile/currency-symbol])
+        max-fees-formatted     (utils/fiat-formatted-for-ui
+                                currency-symbol
+                                max-fees)
         estimated-time         (rf/sub [:wallet/swap-proposal-estimated-time])
         loading-swap-proposal? (rf/sub [:wallet/swap-loading-swap-proposal?])
         max-slippage           (rf/sub [:wallet/swap-max-slippage])]
@@ -152,7 +157,7 @@
         :loading? loading-swap-proposal?}]
       [data-item
        {:title    (i18n/label :t/max-fees)
-        :subtitle (if (and estimated-time max-fees) max-fees (i18n/label :t/unknown))
+        :subtitle (if (and estimated-time max-fees-formatted) max-fees-formatted (i18n/label :t/unknown))
         :loading? loading-swap-proposal?}]
       [data-item
        {:title    (i18n/label :t/max-slippage)

--- a/src/status_im/subs/wallet/dapps/transactions.cljs
+++ b/src/status_im/subs/wallet/dapps/transactions.cljs
@@ -58,10 +58,8 @@
            max-fees-fiat            (wallet-utils/calculate-token-fiat-value {:currency currency
                                                                               :balance  max-fees-ether
                                                                               :token    eth-token})
-           max-fees-fiat-formatted  (-> (wallet-utils/get-standard-crypto-format eth-token
-                                                                                 max-fees-ether)
-                                        (wallet-utils/get-standard-fiat-format currency-symbol
-                                                                               max-fees-fiat))
+           max-fees-fiat-formatted  (wallet-utils/fiat-formatted-for-ui currency-symbol
+                                                                        max-fees-fiat)
            balance                  (-> eth-token
                                         (get-in [:balances-per-chain chain-id :raw-balance])
                                         money/bignumber)

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -302,3 +302,27 @@
      :currency-symbol currency-symbol
      :balance         (or amount 0)
      :token           asset-to-pay-with-current-account-balance})))
+
+(rf/reg-sub
+ :wallet/approval-gas-fees-formatted
+ :<- [:wallet/current-viewing-account]
+ :<- [:wallet/swap-proposal]
+ :<- [:profile/currency]
+ :<- [:profile/currency-symbol]
+ (fn [[account {:keys [approval-gas-fees]} currency currency-symbol]]
+   (let [tokens                  (:tokens account)
+         token-for-fees          (first (filter #(= (string/lower-case (:symbol %))
+                                                    (string/lower-case constants/token-for-fees-symbol))
+                                                tokens))
+         fee-in-crypto-formatted (utils/get-standard-crypto-format
+                                  token-for-fees
+                                  approval-gas-fees)
+         fee-in-fiat             (utils/calculate-token-fiat-value
+                                  {:currency currency
+                                   :balance  approval-gas-fees
+                                   :token    token-for-fees})
+         fee-formatted           (utils/get-standard-fiat-format
+                                  fee-in-crypto-formatted
+                                  currency-symbol
+                                  fee-in-fiat)]
+     fee-formatted)))

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -90,9 +90,8 @@
                               :balance  total-balance
                               :token    token})
          crypto-formatted   (utils/get-standard-crypto-format token total-balance)
-         fiat-formatted     (utils/get-standard-fiat-format crypto-formatted
-                                                            currency-symbol
-                                                            fiat-value)]
+         fiat-formatted     (utils/fiat-formatted-for-ui currency-symbol
+                                                         fiat-value)]
      {:crypto (str crypto-formatted " " token-symbol)
       :fiat   fiat-formatted})))
 
@@ -246,22 +245,18 @@
  :<- [:profile/currency-symbol]
  (fn [[account swap-proposal currency currency-symbol] [_ token-symbol-for-fees]]
    (when token-symbol-for-fees
-     (let [tokens                  (:tokens account)
-           token-for-fees          (first (filter #(= (string/lower-case (:symbol %))
-                                                      (string/lower-case token-symbol-for-fees))
-                                                  tokens))
-           fee-in-native-token     (send-utils/calculate-full-route-gas-fee [swap-proposal])
-           fee-in-crypto-formatted (utils/get-standard-crypto-format
-                                    token-for-fees
-                                    fee-in-native-token)
-           fee-in-fiat             (utils/calculate-token-fiat-value
-                                    {:currency currency
-                                     :balance  fee-in-native-token
-                                     :token    token-for-fees})
-           fee-formatted           (utils/get-standard-fiat-format
-                                    fee-in-crypto-formatted
-                                    currency-symbol
-                                    fee-in-fiat)]
+     (let [tokens              (:tokens account)
+           token-for-fees      (first (filter #(= (string/lower-case (:symbol %))
+                                                  (string/lower-case token-symbol-for-fees))
+                                              tokens))
+           fee-in-native-token (send-utils/calculate-full-route-gas-fee [swap-proposal])
+           fee-in-fiat         (utils/calculate-token-fiat-value
+                                {:currency currency
+                                 :balance  fee-in-native-token
+                                 :token    token-for-fees})
+           fee-formatted       (utils/fiat-formatted-for-ui
+                                currency-symbol
+                                fee-in-fiat)]
        fee-formatted))))
 
 (rf/reg-sub
@@ -310,19 +305,15 @@
  :<- [:profile/currency]
  :<- [:profile/currency-symbol]
  (fn [[account {:keys [approval-gas-fees]} currency currency-symbol]]
-   (let [tokens                  (:tokens account)
-         token-for-fees          (first (filter #(= (string/lower-case (:symbol %))
-                                                    (string/lower-case constants/token-for-fees-symbol))
-                                                tokens))
-         fee-in-crypto-formatted (utils/get-standard-crypto-format
-                                  token-for-fees
-                                  approval-gas-fees)
-         fee-in-fiat             (utils/calculate-token-fiat-value
-                                  {:currency currency
-                                   :balance  approval-gas-fees
-                                   :token    token-for-fees})
-         fee-formatted           (utils/get-standard-fiat-format
-                                  fee-in-crypto-formatted
-                                  currency-symbol
-                                  fee-in-fiat)]
+   (let [tokens         (:tokens account)
+         token-for-fees (first (filter #(= (string/lower-case (:symbol %))
+                                           (string/lower-case constants/token-for-fees-symbol))
+                                       tokens))
+         fee-in-fiat    (utils/calculate-token-fiat-value
+                         {:currency currency
+                          :balance  approval-gas-fees
+                          :token    token-for-fees})
+         fee-formatted  (utils/fiat-formatted-for-ui
+                         currency-symbol
+                         fee-in-fiat)]
      fee-formatted)))

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -238,12 +238,11 @@
  :-> :estimated-time)
 
 (rf/reg-sub
- :wallet/wallet-swap-proposal-fee-fiat-formatted
+ :wallet/wallet-swap-proposal-fee-fiat
  :<- [:wallet/current-viewing-account]
  :<- [:wallet/swap-proposal]
  :<- [:profile/currency]
- :<- [:profile/currency-symbol]
- (fn [[account swap-proposal currency currency-symbol] [_ token-symbol-for-fees]]
+ (fn [[account swap-proposal currency] [_ token-symbol-for-fees]]
    (when token-symbol-for-fees
      (let [tokens              (:tokens account)
            token-for-fees      (first (filter #(= (string/lower-case (:symbol %))
@@ -253,11 +252,8 @@
            fee-in-fiat         (utils/calculate-token-fiat-value
                                 {:currency currency
                                  :balance  fee-in-native-token
-                                 :token    token-for-fees})
-           fee-formatted       (utils/fiat-formatted-for-ui
-                                currency-symbol
-                                fee-in-fiat)]
-       fee-formatted))))
+                                 :token    token-for-fees})]
+       fee-in-fiat))))
 
 (rf/reg-sub
  :wallet/swap-asset-to-pay-balance-for-chain-data
@@ -299,12 +295,11 @@
      :token           asset-to-pay-with-current-account-balance})))
 
 (rf/reg-sub
- :wallet/approval-gas-fees-formatted
+ :wallet/approval-gas-fees
  :<- [:wallet/current-viewing-account]
  :<- [:wallet/swap-proposal]
  :<- [:profile/currency]
- :<- [:profile/currency-symbol]
- (fn [[account {:keys [approval-gas-fees]} currency currency-symbol]]
+ (fn [[account {:keys [approval-gas-fees]} currency]]
    (let [tokens         (:tokens account)
          token-for-fees (first (filter #(= (string/lower-case (:symbol %))
                                            (string/lower-case constants/token-for-fees-symbol))
@@ -312,8 +307,6 @@
          fee-in-fiat    (utils/calculate-token-fiat-value
                          {:currency currency
                           :balance  approval-gas-fees
-                          :token    token-for-fees})
-         fee-formatted  (utils/fiat-formatted-for-ui
-                         currency-symbol
-                         fee-in-fiat)]
-     fee-formatted)))
+                          :token    token-for-fees})]
+     fee-in-fiat)))
+

--- a/src/status_im/subs/wallet/swap_test.cljs
+++ b/src/status_im/subs/wallet/swap_test.cljs
@@ -257,7 +257,7 @@
       swap-data)
     (is (match? "0x10000" (rf/sub [sub-name])))))
 
-(h/deftest-sub :wallet/wallet-swap-proposal-fee-fiat-formatted
+(h/deftest-sub :wallet/wallet-swap-proposal-fee-fiat
   [sub-name]
   (testing "wallet send fee calculated and formatted in fiat"
     (swap! rf-db/app-db
@@ -266,9 +266,8 @@
            (assoc-in [:wallet :current-viewing-account-address] "0x1")
            (assoc-in [:wallet :ui :swap] swap-data)
            (assoc-in [:currencies] currencies)
-           (assoc-in [:profile/profile :currency] :usd)
-           (assoc-in [:profile/profile :currency-symbol] "$")))
+           (assoc-in [:profile/profile :currency] :usd)))
 
     (let [token-symbol-for-fees "ETH"
           result                (rf/sub [sub-name token-symbol-for-fees])]
-      (is (match? result "$1.00")))))
+      (is (match? result 1)))))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -768,22 +768,18 @@
  :<- [:profile/currency-symbol]
  (fn [[account route currency currency-symbol] [_ token-symbol-for-fees]]
    (when token-symbol-for-fees
-     (let [tokens                  (:tokens account)
-           token-for-fees          (first (filter #(= (string/lower-case (:symbol %))
-                                                      (string/lower-case token-symbol-for-fees))
-                                                  tokens))
-           fee-in-native-token     (send-utils/calculate-full-route-gas-fee route)
-           fee-in-crypto-formatted (utils/get-standard-crypto-format
-                                    token-for-fees
-                                    fee-in-native-token)
-           fee-in-fiat             (utils/calculate-token-fiat-value
-                                    {:currency currency
-                                     :balance  fee-in-native-token
-                                     :token    token-for-fees})
-           fee-formatted           (utils/get-standard-fiat-format
-                                    fee-in-crypto-formatted
-                                    currency-symbol
-                                    fee-in-fiat)]
+     (let [tokens              (:tokens account)
+           token-for-fees      (first (filter #(= (string/lower-case (:symbol %))
+                                                  (string/lower-case token-symbol-for-fees))
+                                              tokens))
+           fee-in-native-token (send-utils/calculate-full-route-gas-fee route)
+           fee-in-fiat         (utils/calculate-token-fiat-value
+                                {:currency currency
+                                 :balance  fee-in-native-token
+                                 :token    token-for-fees})
+           fee-formatted       (utils/fiat-formatted-for-ui
+                                currency-symbol
+                                fee-in-fiat)]
        fee-formatted))))
 
 (rf/reg-sub


### PR DESCRIPTION
fixes #21428

### Summary

Incorrect fee was used before, that is fixed.
Also minor refactoring done

### Review notes
`get-standard-fiat-format` was refactored, explanation in comment to the code

### Testing notes
<!-- (Optional) -->

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional
- wallet / transactions


status: ready
