### PR TITLE
feat(wallet)_: keycard support for swap and approval

### DIFF
--- a/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
@@ -228,6 +228,7 @@
       :container-style     {:z-index 2}
       :customization-color (:color account)
       :disabled?           (or loading-swap-proposal? (not swap-proposal))
+      :keycard-supported?  true
       :on-auth-success     on-auth-success
       :auth-button-label   (i18n/label :t/confirm)}]))
 

--- a/src/status_im/contexts/wallet/swap/swap_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/swap/swap_confirmation/view.cljs
@@ -178,6 +178,7 @@
                                (not swap-proposal)
                                (not transaction-for-signing))
       :auth-button-label   (i18n/label :t/confirm)
+      :keycard-supported?  true
       :on-auth-success     (fn [data]
                              (rf/dispatch [:wallet/stop-get-swap-proposal])
                              (rf/dispatch [:wallet/prepare-signatures-for-transactions :swap data]))}]))


### PR DESCRIPTION
fixes #21619

### Summary

This PR adds support for Keycard in the swap flow

### Review Notes

Since we share the same signals for all transaction building and signing, the keycard support for swap is a bit easier

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the wallet tab
- Perform a swap transaction with a Keycard
- Verify the transaction is successfully placed

status: ready 
