### PR TITLE
fix: chats leaking to other profiles

### DIFF
--- a/src/status_im/contexts/profile/logout/events.cljs
+++ b/src/status_im/contexts/profile/logout/events.cljs
@@ -14,8 +14,11 @@
                   network/status network/expensive?
                   centralized-metrics/user-confirmed?]
     network-type :network/network-type
-    :as          _db}]
+    :as          db}]
   (assoc db/app-db
+         ;; We must carry over the current `:selected-stack-id`, otherwise the
+         ;; app will start with `:view-id` as nil.
+         :shell/selected-stack-id             (:shell/selected-stack-id db)
          :profile/logging-out?                true
          :centralized-metrics/user-confirmed? user-confirmed?
          :network/type                        network-type
@@ -44,4 +47,3 @@
          [:dispatch-later
           {:ms       100
            :dispatch [:profile.logout/reset-state]}]]}))
-

--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -9,7 +9,6 @@
     [native-module.core :as native-module]
     [re-frame.core :as re-frame]
     [re-frame.interop :as interop]
-    [react-native.async-storage :as async-storage]
     [react-native.core :as rn]
     [react-native.platform :as platform]
     [react-native.shake :as react-native-shake]
@@ -59,9 +58,6 @@
   (react-native-shake/add-shake-listener #(re-frame/dispatch [:shake-event]))
   (universal-links/initialize)
   (interceptors/register-global-interceptors)
-
-  ;; Shell
-  (async-storage/get-item :selected-stack-id #(re-frame/dispatch [:shell/change-tab %]))
 
   (when config/quo-preview-enabled?
     (ff/load-flags))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -62,6 +62,9 @@
   (rf/merge
    cofx
    {:db db/app-db
+    :effects.async-storage/get {:keys [:selected-stack-id]
+                                :cb   (fn [{:keys [selected-stack-id]}]
+                                        (rf/dispatch [:shell/change-tab selected-stack-id]))}
     :theme/init-theme nil
     :effects.network/listen-to-network-info nil
     :effects.biometric/get-supported-type nil


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/21696

### Summary

This PR fixes a regression introduced in PR https://github.com/status-im/status-mobile/pull/21634.

What's important is that the fix for chats leaking to other profiles was a client-side bug, not in status-go, thus no private data was leaking to other profiles. This PR keeps the existing workaround to memoize chats.

#### Areas that may be impacted

- Showing chats after login.

### Steps to test

Steps are described in the issue. Just create one profile `UserA` with 1 chat and create another profile `UserB` without chats. Close the app, login with `UserA`, logout, login with `UserB`. You will see the chat from `UserA` appears in `UserB` list of recent chats.

Check the same steps in this PR and the issue should be gone.

status: ready