### PR TITLE
fix: ensure keycard pin error message is visible

### DIFF
--- a/src/quo/components/pin_input/view.cljs
+++ b/src/quo/components/pin_input/view.cljs
@@ -6,7 +6,7 @@
             [react-native.core :as rn]))
 
 (defn view
-  [{:keys [number-of-pins number-of-filled-pins error? info]
+  [{:keys [number-of-pins number-of-filled-pins error? info info-error?]
     :or   {number-of-pins 6 number-of-filled-pins 0}}]
   (let [theme (quo.theme/use-theme)]
     [rn/view {:style {:align-items :center}}
@@ -20,7 +20,7 @@
                    (= i (inc number-of-filled-pins)) :active)}])]
      (when info
        [text/text
-        {:style {:color (if error?
+        {:style {:color (if (or error? info-error?)
                           (colors/theme-colors colors/danger-50 colors/danger-60 theme)
                           (colors/theme-colors colors/neutral-50 colors/neutral-40 theme))}
          :size  :paragraph-2}

--- a/src/status_im/contexts/keycard/events.cljs
+++ b/src/status_im/contexts/keycard/events.cljs
@@ -45,6 +45,7 @@
      (when-not (or tag-was-lost? (nil? pin-retries-count))
        {:db (-> db
                 (assoc-in [:keycard :application-info :pin-retry-counter] pin-retries-count)
+                (assoc-in [:keycard :pin :text] "")
                 (assoc-in [:keycard :pin :status] :error))
         :fx [[:dispatch [:keycard/disconnect]]
              (when (zero? pin-retries-count)

--- a/src/status_im/contexts/keycard/pin/enter/view.cljs
+++ b/src/status_im/contexts/keycard/pin/enter/view.cljs
@@ -14,5 +14,4 @@
       {:icon-name :i/close
        :on-press  events-helper/navigate-back}]
      [quo/page-top {:title (i18n/label :t/enter-keycard-pin)}]
-     [rn/view {:style {:flex 1}}]
      [keycard.pin/auth {:on-complete on-complete}]]))

--- a/src/status_im/contexts/keycard/pin/view.cljs
+++ b/src/status_im/contexts/keycard/pin/view.cljs
@@ -29,7 +29,7 @@
         :info                  (when error?
                                  (if (not (string/blank? error-message))
                                    error-message
-                                   (i18n/label :t/pin-retries-left {:number pin-retry-counter})))}]
+                                   (i18n/label-pluralize pin-retry-counter :t/pin-retries-left)))}]
       [quo/numbered-keyboard
        {:delete-key? true
         :on-delete   #(rf/dispatch [:keycard.pin/delete-pressed])

--- a/src/status_im/contexts/keycard/pin/view.cljs
+++ b/src/status_im/contexts/keycard/pin/view.cljs
@@ -25,7 +25,7 @@
        {:blur?                 false
         :number-of-pins        constants/pincode-length
         :number-of-filled-pins (count text)
-        :error?                error?
+        :info-error?           error?
         :info                  (when error?
                                  (if (not (string/blank? error-message))
                                    error-message

--- a/src/status_im/contexts/keycard/pin/view.cljs
+++ b/src/status_im/contexts/keycard/pin/view.cljs
@@ -13,8 +13,14 @@
         pin-retry-counter              (rf/sub [:keycard/pin-retry-counter])
         error?                         (or error? (= status :error))]
     (rn/use-unmount #(rf/dispatch [:keycard.pin/clear]))
-    [rn/view {:padding-bottom 12 :flex 1}
-     [rn/view {:flex 1 :justify-content :center :align-items :center :padding 34}
+    [rn/view
+     {:style {:flex           1
+              :flex-direction :row
+              :align-items    :flex-end}}
+     [rn/view
+      {:style {:flex           1
+               :gap            34
+               :padding-bottom 12}}
       [quo/pin-input
        {:blur?                 false
         :number-of-pins        constants/pincode-length
@@ -23,9 +29,9 @@
         :info                  (when error?
                                  (if (not (string/blank? error-message))
                                    error-message
-                                   (i18n/label :t/pin-retries-left {:number pin-retry-counter})))}]]
-     [quo/numbered-keyboard
-      {:delete-key? true
-       :on-delete   #(rf/dispatch [:keycard.pin/delete-pressed])
-       :on-press    #(rf/dispatch [:keycard.pin/number-pressed % constants/pincode-length
-                                   on-complete])}]]))
+                                   (i18n/label :t/pin-retries-left {:number pin-retry-counter})))}]
+      [quo/numbered-keyboard
+       {:delete-key? true
+        :on-delete   #(rf/dispatch [:keycard.pin/delete-pressed])
+        :on-press    #(rf/dispatch [:keycard.pin/number-pressed % constants/pincode-length
+                                    on-complete])}]]]))

--- a/src/status_im/contexts/keycard/pin/view.cljs
+++ b/src/status_im/contexts/keycard/pin/view.cljs
@@ -15,12 +15,9 @@
     (rn/use-unmount #(rf/dispatch [:keycard.pin/clear]))
     [rn/view
      {:style {:flex           1
-              :flex-direction :row
-              :align-items    :flex-end}}
-     [rn/view
-      {:style {:flex           1
-               :gap            34
-               :padding-bottom 12}}
+              :gap            34
+              :padding-bottom 12}}
+     [rn/view {:style {:flex 1 :justify-content :center :align-items :center}}
       [quo/pin-input
        {:blur?                 false
         :number-of-pins        constants/pincode-length
@@ -29,9 +26,9 @@
         :info                  (when error?
                                  (if (not (string/blank? error-message))
                                    error-message
-                                   (i18n/label-pluralize pin-retry-counter :t/pin-retries-left)))}]
-      [quo/numbered-keyboard
-       {:delete-key? true
-        :on-delete   #(rf/dispatch [:keycard.pin/delete-pressed])
-        :on-press    #(rf/dispatch [:keycard.pin/number-pressed % constants/pincode-length
-                                    on-complete])}]]]))
+                                   (i18n/label-pluralize pin-retry-counter :t/pin-retries-left)))}]]
+     [quo/numbered-keyboard
+      {:delete-key? true
+       :on-delete   #(rf/dispatch [:keycard.pin/delete-pressed])
+       :on-press    #(rf/dispatch [:keycard.pin/number-pressed % constants/pincode-length
+                                   on-complete])}]]))

--- a/src/status_im/contexts/preview/quo/pin_input/pin_input.cljs
+++ b/src/status_im/contexts/preview/quo/pin_input/pin_input.cljs
@@ -11,6 +11,8 @@
     :key  :number-of-filled-pins}
    {:type :boolean
     :key  :error?}
+   {:type :boolean
+    :key  :info-error?}
    {:type :text
     :key  :info}])
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -1981,7 +1981,10 @@
   "pin-one-attempt-blocked-before": "Be careful, you have only",
   "pin-one-attempt-frozen-after": "before your Keycard gets frozen",
   "pin-one-attempt-frozen-before": "Be careful, you have only",
-  "pin-retries-left": "{{number}} attempts left",
+  "pin-retries-left": {
+    "one": "Wrong PIN, 1 attempt left",
+    "other": "Wrong PIN, {{count}} attempts left"
+  },
   "pin-to-channel": "Pin to the channel",
   "pin-to-chat": "Pin to the chat",
   "Pinned-a-message": "Pinned a message",


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21645

### Summary

* This PR attempts to resolve an issue with the keycard PIN error message not being visible after failing to enter the correct PIN. Now the error message should be visible when onboarding with Keycard and sign-in with Keycard.
* This PR also updates the verbiage of the error message to match the designs
* This PR also adds some logic to clear the PIN entry after a PIN error has occurred.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Onboarding - Login with Keycard 
- Login - Login with Keycard

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile app
- Choose to recover profile and login with Keycard
- Scan Keycard
- Enter wrong PIN and scan Keycard again
- Verify error message is visible
- Enter the correct PIN and Scan Keycard
- If successful with recovering the profile, then logout of profile
- Attempt to sign-in to profile with Keycard with wrong PIN
- Verify error message is visible

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### After changes iOS

| Login | Onboard |
|---|---|
| ![IMG_0010](https://github.com/user-attachments/assets/94c34e3e-de1d-4589-84e5-0d029507c33a) | ![IMG_0012](https://github.com/user-attachments/assets/3dfef277-05f4-4b53-92b9-2000ae5632ad) |


#### After changes Android

WIP

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
