### PR TITLE
fix(wallet)_: price not found on swap

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v3.6.0",
-    "commit-sha1": "00a8a72ac2cc0933503cdf88cc5eafa45ab5e182",
-    "src-sha256": "0ka6c7bg8mnwqpyn8rv15cba537vp2fm8yxlyl5s17lwai5hqnk5"
+    "version": "fix/swap-bridge-sending",
+    "commit-sha1": "758c477b43d081afbd24d3598ac0b2971f91b112",
+    "src-sha256": "1mcxm2rnwbly8xjapp65nhdr9z10y63cnvridxpfiw55f3ssinpb"
 }


### PR DESCRIPTION
fixes #21555

### Summary

This PR fixes the `Price route not found` error thrown on performing ERC20 Bridge and Swap transactions

Status-go PR: https://github.com/status-im/status-go/pull/6059






status: ready 
