### PR TITLE
fix(wallet)_: error on tapping from/to section in tx confirmation screen

### DIFF
--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -286,37 +286,33 @@
            :gradient-cover?          true
            :customization-color      (:color account)}
           [rn/view
-           [rn/pressable
-            {:on-press #(rf/dispatch [:navigate-to-within-stack
-                                      [:screen/wallet.transaction-details
-                                       :screen/wallet.transaction-confirmation]])}
-            [transaction-title
-             {:token-display-name token-symbol
-              :amount             amount
-              :account            account
-              :type               type
-              :recipient          recipient
-              :route              route
-              :to-network         bridge-to-network
-              :image-url          image-url
-              :transaction-type   transaction-type
-              :collectible?       collectible?}]
-            [user-summary
-             {:summary-type        :status-account
-              :accessibility-label :summary-from-label
-              :label               (i18n/label :t/from-capitalized)
-              :account-props       from-account-props
-              :theme               theme}]
-            [user-summary
-             {:summary-type        (if (= transaction-type :tx/bridge)
-                                     :status-account
-                                     :account)
-              :accessibility-label :summary-to-label
-              :label               (i18n/label :t/to-capitalized)
-              :account-props       (if (= transaction-type :tx/bridge)
-                                     from-account-props
-                                     user-props)
-              :recipient           recipient
-              :bridge-tx?          (= transaction-type :tx/bridge)
-              :account-to?         true
-              :theme               theme}]]]]]))))
+           [transaction-title
+            {:token-display-name token-symbol
+             :amount             amount
+             :account            account
+             :type               type
+             :recipient          recipient
+             :route              route
+             :to-network         bridge-to-network
+             :image-url          image-url
+             :transaction-type   transaction-type
+             :collectible?       collectible?}]
+           [user-summary
+            {:summary-type        :status-account
+             :accessibility-label :summary-from-label
+             :label               (i18n/label :t/from-capitalized)
+             :account-props       from-account-props
+             :theme               theme}]
+           [user-summary
+            {:summary-type        (if (= transaction-type :tx/bridge)
+                                    :status-account
+                                    :account)
+             :accessibility-label :summary-to-label
+             :label               (i18n/label :t/to-capitalized)
+             :account-props       (if (= transaction-type :tx/bridge)
+                                    from-account-props
+                                    user-props)
+             :recipient           recipient
+             :bridge-tx?          (= transaction-type :tx/bridge)
+             :account-to?         true
+             :theme               theme}]]]]))))


### PR DESCRIPTION
fixes #21693

### Summary

This PR fixes the error thrown when tapping the From or To sections in the transaction confirmation screen.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the Wallet tab
- Go to the send flow
- Choose an asset and an account or enter an address to send
- Enter an amount and generate a route
- Navigate to transaction confirmation
- Verify the app is not throwing any error when tapping the From or To sections

status: ready 
