### PR TITLE
chore(analytics): Improve tracking of login and onboarding completion

### DIFF
--- a/src/status_im/contexts/centralized_metrics/events.cljs
+++ b/src/status_im/contexts/centralized_metrics/events.cljs
@@ -4,7 +4,6 @@
     [re-frame.interceptor :as interceptor]
     status-im.contexts.centralized-metrics.effects
     [status-im.contexts.centralized-metrics.tracking :as tracking]
-    [taoensso.timbre :as log]
     [utils.re-frame :as rf]))
 
 (defn push-event?
@@ -16,7 +15,6 @@
   [context]
   (when (push-event? (interceptor/get-coeffect context :db))
     (when-let [event (tracking/metrics-event (interceptor/get-coeffect context :event))]
-      (log/debug "tracking event" event)
       (if (or (seq? event) (vector? event))
         (doseq [e event]
           (native-module/add-centralized-metric e))

--- a/src/status_im/contexts/centralized_metrics/tracking_test.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking_test.cljs
@@ -42,19 +42,19 @@
 
 (deftest track-view-id-event-test
   (testing "returns correct navigation event for view-id"
-    (is (= {:metric
-            {:eventName  "navigation"
-             :platform   platform-os
-             :appVersion app-version
-             :eventValue {:viewId "communities-stack"}}}
+    (is (= [{:metric
+             {:eventName  "navigation"
+              :platform   platform-os
+              :appVersion app-version
+              :eventValue {:viewId "communities-stack"}}}]
            (tracking/track-view-id-event :communities-stack)))
-    (is (= {:metric
-            {:eventName  "navigation"
-             :platform   platform-os
-             :appVersion app-version
-             :eventValue {:viewId "onboarding.create-profile-info"}}}
+    (is (= [{:metric
+             {:eventName  "navigation"
+              :platform   platform-os
+              :appVersion app-version
+              :eventValue {:viewId "onboarding.create-profile-info"}}}]
            (tracking/track-view-id-event :screen/onboarding.create-profile)))
-    (is (nil? (tracking/track-view-id-event :unknown-stack)))))
+    (is (= [] (tracking/track-view-id-event :unknown-stack)))))
 
 (deftest tracked-event-test
   (testing "returns correct event for given inputs"
@@ -70,16 +70,16 @@
              :appVersion app-version
              :eventValue {:enabled true}}}
            (tracking/metrics-event [:centralized-metrics/toggle-centralized-metrics true])))
-    (is (= {:metric
-            {:eventName  "navigation"
-             :platform   platform-os
-             :appVersion app-version
-             :eventValue {:viewId "wallet-stack"}}}
+    (is (= [{:metric
+             {:eventName  "navigation"
+              :platform   platform-os
+              :appVersion app-version
+              :eventValue {:viewId "wallet-stack"}}}]
            (tracking/metrics-event [:set-view-id :wallet-stack])))
     (is (nil? (tracking/metrics-event [:unknown-event])))
-    (is (= {:metric
-            {:eventName  "navigation"
-             :platform   platform-os
-             :appVersion app-version
-             :eventValue {:viewId "onboarding.intro"}}}
+    (is (= [{:metric
+             {:eventName  "navigation"
+              :platform   platform-os
+              :appVersion app-version
+              :eventValue {:viewId "onboarding.intro"}}}]
            (tracking/metrics-event [:set-view-id :screen/onboarding.intro])))))

--- a/src/status_im/contexts/onboarding/events.cljs
+++ b/src/status_im/contexts/onboarding/events.cljs
@@ -3,8 +3,6 @@
     [re-frame.core :as re-frame]
     status-im.common.biometric.events
     [status-im.constants :as constants]
-    [status-im.contexts.profile.create.events :as profile.create]
-    [status-im.contexts.profile.recover.events :as profile.recover]
     [status-im.contexts.shell.constants :as shell.constants]
     [taoensso.timbre :as log]
     [utils.i18n :as i18n]
@@ -78,30 +76,28 @@
  (fn [_ [error]]
    {:dispatch [:biometric/show-message (ex-cause error)]}))
 
-(rf/defn create-account-and-login
-  {:events [:onboarding/create-account-and-login]}
-  [{:keys [db] :as cofx}]
-  (let [{:keys [seed-phrase]
-         :as   profile}            (:onboarding/profile db)
-        syncing-account-recovered? (and (seq (:syncing/key-uid db))
-                                        (= (:syncing/key-uid db)
-                                           (get-in db [:onboarding/profile :key-uid])))]
-    (rf/merge cofx
-              {:fx [[:dispatch
-                     [:navigate-to-within-stack
-                      [:screen/onboarding.preparing-status
-                       (get db
-                            :onboarding/navigated-to-enter-seed-phrase-from-screen
-                            :screen/onboarding.new-to-status)]]]
-                    (when-not syncing-account-recovered?
-                      [:dispatch [:syncing/clear-syncing-installation-id]])]
-               :db (-> db
-                       (dissoc :profile/login)
-                       (dissoc :auth-method)
-                       (assoc :onboarding/new-account? true))}
-              (if seed-phrase
-                (profile.recover/recover-profile-and-login profile)
-                (profile.create/create-profile-and-login profile)))))
+(rf/reg-event-fx :onboarding/create-account-and-login
+ (fn [{:keys [db]}]
+   (let [{:keys [seed-phrase]
+          :as   profile}            (:onboarding/profile db)
+         syncing-account-recovered? (and (seq (:syncing/key-uid db))
+                                         (= (:syncing/key-uid db)
+                                            (get-in db [:onboarding/profile :key-uid])))]
+     {:db (-> db
+              (dissoc :profile/login)
+              (dissoc :auth-method)
+              (assoc :onboarding/new-account? true))
+      :fx [[:dispatch
+            [:navigate-to-within-stack
+             [:screen/onboarding.preparing-status
+              (get db
+                   :onboarding/navigated-to-enter-seed-phrase-from-screen
+                   :screen/onboarding.new-to-status)]]]
+           (when-not syncing-account-recovered?
+             [:dispatch [:syncing/clear-syncing-installation-id]])
+           (if seed-phrase
+             [:dispatch [:profile.recover/recover-and-login profile]]
+             [:dispatch [:profile.create/create-and-login profile]])]})))
 
 (rf/defn on-delete-profile-success
   {:events [:onboarding/on-delete-profile-success]}
@@ -207,4 +203,3 @@
               :on-error        #(log/error "failed to save biometrics"
                                            {:key-uid key-uid
                                             :error   %})}))))
-

--- a/src/status_im/contexts/profile/create/events.cljs
+++ b/src/status_im/contexts/profile/create/events.cljs
@@ -6,14 +6,13 @@
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
 
-(rf/defn create-profile-and-login
-  {:events [:profile.create/create-and-login]}
-  [{:keys [db]} {:keys [display-name password image-path color]}]
-  (let [login-sha3-password (native-module/sha3 (security/safe-unmask-data password))]
-    {:db (assoc-in db [:syncing :login-sha3-password] login-sha3-password)
-     :effects.profile/create-and-login
-     (assoc (profile.config/create)
-            :displayName        display-name
-            :password           login-sha3-password
-            :imagePath          (profile.config/strip-file-prefix image-path)
-            :customizationColor color)}))
+(rf/reg-event-fx :profile.create/create-and-login
+ (fn [{:keys [db]} [{:keys [display-name password image-path color]}]]
+   (let [login-sha3-password (native-module/sha3 (security/safe-unmask-data password))]
+     {:db (assoc-in db [:syncing :login-sha3-password] login-sha3-password)
+      :fx [[:effects.profile/create-and-login
+            (assoc (profile.config/create)
+                   :displayName        display-name
+                   :password           login-sha3-password
+                   :imagePath          (profile.config/strip-file-prefix image-path)
+                   :customizationColor color)]]})))

--- a/src/status_im/contexts/profile/recover/events.cljs
+++ b/src/status_im/contexts/profile/recover/events.cljs
@@ -7,23 +7,22 @@
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
 
-(rf/defn recover-profile-and-login
-  {:events [:profile.recover/recover-and-login]}
-  [{:keys [db]} {:keys [display-name password image-path color seed-phrase]}]
-  (let [login-sha3-password (native-module/sha3 (security/safe-unmask-data password))]
-    {:db
-     (-> db
-         (assoc :onboarding/recovered-account? true)
-         (assoc-in [:syncing :login-sha3-password] login-sha3-password))
-
-     :effects.profile/restore-and-login
-     (assoc (profile.config/create)
-            :displayName        display-name
-            :mnemonic           (security/safe-unmask-data seed-phrase)
-            :password           login-sha3-password
-            :imagePath          (profile.config/strip-file-prefix image-path)
-            :customizationColor (or color constants/profile-default-color)
-            :fetchBackup        true)}))
+(rf/reg-event-fx :profile.recover/recover-and-login
+ (fn [{:keys [db]} [{:keys [display-name password image-path color seed-phrase]}]]
+   (let [login-sha3-password (native-module/sha3 (security/safe-unmask-data password))]
+     {:db
+      (-> db
+          (assoc :onboarding/recovered-account? true)
+          (assoc-in [:syncing :login-sha3-password] login-sha3-password))
+      :fx
+      [[:effects.profile/restore-and-login
+        (assoc (profile.config/create)
+               :displayName        display-name
+               :mnemonic           (security/safe-unmask-data seed-phrase)
+               :password           login-sha3-password
+               :imagePath          (profile.config/strip-file-prefix image-path)
+               :customizationColor (or color constants/profile-default-color)
+               :fetchBackup        true)]]})))
 
 (rf/reg-event-fx :profile.recover/validate-recovery-phrase
  (fn [_ [phrase {:keys [on-success on-error]}]]

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -31,7 +31,9 @@
     status-im.contexts.network.events
     status-im.contexts.onboarding.common.overlay.events
     status-im.contexts.onboarding.events
+    status-im.contexts.profile.create.events
     status-im.contexts.profile.events
+    status-im.contexts.profile.recover.events
     status-im.contexts.profile.settings.events
     status-im.contexts.settings.language-and-currency.events
     status-im.contexts.settings.wallet.saved-addresses.events


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/21679

### Summary

This PR improves tracking of login and successful onboarding completion according to requests from non-technical analytics users and to synchronize with desktop. We now publish two new events `user-logged-in` and `onboarding-completed`.

- [x] Updated source of truth in Notion https://www.notion.so/Event-Tracking-Specification-Mobile-11a8f96fb65c8032a05efcebea3a1ce6?pvs=4#1538f96fb65c80bbb661e1d12089f653

### Areas that may be impacted

- No impact is expected whatsoever, but login and onboarding code were lightly touched.

### Steps to test

I tested myself the tracking of new events, as well as if existing events are still tracked correctly. I also tested login, profile recover via seed phrase and onboarding pairing. I'm kindly requesting QA for this PR due to the release right around the corner.

- Event `user-logged-in` is always published, whenever the profile login is successful. If the user created a profile, we publish both `onboarding-completed` and `user-logged-in`.
- Event `onboarding-completed` is published if the user created a profile, recovered using seed phrase or paired devices successfully.

status: ready