### PR TITLE
fix(wallet)_: Paraswap contract address

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -605,7 +605,7 @@
   {:name                     :paraswap
    :full-name                "ParaSwap"
    :color                    :blue
-   :contract-address         "0xdef171fe48cf0115b1d80b88dc8eab59176fee57"
+   :contract-address         "0x6a000f20005980200259b80c5102003040001068"
    :terms-and-conditions-url "https://files.paraswap.io/tos_v4.pdf"})
 (def ^:const swap-providers
   {:paraswap swap-provider-paraswap})

--- a/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
@@ -148,10 +148,12 @@
 
 (defn- spender-contract-section
   []
-  (let [theme            (quo.theme/use-theme)
-        network          (rf/sub [:wallet/swap-network])
-        provider         (rf/sub [:wallet/swap-proposal-provider])
-        network-chain-id (:chain-id network)]
+  (let [theme                    (quo.theme/use-theme)
+        network                  (rf/sub [:wallet/swap-network])
+        provider                 (rf/sub [:wallet/swap-proposal-provider])
+        spender-contract-address (or (rf/sub [:wallet/swap-proposal-approval-contract-address])
+                                     (:contract-address provider))
+        network-chain-id         (:chain-id network)]
     [rn/view {:style style/summary-section-container}
      [quo/text
       {:size                :paragraph-2
@@ -164,10 +166,10 @@
         {:type            :token-contract
          :option-icon     :i/options
          :on-option-press #(on-option-press {:chain-id         network-chain-id
-                                             :contract-address (:contract-address provider)})
+                                             :contract-address spender-contract-address})
          :unlimited-icon? false
          :label           (:full-name provider)
-         :description     (address-utils/get-short-wallet-address (:contract-address provider))
+         :description     (address-utils/get-short-wallet-address spender-contract-address)
          :avatar-props    {:image (resources/get-network (:name provider))}}])]))
 
 (defn- data-item

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -228,6 +228,11 @@
  :-> :approval-required)
 
 (rf/reg-sub
+ :wallet/swap-proposal-approval-contract-address
+ :<- [:wallet/swap-proposal]
+ :-> :approval-contract-address)
+
+(rf/reg-sub
  :wallet/swap-proposal-approval-amount-required
  :<- [:wallet/swap-proposal]
  :-> :approval-amount-required)


### PR DESCRIPTION

### Summary

This PR fixes ParaSwap contract address displayed on the setting approval cap for a token. Since, we use ParaSwap v6.2, the contract address is changed.

|  Before   | After
| --- | --- | 
| <img width="250" src="https://github.com/user-attachments/assets/30ec6f82-428b-493c-b93d-6fd9def7d39b" />  | <img width="250" src="https://github.com/user-attachments/assets/bade81fe-f1eb-4918-b96e-f6172ed9b7b5" /> | 


### Review notes

Since we get the approval contract address in the swap proposal, we take that as higher precedence over the hardcoded value in the constants file.


### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to Swap flow
- Set a spending cap for a token
- Verify the contract address for ParaSwap is `0x6a000f20005980200259b80c5102003040001068`

status: ready


