### PR TITLE
fix_: use 24h batches to retrieve message history

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v6.1.0",
-    "commit-sha1": "c014fbfc1ec739aad2db951fdcff6182d4dbd919",
-    "src-sha256": "16im0nc8zri5z1wvzbh83331g02iy305m2lca4ljjgdmlaq6l2zx"
+    "version": "35e4c9e11c620caffec3db5052831a61e177a8fc",
+    "commit-sha1": "35e4c9e11c620caffec3db5052831a61e177a8fc",
+    "src-sha256": "0k6xz65ivab5bl150hscyhkmsp0yfhb15gl05rbjgvrlp14d7vpq"
 }


### PR DESCRIPTION
Instead of retrieving 30d of messages, split the request in 24h batches. 
Requires: https://github.com/status-im/status-go/pull/6115

To test this:
Ensure that profiles restore from backup successfully, as well as curated communities, and message history older than 24h