### PR TITLE
fix_: sometimes balances are not updated until relogin

### DIFF
--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -215,7 +215,7 @@
    {:db (assoc-in db [:wallet :ui :tokens-loading address] true)
     :fx [[:json-rpc/call
           [{:method     "wallet_fetchOrGetCachedWalletBalances"
-            :params     [[address]]
+            :params     [[address] true]
             :on-success [:wallet/store-wallet-token address]
             :on-error   [:wallet/get-wallet-token-for-account-failed address]}]]]}))
 

--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -125,7 +125,7 @@
   (let [expected-effects {:db {:wallet {:ui {:tokens-loading {address true}}}}
                           :fx [[:json-rpc/call
                                 [{:method     "wallet_fetchOrGetCachedWalletBalances"
-                                  :params     [[address]]
+                                  :params     [[address] true]
                                   :on-success [:wallet/store-wallet-token address]
                                   :on-error   [:wallet/get-wallet-token-for-account-failed
                                                address]}]]]}]


### PR DESCRIPTION
fixes #21725 

### Summary

This PR fixes balances not being updated after a bridge or send, caused by basically cached balances. This relies on a status-go change which enabled to force refresh balances if needed. In this case, after the user makes a send, bridge or swap transaction we set a flag in app-db to force refresh balances the next time the balances are refreshed.

Should not merge until https://github.com/status-im/status-go/pull/6160 is merged and status-go version is updated accordingly, but we can safely test the changes here.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

1. Select asset for bridge
2. Remember the balance before bridge
3. Perform send, bridge or swap
4. Check if balance has been updated (try pull to refresh)

status: ready