### PR TITLE
[#21476] Part 3 - Extra fixes

### DIFF
--- a/src/quo/components/common/no_flicker_image.cljs
+++ b/src/quo/components/common/no_flicker_image.cljs
@@ -36,10 +36,11 @@
   "Same as rn/image but cache the image source in a js/Set, so the image won't
   flicker when re-render on android"
   [props]
-  (let [[loaded-source set-loaded-source] (rn/use-state nil)
-        on-source-loaded                  (rn/use-callback #(set-loaded-source %))]
+  (let [[loaded-source set-loaded-source] (rn/use-state nil)]
     (if platform/ios?
       [rn/image props]
       [:<>
-       [rn/image (assoc props :source loaded-source)]
-       [caching-image props on-source-loaded]])))
+       [rn/image
+        (cond-> props
+          loaded-source (assoc :source loaded-source))]
+       [caching-image props set-loaded-source]])))

--- a/src/status_im/common/standard_authentication/password_input/view.cljs
+++ b/src/status_im/common/standard_authentication/password_input/view.cljs
@@ -4,6 +4,7 @@
     [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
+    [status-im.common.biometric.utils :as biometric]
     [status-im.common.standard-authentication.forgot-password-doc.view :as forgot-password-doc]
     [status-im.common.standard-authentication.password-input.style :as style]
     [utils.debounce :as debounce]
@@ -54,7 +55,8 @@
                                      {:password (security/mask-data
                                                  entered-password)
                                       :error    ""}]
-                                    100)))]
+                                    100)))
+        biometric-type          (rf/sub [:biometrics/supported-type])]
     [:<>
      [rn/view {:style {:flex-direction :row}}
       [quo/input
@@ -76,6 +78,6 @@
           :icon-only?      true
           :background      (when blur? :blur)
           :type            :outline}
-         :i/face-id])]
+         (biometric/get-icon-by-type biometric-type)])]
      (when error?
        [error-info error-message processing shell?])]))

--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -3,6 +3,7 @@
     [quo.core :as quo]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
+    [status-im.common.biometric.utils :as biometric]
     [status-im.constants :as constants]
     [utils.re-frame :as rf]))
 
@@ -26,12 +27,15 @@
                                           :on-auth-success       on-auth-success
                                           :on-auth-fail          on-auth-fail
                                           :auth-button-label     auth-button-label}]))
-                         (vec (conj dependencies on-auth-success on-auth-fail)))]
+                         (vec (conj dependencies on-auth-success on-auth-fail)))
+        biometric-type  (rf/sub [:biometrics/supported-type])]
     [quo/slide-button
      {:container-style     container-style
       :size                size
       :customization-color customization-color
       :on-complete         on-complete
-      :track-icon          (if biometric-auth? :i/face-id :password)
+      :track-icon          (if biometric-auth?
+                             (biometric/get-icon-by-type biometric-type)
+                             :password)
       :track-text          track-text
       :disabled?           disabled?}]))

--- a/src/status_im/contexts/onboarding/enable_biometrics/view.cljs
+++ b/src/status_im/contexts/onboarding/enable_biometrics/view.cljs
@@ -10,7 +10,6 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-
 (defn page-title
   []
   [quo/text-combinations
@@ -26,12 +25,13 @@
         bio-type-label           (biometric/get-label-by-type supported-biometric-type)
         profile-color            (or (:color (rf/sub [:onboarding/profile]))
                                      (rf/sub [:profile/customization-color]))
-        syncing-results?         (= :screen/onboarding.syncing-results @state/root-id)]
+        syncing-results?         (= :screen/onboarding.syncing-results @state/root-id)
+        biometric-type           (rf/sub [:biometrics/supported-type])]
     [rn/view {:style (style/buttons insets)}
      [quo/button
       {:size                40
        :accessibility-label :enable-biometrics-button
-       :icon-left           :i/face-id
+       :icon-left           (biometric/get-icon-by-type biometric-type)
        :customization-color profile-color
        :on-press            #(rf/dispatch [:onboarding/enable-biometrics])}
       (i18n/label :t/biometric-enable-button {:bio-type-label bio-type-label})]


### PR DESCRIPTION
fixes #21476

### Summary

While solving:
- https://github.com/status-im/status-mobile/pull/21628

Some extra fixes were applied, to make the review easier I split them in a different PR, This PR solves:

1. An always shown warning in the login screen about `null` not being an image. This error probably happened in other places too

2. The authentication icons, now they show face-id when the device supports it, otherwise it shows the fingerprint icon


status: ready