### PR TITLE
Upgrade nix interpreter from 2.19.3 to 2.24.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,6 @@ export NODE_OPTIONS += --openssl-legacy-provider
 # The path can be anything, but home is usually safest.
 export KEYSTORE_PATH ?= $(HOME)/.gradle/status-im.keystore
 
-# Our custom config is located in nix/nix.conf
-export NIX_USER_CONF_FILES = $(PWD)/nix/nix.conf
 # Location of symlinks to derivations that should not be garbage collected
 export _NIX_GCROOTS = ./.nix-gcroots
 # Defines which variables will be kept for Nix pure shell, use semicolon as divider

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -5,7 +5,7 @@ library 'status-jenkins-lib@v1.9.13'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'linux && x86_64 && nix-2.19' }
+  agent { label 'linux && x86_64 && nix-2.24' }
 
   options {
     timestamps()

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -5,7 +5,7 @@ library 'status-jenkins-lib@v1.9.13'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'macos && arm64 && nix-2.19 && xcode-15.1' }
+  agent { label 'macos && arm64 && nix-2.24 && xcode-15.1' }
 
   parameters {
     string(

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -5,7 +5,7 @@ library 'status-jenkins-lib@v1.9.13'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'linux && x86_64 && nix-2.19' }
+  agent { label 'linux && x86_64 && nix-2.24' }
 
   options {
     timestamps()

--- a/nix/scripts/lib.sh
+++ b/nix/scripts/lib.sh
@@ -38,8 +38,8 @@ nix_install_type() {
             "${UID}")   echo "single";;
             "(${UID})") echo "single";;
             "")         echo "none";
-                        echo "No Nix installtion detected!" >&2;;
-            *)          echo "Unknown Nix installtion type!" >&2; exit 1;;
+                        echo "No Nix installation detected!" >&2;;
+            *)          echo "Unknown Nix installation type!" >&2; exit 1;;
         esac
     fi
 }

--- a/nix/scripts/version.sh
+++ b/nix/scripts/version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-export NIX_VERSION="2.19.3"
-export NIX_PACKAGE="nixVersions.nix_2_19"
+export NIX_VERSION="2.24.11"
+export NIX_PACKAGE="nixVersions.nix_2_24"
 export NIX_INSTALL_URL="https://nixos.org/releases/nix/nix-${NIX_VERSION}/install"
-export NIX_INSTALL_SHA256="73d47b0ab783fddca1b2d44a03d52a74c97c28a1fc8ff5a29419079302ef9c3d"
+export NIX_INSTALL_SHA256="5c610a0e97c8a2dd48c1a630608502e43fdecd7d2572463dd4166126106d9188"
 export NIX_INSTALL_PATH="/tmp/nix-install-${NIX_VERSION}"

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -38,6 +38,9 @@ in mkShell {
   LANG="en_US.UTF-8";
   LANGUAGE="en_US.UTF-8";
 
+  # Important to load our own Nix binary cache.
+  NIX_CONFIG = builtins.readFile ./nix.conf;
+
   # just a nicety for easy access to node scripts
   shellHook = ''
     export STATUS_MOBILE_HOME=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
## Summary

This PR upgrades nix to 2.24.11
We also fix the following warnings :

```
warning: ignoring the client-specified setting 'keep-derivations', because it is a restricted setting and you are not a trusted user
warning: ignoring the client-specified setting 'keep-outputs', because it is a restricted setting and you are not a trusted user
warning: ignoring the client-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
warning: ignoring the client-specified setting 'stalled-download-timeout', because it is a restricted setting and you are not a trusted user
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
warning: ignoring the client-specified setting 'trusted-substituters', because it is a restricted setting and you are not a trusted user
```

## Review notes (warning this maybe time consuming)
- `make nix-purge`
- `restart your system`
- `make shell` will then install nix 2.24.11 for you. 
- Please test common workflows and make commands like : 
  - `make run-ios`
  - `make run-android`
  - `make run-clojure`

## Testing notes
should not be needed.

## Platforms
- Android
- iOS

status: ready
