### PR TITLE
fix_: incorrect USDT estimation and decimals on swap on arbitrum network

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v6.2.0",
-    "commit-sha1": "896eb635029e025cc446d73768038fb6c3afe2fb",
-    "src-sha256": "08vpcxdhjh2szsarbnhqlgdnmn8i7zp11nk0j02gj3xjlzdn9yjy"
+    "version": "v6.3.0",
+    "commit-sha1": "a61f28bf135911c1eaf14a61e4a8cfc0170e2ab6",
+    "src-sha256": "1i9k1kal1q2g8qirzrz5mqa188pb795wxqqjyzxlbrpx8fgkzx3l"
 }


### PR DESCRIPTION
fixes #21738

### Summary

This PR fixes incorrect USDT estimation and decimals on swap on arbitrum network.

Should not merge until https://github.com/status-im/status-go/pull/6158 is merged and status-go version is updated accordingly, but we can safely test the changes here.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

### Precondition:
- The user has no USDT balance on the Arbitrum network (this step is required)

### Steps to Reproduce:
1. Navigate to the Swap page.
2. Select Arbitrum as the network
3. Set some asset "Assets to send" field value of which more than 1 USD (example: in my case 0.001 eth = 3 USD)
4. Verify the "Assets to receive" field and USDT decimals are correctly displayed

status: ready