### PR TITLE
[#21615] fix: hide mercuryo provider

### DIFF
--- a/src/status_im/contexts/wallet/sheets/buy_token/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/buy_token/view.cljs
@@ -49,6 +49,7 @@
                   (rf/dispatch [:wallet/get-crypto-on-ramps])))
   (let [crypto-on-ramps                 (rf/sub [:wallet/crypto-on-ramps])
         account                         (rf/sub [:wallet/current-viewing-account-or-default])
+        has-recurrent?                  (seq (:recurrent crypto-on-ramps))
         [selected-tab set-selected-tab] (rn/use-state initial-tab)
         [min-height set-min-height]     (rn/use-state 0)
         on-layout                       (rn/use-callback
@@ -56,18 +57,27 @@
                                            (oops/oget % :nativeEvent :layout :height)))]
     [:<>
      [quo/drawer-top {:title (or title (i18n/label :t/ways-to-buy-assets))}]
-     [quo/segmented-control
-      {:size            32
-       :container-style style/tabs
-       :default-active  initial-tab
-       :on-change       set-selected-tab
-       :data            tabs}]
-     [rn/flat-list
-      {:data        (if (= selected-tab :recurrent)
-                      (:recurrent crypto-on-ramps)
-                      (:one-time crypto-on-ramps))
-       :on-layout   on-layout
-       :style       (style/list-container min-height)
-       :render-data {:tab     selected-tab
-                     :account account}
-       :render-fn   crypto-on-ramp-item}]]))
+     (when has-recurrent?
+       [:<>
+        [quo/segmented-control
+         {:size            32
+          :container-style style/tabs
+          :default-active  initial-tab
+          :on-change       set-selected-tab
+          :data            tabs}]
+        [rn/flat-list
+         {:data        (if (= selected-tab :recurrent)
+                         (:recurrent crypto-on-ramps)
+                         (:one-time crypto-on-ramps))
+          :on-layout   on-layout
+          :style       (style/list-container min-height)
+          :render-data {:tab     selected-tab
+                        :account account}
+          :render-fn   crypto-on-ramp-item}]])
+     (when-not has-recurrent?
+       [rn/flat-list
+        {:data        (:one-time crypto-on-ramps)
+         :on-layout   on-layout
+         :style       (style/list-container min-height)
+         :render-data {:account account}
+         :render-fn   crypto-on-ramp-item}])]))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v3.10.0",
-    "commit-sha1": "906c50bf26ef85b9a15eb3b640a6cbe2e1071260",
-    "src-sha256": "05di85jgy2avnl6y1pgx1kzqng9k068braj5fhaknpalm8yyln7k"
+    "version": "fix/hide-mercuryo-provider",
+    "commit-sha1": "2d4174571d1d536ac88d5756b90d4864df120336",
+    "src-sha256": "1j6l1s3dqr8qmh6ikh26n9bfx8cxnp75fg0ljx7k1x4yv9r4h68x"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "fix/hide-mercuryo-provider",
-    "commit-sha1": "43056094932b9b15cce5827a19dafc27cf8160a6",
-    "src-sha256": "08hdi66wq9zxkih2a84526a96qzq9fsnq4p8qdf9bk340y1sgsrj"
+    "version": "v4.0.0",
+    "commit-sha1": "032eb5b6ee71b675b7d1d63198e79e2c18063654",
+    "src-sha256": "06qffndymgl80c08w96rs02ycxigai7y06d7ljwrkfr4brc86r21"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "fix/hide-mercuryo-provider",
-    "commit-sha1": "2d4174571d1d536ac88d5756b90d4864df120336",
-    "src-sha256": "1j6l1s3dqr8qmh6ikh26n9bfx8cxnp75fg0ljx7k1x4yv9r4h68x"
+    "commit-sha1": "43056094932b9b15cce5827a19dafc27cf8160a6",
+    "src-sha256": "08hdi66wq9zxkih2a84526a96qzq9fsnq4p8qdf9bk340y1sgsrj"
 }


### PR DESCRIPTION
fixes #21615

### Summary

hide Mercuryo from the list of on-ramp providers
so that we stay compliant with UK law.

Note: it only has [status-go changes](https://github.com/status-im/status-go/pull/6100)


#### Areas that maybe impacted

- Ways to buy asset modal

### Result

<img src="https://github.com/user-attachments/assets/407feb76-2849-43a2-a985-ab0495dbd133" width="390px"/>


status: ready 