### PR TITLE
[#18554] incorrect drawer for non community members

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/content/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/content/view.cljs
@@ -211,45 +211,44 @@
   (let [show-delivery-state? (reagent/atom false)]
     (fn [{:keys [message-data context keyboard-shown? hide-reactions?
                  in-reaction-or-action-menu? show-user-info?]}]
-      (let [theme                                       (quo.theme/use-theme)
-            {:keys [content-type quoted-message content outgoing outgoing-status pinned-by pinned
-                    bridge-message
-                    last-in-group? message-id chat-id]} message-data
-            {:keys [disable-message-long-press?]}       context
-            first-image                                 (first (:album message-data))
-            outgoing-status                             (if (= content-type
-                                                               constants/content-type-album)
-                                                          (:outgoing-status first-image)
-                                                          outgoing-status)
-            outgoing                                    (if (= content-type
-                                                               constants/content-type-album)
-                                                          (:outgoing first-image)
-                                                          outgoing)
-            context                                     (assoc context
-                                                               :on-long-press
-                                                               #(on-long-press message-data
-                                                                               context
-                                                                               keyboard-shown?))
-            response-to                                 (:response-to content)
-            height                                      (rf/sub [:dimensions/window-height])
+      (let [theme                  (quo.theme/use-theme)
+            {:keys [content-type quoted-message content outgoing outgoing-status pinned-by
+                    pinned bridge-message last-in-group? message-id
+                    chat-id]}      message-data
+            first-image            (first (:album message-data))
+            outgoing-status        (if (= content-type
+                                          constants/content-type-album)
+                                     (:outgoing-status first-image)
+                                     outgoing-status)
+            outgoing               (if (= content-type
+                                          constants/content-type-album)
+                                     (:outgoing first-image)
+                                     outgoing)
+            context                (assoc context
+                                          :on-long-press
+                                          #(on-long-press message-data
+                                                          context
+                                                          keyboard-shown?))
+            response-to            (:response-to content)
+            height                 (rf/sub [:dimensions/window-height])
             {window-width :width
-             window-scale :scale}                       (rn/get-window)
-            message-container-data                      {:window-width           window-width
-                                                         :padding-right          20
-                                                         :padding-left           20
-                                                         :avatar-container-width 32
-                                                         :message-margin-left    8}
-            reactions                                   (rf/sub [:chats/message-reactions message-id
-                                                                 chat-id])
-            six-reactions?                              (-> reactions
-                                                            count
-                                                            (= 6))
-            content-type                                (if (and
-                                                             (= content-type
-                                                                constants/content-type-bridge-message)
-                                                             (seq (:parsed-text content)))
-                                                          constants/content-type-text
-                                                          content-type)]
+             window-scale :scale}  (rn/get-window)
+            message-container-data {:window-width           window-width
+                                    :padding-right          20
+                                    :padding-left           20
+                                    :avatar-container-width 32
+                                    :message-margin-left    8}
+            reactions              (rf/sub [:chats/message-reactions message-id
+                                            chat-id])
+            six-reactions?         (-> reactions
+                                       count
+                                       (= 6))
+            content-type           (if (and
+                                        (= content-type
+                                           constants/content-type-bridge-message)
+                                        (seq (:parsed-text content)))
+                                     constants/content-type-text
+                                     content-type)]
         [rn/touchable-highlight
          {:accessibility-label (if (and outgoing (= outgoing-status :sending))
                                  :message-sending
@@ -274,7 +273,7 @@
                                      (reset! show-delivery-state? true)
                                      (js/setTimeout #(reset! show-delivery-state? false)
                                                     delivery-state-showing-time-ms))))
-          :on-long-press       (when-not disable-message-long-press?
+          :on-long-press       (when-not (:disable-message-long-press? context)
                                  #(on-long-press message-data context keyboard-shown?))}
          [:<>
           (when pinned-by
@@ -351,21 +350,20 @@
   (rf/dispatch [:dismiss-keyboard])
   (rf/dispatch
    [:show-bottom-sheet
-    {:content (drawers/reactions-and-actions message-data context)
+    {:content       (drawers/reactions-and-actions message-data context)
      :border-radius 16
-     :selected-item
-     (if (or deleted? deleted-for-me?)
-       (fn [] [content.deleted/deleted-message message-data])
-       (fn []
-         [rn/view
-          {:pointer-events :none
-           :style          style/drawer-message-container}
-          [user-message-content
-           {:message-data                message-data
-            :context                     context
-            :keyboard-shown?             keyboard-shown?
-            :in-reaction-or-action-menu? true
-            :show-user-info?             false}]]))}]))
+     :selected-item (if (or deleted? deleted-for-me?)
+                      (fn [] [content.deleted/deleted-message message-data])
+                      (fn []
+                        [rn/view
+                         {:pointer-events :none
+                          :style          style/drawer-message-container}
+                         [user-message-content
+                          {:message-data                message-data
+                           :context                     context
+                           :keyboard-shown?             keyboard-shown?
+                           :in-reaction-or-action-menu? true
+                           :show-user-info?             false}]]))}]))
 
 (defn check-if-system-message?
   [content-type]

--- a/src/status_im/contexts/chat/messenger/messages/drawers/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/drawers/view.cljs
@@ -99,76 +99,90 @@
     :as   message-data}
    {:keys [able-to-send-message? community? community-member? can-delete-message-for-everyone?
            message-pin-enabled group-chat group-admin?]}]
-  (concat
-   (when (and outgoing
-              (not (or deleted? deleted-for-me?))
-              ;; temporarily disable edit image message until
-              ;; https://github.com/status-im/status-mobile/issues/15298 is implemented
-              (not= content-type constants/content-type-image)
-              (not= content-type constants/content-type-audio))
-     [{:type                :main
-       :on-press            #(rf/dispatch [:chat.ui/edit-message message-data])
-       :label               (i18n/label :t/edit-message)
-       :icon                :i/edit
-       :accessibility-label :edit-message
-       :id                  :edit}])
-   (when (and able-to-send-message? (not= outgoing-status :sending) (not (or deleted? deleted-for-me?)))
-     [{:type                :main
-       :on-press            #(rf/dispatch [:chat.ui/reply-to-message message-data])
-       :label               (i18n/label :t/message-reply)
-       :icon                :i/reply
-       :accessibility-label :reply-message
-       :id                  :reply}])
-   (when (and (not (or deleted? deleted-for-me?))
-              (not= content-type constants/content-type-audio))
-     [{:type                :main
-       :on-press            #(clipboard/set-string
-                              (reply/get-quoted-text-with-mentions
-                               (get content :parsed-text)))
-       :label               (i18n/label :t/copy-text)
-       :accessibility-label :copy-text
-       :icon                :i/copy
-       :id                  :copy}])
-   ;; pinning images are temporarily disabled
-   (when (and message-pin-enabled
-              (not= content-type constants/content-type-image)
-              (or community-member? (not community?)))
-     [{:type                :main
-       :on-press            #(pin-message message-data)
-       :label               (i18n/label (if pinned-by
-                                          (if community? :t/unpin-from-channel :t/unpin-from-chat)
-                                          (if community? :t/pin-to-channel :t/pin-to-chat)))
-       :accessibility-label (if pinned-by :unpin-message :pin-message)
-       :icon                :i/pin
-       :id                  (if pinned-by :unpin :pin)}])
-   (when-not (or deleted? deleted-for-me? bridge-message)
-     [{:type                :danger
-       :on-press            (fn []
-                              (rf/dispatch
-                               [:hide-bottom-sheet])
-                              (rf/dispatch [:chat.ui/delete-message-for-me message-data
-                                            config/delete-message-for-me-undo-time-limit-ms]))
+  (let [edit-message?        (and community-member?
+                                  outgoing
+                                  (not (or deleted? deleted-for-me?))
+                                  ;; temporarily disable edit image message until
+                                  ;; https://github.com/status-im/status-mobile/issues/15298 is
+                                  ;; implemented
+                                  (not= content-type constants/content-type-image)
+                                  (not= content-type constants/content-type-audio))
+        reply?               (and able-to-send-message?
+                                  (not= outgoing-status :sending)
+                                  (not (or deleted? deleted-for-me?)))
+        copy-text?           (and (not (or deleted? deleted-for-me?))
+                                  (not= content-type constants/content-type-audio))
+        ;; pinning images are temporarily disabled
+        pin-message?         (and message-pin-enabled
+                                  (not= content-type constants/content-type-image)
+                                  (or community-member? (not community?)))
+        delete-for-me?       (and community-member?
+                                  (not (or deleted? deleted-for-me? bridge-message)))
+        delete-for-everyone? (and community-member?
+                                  (or (not deleted?)
+                                      outgoing
+                                      (and community? can-delete-message-for-everyone?)
+                                      (and group-chat group-admin?)
+                                      (not bridge-message)))]
+    (cond-> []
+      edit-message?
+      (conj {:type                :main
+             :on-press            #(rf/dispatch [:chat.ui/edit-message message-data])
+             :label               (i18n/label :t/edit-message)
+             :icon                :i/edit
+             :accessibility-label :edit-message
+             :id                  :edit})
 
-       :label               (i18n/label :t/delete-for-me)
-       :accessibility-label :delete-for-me
-       :icon                :i/delete
-       :id                  :delete-for-me}])
-   (when (cond
-           deleted?       false
-           outgoing       true
-           community?     can-delete-message-for-everyone?
-           group-chat     group-admin?
-           bridge-message false
-           :else          false)
-     [{:type                :danger
-       :on-press            (fn []
-                              (rf/dispatch [:hide-bottom-sheet])
-                              (rf/dispatch [:chat.ui/delete-message message-data
-                                            config/delete-message-undo-time-limit-ms]))
-       :label               (i18n/label :t/delete-for-everyone)
-       :accessibility-label :delete-for-everyone
-       :icon                :i/delete
-       :id                  :delete-for-all}])))
+      reply?
+      (conj {:type                :main
+             :on-press            #(rf/dispatch [:chat.ui/reply-to-message message-data])
+             :label               (i18n/label :t/message-reply)
+             :icon                :i/reply
+             :accessibility-label :reply-message
+             :id                  :reply})
+
+      copy-text?
+      (conj {:type                :main
+             :on-press            #(clipboard/set-string
+                                    (reply/get-quoted-text-with-mentions
+                                     (get content :parsed-text)))
+             :label               (i18n/label :t/copy-text)
+             :accessibility-label :copy-text
+             :icon                :i/copy
+             :id                  :copy})
+
+      pin-message?
+      (conj {:type                :main
+             :on-press            #(pin-message message-data)
+             :label               (i18n/label (if pinned-by
+                                                (if community? :t/unpin-from-channel :t/unpin-from-chat)
+                                                (if community? :t/pin-to-channel :t/pin-to-chat)))
+             :accessibility-label (if pinned-by :unpin-message :pin-message)
+             :icon                :i/pin
+             :id                  (if pinned-by :unpin :pin)})
+
+      delete-for-me?
+      (conj {:type                :danger
+             :on-press            (fn []
+                                    (rf/dispatch [:hide-bottom-sheet])
+                                    (rf/dispatch [:chat.ui/delete-message-for-me message-data
+                                                  config/delete-message-for-me-undo-time-limit-ms]))
+
+             :label               (i18n/label :t/delete-for-me)
+             :accessibility-label :delete-for-me
+             :icon                :i/delete
+             :id                  :delete-for-me})
+
+      delete-for-everyone?
+      (conj {:type                :danger
+             :on-press            (fn []
+                                    (rf/dispatch [:hide-bottom-sheet])
+                                    (rf/dispatch [:chat.ui/delete-message message-data
+                                                  config/delete-message-undo-time-limit-ms]))
+             :label               (i18n/label :t/delete-for-everyone)
+             :accessibility-label :delete-for-everyone
+             :icon                :i/delete
+             :id                  :delete-for-all}))))
 
 (defn extract-id
   [reactions id]
@@ -209,21 +223,24 @@
            (rf/dispatch [:hide-bottom-sheet]))}])]))
 
 (defn reactions-and-actions
-  [message-data
-   {:keys [chat-id] :as context}]
+  [message-data {:keys [chat-id community-member?] :as context}]
   (fn []
-    (let [data                                          (if (contains? message-data :album-id)
-                                                          (first (:album message-data))
-                                                          message-data)
-          {:keys [message-id deleted? deleted-for-me?]} data
-          outgoing-status                               (:outgoing-status data)
-          actions                                       (get-actions data context)
-          main-actions                                  (filter #(= (:type %) :main) actions)
-          danger-actions                                (filter #(= (:type %) :danger) actions)
-          admin-actions                                 (filter #(= (:type %) :admin) actions)]
+    (let [data                    (if (contains? message-data :album-id)
+                                    (first (:album message-data))
+                                    message-data)
+          {:keys [deleted-for-me?
+                  outgoing-status
+                  deleted?
+                  message-id]}    data
+          actions                 (get-actions data context)
+          {main-actions   :main
+           danger-actions :danger
+           admin-actions  :admin} (group-by :type actions)]
       [:<>
        ;; REACTIONS
-       (when (and (not= outgoing-status :sending) (not (or deleted? deleted-for-me?)))
+       (when (and (or community-member?)
+                  (not= outgoing-status :sending)
+                  (not (or deleted? deleted-for-me?)))
          [reactions {:chat-id chat-id :message-id message-id}])
        ;; MAIN ACTIONS
        [rn/view {:style {:padding-horizontal 8}}

--- a/src/status_im/contexts/chat/messenger/messages/drawers/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/drawers/view.cljs
@@ -99,7 +99,7 @@
     :as   message-data}
    {:keys [able-to-send-message? community? community-member? can-delete-message-for-everyone?
            message-pin-enabled group-chat group-admin?]}]
-  (let [edit-message?        (and community-member?
+  (let [edit-message?        (and (or community-member? (not community?))
                                   outgoing
                                   (not (or deleted? deleted-for-me?))
                                   ;; temporarily disable edit image message until
@@ -116,23 +116,17 @@
         pin-message?         (and message-pin-enabled
                                   (not= content-type constants/content-type-image)
                                   (or community-member? (not community?)))
-        delete-for-me?       (and community-member?
+        delete-for-me?       (and (or community-member? (not community?))
                                   (not (or deleted? deleted-for-me? bridge-message)))
-        delete-for-everyone? (and community-member?
-                                  (or (not deleted?)
-                                      outgoing
-                                      (and community? can-delete-message-for-everyone?)
-                                      (and group-chat group-admin?)
-                                      (not bridge-message)))]
+        delete-for-everyone? (and (or community-member? (not community?))
+                                  (cond
+                                    deleted?       false
+                                    outgoing       true
+                                    community?     can-delete-message-for-everyone?
+                                    group-chat     group-admin?
+                                    bridge-message false
+                                    :else          false))]
     (cond-> []
-      edit-message?
-      (conj {:type                :main
-             :on-press            #(rf/dispatch [:chat.ui/edit-message message-data])
-             :label               (i18n/label :t/edit-message)
-             :icon                :i/edit
-             :accessibility-label :edit-message
-             :id                  :edit})
-
       reply?
       (conj {:type                :main
              :on-press            #(rf/dispatch [:chat.ui/reply-to-message message-data])
@@ -140,6 +134,14 @@
              :icon                :i/reply
              :accessibility-label :reply-message
              :id                  :reply})
+
+      edit-message?
+      (conj {:type                :main
+             :on-press            #(rf/dispatch [:chat.ui/edit-message message-data])
+             :label               (i18n/label :t/edit-message)
+             :icon                :i/edit
+             :accessibility-label :edit-message
+             :id                  :edit})
 
       copy-text?
       (conj {:type                :main
@@ -223,7 +225,7 @@
            (rf/dispatch [:hide-bottom-sheet]))}])]))
 
 (defn reactions-and-actions
-  [message-data {:keys [chat-id community-member?] :as context}]
+  [message-data {:keys [chat-id community? community-member?] :as context}]
   (fn []
     (let [data                    (if (contains? message-data :album-id)
                                     (first (:album message-data))
@@ -238,7 +240,7 @@
            admin-actions  :admin} (group-by :type actions)]
       [:<>
        ;; REACTIONS
-       (when (and (or community-member?)
+       (when (and (or community-member? (not community?))
                   (not= outgoing-status :sending)
                   (not (or deleted? deleted-for-me?)))
          [reactions {:chat-id chat-id :message-id message-id}])

--- a/src/status_im/contexts/chat/messenger/messages/scroll_to_bottom/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/scroll_to_bottom/style.cljs
@@ -2,11 +2,13 @@
   (:require [react-native.safe-area :as safe-area]
             [status-im.contexts.shell.jump-to.constants :as shell.constants]))
 
+(def ^:private bottom-drawer-height 46)
+
 (defn shell-button-container
   [able-to-send-messages?]
   {:z-index 1
    :bottom  (+ (safe-area/get-bottom)
-               (when-not able-to-send-messages? 46)
+               (when-not able-to-send-messages? bottom-drawer-height)
                shell.constants/floating-shell-button-height)})
 
 (def scroll-to-bottom-button

--- a/src/status_im/contexts/chat/messenger/messages/scroll_to_bottom/style.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/scroll_to_bottom/style.cljs
@@ -1,9 +1,13 @@
 (ns status-im.contexts.chat.messenger.messages.scroll-to-bottom.style
-  (:require [status-im.contexts.shell.jump-to.constants :as shell.constants]))
+  (:require [react-native.safe-area :as safe-area]
+            [status-im.contexts.shell.jump-to.constants :as shell.constants]))
 
-(def shell-button-container
+(defn shell-button-container
+  [able-to-send-messages?]
   {:z-index 1
-   :bottom  shell.constants/floating-shell-button-height})
+   :bottom  (+ (safe-area/get-bottom)
+               (when-not able-to-send-messages? 46)
+               shell.constants/floating-shell-button-height)})
 
 (def scroll-to-bottom-button
   {:position :absolute

--- a/src/status_im/contexts/chat/messenger/messages/scroll_to_bottom/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/scroll_to_bottom/view.cljs
@@ -12,8 +12,9 @@
         scroll-down-button-opacity (worklets/scroll-down-button-opacity
                                     chat-list-scroll-y
                                     false
-                                    window-height)]
-    [rn/view {:style style/shell-button-container}
+                                    window-height)
+        able-to-send-message?      (rf/sub [:chats/able-to-send-message?])]
+    [rn/view {:style (style/shell-button-container able-to-send-message?)}
      [quo/floating-shell-button
       {:scroll-to-bottom {:on-press #(rf/dispatch [:chat.ui/scroll-to-bottom])}}
       style/scroll-to-bottom-button


### PR DESCRIPTION
fixes #21384
fixes #18554

### Summary

This PR fixes the modal shown for non-members that sent a message in a community in a chat:

https://github.com/user-attachments/assets/63096804-9136-465a-8078-4e9d2faa8fe9

There are some missing options, such as "forward", but they haven't been implemented yet.

Addintionally fixes:
- #21384

iOS | Android
<img src="https://github.com/user-attachments/assets/363905db-3b0c-49e6-9168-73a867b5aaf7" height="600"> <img src="https://github.com/user-attachments/assets/21a9b226-4af0-4165-b773-86dd5ebdd0c4" height="600">

#### Platforms

- Android
- iOS

status: ready