### PR TITLE
[#21323] fix: wrong networks when asset not available in default account

### DIFF
--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -16,7 +16,9 @@
          test-networks-enabled? (get-in db [:profile/profile :test-networks-enabled?])
          view-id                (:view-id db)
          root-screen?           (or (= view-id :wallet-stack) (nil? view-id))
-         account                (or from-account (swap-utils/wallet-account wallet))
+         available-accounts     (utils/get-accounts-with-token-balance (:accounts wallet)
+                                                                       (:asset-to-pay data))
+         account                (or from-account (swap-utils/wallet-account wallet available-accounts))
          asset-to-pay           (if (get-in data [:asset-to-pay :networks])
                                   (:asset-to-pay data)
                                   (swap-utils/select-asset-to-pay-by-symbol
@@ -24,8 +26,7 @@
                                     :account                account
                                     :test-networks-enabled? test-networks-enabled?
                                     :token-symbol           (get-in data [:asset-to-pay :symbol])}))
-         multi-account-balance? (-> (utils/get-accounts-with-token-balance (:accounts wallet)
-                                                                           asset-to-pay)
+         multi-account-balance? (-> available-accounts
                                     (count)
                                     (> 1))
          network'               (or network

--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -21,7 +21,7 @@
          account                (or from-account
                                     (swap-utils/current-viewing-account wallet)
                                     (first available-accounts))
-         asset-to-pay           (if (get-in data [:asset-to-pay :networks])
+         asset-to-pay           (if (and (not from-account) (get-in data [:asset-to-pay :networks]))
                                   (:asset-to-pay data)
                                   (swap-utils/select-asset-to-pay-by-symbol
                                    {:wallet                 wallet

--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -18,7 +18,9 @@
          root-screen?           (or (= view-id :wallet-stack) (nil? view-id))
          available-accounts     (utils/get-accounts-with-token-balance (:accounts wallet)
                                                                        (:asset-to-pay data))
-         account                (or from-account (swap-utils/wallet-account wallet available-accounts))
+         account                (or from-account
+                                    (swap-utils/current-viewing-account wallet)
+                                    (first available-accounts))
          asset-to-pay           (if (get-in data [:asset-to-pay :networks])
                                   (:asset-to-pay data)
                                   (swap-utils/select-asset-to-pay-by-symbol

--- a/src/status_im/contexts/wallet/swap/utils.cljs
+++ b/src/status_im/contexts/wallet/swap/utils.cljs
@@ -30,18 +30,13 @@
     :else
     (i18n/label :t/something-went-wrong-please-try-again-later)))
 
-(defn wallet-account
-  "Picks the account that's gonna be used for the swap operation.
-   It's gonna be either the preselected account defined by
-   `[:wallet :current-viewing-account-address]` in `db`
-   or the first operable account from the list of available accounts (accounts with token balance)."
-  [wallet available-accounts]
-  (if-let [wallet-address (get wallet :current-viewing-account-address)]
+(defn current-viewing-account
+  [wallet]
+  (when-let [wallet-address (get wallet :current-viewing-account-address)]
     (-> wallet
         :accounts
         vals
-        (utils/get-account-by-address wallet-address))
-    (first available-accounts)))
+        (utils/get-account-by-address wallet-address))))
 
 (defn select-asset-to-pay-by-symbol
   "Selects an asset to pay by token symbol.

--- a/src/status_im/contexts/wallet/swap/utils.cljs
+++ b/src/status_im/contexts/wallet/swap/utils.cljs
@@ -33,10 +33,7 @@
 (defn current-viewing-account
   [wallet]
   (when-let [wallet-address (get wallet :current-viewing-account-address)]
-    (-> wallet
-        :accounts
-        vals
-        (utils/get-account-by-address wallet-address))))
+    (get-in wallet [:accounts wallet-address])))
 
 (defn select-asset-to-pay-by-symbol
   "Selects an asset to pay by token symbol.

--- a/src/status_im/contexts/wallet/swap/utils.cljs
+++ b/src/status_im/contexts/wallet/swap/utils.cljs
@@ -30,33 +30,24 @@
     :else
     (i18n/label :t/something-went-wrong-please-try-again-later)))
 
-(defn- first-operable-account
-  [accounts]
-  (->> accounts
-       vals
-       (remove :watch-only?)
-       (filter :operable?)
-       (sort-by :position)
-       first))
-
 (defn wallet-account
-  "Picks the account that's gonna be used for the swap operation. 
-   It's gonna be either the preselected account defined by 
+  "Picks the account that's gonna be used for the swap operation.
+   It's gonna be either the preselected account defined by
    `[:wallet :current-viewing-account-address]` in `db`
-   or the first operable account."
-  [wallet]
+   or the first operable account from the list of available accounts (accounts with token balance)."
+  [wallet available-accounts]
   (if-let [wallet-address (get wallet :current-viewing-account-address)]
     (-> wallet
         :accounts
         vals
         (utils/get-account-by-address wallet-address))
-    (-> wallet :accounts first-operable-account)))
+    (first available-accounts)))
 
 (defn select-asset-to-pay-by-symbol
   "Selects an asset to pay by token symbol.
    It's used for cases when only token symbol is available and the information
-   about token needs to be extracted from the database. 
-   That happens when token is being selected on the home screen and 
+   about token needs to be extracted from the database.
+   That happens when token is being selected on the home screen and
    it basically indicates that no account pre-selection was made."
   [{:keys [wallet account test-networks-enabled? token-symbol]}]
   (let [networks (-> (get-in wallet [:networks (if test-networks-enabled? :test :prod)])
@@ -73,7 +64,7 @@
 
 (defn select-default-asset-to-receive
   "Selects an asset to receive if it was not provided explicitly.
-   The principle of how the asset is being selected is simple: we get the 
+   The principle of how the asset is being selected is simple: we get the
    whole list, remove the currently selected `asset-to-pay` from it, and choose
    the first one of what's left."
   [{:keys [wallet account test-networks-enabled? asset-to-pay]}]
@@ -86,7 +77,7 @@
 (defn select-network
   "Chooses the network.
    Usually user needs to do the selection first and if the selection was done
-   then the list of networks for the defined token will always contain 
+   then the list of networks for the defined token will always contain
    one entry. Otherwise `nil` will be returned from here which will serve
    as an indicator that the network selector needs to be displayed."
   [{:keys [networks]}]


### PR DESCRIPTION
fixes #21323

### Summary

The drawer with networks should display the balances of correct account

#### Areas that maybe impacted

- Swap asset

### Steps to test

- Go to wallet main page
- Long-tap on an asset available only second account, and not present in default account 
- Tap swap option.

### Result

https://github.com/user-attachments/assets/18e8c1ce-0e72-414b-9ca1-8de2e98ed13d



status: ready
