### PR TITLE
chore(perf): Do not convert response from wakuext_startMessenger to CLJS

### DIFF
--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -53,9 +53,10 @@
             pairing-completed?
             (dissoc :syncing))
       :fx (into [[:json-rpc/call
-                  [{:method     "wakuext_startMessenger"
-                    :on-success [:profile.login/messenger-started]
-                    :on-error   #(log/error "failed to start messenger" %)}]]
+                  [{:method      "wakuext_startMessenger"
+                    :js-response true
+                    :on-success  [:profile.login/messenger-started]
+                    :on-error    #(log/error "failed to start messenger" %)}]]
                  [:dispatch [:community/fetch]]
 
                  ;; Wallet initialization can be delayed a little bit because we


### PR DESCRIPTION
### Summary

A one-liner PR that can help with potential freezes right after login, especially in low-end devices with lots of data.

### Implementation

The default behavior for the effect `:json-rpc/call` is to transform the response to CLJS data using `(js->clj data :keywordize-keys true)`, even if the result is never used. The problem is that the response from `wakuext_startMessenger` can be a very large struct! This PR simply adds the missing line `:js-response true`.

https://github.com/status-im/status-mobile/blob/ca22b67d0e82a3cb123be2174b3ef2157e676e08/src/status_im/common/json_rpc/events.cljs#L85-L87

```go
type MessengerResponse struct {
	Contacts                      []*Contact
	Invitations                   []*GroupChatInvitation
	CommunityChanges              []*communities.CommunityChanges
	AnonymousMetrics              []*appmetrics.AppMetric
	Mailservers                   []mailservers.Mailserver
	CommunityStorenodes           []storenodes.Storenode
	Bookmarks                     []*browsers.Bookmark
	Settings                      []*settings.SyncSettingField
	IdentityImages                []images.IdentityImage
	CustomizationColor            string
	WatchOnlyAccounts             []*accounts.Account
	Keypairs                      []*accounts.Keypair
	AccountsPositions             []*accounts.Account
	TokenPreferences              []walletsettings.TokenPreferences
	CollectiblePreferences        []walletsettings.CollectiblePreferences
	DiscordCategories             []*discord.Category
	DiscordChannels               []*discord.Channel
	DiscordOldestMessageTimestamp int
	BackupHandled                 bool

	// notifications a list of notifications derived from messenger events
	// that are useful to notify the user about
	installations                    map[string]*multidevice.Installation
	notifications                    map[string]*localnotifications.Notification
	requestsToJoinCommunity          map[string]*communities.RequestToJoin
	chats                            map[string]*Chat
	removedChats                     map[string]bool
	removedMessages                  map[string]*RemovedMessage
	deletedMessages                  map[string]string
	communities                      map[string]*communities.Community
	communitiesSettings              map[string]*communities.CommunitySettings
	activityCenterNotifications      map[string]*ActivityCenterNotification
	activityCenterState              *ActivityCenterState
	messages                         map[string]*common.Message
	pinMessages                      map[string]*common.PinMessage
	discordMessages                  map[string]*protobuf.DiscordMessage
	discordMessageAttachments        map[string]*protobuf.DiscordMessageAttachment
	discordMessageAuthors            map[string]*protobuf.DiscordMessageAuthor
	currentStatus                    *UserStatus
	statusUpdates                    map[string]UserStatus
	clearedHistories                 map[string]*ClearedHistory
	verificationRequests             map[string]*verification.Request
	trustStatus                      map[string]verification.TrustStatus
	emojiReactions                   map[string]*EmojiReaction
	savedAddresses                   map[string]*wallet.SavedAddress
	ensUsernameDetails               []*ensservice.UsernameDetail
	updatedProfileShowcaseContactIDs map[string]bool
	seenAndUnseenMessages            map[string]*SeenUnseenMessages
}
```

#### Areas that may be impacted

None.

### Steps to test

I did a manual test to login. The change should be 100% safe with no need for QA.

status: ready