### PR TITLE
Feature: add "close community" action to opened/spectated communities

### DIFF
--- a/src/status_im/contexts/communities/actions/community_options/component_spec.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/component_spec.cljs
@@ -130,4 +130,12 @@
                                                             :role-permissions? true}
                    :profile/test-networks-enabled?         false})
     (h/render [options/community-options-bottom-sheet {:id "test"}])
-    (h/is-truthy (h/get-by-translation-text :t/unmute-community))))
+    (h/is-truthy (h/get-by-translation-text :t/unmute-community)))
+
+  (h/test "opened community"
+    (h/setup-subs {:communities/my-pending-request-to-join nil
+                   :communities/community                  {:joined    false
+                                                            :spectated true}
+                   :profile/test-networks-enabled?         false})
+    (h/render [options/community-options-bottom-sheet {:id "test"}])
+    (h/is-truthy (h/get-by-translation-text :t/close-community))))

--- a/src/status_im/contexts/communities/actions/community_options/view.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/view.cljs
@@ -135,7 +135,7 @@
                                                          request-id])}])})
 
 (defn not-joined-options
-  [id token-gated? intro-message test-networks-enabled?]
+  [{:keys [id token-gated? intro-message test-networks-enabled?]}]
   (let [common   [(show-qr id) (share-community id)]
         specific (cond
                    (and token-gated? (not test-networks-enabled?))
@@ -149,16 +149,16 @@
     [(concat specific common)]))
 
 (defn join-request-sent-options
-  [id token-gated? request-id intro-message test-networks-enabled?]
-  [(conj (first (not-joined-options id token-gated? intro-message test-networks-enabled?))
+  [{:keys [id request-id] :as config}]
+  [(conj (first (not-joined-options config))
          (assoc (cancel-request-to-join id request-id) :add-divider? true))])
 
 (defn banned-options
-  [id token-gated? intro-message test-networks-enabled?]
-  (not-joined-options id token-gated? intro-message test-networks-enabled?))
+  [config]
+  (not-joined-options config))
 
 (defn joined-options
-  [id token-gated? muted? muted-till color intro-message]
+  [{:keys [id token-gated? muted? muted-till color intro-message]}]
   [[(view-members id)
     (view-rules id intro-message)
     (when token-gated? (view-token-gating id))
@@ -173,7 +173,7 @@
    [(assoc (leave-community id color) :add-divider? true)]])
 
 (defn owner-options
-  [id token-gated? muted? muted-till intro-message]
+  [{:keys [id token-gated? muted? muted-till intro-message]}]
   [[(view-members id)
     (view-rules id intro-message)
     (when token-gated? (view-token-gating id))
@@ -186,22 +186,22 @@
 
 (defn get-context-drawers
   [{:keys [id]}]
-  (let [{:keys [role-permissions? admin joined
-                muted banList muted-till color
-                intro-message]} (rf/sub [:communities/community id])
-        request-id              (rf/sub [:communities/my-pending-request-to-join id])
-        test-networks?          (rf/sub [:profile/test-networks-enabled?])]
+  (let [{:keys [admin joined banList]
+         :as   community} (rf/sub [:communities/community id])
+        request-id        (rf/sub [:communities/my-pending-request-to-join id])
+        test-networks?    (rf/sub [:profile/test-networks-enabled?])
+        config            (assoc (select-keys community
+                                              [:id :muted :muted-till :color
+                                               :intro-message :spectated
+                                               :role-permissions?])
+                                 :test-networks? test-networks?
+                                 :request-id     request-id)]
     (cond
-      admin
-      (owner-options id role-permissions? muted muted-till intro-message)
-      joined
-      (joined-options id role-permissions? muted muted-till color intro-message)
-      request-id
-      (join-request-sent-options id role-permissions? request-id intro-message test-networks?)
-      banList
-      (banned-options id role-permissions? intro-message test-networks?)
-      :else
-      (not-joined-options id role-permissions? intro-message test-networks?))))
+      admin      (owner-options config)
+      joined     (joined-options config)
+      request-id (join-request-sent-options config)
+      banList    (banned-options config)
+      :else      (not-joined-options config))))
 
 (defn community-options-bottom-sheet
   [id]

--- a/src/status_im/contexts/communities/actions/community_options/view.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/view.cljs
@@ -129,7 +129,7 @@
   {:icon                :i/close-circle
    :label               (i18n/label :t/close-community)
    :accessibility-label :close-community
-   :danger?             false
+   :danger?             true
    :on-press            #(rf/dispatch [:communities/leave id])})
 
 (defn cancel-request-to-join
@@ -157,7 +157,7 @@
     [(concat specific
              common
              (when (and spectated? (not join-pending?))
-               [(close-community id)]))]))
+               [(assoc (close-community id) :add-divider? true)]))]))
 
 (defn join-request-sent-options
   [{:keys [id request-id] :as config}]

--- a/src/status_im/contexts/communities/actions/community_options/view.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/view.cljs
@@ -124,6 +124,14 @@
    :on-press            #(rf/dispatch [:show-bottom-sheet
                                        {:content (fn [] [leave-menu/leave-sheet id color])}])})
 
+(defn close-community
+  [id]
+  {:icon                :i/close-circle
+   :label               (i18n/label :t/close-community)
+   :accessibility-label :close-community
+   :danger?             false
+   :on-press            #(rf/dispatch [:communities/leave id])})
+
 (defn cancel-request-to-join
   [id request-id]
   {:icon                :i/block
@@ -135,7 +143,7 @@
                                                          request-id])}])})
 
 (defn not-joined-options
-  [{:keys [id token-gated? intro-message test-networks-enabled?]}]
+  [{:keys [id join-pending? spectated? token-gated? intro-message test-networks-enabled?]}]
   (let [common   [(show-qr id) (share-community id)]
         specific (cond
                    (and token-gated? (not test-networks-enabled?))
@@ -146,7 +154,10 @@
 
                    (not token-gated?)
                    [(view-members id) (view-rules id intro-message) (invite-contacts id)])]
-    [(concat specific common)]))
+    [(concat specific
+             common
+             (when (and spectated? (not join-pending?))
+               [(close-community id)]))]))
 
 (defn join-request-sent-options
   [{:keys [id request-id] :as config}]
@@ -186,16 +197,23 @@
 
 (defn get-context-drawers
   [{:keys [id]}]
-  (let [{:keys [admin joined banList]
-         :as   community} (rf/sub [:communities/community id])
+  (let [{:keys
+         [id admin joined
+          banList color muted muted-till
+          spectated role-permissions?
+          intro-message]} (rf/sub [:communities/community id])
         request-id        (rf/sub [:communities/my-pending-request-to-join id])
         test-networks?    (rf/sub [:profile/test-networks-enabled?])
-        config            (assoc (select-keys community
-                                              [:id :muted :muted-till :color
-                                               :intro-message :spectated
-                                               :role-permissions?])
-                                 :test-networks? test-networks?
-                                 :request-id     request-id)]
+        config            {:id             id
+                           :color          color
+                           :muted-till     muted-till
+                           :muted?         muted
+                           :spectated?     spectated
+                           :token-gated?   role-permissions?
+                           :intro-message  intro-message
+                           :test-networks? test-networks?
+                           :join-pending?  (boolean request-id)
+                           :request-id     request-id}]
     (cond
       admin      (owner-options config)
       joined     (joined-options config)

--- a/translations/en.json
+++ b/translations/en.json
@@ -395,6 +395,7 @@
   "close-app-title": "Warning!",
   "close-chat": "Close chat",
   "close-chat-confirmation": "This conversation will disappear from the list.\nIt will appear again if the contact sends a new message.",
+  "close-community": "Close community",
   "close-contact-search": "Close contact search",
   "code-snippet": "Code snippet",
   "collectibles": "Collectibles",


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/20594

### Summary

* This PR attempts to resolve an issue with not being able to "close" or leave a community after opening a community. Now communities that are opened, but not joined or pending, will show a "close community" action so that users can remove opened communities from their opened tab list.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Community action drawer


### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile app
- View / open a community
- Open the community action drawer

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### After changes on iOS

https://github.com/user-attachments/assets/b922228c-a3e6-4556-91e9-e53c282925c5

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
