### PR TITLE
feature: add keycard metric events

### DIFF
--- a/src/status_im/contexts/centralized_metrics/tracking.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking.cljs
@@ -54,10 +54,10 @@
 
       (= :screen/onboarding.syncing-results view-id)
       (conj (key-value-event "onboarding-completed"))
-      
+
       (= :screen/keycard.migrate.success view-id)
       (conj (key-value-event "keycard-migration-succeeded"))
-      
+
       (= :screen/keycard.migrate.fail view-id)
       (conj (key-value-event "keycard-migration-failed")))))
 

--- a/src/status_im/contexts/centralized_metrics/tracking.cljs
+++ b/src/status_im/contexts/centralized_metrics/tracking.cljs
@@ -53,7 +53,13 @@
       (conj (navigation-event (name view-id)))
 
       (= :screen/onboarding.syncing-results view-id)
-      (conj (key-value-event "onboarding-completed")))))
+      (conj (key-value-event "onboarding-completed"))
+      
+      (= :screen/keycard.migrate.success view-id)
+      (conj (key-value-event "keycard-migration-succeeded"))
+      
+      (= :screen/keycard.migrate.fail view-id)
+      (conj (key-value-event "keycard-migration-failed")))))
 
 (defn navigated-to-collectibles-tab-event
   [location]

--- a/src/status_im/contexts/communities/actions/request_to_join/view.cljs
+++ b/src/status_im/contexts/communities/actions/request_to_join/view.cljs
@@ -30,7 +30,8 @@
           {:keys [color name images]} (rf/sub [:communities/community id])
           keycard?                    (rf/sub [:keycard/keycard-profile?])
           keycard-feature-unavailable (rn/use-callback
-                                       #(rf/dispatch [:keycard/feature-unavailable-show]))]
+                                       #(rf/dispatch [:keycard/feature-unavailable-show
+                                                      {:feature-name :community.request-to-join}]))]
       [rn/safe-area-view {:flex 1}
        [gesture/scroll-view {:style style/container}
         [rn/view style/page-container

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -147,7 +147,8 @@
                                    [:show-bottom-sheet {:content token-gated-communities-info}])
      keycard?                    (rf/sub [:keycard/keycard-profile?])
      keycard-feature-unavailable (rn/use-callback
-                                  #(rf/dispatch [:keycard/feature-unavailable-show]))]
+                                  #(rf/dispatch [:keycard/feature-unavailable-show
+                                                 {:feature-name :community.request-to-join}]))]
 
     (cond
       networks-not-supported?

--- a/src/status_im/contexts/keycard/feature_unavailable/events.cljs
+++ b/src/status_im/contexts/keycard/feature_unavailable/events.cljs
@@ -1,16 +1,27 @@
 (ns status-im.contexts.keycard.feature-unavailable.events
   (:require
+    [status-im.constants :as constants]
     [status-im.contexts.keycard.feature-unavailable.view :as feature-unavailable]
     [utils.re-frame :as rf]))
 
 (rf/reg-event-fx
+ :keycard/feature-unavailable-upvote
+ (fn [_ [{:keys [feature-name]}]]
+   {:fx [[:dispatch [:open-url constants/mobile-upvote-link]]
+         [:dispatch
+          [:centralized-metrics/track
+           :metric/feature-unavailable-upvote
+           {:feature-name feature-name}]]]}))
+
+(rf/reg-event-fx
  :keycard/feature-unavailable-show
- (fn [_ [options]]
+ (fn [_ [{:keys [feature-name theme] :as options}]]
    {:fx [[:dispatch
           [:show-bottom-sheet
-           {:theme   (:theme options)
-            :content feature-unavailable/view}]]
+           {:theme   theme
+            :content (fn []
+                       (feature-unavailable/view options))}]]
          [:dispatch
           [:centralized-metrics/track
            :metric/feature-unavailable
-           {:feature-name (:feature-name options)}]]]}))
+           {:feature-name feature-name}]]]}))

--- a/src/status_im/contexts/keycard/feature_unavailable/events.cljs
+++ b/src/status_im/contexts/keycard/feature_unavailable/events.cljs
@@ -9,4 +9,8 @@
    {:fx [[:dispatch
           [:show-bottom-sheet
            {:theme   (:theme options)
-            :content feature-unavailable/view}]]]}))
+            :content feature-unavailable/view}]]
+         [:dispatch
+          [:centralized-metrics/track
+           :metric/feature-unavailable
+           {:feature-name (:feature-name options)}]]]}))

--- a/src/status_im/contexts/keycard/feature_unavailable/view.cljs
+++ b/src/status_im/contexts/keycard/feature_unavailable/view.cljs
@@ -1,16 +1,15 @@
 (ns status-im.contexts.keycard.feature-unavailable.view
   (:require
     [quo.core :as quo]
-    [status-im.constants :as constants]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
 (defn on-upvote
-  []
-  (rf/dispatch [:open-url constants/mobile-upvote-link]))
+  [feature-name]
+  (rf/dispatch [:keycard/feature-unavailable-upvote {:feature-name feature-name}]))
 
 (defn view
-  []
+  [{:keys [feature-name]}]
   [:<>
    [quo/drawer-top
     {:title       (i18n/label :t/feature-unavailable)
@@ -24,5 +23,5 @@
      [quo/text
       {:style    {:text-decoration-line :underline}
        :size     :paragraph-2
-       :on-press on-upvote}
+       :on-press #(on-upvote feature-name)}
       (i18n/label :t/upvote-it)]]]])

--- a/src/status_im/contexts/keycard/migrate/re_encrypting/events.cljs
+++ b/src/status_im/contexts/keycard/migrate/re_encrypting/events.cljs
@@ -27,8 +27,5 @@
              :callback
              (fn [{:keys [error]}]
                (if (string/blank? error)
-                 (do (rf/dispatch [:navigate-to :screen/keycard.migrate.success])
-                     (rf/dispatch [:centralized-metrics/track :metric/keycard-migration-succeeded]))
-                 (do (rf/dispatch [:navigate-to :screen/keycard.migrate.fail])
-                     (rf/dispatch [:centralized-metrics/track
-                                   :metric/keycard-migration-failed]))))}]]})))
+                 (rf/dispatch [:navigate-to :screen/keycard.migrate.success])
+                 (rf/dispatch [:navigate-to :screen/keycard.migrate.fail])))}]]})))

--- a/src/status_im/contexts/keycard/migrate/re_encrypting/events.cljs
+++ b/src/status_im/contexts/keycard/migrate/re_encrypting/events.cljs
@@ -27,5 +27,8 @@
              :callback
              (fn [{:keys [error]}]
                (if (string/blank? error)
-                 (rf/dispatch [:navigate-to :screen/keycard.migrate.success])
-                 (rf/dispatch [:navigate-to :screen/keycard.migrate.fail])))}]]})))
+                 (do (rf/dispatch [:navigate-to :screen/keycard.migrate.success])
+                     (rf/dispatch [:centralized-metrics/track :metric/keycard-migration-succeeded]))
+                 (do (rf/dispatch [:navigate-to :screen/keycard.migrate.fail])
+                     (rf/dispatch [:centralized-metrics/track
+                                   :metric/keycard-migration-failed]))))}]]})))

--- a/src/status_im/contexts/profile/login/events.cljs
+++ b/src/status_im/contexts/profile/login/events.cljs
@@ -47,7 +47,8 @@
                                               settings
                                               {:log-level log-level}))
                                 (assoc-in [:activity-center :loading?] true)
-                                (dissoc :centralized-metrics/onboarding-enabled?))]
+                                (dissoc :centralized-metrics/onboarding-enabled?))
+         keycard?           (get-in new-db [:profile/profile :keycard-pairing])]
      {:db (cond-> new-db
             pairing-completed? (dissoc :syncing))
       :fx (into [[:json-rpc/call
@@ -75,8 +76,10 @@
                    [:effects.chat/open-last-chat (:key-uid profile-overview)])
 
                  (when (:centralized-metrics/onboarding-enabled? db)
-                   [:dispatch [:profile.settings/toggle-telemetry true]])]
+                   [:dispatch [:profile.settings/toggle-telemetry true]])
 
+                 (when keycard?
+                   [:dispatch [:centralized-metrics/track :metric/keycard-login]])]
                 (cond
                   pairing-completed?
                   [[:dispatch [:update-theme-and-init-root :screen/onboarding.syncing-results]]]

--- a/src/status_im/contexts/profile/settings/screens/password/view.cljs
+++ b/src/status_im/contexts/profile/settings/screens/password/view.cljs
@@ -12,7 +12,7 @@
     (if keycard-profile?
       (rf/dispatch [:keycard/feature-unavailable-show
                     {:theme        :dark
-                     :feature-name :settings/enable-biometrics}])
+                     :feature-name :settings.enable-biometrics}])
       (rf/dispatch
        [:standard-auth/authorize-with-password
         {:blur?             true

--- a/src/status_im/contexts/profile/settings/screens/password/view.cljs
+++ b/src/status_im/contexts/profile/settings/screens/password/view.cljs
@@ -10,7 +10,9 @@
   [button-label theme keycard-profile?]
   (fn []
     (if keycard-profile?
-      (rf/dispatch [:keycard/feature-unavailable-show {:theme :dark}])
+      (rf/dispatch [:keycard/feature-unavailable-show
+                    {:theme        :dark
+                     :feature-name :settings/enable-biometrics}])
       (rf/dispatch
        [:standard-auth/authorize-with-password
         {:blur?             true

--- a/src/status_im/contexts/syncing/syncing_devices_list/view.cljs
+++ b/src/status_im/contexts/syncing/syncing_devices_list/view.cljs
@@ -41,8 +41,10 @@
                                                      other-devices)
         keycard?                                    (rf/sub [:keycard/keycard-profile?])
         keycard-feature-unavailable                 (rn/use-callback
-                                                     #(rf/dispatch [:keycard/feature-unavailable-show
-                                                                    {:theme :dark}]))]
+                                                     #(rf/dispatch
+                                                       [:keycard/feature-unavailable-show
+                                                        {:theme        :dark
+                                                         :feature-name :settings.setup-syncing}]))]
     [quo/overlay {:type :shell :top-inset? true}
      [quo/page-nav
       {:type       :no-title

--- a/src/status_im/contexts/wallet/common/account_switcher/view.cljs
+++ b/src/status_im/contexts/wallet/common/account_switcher/view.cljs
@@ -48,7 +48,8 @@
                               {:icon-name :i/dapps
                                :on-press  #(rf/dispatch
                                             (if keycard?
-                                              [:keycard/feature-unavailable-show]
+                                              [:keycard/feature-unavailable-show
+                                               {:feature-name :wallet.show-connected-dapps}]
                                               [:navigate-to :screen/wallet.connected-dapps]))})
                             (when-not sending-collectible?
                               {:content-type        :account-switcher

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
@@ -36,7 +36,9 @@
      (cond
 
        keycard?
-       {:fx [[:dispatch [:keycard/feature-unavailable-show]]]}
+       {:fx [[:dispatch
+              [:keycard/feature-unavailable-show
+               {:feature-name :wallet.scan-dapp-connection}]]]}
 
        (or (not valid-wc-uri?)
            (not version-supported?)


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21685

### Summary

* This PR attempts to add metric events for the following keycard events:
  * When a user successfully logins with Keycard
  * When a user succeeds or fails to migrate profile to Keycard
  * When a Keycard user encounters a feature that is unavailable
  * When a Keycard user navigates to the feature upvote url for an unavailable feature

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- Keycard analytics

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- WIP

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
