### PR TITLE
Fix sending collectible by building transaction before signing

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -337,6 +337,13 @@
               :flow-id        :wallet-send-flow}]]]})))
 
 (rf/reg-event-fx
+ :wallet/build-transaction-for-collectible-route
+ (fn [{:keys [db]}]
+   (let [last-request-uuid (get-in db [:wallet :ui :send :last-request-uuid])]
+     {:db (update-in db [:wallet :ui :send] dissoc :transaction-for-signing)
+      :fx [[:dispatch [:wallet/build-transactions-from-route {:request-uuid last-request-uuid}]]]})))
+
+(rf/reg-event-fx
  :wallet/set-token-amount-to-bridge
  (fn [{:keys [db]} [{:keys [amount stack-id start-flow?]}]]
    (let [last-request-uuid (get-in db [:wallet :ui :send :last-request-uuid])]

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -256,8 +256,7 @@
         ;; as route is available.
         (rn/use-effect
          (fn []
-           (when (and (or (= transaction-type :tx/collectible-erc-1155)
-                          (= transaction-type :tx/collectible-erc-721))
+           (when (and (send-utils/tx-type-collectible? transaction-type)
                       first-route)
              (rf/dispatch [:wallet/build-transaction-for-collectible-route])))
          [first-route])

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -252,7 +252,7 @@
         ;; In token send flow we already have transaction built when
         ;; we reach confirmation screen. But in send collectible flow
         ;; routes request happens at the same time with navigation to
-        ;; confirmation screen. So we need to build the transaction ass soon
+        ;; confirmation screen. So we need to build the transaction as soon
         ;; as route is available.
         (rn/use-effect
          (fn []

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -256,7 +256,9 @@
         ;; as route is available.
         (rn/use-effect
          (fn []
-           (when (and (= transaction-type :tx/collectible-erc-1155) first-route)
+           (when (and (or (= transaction-type :tx/collectible-erc-1155)
+                          (= transaction-type :tx/collectible-erc-721))
+                      first-route)
              (rf/dispatch [:wallet/build-transaction-for-collectible-route])))
          [first-route])
         [rn/view {:style {:flex 1}}

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -249,6 +249,16 @@
             user-props                {:full-name to-address
                                        :address   (utils/get-shortened-address
                                                    to-address)}]
+        ;; In token send flow we already have transaction built when
+        ;; we reach confirmation screen. But in send collectible flow
+        ;; routes request happens at the same time with navigation to
+        ;; confirmation screen. So we need to build the transaction ass soon
+        ;; as route is available.
+        (rn/use-effect
+         (fn []
+           (when (and (= transaction-type :tx/collectible-erc-1155) first-route)
+             (rf/dispatch [:wallet/build-transaction-for-collectible-route])))
+         [first-route])
         [rn/view {:style {:flex 1}}
          [floating-button-page/view
           {:footer-container-padding 0


### PR DESCRIPTION
fixes #21702

### Summary

After migrating to new endpoint for sending transaction the `build transaction` step wasn't added to collectibles send flow which resulted in inability to send transaction. This PR fixes the problem.

### Review notes
The fix looks "dirty" and probably more thought can be put in the way we organise events to have consistency between sending tokens and collectibles, but for pre-release "duct tape fix" I believe should be ok.

### Testing notes
Here is the transaction I've made with the help of fix.
https://sepolia.etherscan.io/tx/0x6b7b5fa210839e668f623af5117e86cf1b67d8fd1c80cc4ecf810bd8fe87048e

#### Platforms

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- wallet / transactions


### Steps to test
- Open Status
- Follow send collectible flow to reach confirmation screen
- Ensure that "slide to send" button is enabled, signing is possible and transaction can be send


status: ready 


