### PR TITLE
fix(wallet)_: Logic for calculating zero balance

### DIFF
--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -711,13 +711,11 @@
 (rf/reg-sub
  :wallet/zero-balance-in-all-non-watched-accounts?
  :<- [:wallet/aggregated-tokens]
- :<- [:profile/currency]
- :<- [:wallet/prices-per-token]
- (fn [[aggregated-tokens currency prices-per-token]]
-   (let [balance (utils/calculate-balance-from-tokens {:currency         currency
-                                                       :tokens           aggregated-tokens
-                                                       :prices-per-token prices-per-token})]
-     (and (not-empty aggregated-tokens) (money/equal-to balance 0)))))
+ (fn [aggregated-tokens]
+   (let [zero-balance? (->> aggregated-tokens
+                            (mapcat (comp vals :balances-per-chain))
+                            (every? #(money/equal-to (:raw-balance %) 0)))]
+     (and (not-empty aggregated-tokens) zero-balance?))))
 
 (rf/reg-sub
  :wallet/network-preference-details

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -1008,3 +1008,128 @@
         (update accounts "0x2" assoc :operable :partially)))
     (is (true? (rf/sub [sub-name])))))
 
+(h/deftest-sub :wallet/zero-balance-in-all-non-watched-accounts?
+  [sub-name]
+  (testing "returns true if the balance is zero in all non-watched accounts"
+    (swap! rf-db/app-db
+      #(assoc-in %
+        [:wallet :accounts]
+        {"0x1" {:address "0x1"
+                :watch-only? false
+                :tokens
+                [{:balances-per-chain {constants/ethereum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}
+                                       constants/optimism-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}
+                                       constants/arbitrum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}}}
+                 {:balances-per-chain {constants/ethereum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}
+                                       constants/optimism-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}
+                                       constants/arbitrum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}}}]}
+         "0x2" {:address "0x2"
+                :watch-only? false
+                :tokens
+                [{:balances-per-chain {constants/ethereum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}
+                                       constants/optimism-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}
+                                       constants/arbitrum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}}}
+                 {:balances-per-chain {constants/ethereum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}
+                                       constants/optimism-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}
+                                       constants/arbitrum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}}}]}
+
+         "0x3"
+         {:address     "0x3"
+          :watch-only? true
+          :tokens      [{:balances-per-chain {constants/ethereum-mainnet-chain-id {:raw-balance
+                                                                                   (money/bignumber
+                                                                                    "2")
+                                                                                   :has-error false}
+                                              constants/optimism-mainnet-chain-id {:raw-balance
+                                                                                   (money/bignumber
+                                                                                    "1")
+                                                                                   :has-error false}
+                                              constants/arbitrum-mainnet-chain-id {:raw-balance
+                                                                                   (money/bignumber
+                                                                                    "0")
+                                                                                   :has-error false}}}
+                        {:balances-per-chain {constants/ethereum-mainnet-chain-id {:raw-balance
+                                                                                   (money/bignumber
+                                                                                    "0")
+                                                                                   :has-error false}
+                                              constants/optimism-mainnet-chain-id {:raw-balance
+                                                                                   (money/bignumber
+                                                                                    "2")
+                                                                                   :has-error false}
+                                              constants/arbitrum-mainnet-chain-id {:raw-balance
+                                                                                   (money/bignumber
+                                                                                    "0")
+                                                                                   :has-error
+                                                                                   false}}}]}}))
+    (is (true? (rf/sub [sub-name]))))
+  (testing "returns false if the balance is not zero in all non-watched accounts"
+    (swap! rf-db/app-db
+      #(assoc-in %
+        [:wallet :accounts]
+        {"0x1" {:address "0x1"
+                :watch-only? false
+                :tokens
+                [{:balances-per-chain {constants/ethereum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "2")
+                                                                            :has-error   false}
+                                       constants/optimism-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "1")
+                                                                            :has-error   false}
+                                       constants/arbitrum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}}}
+                 {:balances-per-chain {constants/ethereum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}
+                                       constants/optimism-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "2")
+                                                                            :has-error   false}
+                                       constants/arbitrum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}}}]}
+         "0x2" {:address "0x2"
+                :watch-only? true
+                :tokens
+                [{:balances-per-chain {constants/ethereum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "2")
+                                                                            :has-error   false}
+                                       constants/optimism-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "1")
+                                                                            :has-error   false}
+                                       constants/arbitrum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}}}
+                 {:balances-per-chain {constants/ethereum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}
+                                       constants/optimism-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "2")
+                                                                            :has-error   false}
+                                       constants/arbitrum-mainnet-chain-id {:raw-balance (money/bignumber
+                                                                                          "0")
+                                                                            :has-error   false}}}]}}))
+    (is (false? (rf/sub [sub-name])))))


### PR DESCRIPTION
### Summary

This PR fixes logic to calculate whether the user has zero balance in all non-watched accounts.

### Review notes

Follow-up of https://github.com/status-im/status-mobile/pull/21690

Previously, we relied on the fiat value, which depends on token prices. The token prices response sometimes has some minor delay, which causes the CTAs/Cards to be shown despite the user having some tokens for a second.

This PR changes to rely only on the token balance.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the Wallet tab
- Verify the "Ways to buy" and "Receive" CTAs are shown only when there is no balance in the accounts

status: ready 

