### PR TITLE
[#21709] fix: big number issue in swap max value

### DIFF
--- a/src/utils/number.cljs
+++ b/src/utils/number.cljs
@@ -64,13 +64,10 @@
   Example usage:
   (convert-to-whole-number 12345 2) ; => 123.45"
   [amount decimals]
-  (let [amount-bn  (money/->bignumber amount)
-        divisor-bn (money/->bignumber (Math/pow 10 decimals))]
-    (if (and amount-bn divisor-bn)
-      (let [result (.div amount-bn divisor-bn)]
-        (-> (.toFixed result decimals)
-            utils.number/remove-trailing-zeroes))
-      "0")))
+  (when-let [[amount-bn divisor-bn] (money/->bignumbers amount (Math/pow 10 decimals))]
+    (-> (.div amount-bn divisor-bn)
+        (.toFixed decimals)
+        remove-trailing-zeroes)))
 
 (defn hex->whole
   [num decimals]

--- a/src/utils/number.cljs
+++ b/src/utils/number.cljs
@@ -64,10 +64,13 @@
   Example usage:
   (convert-to-whole-number 12345 2) ; => 123.45"
   [amount decimals]
-  (-> amount
-      (/ (Math/pow 10 decimals))
-      (.toFixed decimals)
-      remove-trailing-zeroes))
+  (let [amount-bn  (money/->bignumber amount)
+        divisor-bn (money/->bignumber (Math/pow 10 decimals))]
+    (if (and amount-bn divisor-bn)
+      (let [result (.div amount-bn divisor-bn)]
+        (-> (.toFixed result decimals)
+            utils.number/remove-trailing-zeroes))
+      "0")))
 
 (defn hex->whole
   [num decimals]

--- a/src/utils/number.cljs
+++ b/src/utils/number.cljs
@@ -64,9 +64,9 @@
   Example usage:
   (convert-to-whole-number 12345 2) ; => 123.45"
   [amount decimals]
-  (when-let [[amount-bn divisor-bn] (money/->bignumbers amount (Math/pow 10 decimals))]
-    (-> (.div amount-bn divisor-bn)
-        (.toFixed decimals)
+  (when-let [[amount-bn divisor-bn] (money/->bignumbers amount (money/from-decimal decimals))]
+    (-> (money/div amount-bn divisor-bn)
+        (money/to-fixed decimals)
         remove-trailing-zeroes)))
 
 (defn hex->whole

--- a/src/utils/number_test.cljs
+++ b/src/utils/number_test.cljs
@@ -1,6 +1,7 @@
 (ns utils.number-test
   (:require
     [cljs.test :refer [deftest is testing]]
+    [utils.money :as money]
     [utils.number]))
 
 (deftest convert-to-whole-number-test
@@ -21,7 +22,11 @@
 
   (testing "handles zero amount"
     (is (= "0" (utils.number/convert-to-whole-number 0 2)))
-    (is (= "0" (utils.number/convert-to-whole-number 0 0)))))
+    (is (= "0" (utils.number/convert-to-whole-number 0 0))))
+
+  (testing "handles BigNumber amounts with 18 decimals"
+    (let [amount (money/bignumber "3141969777175276657")]
+      (is (= "3.141969777175276657" (utils.number/convert-to-whole-number amount 18))))))
 
 (deftest parse-int-test
   (testing "defaults to zero"


### PR DESCRIPTION
fixes #21709

### Summary

the 0.41601235629850597 dai is pasted, however, user has 0.416012356298505966 which leads to "something went wrong"


#### Areas that maybe impacted

- swap flow


### Steps to test

1. Go to swap
2. Set up asset with 18 decimals
3. Tap "max value"
4. Observe pasted value


### Result

https://github.com/user-attachments/assets/e1355733-de6f-4063-9b95-f237243d90c9




status: ready
