### PR TITLE
fix: add spacing between wrong-password error and forgot-password link

### DIFF
--- a/src/status_im/common/standard_authentication/password_input/style.cljs
+++ b/src/status_im/common/standard_authentication/password_input/style.cljs
@@ -3,6 +3,7 @@
 (def error-message
   {:margin-top     8
    :flex-direction :row
+   :gap            4
    :align-items    :center})
 
 (def auth-button


### PR DESCRIPTION
fixes #21207

### Summary

* This PR attempts to fix an appearance issue when submitting an incorrect password when attuning to sign-in to a profile. Now the "oops, wrong password" error message and the "forgot password?" link will have spacing between them.


#### Platforms

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

* Places where the password input is used for authentication, for example:
  * Profile login

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile app
- Attempt to sign-in to a profile with the wrong password
- Confirm that the wrong-password error message and the forgot-password link are spaced correctly.

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### After changes

<img width="458" alt="Screenshot 2024-11-06 at 10 35 13" src="https://github.com/user-attachments/assets/e35c0ffa-3baf-4dc0-9cf2-b9858defb7c2">

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
