### PR TITLE
Fix send screen: route wasn't rebuilding when fiat value changed slightly

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -332,7 +332,7 @@
                           :status   (when (controlled-input/input-error input-state) :error)}]}]
      [routes/view
       {:token                                     token-by-symbol
-       :send-amount-in-crypto                     amount-in-crypto
+       :input-value                               input-value
        :valid-input?                              valid-input?
        :token-not-supported-in-receiver-networks? unsupported-token-in-receiver?
        :current-screen-id                         current-screen-id

--- a/src/status_im/contexts/wallet/send/routes/view.cljs
+++ b/src/status_im/contexts/wallet/send/routes/view.cljs
@@ -180,7 +180,7 @@
 
 (defn view
   [{:keys [token theme valid-input? request-fetch-routes on-press-to-network current-screen-id
-           token-not-supported-in-receiver-networks? send-amount-in-crypto]}]
+           token-not-supported-in-receiver-networks? input-value]}]
   (let [token-symbol (:symbol token)
         nav-current-screen-id (rf/sub [:view-id])
         active-screen? (= nav-current-screen-id current-screen-id)
@@ -204,7 +204,7 @@
        (when (and active-screen?
                   (> (count token-available-networks-for-suggested-routes) 0))
          (request-fetch-routes 2000)))
-     [send-amount-in-crypto valid-input?])
+     [input-value valid-input?])
     (rn/use-effect
      #(when (and active-screen? (> (count token-available-networks-for-suggested-routes) 0))
         (request-fetch-routes 0))


### PR DESCRIPTION

fixes #21712

### Summary
Now routes are requested (with small delay, as before) whenever value in input field changed.
Before routes were requested when the crypto value changed. But small alterations in fiat price could have lead to crypto price not changed (because we impose restrictions on the amount of crypto decimals) and old route disappeared but new one not requested.

https://github.com/user-attachments/assets/d4ee1ad7-ef4e-48bd-8d67-2c5a6a0fcecd

There were two possible solutions:
1. To not re-request route but leave the old one when fiat value changed slightly 
2. To re-request route with the same crypto value when user slightly changed the fiat value.

By agreement with @VolodLytvynenko I used option 1 because it gives user an immediate feedback on his actions.

### Review notes
PR simply replaces the variable that triggers routes change. Before it was the price of crypto, now it is the value of input field.
I'd say it is not very logical to have `routes` component that depends on input value (same as crypto value), but I avoided any refactors because there is an [upcoming PR](https://github.com/status-im/status-mobile/pull/21595) from @briansztamfater with a lot of changes in that area and I don't want to create obstacles for its merge.

### Testing notes

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- wallet / transactions

### Steps to test
- Open Status
- Go to input amount screen in send flow
- Enter fiat value
- Change it slighlty to ensure that this change didn't result in crypto value change,
- Make sure route was rebuilt


status: ready

