### PR TITLE
fix(wallet)_: token decimals in activities

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -639,3 +639,5 @@
    :more-than-five-minutes  4})
 
 (def ^:const wallet-connect-transaction-refresh-interval-ms 10000)
+
+(def ^:const native-token-symbol "ETH")

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -55,7 +55,7 @@
           (money/add bonder-fees)))
     (-> path :amount-out money/from-hex)))
 
-(defn- convert-wei-to-eth
+(defn convert-wei-to-eth
   [amount native-token? token-decimals]
   (money/with-precision
    (if native-token?

--- a/src/status_im/subs/wallet/activities_test.cljs
+++ b/src/status_im/subs/wallet/activities_test.cljs
@@ -23,34 +23,45 @@
     (swap! rf-db/app-db
       (fn [db]
         (-> db
+            (assoc-in [:wallet :tokens :by-symbols]
+                      (list {:symbol "ETH" :decimals 18}
+                            {:symbol "DAI" :decimals 18}
+                            {:symbol "SNT" :decimals 18}
+                            {:symbol "USDT" :decimals 6}))
             (assoc-in [:wallet :activities]
-                      {"acc1" {1 {:activity-type constants/wallet-activity-type-send
-                                  :amount-out    "0x1"
-                                  :sender        "acc1"
-                                  :recipient     "acc2"
-                                  :timestamp     1588291200}
-                               3 {:activity-type constants/wallet-activity-type-bridge
-                                  :amount-out    "0x1"
-                                  :sender        "acc1"
-                                  :recipient     "acc4"
-                                  :timestamp     1588464000}
-                               4 {:activity-type constants/wallet-activity-type-swap
-                                  :amount-out    "0x1"
-                                  :amount-in     "0x1"
-                                  :sender        "acc1"
-                                  :recipient     "acc4"
-                                  :timestamp     1588464100}
-                               5 {:activity-type constants/wallet-activity-type-send
-                                  :amount-out    "0x1"
-                                  :sender        "acc1"
-                                  :recipient     "acc4"
-                                  :timestamp     1588464050}}
-                       "acc3" {6 {:activity-type constants/wallet-activity-type-receive
-                                  :amount-in     "0x1"
-                                  :sender        "acc4"
-                                  :recipient     "acc3"
-                                  :timestamp     1588464000}}})
-            (assoc-in [:wallet :current-viewing-account-address] "acc1"))))
+                      {"0x1" {1 {:activity-type constants/wallet-activity-type-send
+                                 :amount-out    "0x1"
+                                 :symbol-out    "ETH"
+                                 :sender        "0x1"
+                                 :recipient     "0x2"
+                                 :timestamp     1588291200}
+                              3 {:activity-type constants/wallet-activity-type-bridge
+                                 :amount-out    "0x1"
+                                 :symbol-out    "ETH"
+                                 :sender        "0x1"
+                                 :recipient     "0x1"
+                                 :timestamp     1588464000}
+                              4 {:activity-type constants/wallet-activity-type-swap
+                                 :amount-out    "0x1"
+                                 :symbol-out    "ETH"
+                                 :amount-in     "0x1"
+                                 :symbol-in     "SNT"
+                                 :sender        "0x1"
+                                 :recipient     "0x1"
+                                 :timestamp     1588464100}
+                              5 {:activity-type constants/wallet-activity-type-send
+                                 :amount-out    "0x1"
+                                 :symbol-out    "ETH"
+                                 :sender        "0x1"
+                                 :recipient     "0x4"
+                                 :timestamp     1588464050}}
+                       "0x3" {6 {:activity-type constants/wallet-activity-type-receive
+                                 :amount-in     "0x1"
+                                 :symbol-out    "ETH"
+                                 :sender        "0x4"
+                                 :recipient     "0x3"
+                                 :timestamp     1588464000}}})
+            (assoc-in [:wallet :current-viewing-account-address] "0x1"))))
     (is
      (match?
       [{:title     "May 3, 2020"
@@ -58,39 +69,39 @@
         :data      [{:relative-date    "May 3, 2020"
                      :amount-out       "0"
                      :network-logo-out nil
-                     :recipient        "acc4"
+                     :recipient        "0x1"
                      :tx-type          :swap
                      :network-name-out nil
                      :status           nil
-                     :sender           "acc1"
+                     :sender           "0x1"
                      :timestamp        1588464100}
                     {:relative-date    "May 3, 2020"
                      :amount-out       "0"
                      :network-logo-out nil
-                     :recipient        "acc4"
+                     :recipient        "0x4"
                      :tx-type          :send
                      :network-name-out nil
                      :status           nil
-                     :sender           "acc1"
+                     :sender           "0x1"
                      :timestamp        1588464050}
                     {:relative-date    "May 3, 2020"
                      :amount-out       "0"
                      :network-logo-out nil
-                     :recipient        "acc4"
+                     :recipient        "0x1"
                      :tx-type          :bridge
                      :network-name-out nil
                      :status           nil
-                     :sender           "acc1"
+                     :sender           "0x1"
                      :timestamp        1588464000}]}
        {:title     "May 1, 2020"
         :timestamp 1588291200
         :data      [{:relative-date    "May 1, 2020"
                      :amount-out       "0"
                      :network-logo-out nil
-                     :recipient        "acc2"
+                     :recipient        "0x2"
                      :tx-type          :send
                      :network-name-out nil
                      :status           nil
-                     :sender           "acc1"
+                     :sender           "0x1"
                      :timestamp        1588291200}]}]
       (rf/sub [sub-name])))))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -8,6 +8,7 @@
             [status-im.contexts.wallet.send.utils :as send-utils]
             [status-im.contexts.wallet.sheets.missing-keypair.view :as missing-keypair]
             [status-im.subs.wallet.add-account.address-to-watch]
+            [utils.collection]
             [utils.money :as money]
             [utils.number]
             [utils.security.core :as security]))
@@ -72,6 +73,12 @@
  :wallet/tokens
  :<- [:wallet]
  :-> :tokens)
+
+(rf/reg-sub
+ :wallet/tokens-by-symbol
+ :<- [:wallet/tokens]
+ (fn [{:keys [by-symbol]}]
+   (utils.collection/index-by :symbol by-symbol)))
 
 (rf/reg-sub
  :wallet/prices-per-token


### PR DESCRIPTION
fixes #21728

### Summary

This PR fixes asset values that are shown as 0 in wallet activities.

<img width="300" src="https://github.com/user-attachments/assets/c14eb86d-5123-4a54-b061-e3b3f79ad4bc" />

### Review notes

The issue happens only for tokens that are NOT 18 decimals such as USDT, USDC.e, WBTC, ACH, etc. 

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Perform an ERC20 token transfer / bridge / swap of tokens that are not 18 decimals
- Verify the value is shown as expected in the activity entry

status: ready
