### PR TITLE
Fix: only display spectated communities in opened tab

### DIFF
--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -194,7 +194,8 @@
   (cond
     (:joined community)         :joined
     (boolean (get requests id)) :pending
-    :else                       :opened))
+    (:spectated community)      :opened
+    :else                       :other))
 
 (re-frame/reg-sub
  :communities/grouped-by-status

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -183,10 +183,6 @@
 
 (def memo-communities-stack-items (atom nil))
 
-(defn- merge-opened-communities
-  [{:keys [joined pending] :as assorted-communities}]
-  (update assorted-communities :opened concat joined pending))
-
 (defn- group-communities-by-status
   [requests
    {:keys [id]
@@ -217,7 +213,6 @@
                                     ;; any key.
                                     (map #(dissoc % :members :chats :token-permissions :tokens-metadata))
                                     (group-by #(group-communities-by-status requests %))
-                                    merge-opened-communities
                                     (map (fn [[k v]]
                                            {k (sort-by (fn [{:keys [requested-to-join-at last-opened-at
                                                                     joined-at]}]


### PR DESCRIPTION
fixes #20762

### Summary

* This PR attempts to resolve an issue with displaying un-opened communities in the opened tab in the communities home screen.
* This PR also avoids displaying any joined or pending communities in the opened tab, so only spectated communities will be displayed in the opened tab.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Community tabs for Joined, Pending, Opened

### Steps to test 

- Open Status mobile app
- Create a new profile and login
- Navigate to communities home screen
- Press the "Opened" tab
- Confirm that the list is empty
- Press on the "Discover" banner for discovering communities (ensure app is not Testnet mode)
- Open one of the discovered communities (for example the Status community)
- Close the community overview screen
- Close the discover communities screen
- View the "Opened" tab
- Confirm that the community is displayed
- Open the Status community and request to join
- Close the community overview screen
- Confirm the community is not present in the "Opened" tab
- View the "Pending" tab or the "Joined" tab (depending on whether it's been approved)
- Confirm the community is inside Pending or Joined

<!-- (PRs will only be accepted if squashed into single commit.) -->

### After Changes

https://github.com/user-attachments/assets/bfeebc32-bbce-48d0-8a33-596a5cf8d3ed

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
