### PR TITLE
perf: Optimize messenger initialization

### DIFF
--- a/src/legacy/status_im/chat/models/loading.cljs
+++ b/src/legacy/status_im/chat/models/loading.cljs
@@ -34,8 +34,7 @@
                  new-chats-js)]
      {:db (-> db
               (update :chats merge all-chats)
-              (update :chats-home-list into chats-home-list)
-              (assoc :chats/loading? false))})))
+              (update :chats-home-list into chats-home-list))})))
 
 (rf/defn load-chat-success
   {:events [:chats-list/load-chat-success]}

--- a/src/legacy/status_im/chat/models/loading.cljs
+++ b/src/legacy/status_im/chat/models/loading.cljs
@@ -18,25 +18,24 @@
        clock-value
        "0x0000000000000000000000000000000000000000000000000000000000000000"))
 
-(rf/defn update-chats-in-app-db
-  {:events [:chats-list/load-success]}
-  [{:keys [db]} ^js new-chats-js]
-  (let [{:keys [all-chats chats-home-list]}
-        (reduce (fn [acc ^js chat-js]
-                  (let [{:keys [chat-id profile-public-key timeline? community-id active] :as chat}
-                        (data-store.chats/<-rpc-js chat-js)]
-                    (cond-> acc
-                      (and (not profile-public-key) (not timeline?) (not community-id) active)
-                      (update :chats-home-list conj chat-id)
-                      :always
-                      (assoc-in [:all-chats chat-id] chat))))
-                {:all-chats       {}
-                 :chats-home-list #{}}
-                new-chats-js)]
-    {:db (assoc db
-                :chats           all-chats
-                :chats-home-list chats-home-list
-                :chats/loading?  false)}))
+(rf/reg-event-fx :chats-list/load-success
+ (fn [{:keys [db]} [^js new-chats-js]]
+   (let [{:keys [all-chats chats-home-list]}
+         (reduce (fn [acc ^js chat-js]
+                   (let [{:keys [chat-id profile-public-key timeline? community-id active] :as chat}
+                         (data-store.chats/<-rpc-js chat-js)]
+                     (cond-> acc
+                       (and (not profile-public-key) (not timeline?) (not community-id) active)
+                       (update :chats-home-list conj chat-id)
+                       :always
+                       (assoc-in [:all-chats chat-id] chat))))
+                 {:all-chats       {}
+                  :chats-home-list #{}}
+                 new-chats-js)]
+     {:db (-> db
+              (update :chats merge all-chats)
+              (update :chats-home-list into chats-home-list)
+              (assoc :chats/loading? false))})))
 
 (rf/defn load-chat-success
   {:events [:chats-list/load-chat-success]}

--- a/src/legacy/status_im/data_store/chats.cljs
+++ b/src/legacy/status_im/data_store/chats.cljs
@@ -134,9 +134,9 @@
       unmarshal-members))
 
 (re-frame/reg-fx :fetch-chats-preview
- (fn [{:keys [on-success]}]
+ (fn [{:keys [on-success chat-preview-type]}]
    (json-rpc/call {:method      "wakuext_chatsPreview"
-                   :params      []
+                   :params      [chat-preview-type]
                    :js-response true
                    :on-success  #(on-success ^js %)
                    :on-error    #(log/error "failed to fetch chats" 0 -1 %)})))

--- a/src/legacy/status_im/utils/logging/core.cljs
+++ b/src/legacy/status_im/utils/logging/core.cljs
@@ -135,7 +135,6 @@
                                                  :chat/cooldowns
                                                  :chat/last-outgoing-message-sent-at
                                                  :chat/spam-messages-frequency
-                                                 :chats/loading?
                                                  :dimensions/window]))]
       {:logs/archive-logs [db-json
                            (if (= transport :email)

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -76,6 +76,9 @@
 (def ^:const timeline-chat-type 5)
 (def ^:const community-chat-type 6)
 
+(def ^:const chat-preview-type-community 0)
+(def ^:const chat-preview-type-non-community 1)
+
 (def ^:const contact-request-message-state-none 0)
 (def ^:const contact-request-message-state-pending 1)
 (def ^:const contact-request-message-state-accepted 2)

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -42,10 +42,10 @@
          log-level          (or (:log-level settings) config/log-level)
          pairing-completed? (= (get-in db [:syncing :pairing-status]) :completed)
          new-db             (-> db
-                                (assoc :chats/loading?  true
-                                       :profile/profile (merge profile-overview
-                                                               settings
-                                                               {:log-level log-level}))
+                                (assoc :profile/profile
+                                       (merge profile-overview
+                                              settings
+                                              {:log-level log-level}))
                                 (assoc-in [:activity-center :loading?] true)
                                 (dissoc :centralized-metrics/onboarding-enabled?))]
      {:db (cond-> new-db

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -4,6 +4,7 @@
     [native-module.core :as native-module]
     [status-im.common.keychain.events :as keychain]
     [status-im.config :as config]
+    [status-im.constants :as constants]
     status-im.contexts.profile.login.effects
     [status-im.contexts.profile.rpc :as profile.rpc]
     [taoensso.timbre :as log]
@@ -131,10 +132,15 @@
    (let [new-account? (get db :onboarding/new-account?)]
      {:db (assoc db :messenger/started? true)
       :fx [[:fetch-chats-preview
-            {:on-success (fn [result]
-                           (rf/dispatch [:chats-list/load-success result])
-                           (rf/dispatch [:communities/get-user-requests-to-join])
-                           (rf/dispatch [:profile.login/get-chats-callback]))}]
+            {:chat-preview-type constants/chat-preview-type-non-community
+             :on-success        (fn [result]
+                                  (rf/dispatch [:chats-list/load-success result])
+                                  (rf/dispatch [:profile.login/get-chats-callback]))}]
+           [:fetch-chats-preview
+            {:chat-preview-type constants/chat-preview-type-community
+             :on-success        (fn [result]
+                                  (rf/dispatch [:chats-list/load-success result])
+                                  (rf/dispatch [:communities/get-user-requests-to-join]))}]
            (when (and (:syncing/fallback-flow? db) (:syncing/installation-id db))
              [:dispatch [:pairing/finish-seed-phrase-fallback-syncing]])
            (when-not new-account?

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -100,7 +100,6 @@
 (reg-root-key-sub :chats/chats :chats)
 (reg-root-key-sub :chats/current-chat-id :current-chat-id)
 (reg-root-key-sub :public-group-topic :public-group-topic)
-(reg-root-key-sub :chats/loading? :chats/loading?)
 (reg-root-key-sub :new-chat-name :new-chat-name)
 (reg-root-key-sub :chat/inputs :chat/inputs)
 (reg-root-key-sub :chat/memberships :chat/memberships)

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v4.0.0",
-    "commit-sha1": "032eb5b6ee71b675b7d1d63198e79e2c18063654",
-    "src-sha256": "06qffndymgl80c08w96rs02ycxigai7y06d7ljwrkfr4brc86r21"
+    "version": "perf/start_messenger",
+    "commit-sha1": "a4a8bb1fabdf1159a9eb3adf3185c00656caf35e",
+    "src-sha256": "07ncrgcwwy1d7sjd8xvp2ayy5nnh9rx51ylnc5l0vd06vga1ha7r"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "perf/start_messenger",
-    "commit-sha1": "a4a8bb1fabdf1159a9eb3adf3185c00656caf35e",
-    "src-sha256": "07ncrgcwwy1d7sjd8xvp2ayy5nnh9rx51ylnc5l0vd06vga1ha7r"
+    "version": "v6.0.0",
+    "commit-sha1": "83ea49fc04cd521864a64fd2d94d4e5309a81645",
+    "src-sha256": "0f93s1yr8p24aw9ji5wsmq07vf4599nk4bhr55q0ifx0szhabilx"
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/21456

### Summary

This PR integrates the optimizations coming from the status-go PR https://github.com/status-im/status-go/pull/6106. Now messenger filters are set-up concurrently and we can call the endpoint `wakuext_chatsPreview` twice: once for non-community chats and once for community chats. This way, the user should be able to see some data render before the slow part ends (community-related data). All the hard work is in status-go and executed by @qfrank 

#### Areas that may be impacted

- Login
- Loading of data after login (contacts, chats, etc)

### Steps to test

We need to check two cases for regression (functional and non-functional):

1. You login with a profile with many contacts, chats, opened/joined communities, notifications, etc. If you see all the data after login there's no functional regression.

2. Login with a profile with loads of data and roughly compare the time to see data arrive at different screens (contacts, opened/joined communities, etc) compared to `develop`. In theory, non-community data (e.g. 1:1 chats) can now arrive earlier and doesn't need to wait for the longer times to set-up filters related to community chats. Whichever call to status-go returns first will immediately trigger the client code to render the data.

I already superficially tested both cases, but more extensive QA would be good.

status: ready
