### PR TITLE
[#21644] fix: display zero for empty balances asset

### DIFF
--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -264,6 +264,13 @@
       (str $ address))
     address))
 
+(defn asset-fiat-formatted-for-ui
+  [currency-symbol fiat-value]
+  (cond
+    (money/equal-to fiat-value 0)     (str currency-symbol "0.00")
+    (money/less-than fiat-value 0.01) (str "<" currency-symbol "0.01")
+    :else                             (prettify-balance currency-symbol fiat-value)))
+
 (defn fiat-formatted-for-ui
   [currency-symbol fiat-value]
   (if (money/less-than fiat-value 0.01)
@@ -294,8 +301,8 @@
         formatted-token-price    (prettify-balance currency-symbol price)
         percentage-change        (prettify-percentage-change change-pct-24h)
         crypto-value             (get-standard-crypto-format token balance prices-per-token)
-        fiat-value               (fiat-formatted-for-ui currency-symbol
-                                                        fiat-unformatted-value)]
+        fiat-value               (asset-fiat-formatted-for-ui currency-symbol
+                                                              fiat-unformatted-value)]
     {:token               (:symbol token)
      :token-name          (:name token)
      :state               :default

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -264,18 +264,12 @@
       (str $ address))
     address))
 
-(defn asset-fiat-formatted-for-ui
+(defn fiat-formatted-for-ui
   [currency-symbol fiat-value]
   (cond
     (money/equal-to fiat-value 0)     (str currency-symbol "0.00")
     (money/less-than fiat-value 0.01) (str "<" currency-symbol "0.01")
     :else                             (prettify-balance currency-symbol fiat-value)))
-
-(defn fiat-formatted-for-ui
-  [currency-symbol fiat-value]
-  (if (money/less-than fiat-value 0.01)
-    (str "<" currency-symbol "0.01")
-    (prettify-balance currency-symbol fiat-value)))
 
 (defn prettify-percentage-change
   "Returns unsigned precentage"
@@ -301,8 +295,8 @@
         formatted-token-price    (prettify-balance currency-symbol price)
         percentage-change        (prettify-percentage-change change-pct-24h)
         crypto-value             (get-standard-crypto-format token balance prices-per-token)
-        fiat-value               (asset-fiat-formatted-for-ui currency-symbol
-                                                              fiat-unformatted-value)]
+        fiat-value               (fiat-formatted-for-ui currency-symbol
+                                                        fiat-unformatted-value)]
     {:token               (:symbol token)
      :token-name          (:name token)
      :state               :default


### PR DESCRIPTION
fixes #21644

### Summary

The price for empty assets should estimated as 0.00

#### Areas that maybe impacted

- Wallet page -> asset list

### Steps to test

- Create new accout
- Go to wallet
- Check default assets (example: snt, dai, eth)


### Result

<img src="https://github.com/user-attachments/assets/f1fc4bed-260f-480f-af28-5c6186e42eb4" width="390px"/>


status: ready

