### PR TITLE
fix Unable to tap on chats/channels after opening profile link

### DIFF
--- a/src/legacy/status_im/qr_scanner/core.cljs
+++ b/src/legacy/status_im/qr_scanner/core.cljs
@@ -62,7 +62,7 @@
     (cond
       (and public-key own)
       (rf/merge cofx
-                {:pop-to-root-fx :shell-stack}
+                (navigation/pop-to-root :shell-stack)
                 (navigation/navigate-to :my-profile nil))
 
       (and public-key (not own))

--- a/src/status_im/common/universal_links.cljs
+++ b/src/status_im/common/universal_links.cljs
@@ -74,7 +74,7 @@
   (cond
     (and public-key (own-public-key? db public-key))
     (rf/merge cofx
-              {:pop-to-root-fx :shell-stack}
+              (navigation/pop-to-root :shell-stack)
               (navigation/navigate-to :settings nil))
 
     public-key

--- a/src/status_im/contexts/chat/messenger/messages/navigation/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/navigation/view.cljs
@@ -103,7 +103,13 @@
         :background          :blur
         :size                32
         :accessibility-label :back-button
-        :on-press            #(rf/dispatch [:navigate-back])}
+        :on-press            (fn []
+                               (rf/dispatch [:navigate-back])
+                               ;; In IOS view-id might be incorrect (if screen closed using swipe),
+                               ;; so we can't rely on `:navigate-back` to close the chat.
+                               ;; https://github.com/status-im/status-mobile/pull/21643#issuecomment-248896204451
+                               (when platform/ios?
+                                 (rf/dispatch [:chat/close])))}
        (if (= chat-type constants/community-chat-type) :i/arrow-left :i/close)]
       [header-content-container chat]
       [quo/button

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -3,6 +3,7 @@
     [clojure.string :as string]
     [re-frame.core :as re-frame]
     [react-native.core :as react]
+    [react-native.platform :as platform]
     [utils.re-frame :as rf]
     [utils.url :as url]))
 
@@ -50,7 +51,8 @@
   {:events [:navigate-back]}
   [{:keys [db]}]
   {:fx [[:navigate-back nil]
-        (when (= (:view-id db) :chat)
+        ;; Required for navigating back using the Android hardware back button
+        (when (and platform/android? (= (:view-id db) :chat))
           [:dispatch [:chat/close]])]})
 
 (rf/defn navigate-back-to


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21065

### Summary

We need to ensure that the chat is properly closed when popping to the root. This was not happening previously because, for universal links, we were directly calling the `pop-to-root-fx` instead of the `pop-to-root` event, which is responsible for closing the chat, as mentioned in the [comment](https://github.com/status-im/status-mobile/pull/21142#discussion_r1735986515).

status: ready