### PR TITLE
Fix appearance of Create Password and Change Password forms

### DIFF
--- a/src/status_im/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im/contexts/onboarding/create_password/view.cljs
@@ -40,7 +40,7 @@
       [quo/info-message
        {:status status
         :size   :default
-        :icon   (if (= status :success) :i/positive-state :i/info)
+        :icon   (if (= status :success) :i/check-circle :i/info)
         :color  (when (= status :default)
                   colors/white-70-blur)}
        text])]])

--- a/src/status_im/contexts/profile/settings/screens/password/change_password/new_password_form.cljs
+++ b/src/status_im/contexts/profile/settings/screens/password/change_password/new_password_form.cljs
@@ -27,7 +27,7 @@
        (cond-> {:status status
                 :size   :default}
          (not= :success status) (assoc :icon :i/info)
-         (= :success status)    (assoc :icon :i/positive-state)
+         (= :success status)    (assoc :icon :i/check-circle)
          (= :default status)    (assoc :color colors/white-70-blur))
        text])]])
 

--- a/src/status_im/contexts/profile/settings/screens/password/change_password/new_password_form.cljs
+++ b/src/status_im/contexts/profile/settings/screens/password/change_password/new_password_form.cljs
@@ -141,9 +141,10 @@
       (when same-passwords?
         [rn/view {:style style/disclaimer-container}
          [quo/disclaimer
-          {:blur?     true
-           :on-change on-disclaimer-change
-           :checked?  disclaimer-accepted?}
+          {:blur?               true
+           :customization-color customization-color
+           :on-change           on-disclaimer-change
+           :checked?            disclaimer-accepted?}
           (i18n/label :t/password-creation-disclaimer)]])
       (when (and focused? (not same-passwords?))
         [help


### PR DESCRIPTION
Fixes #21191
Fixes #21543

### Summary

* This PR attempts to fix some styling issues for the Change Password and Create Profile Password screens.
  * We know use the `check-circle` icon for the password hints when displayed in the success-state.
  * And we use the `customization-color` when displaying the filled checkbox for the confirmation checkbox.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Onboarding - Create Profile Password
- Settings - Change Password

### Steps to test

- Open Status mobile
- Create a new profile
- Fill in the profile details and proceed to the create password screen
- Input matching passwords to see the success state
- Press the confirmation checkbox to see the filled checkbox with the customisation colour
- After proceeding through the rest of the onboarding, navigate to the profile settings
- Once inside the settings screens, press on Change Password
- Enter the current password and proceed to the next step
- Then enter the new password in both input fields to see the success state
- Press the confirmation checkbox to see the filled checkbox with the customisation colour

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before changes

Screenshots for the before appearance can be found in issues: #21191 and #21543

### After changes

#### Onboarding - Create Password

<img width="600" alt="Screenshot 2024-10-31 at 09 47 34" src="https://github.com/user-attachments/assets/4ea59778-5ab9-4298-b90e-662b1d01a704">

#### Settings - Change Password

<img width="600" alt="Screenshot 2024-10-31 at 09 07 18" src="https://github.com/user-attachments/assets/6abdd540-6f32-44c6-a652-08496f12768a">

status: ready <!-- Can be ready or wip -->