### PR TITLE
fix_: slider reset in standard authentication

### DIFF
--- a/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
+++ b/src/status_im/common/standard_authentication/standard_auth/slide_button/view.cljs
@@ -15,18 +15,18 @@
         auth-method     (rf/sub [:auth-method])
         biometric-auth? (= auth-method constants/auth-method-biometric)
         on-complete     (rn/use-callback
-                         (fn [reset]
-                           (rf/dispatch [:standard-auth/authorize
-                                         {:on-close              (fn [success?]
-                                                                   (js/setTimeout #(reset success?) 200))
-                                          :auth-button-icon-left auth-button-icon-left
-                                          :theme                 theme
-                                          :blur?                 blur?
-                                          :keycard-supported?    keycard-supported?
-                                          :biometric-auth?       biometric-auth?
-                                          :on-auth-success       on-auth-success
-                                          :on-auth-fail          on-auth-fail
-                                          :auth-button-label     auth-button-label}]))
+                         (fn [reset-slider-fn]
+                           (js/setTimeout #(reset-slider-fn false) 500)
+                           (rf/dispatch
+                            [:standard-auth/authorize
+                             {:auth-button-icon-left auth-button-icon-left
+                              :theme                 theme
+                              :blur?                 blur?
+                              :keycard-supported?    keycard-supported?
+                              :biometric-auth?       biometric-auth?
+                              :on-auth-success       on-auth-success
+                              :on-auth-fail          on-auth-fail
+                              :auth-button-label     auth-button-label}]))
                          (vec (conj dependencies on-auth-success on-auth-fail)))
         biometric-type  (rf/sub [:biometrics/supported-type])]
     [quo/slide-button


### PR DESCRIPTION
fixes #21768

### Summary

This PR resets the slider-button after the completion of slider in standard authentication.

| Password | Keycard |
| --- | --- | 
| <video src="https://github.com/user-attachments/assets/338b65a0-3887-4632-9f27-4641e2cafe1d" />  | <video src="https://github.com/user-attachments/assets/ef667a6f-af96-45cc-9de0-708f8f55986c" />  | 

### Review notes

The bug is caused by the `slider-button` component in the standard auth. On drag completion of slider the `on-complete` method receives the `reset-slider-fn` which needs to be called back to reset the slider (with boolean flag arg to reset the slider position to start). 

This happens for password authentication sheet as on close of the sheet, it happens. If we want to incorporate the same in keycard flows, it will be huge as different context has different methods or event dispatches in keycard flows.

So, I moved the `reset-slider-fn` out from `on-close` and execute it out on the completion with doubled delay because giving time for the dispatches to complete and also doesn't want the user to feel the slider resets very quickly.


### Platforms

- Android
- iOS

### Steps to test

##### Prerequisite: A user with Keycard

- Open Status
- Login to the profile with a Keycard
- Navigate to `Wallet > Send` (till transaction confirmation screen)
- Slide to send and close the Keycard PIN drawer
- Verify the slider can be slide again which opens the Keycard PIN drawer again

status: ready 


