### PR TITLE
fix(wallet)_: tx data cleanup after send or bridge tx

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -619,7 +619,7 @@
 
 (rf/reg-event-fx :wallet/clean-up-transaction-flow
  (fn [_]
-   {:fx [[:dispatch [:wallet/clean-send-data]]
+   {:fx [[:dispatch [:dismiss-modal :screen/wallet.transaction-confirmation]]
          [:dispatch [:wallet/clean-scanned-address]]
          [:dispatch [:wallet/clean-local-suggestions]]
          [:dispatch [:wallet/clean-send-address]]
@@ -629,9 +629,11 @@
 (rf/reg-event-fx :wallet/end-transaction-flow
  (fn [{:keys [db]}]
    (let [address (get-in db [:wallet :current-viewing-account-address])]
-     {:fx [[:dispatch [:dismiss-modal :screen/wallet.transaction-confirmation]]
-           [:dispatch [:wallet/navigate-to-account-within-stack address]]
-           [:dispatch [:wallet/select-account-tab :activity]]]})))
+     {:fx [[:dispatch [:wallet/navigate-to-account-within-stack address]]
+           [:dispatch [:wallet/select-account-tab :activity]]
+           [:dispatch-later
+            [{:ms       20
+              :dispatch [:wallet/clean-up-transaction-flow]}]]]})))
 
 (rf/reg-event-fx
  :wallet/build-transactions-from-route

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -258,8 +258,6 @@
                                              (set-input-state
                                               #(controlled-input/->crypto % conversion-rate)))
                                            (set-crypto-currency (not crypto-currency?)))]
-    (rn/use-unmount
-     #(rf/dispatch [:wallet/clean-up-transaction-flow]))
     (rn/use-effect
      (fn []
        (when active-screen?

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -285,9 +285,13 @@
   [bn1 bn2]
   (.round (.mul ^js bn1 bn2) 0))
 
-(defn div
+(defn- div*
   [bn1 bn2]
   (.dividedBy ^js bn1 bn2))
+
+(def div
+  "Divides with defaults, this version is able to receive `nil` and takes them as 0."
+  (fnil div* (bignumber 0) (bignumber 1)))
 
 (defn div-and-round
   [bn1 bn2]


### PR DESCRIPTION

fixes #21767

### Summary

This PR fixes the token/networks going to zero/disabled in the "Bridge to" screen when the user navigates back from the input screen.

### Review notes

The bug is a regression from https://github.com/status-im/status-mobile/issues/21720. This PR reverts part of the changes in #21720 as the TX state cleanup on the amount input page affects the Send/Bridge flow when navigating back from the input amount screen and the navigation glitch on completing the transaction.

This PR fixes original issue #21720 by creating a `div` method with a nil wrap.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to Wallet tab > Account
- Open the Bridge flow and select an asset and network to bridge to
- Navigate back from the input amount page
- Verify the Networks (Bridge to) screen doesn't go to zero/disabled 
- Navigate back to Wallet home
- Verify the Send/Bridge transaction is placed successfully using the input of crypto or fiat amount

status: ready 
