### PR TITLE
feature: display registered profile keycards inside keycard settings

### DIFF
--- a/src/status_im/contexts/settings/keycard/style.cljs
+++ b/src/status_im/contexts/settings/keycard/style.cljs
@@ -2,10 +2,6 @@
   (:require
     [quo.foundations.colors :as colors]))
 
-(defn page-wrapper
-  [inset]
-  {:padding-top inset})
-
 (def registered-keycards-container
   {:gap                12
    :padding-horizontal 20})

--- a/src/status_im/contexts/settings/keycard/style.cljs
+++ b/src/status_im/contexts/settings/keycard/style.cljs
@@ -7,7 +7,8 @@
   {:padding-top inset})
 
 (def registered-keycards-container
-  {:padding-horizontal 20})
+  {:gap 12
+   :padding-horizontal 20})
 
 (def keycard-row
   {:gap              12

--- a/src/status_im/contexts/settings/keycard/style.cljs
+++ b/src/status_im/contexts/settings/keycard/style.cljs
@@ -7,7 +7,7 @@
   {:padding-top inset})
 
 (def registered-keycards-container
-  {:gap 12
+  {:gap                12
    :padding-horizontal 20})
 
 (def keycard-row

--- a/src/status_im/contexts/settings/keycard/style.cljs
+++ b/src/status_im/contexts/settings/keycard/style.cljs
@@ -1,0 +1,25 @@
+(ns status-im.contexts.settings.keycard.style
+  (:require
+    [quo.foundations.colors :as colors]))
+
+(defn page-wrapper
+  [inset]
+  {:padding-top inset})
+
+(def registered-keycards-container
+  {:padding-horizontal 20})
+
+(def keycard-row
+  {:gap              12
+   :padding          12
+   :border-radius    16
+   :flex-direction   :row
+   :background-color colors/white-opa-5})
+
+(def keycard-owner
+  {:gap            4
+   :flex-direction :row
+   :align-items    :center})
+
+(def keycard-owner-name
+  {:color colors/white-opa-40})

--- a/src/status_im/contexts/settings/keycard/view.cljs
+++ b/src/status_im/contexts/settings/keycard/view.cljs
@@ -2,16 +2,53 @@
   (:require [quo.core :as quo]
             [quo.foundations.colors :as colors]
             [react-native.core :as rn]
+            [react-native.safe-area :as safe-area]
             [status-im.common.events-helper :as events-helper]
             [status-im.common.resources :as resources]
             [status-im.constants :as constants]
+            [status-im.contexts.settings.keycard.style :as style]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
+(defn registered-keycard
+  [{:keys [profile-name profile-image customization-color keycard-name]}]
+  [rn/view {:style style/keycard-row}
+   [quo/icon :i/keycard-card
+    {:size  20
+     :color colors/white-70-blur}]
+   [rn/view {}
+    [quo/text keycard-name]
+    [rn/view {:style style/keycard-owner}
+     [quo/user-avatar
+      {:full-name           profile-name
+       :photo-path          profile-image
+       :customization-color customization-color
+       :size                :xxxs}]
+     [quo/text
+      {:size  :paragraph-2
+       :style style/keycard-owner-name}
+      profile-name]]]])
+
+(defn registered-keycards
+  []
+  (let [keycards (rf/sub [:keycard/registered-keycards])]
+    [:<>
+     [quo/divider-label
+      {:counter? false
+       :tight?   true
+       :blur?    true}
+      (i18n/label :t/registered-keycards)]
+     [rn/view {:style style/registered-keycards-container}
+      (doall (for [keycard keycards]
+               [registered-keycard keycard]))]]))
+
 (defn view
   []
-  (let [keycard-profile? (rf/sub [:keycard/keycard-profile?])]
-    [:<>
+  (let [insets           (safe-area/get-insets)
+        keycard-profile? (rf/sub [:keycard/keycard-profile?])]
+    [quo/overlay
+     {:type            :shell
+      :container-style (style/page-wrapper (:top insets))}
      [quo/page-nav
       {:key        :header
        :background :blur
@@ -20,7 +57,7 @@
      [quo/page-top
       {:title (i18n/label :t/keycard)}]
      (if keycard-profile?
-       [:<>]
+       [registered-keycards]
        [rn/view {:style {:padding-horizontal 28 :padding-top 20}}
         [quo/small-option-card
          {:variant             :main

--- a/src/status_im/contexts/settings/keycard/view.cljs
+++ b/src/status_im/contexts/settings/keycard/view.cljs
@@ -2,7 +2,6 @@
   (:require [quo.core :as quo]
             [quo.foundations.colors :as colors]
             [react-native.core :as rn]
-            [react-native.safe-area :as safe-area]
             [status-im.common.events-helper :as events-helper]
             [status-im.common.resources :as resources]
             [status-im.constants :as constants]
@@ -47,11 +46,8 @@
 
 (defn view
   []
-  (let [insets           (safe-area/get-insets)
-        keycard-profile? (rf/sub [:keycard/keycard-profile?])]
-    [quo/overlay
-     {:type            :shell
-      :container-style (style/page-wrapper (:top insets))}
+  (let [keycard-profile? (rf/sub [:keycard/keycard-profile?])]
+    [:<>
      [quo/page-nav
       {:key        :header
        :background :blur

--- a/src/status_im/contexts/settings/keycard/view.cljs
+++ b/src/status_im/contexts/settings/keycard/view.cljs
@@ -39,8 +39,9 @@
        :blur?    true}
       (i18n/label :t/registered-keycards)]
      [rn/view {:style style/registered-keycards-container}
-      (doall (for [keycard keycards]
-               [registered-keycard keycard]))]]))
+      (for [keycard keycards]
+        ^{:key (:keycard-uid keycard)}
+        [registered-keycard keycard])]]))
 
 (defn view
   []

--- a/src/status_im/contexts/settings/keycard/view.cljs
+++ b/src/status_im/contexts/settings/keycard/view.cljs
@@ -11,13 +11,13 @@
             [utils.re-frame :as rf]))
 
 (defn registered-keycard
-  [{:keys [profile-name profile-image customization-color keycard-name]}]
+  [{:keys [profile-name profile-image customization-color]}]
   [rn/view {:style style/keycard-row}
    [quo/icon :i/keycard-card
     {:size  20
      :color colors/white-70-blur}]
    [rn/view {}
-    [quo/text keycard-name]
+    [quo/text profile-name]
     [rn/view {:style style/keycard-owner}
      [quo/user-avatar
       {:full-name           profile-name

--- a/src/status_im/contexts/settings/keycard/view.cljs
+++ b/src/status_im/contexts/settings/keycard/view.cljs
@@ -16,7 +16,7 @@
    [quo/icon :i/keycard-card
     {:size  20
      :color colors/white-70-blur}]
-   [rn/view {}
+   [rn/view
     [quo/text profile-name]
     [rn/view {:style style/keycard-owner}
      [quo/user-avatar

--- a/src/status_im/contexts/settings/keycard/view.cljs
+++ b/src/status_im/contexts/settings/keycard/view.cljs
@@ -21,8 +21,10 @@
     [rn/view {:style style/keycard-owner}
      [quo/user-avatar
       {:full-name           profile-name
-       :photo-path          profile-image
+       :profile-picture     profile-image
        :customization-color customization-color
+       :status-indicator    false
+       :ring?               false
        :size                :xxxs}]
      [quo/text
       {:size  :paragraph-2

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -320,7 +320,8 @@
    {:name      :screen/settings.keycard
     :metrics   {:track?   :true
                 :alias-id :settings.keycard}
-    :options   options/transparent-modal-screen-options
+    :options   {:theme  :dark
+                :insets {:top? true :bottom? true}}
     :component settings.keycard/view}
 
    {:name      :edit-profile

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -320,8 +320,7 @@
    {:name      :screen/settings.keycard
     :metrics   {:track?   :true
                 :alias-id :settings.keycard}
-    :options   {:theme  :dark
-                :insets {:top? true :bottom? true}}
+    :options   options/transparent-modal-screen-options
     :component settings.keycard/view}
 
    {:name      :edit-profile

--- a/src/status_im/subs/keycard.cljs
+++ b/src/status_im/subs/keycard.cljs
@@ -7,6 +7,40 @@
    (not (nil? (get-in db [:profile/profile :keycard-pairing])))))
 
 (rf/reg-sub
+ :keycard/keycard-profile
+ :<- [:profile/name]
+ :<- [:profile/image]
+ :<- [:profile/customization-color]
+ (fn [[profile-name profile-image customization-color]]
+   {:profile-name        profile-name
+    :profile-image       profile-image
+    :customization-color customization-color}))
+
+(rf/reg-sub
+ :keycard/keypairs-keycards
+ :<- [:wallet/keypairs-list]
+ (fn [keypairs]
+   (reduce (fn [keycards keypair]
+             (if (and (= :profile (:type keypair))
+                      (:keycards keypair))
+               (concat keycards (:keycards keypair))
+               keycards))
+           []
+           keypairs)))
+
+(rf/reg-sub
+ :keycard/registered-keycards
+ :<- [:keycard/keycard-profile]
+ :<- [:keycard/keypairs-keycards]
+ (fn [[keycard-profile keycards]]
+   (->> keycards
+        (map (fn [keycard]
+               (assoc keycard
+                      :profile-name        (:profile-name keycard-profile)
+                      :profile-image       (:profile-image keycard-profile)
+                      :customization-color (:customization-color keycard-profile)))))))
+
+(rf/reg-sub
  :keycard/nfc-enabled?
  :<- [:keycard]
  (fn [keycard]

--- a/src/status_im/subs/keycard.cljs
+++ b/src/status_im/subs/keycard.cljs
@@ -16,12 +16,15 @@
     :profile-image       profile-image
     :customization-color customization-color}))
 
+(defn profile-keypair-keycards?
+  [{:keys [type keycards]}]
+  (and (= :profile type) keycards))
+
 (rf/reg-sub
  :keycard/keypairs-keycards
  :<- [:wallet/keypairs-list]
  (fn [keypairs]
-   (transduce (comp (filter (fn [{:keys [type keycards]}]
-                              (and (= :profile type) keycards)))
+   (transduce (comp (filter profile-keypair-keycards?)
                     (mapcat :keycards))
               conj
               keypairs)))

--- a/src/status_im/subs/keycard.cljs
+++ b/src/status_im/subs/keycard.cljs
@@ -20,13 +20,11 @@
  :keycard/keypairs-keycards
  :<- [:wallet/keypairs-list]
  (fn [keypairs]
-   (reduce (fn [keycards keypair]
-             (if (and (= :profile (:type keypair))
-                      (:keycards keypair))
-               (concat keycards (:keycards keypair))
-               keycards))
-           []
-           keypairs)))
+   (transduce (comp (filter (fn [{:keys [type keycards]}]
+                              (and (= :profile type) keycards)))
+                    (mapcat :keycards))
+              conj
+              keypairs)))
 
 (rf/reg-sub
  :keycard/registered-keycards

--- a/src/status_im/subs/keycard.cljs
+++ b/src/status_im/subs/keycard.cljs
@@ -33,12 +33,12 @@
  :<- [:keycard/keycard-profile]
  :<- [:keycard/keypairs-keycards]
  (fn [[keycard-profile keycards]]
-   (->> keycards
-        (map (fn [keycard]
-               (assoc keycard
-                      :profile-name        (:profile-name keycard-profile)
-                      :profile-image       (:profile-image keycard-profile)
-                      :customization-color (:customization-color keycard-profile)))))))
+   (map (fn [keycard]
+          (assoc keycard
+                 :profile-name        (:profile-name keycard-profile)
+                 :profile-image       (:profile-image keycard-profile)
+                 :customization-color (:customization-color keycard-profile)))
+        keycards)))
 
 (rf/reg-sub
  :keycard/nfc-enabled?

--- a/translations/en.json
+++ b/translations/en.json
@@ -2111,6 +2111,7 @@
   "reduced-tip": "priority tip will be reduced",
   "refresh": "Refresh",
   "registered": "registered",
+  "registered-keycards": "Registered Keycards",
   "reject": "Reject",
   "reject-and-delete": "Reject and delete",
   "remember-me": "Remember me",


### PR DESCRIPTION
fixes #21515 

### Summary

* This PR attempts to add some logic for displaying registered keycards related to the user's profile.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Settings - Keycards

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status mobile app
- Login with a profile that uses keycard
- Open settings screen
- Open Keycard settings screen

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### Changes in iOS

![IMG_0013](https://github.com/user-attachments/assets/700d8303-148e-4818-b052-c6fc1652456e)

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
