### PR TITLE
fix(wallet)_: default token image

### DIFF
--- a/src/quo/components/utilities/token/view.cljs
+++ b/src/quo/components/utilities/token/view.cljs
@@ -1,7 +1,6 @@
 (ns quo.components.utilities.token.view
   (:require
     [clojure.string :as string]
-    [quo.components.markdown.text :as quo]
     [quo.components.utilities.token.loader :as token-loader]
     [react-native.core :as rn]
     [schema.core :as schema]
@@ -33,22 +32,7 @@
            :height size-number)))
 
 (def ^:private b64-png-image-prefix "data:image/png;base64,")
-
-(defn temp-empty-symbol
-  [token size style]
-  [rn/view
-   {:style (token-style (merge {:justify-content :center
-                                :align-items     :center
-                                :border-radius   20
-                                :border-width    1
-                                :border-color    :grey}
-                               style)
-                        size)}
-   [quo/text {:style {:color :grey}}
-    (some-> token
-            name
-            first
-            string/capitalize)]])
+(def ^:const default-token-image (js/require "../resources/images/tokens/default-token.png"))
 
 (defn- normalize-b64-string
   [b64-image]
@@ -69,13 +53,12 @@
   "
   [{:keys [token size style image-source]
     :or   {size 32}}]
-  (let [img-src (if (string? image-source)
-                  (normalize-b64-string image-source)
-                  image-source)]
-    (if-let [existing-source (or img-src (token-loader/get-token-image token))]
-      [rn/image
-       {:style  (token-style style size)
-        :source existing-source}]
-      [temp-empty-symbol token size style])))
+  (let [img-src     (if (string? image-source)
+                      (normalize-b64-string image-source)
+                      image-source)
+        token-image (or img-src (token-loader/get-token-image token) default-token-image)]
+    [rn/image
+     {:style  (token-style style size)
+      :source token-image}]))
 
 (def view (schema/instrument #'view-internal ?schema))


### PR DESCRIPTION
### Summary

This PR replace the fallback for an unknown token image (where we display the first letter of the token name) with default token image

 | Before    | After
| --- | --- | 
| <img width="250" src="https://github.com/user-attachments/assets/a25726b5-5b97-4636-8fa7-df8958d03e1c" />  | <img width="250" src="https://github.com/user-attachments/assets/54c21fd0-13cb-4e3e-a5e8-9043abdc23f7" />  | 
| <img width="250" src="https://github.com/user-attachments/assets/6e85c5f3-9e8c-4209-b566-2f584f376758" /> | <img width="250" src="https://github.com/user-attachments/assets/13db0ef1-98b8-45c8-bfbb-5bd24b7b17d8" /> | 

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the Wallet tab
- Verify the token which doesn't have the logo/image has the default token image


status: ready 
