### PR TITLE
fix: avoid re-renders inside contact-list for new-chat sheet

### DIFF
--- a/src/status_im/common/bottom_sheet_screen/view.cljs
+++ b/src/status_im/common/bottom_sheet_screen/view.cljs
@@ -47,7 +47,8 @@
         animating?          (reagent/atom true)
         set-animating-true  #(reset! animating? true)
         set-animating-false (fn [ms]
-                              (js/setTimeout #(reset! animating? false) ms))]
+                              (js/setTimeout #(reset! animating? false) ms))
+        on-scroll-update    #(on-scroll % curr-scroll)]
     (fn [{:keys [content skip-background?]}]
       (let [theme                    (quo.theme/use-theme)
             {:keys [top] :as insets} (safe-area/get-insets)
@@ -94,5 +95,5 @@
              :close            close
              :scroll-enabled?  scroll-enabled?
              :current-scroll   curr-scroll
-             :on-scroll        #(on-scroll % curr-scroll)
+             :on-scroll        on-scroll-update
              :sheet-animating? animating?}]]]]))))

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -86,7 +86,7 @@
      item]))
 
 (defn view
-  [{:keys [scroll-enabled? on-scroll close]}]
+  [{:keys [on-scroll close]}]
   (let [theme                             (quo.theme/use-theme)
         contacts                          (rf/sub [:contacts/sorted-and-grouped-by-first-letter])
         selected-contacts-count           (rf/sub [:selected-contacts-count])
@@ -137,7 +137,6 @@
          :render-section-footer-fn contact-list/contacts-section-footer
          :content-container-style  {:padding-bottom 70}
          :render-fn                render-fn
-         :scroll-enabled           @scroll-enabled?
          :on-scroll                on-scroll}])
      (when contacts-selected?
        [rn/view

--- a/src/status_im/contexts/chat/home/new_chat/view.cljs
+++ b/src/status_im/contexts/chat/home/new_chat/view.cljs
@@ -70,7 +70,7 @@
         (re-frame/dispatch [:select-contact public-key])))))
 
 (defn contact-item-render
-  [{:keys [public-key] :as item} set-has-error]
+  [{:keys [public-key] :as item} _ _ {:keys [set-has-error]}]
   (let [user-selected? (rf/sub [:is-contact-selected? public-key])
         on-toggle      (fn []
                          (-> public-key
@@ -94,9 +94,6 @@
         customization-color               (rf/sub [:profile/customization-color])
         one-contact-selected?             (= selected-contacts-count 1)
         [has-error? set-has-error]        (rn/use-state false)
-        render-fn                         (rn/use-callback (fn [item]
-                                                             (contact-item-render item set-has-error))
-                                                           [set-has-error])
         contacts-selected?                (pos? selected-contacts-count)
         {:keys [primary-name public-key]} (when one-contact-selected?
                                             (rf/sub [:contacts/contact-by-identity
@@ -136,7 +133,8 @@
          :render-section-header-fn contact-list/contacts-section-header
          :render-section-footer-fn contact-list/contacts-section-footer
          :content-container-style  {:padding-bottom 70}
-         :render-fn                render-fn
+         :render-fn                contact-item-render
+         :render-data              {:set-has-error set-has-error}
          :on-scroll                on-scroll}])
      (when contacts-selected?
        [rn/view

--- a/src/utils/image_server.cljs
+++ b/src/utils/image_server.cljs
@@ -74,7 +74,7 @@
   `ring?` shows or hides ring for account with ens name"
   [{:keys [port public-key image-name key-uid size theme indicator-size
            indicator-border indicator-center-to-edge indicator-color ring?
-           ring-width ratio]}]
+           ring-width ratio clock]}]
   (str
    image-server-uri-prefix
    port
@@ -90,7 +90,7 @@
    "&theme="
    (current-theme-index theme)
    "&clock="
-   (timestamp)
+   clock
    "&indicatorColor="
    (js/encodeURIComponent indicator-color)
    "&indicatorSize="
@@ -118,7 +118,7 @@
   [{:keys [port public-key key-uid theme ring? length size customization-color
            color font-size font-file uppercase-ratio indicator-size
            indicator-border indicator-center-to-edge indicator-color full-name
-           ring-width ratio]}]
+           ring-width ratio clock]}]
   (str
    image-server-uri-prefix
    port
@@ -144,9 +144,9 @@
    "&theme="
    (current-theme-index theme)
    "&clock="
+   clock
    "&name="
    (js/encodeURIComponent full-name)
-   (timestamp)
    "&indicatorColor="
    (js/encodeURIComponent indicator-color)
    "&indicatorSize="

--- a/src/utils/image_server.cljs
+++ b/src/utils/image_server.cljs
@@ -7,8 +7,7 @@
     [react-native.fs :as utils.fs]
     [react-native.platform :as platform]
     [schema.core :as schema]
-    [status-im.config :as config]
-    [utils.datetime :as datetime]))
+    [status-im.config :as config]))
 
 (def ^:const image-server-uri-prefix config/STATUS_BACKEND_SERVER_IMAGE_SERVER_URI_PREFIX)
 (def ^:const account-images-action "/accountImages")
@@ -39,8 +38,6 @@
     (callback (str (utils.fs/main-bundle-path)
                    "/"
                    font-file-name))))
-
-(defn timestamp [] (datetime/timestamp))
 
 (defn current-theme-index
   [theme]

--- a/src/utils/image_server_test.cljs
+++ b/src/utils/image_server_test.cljs
@@ -6,8 +6,7 @@
 
 (t/deftest get-account-image-uri-test
   (with-redefs
-    [sut/current-theme-index identity
-     sut/timestamp           (constantly "timestamp")]
+    [sut/current-theme-index identity]
     (t/is
      (=
       (sut/get-account-image-uri {:port                     "port"
@@ -15,6 +14,7 @@
                                   :ratio                    2
                                   :image-name               "image-name"
                                   :key-uid                  "key-uid"
+                                  :clock                    "timestamp"
                                   :theme                    :dark
                                   :indicator-size           2
                                   :indicator-color          "rgba(9,16,28,0.08)"
@@ -26,8 +26,7 @@
 (t/deftest get-account-initials-uri-test
   (with-redefs
     [sut/current-theme-index identity
-     colors/resolve-color    str
-     sut/timestamp           (constantly "timestamp")]
+     colors/resolve-color    str]
     (t/is
      (=
       (sut/get-initials-avatar-uri
@@ -35,6 +34,7 @@
         :public-key               "public-key"
         :ratio                    2
         :key-uid                  "key-uid"
+        :clock                    "timestamp"
         :full-name                "full-name"
         :length                   "length"
         :size                     48
@@ -49,4 +49,4 @@
         :indicator-center-to-edge 6
         :indicator-color          "#0E1620"
         :ring-width               4})
-      "https://localhost:port/accountInitials?publicKey=public-key&keyUid=key-uid&length=length&size=96&bgColor=%3Ablue%3Alight&color=%230E162000&fontSize=24&fontFile=%2Ffont%2FInter%20Medium.otf&uppercaseRatio=0.6&theme=:light&clock=&name=full-nametimestamp&indicatorColor=%230E1620&indicatorSize=4&indicatorBorder=0&indicatorCenterToEdge=12&addRing=1&ringWidth=8"))))
+      "https://localhost:port/accountInitials?publicKey=public-key&keyUid=key-uid&length=length&size=96&bgColor=%3Ablue%3Alight&color=%230E162000&fontSize=24&fontFile=%2Ffont%2FInter%20Medium.otf&uppercaseRatio=0.6&theme=:light&clock=timestamp&name=full-name&indicatorColor=%230E1620&indicatorSize=4&indicatorBorder=0&indicatorCenterToEdge=12&addRing=1&ringWidth=8"))))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes https://github.com/status-im/status-mobile/issues/20532

### Summary

* This PR attempts to fix the contact list re-rendering issue when panning in the contact list or selecting a contact from the contact list inside the New Chat screen.
  * It seems that the contact-list is inside a bottom-sheet, and the bottom-sheet supports a drag gesture for closing the sheet. When this gesture occurs, it seems we attempt to prevent scrolling in the scroll-view by setting `:scroll-enabled` to `false`. However, when this prop is changed the scroll-view will re-render all the list items, which can cause the contact images to flicker and it seems to interfere with selecting a contact.
    * Here's a snippet of the code that handles setting the `scroll-enabled` reagent atom: https://github.com/status-im/status-mobile/blob/014f44683554ae7678b875a1ca14e452c01154c4/src/status_im/common/bottom_sheet_screen/view.cljs#L16-L36
  * One solution would be to re-write the drag gesture or the composition of the gesture handler with a scroll view. It's possible this could be done in a way that avoids disabling the scrolling and causing a re-render in the scroll-view.
  * Another solution would be to avoid setting `scroll-enabled` for the contact list, which solves the re-rendering issue, but does not allow the drag gesture to override the scroll gesture.
  * In this PR we currently use the second approach, which matches the way we implement this functionality for the manage-embers screen for group chats.
    * Note, the drag gesture still will work on the top portion of the bottom-sheet, and the user can still close the sheet by pressing the "X" icon.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Creating a new-chat

### Steps to test
- Open the Status Mobile app
- Login to a profile
- Navigate to the messenger home screen
- Press the "+" icon and select "New Chat" from the bottom drawer
- If there's a contact list with many contacts, attempt to scroll the contact list by scrolling up and down
- Attempt to select a contact from the contact list
- Attempt to close the bottom-sheet by pulling the top of the bottom sheet down

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

Note, that in these screen recordings I've intentionally duplicated my contacts in the contact list because I didn't have enough contacts added to my profiles. So that's why there's repeated data and multiple items selected when selecting a single contact.

| Status  | iOS (if available)    | Android (if available)
| --- | --- | --- |
| Before |  <video src="https://github.com/user-attachments/assets/81181dd2-5d37-46cc-8696-bc12477c3d04" /> | <video src="https://github.com/user-attachments/assets/83ebf959-f086-4119-a57f-e1a83ea8b4e9" />  |
| After  | <video src="https://github.com/user-attachments/assets/7fbb8e10-fb81-4044-9d88-f65f000ca447" />  | <video src="https://github.com/user-attachments/assets/46f27d41-530b-4f20-a54c-b10d4bfdd57e" /> |

status: ready <!-- Can be ready or wip -->