### PR TITLE
fix(group-chat): Missing group chat name when clearing chat history

### DIFF
--- a/src/status_im/common/home/actions/view.cljs
+++ b/src/status_im/common/home/actions/view.cljs
@@ -159,10 +159,10 @@
           :add-divider?        needs-divider?}))
 
 (defn clear-history-entry
-  [chat-id needs-divider?]
+  [chat needs-divider?]
   (entry {:icon                :i/delete
           :label               (i18n/label :t/clear-history)
-          :on-press            #(clear-history-action chat-id)
+          :on-press            #(clear-history-action chat)
           :danger?             true
           :sub-label           nil
           :accessibility-label :clear-history

--- a/src/status_im/subs/chats.cljs
+++ b/src/status_im/subs/chats.cljs
@@ -171,29 +171,26 @@
      chat.events/public-chat?    :public-chat
      :chat)))
 
-(re-frame/reg-sub
- :chats/current-chat-chat-view
+(re-frame/reg-sub :chats/current-chat-chat-view
  :<- [:chats/current-chat]
- (fn [current-chat]
-   (assoc
-    (select-keys current-chat
-                 [:chat-id
-                  :able-to-send-message?
-                  :group-chat
-                  :admins
-                  :invitation-admin
-                  :public?
-                  :chat-type
-                  :color
-                  :contact-request-state
-                  :chat-name
-                  :synced-to
-                  :synced-from
-                  :community-id
-                  :emoji
-                  :description])
-    :empty-chat?
-    (not (:last-message current-chat)))))
+ (fn [chat]
+   {:able-to-send-message? (:able-to-send-message? chat)
+    :admins                (:admins chat)
+    :chat-id               (:chat-id chat)
+    :chat-name             (:chat-name chat)
+    :chat-type             (:chat-type chat)
+    :color                 (:color chat)
+    :community-id          (:community-id chat)
+    :contact-request-state (:contact-request-state chat)
+    :description           (:description chat)
+    :emoji                 (:emoji chat)
+    :empty-chat?           (not (:last-message chat))
+    :group-chat            (:group-chat chat)
+    :invitation-admin      (:invitation-admin chat)
+    :name                  (:name chat)
+    :public?               (:public? chat)
+    :synced-from           (:synced-from chat)
+    :synced-to             (:synced-to chat)}))
 
 (re-frame/reg-sub
  :chats/current-chat-exist?


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/21639

### Summary

Fix missing group name when user chooses drawer option to clear chat history from within the group chat screen.

### Areas that may be impacted

Chat option to clear history.

### Steps to test

Please refer to the reproduction steps specified in the issue. With the fix applied, you should see the group chat name in the drawer when you try to clear the history from the list of group chats and from within each group chat options drawer.

status: ready