### PR TITLE
fix: use image clock when updating profile images to cause re-render

### DIFF
--- a/src/status_im/contexts/profile/edit/header/events.cljs
+++ b/src/status_im/contexts/profile/edit/header/events.cljs
@@ -5,9 +5,11 @@
             [utils.re-frame :as rf]))
 
 (rf/reg-event-fx :profile/update-local-picture
- (fn [{:keys [db]} [images]]
+ (fn [{:keys [db now]} [images]]
    {:db (if images
-          (assoc-in db [:profile/profile :images] images)
+          (assoc-in db
+           [:profile/profile :images]
+           (map #(assoc % :clock now) images))
           (update db :profile/profile dissoc :images))}))
 
 (rf/reg-event-fx :profile/edit-profile-picture-success

--- a/src/status_im/contexts/profile/settings/events.cljs
+++ b/src/status_im/contexts/profile/settings/events.cljs
@@ -129,8 +129,10 @@
            [:dispatch [:hide-bottom-sheet]]]})))
 
 (rf/reg-event-fx :profile.settings/update-local-picture
- (fn [{:keys [db]} [images]]
-   {:db (assoc-in db [:profile/profile :images] images)}))
+ (fn [{:keys [db now]} [images]]
+   {:db (assoc-in db
+         [:profile/profile :images]
+         (map #(assoc % :clock now) images))}))
 
 (rf/reg-event-fx :profile.settings/mnemonic-was-shown
  (fn [_]

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -65,6 +65,7 @@
  (fn [[profiles port font-file theme] [_ target-key-uid]]
    (let [{:keys [images ens-name? customization-color] :as profile} (get profiles target-key-uid)
          image-name                                                 (-> images first :type)
+         image-clock                                                (-> images first :clock)
          override-ring?                                             (when ens-name? false)]
      (when (and profile port)
        {:config
@@ -75,6 +76,7 @@
                      :image-name     image-name
                      :key-uid        target-key-uid
                      :theme          theme
+                     :clock          image-clock
                      :override-ring? override-ring?}}
           {:type    :initials
            :options {:port                port
@@ -281,7 +283,10 @@
                 customization-color]} profile
         ens-name?                     (or ens-name? (seq ens-names))
         avatar-opts                   (assoc avatar-opts :override-ring? (when ens-name? false))
-        images-with-uri               (mapv (fn [{key-uid :keyUid image-name :type :as image}]
+        images-with-uri               (mapv (fn [{key-uid     :keyUid
+                                                  image-name  :type
+                                                  image-clock :clock
+                                                  :as         image}]
                                               (assoc image
                                                      :config
                                                      {:type    :account
@@ -289,6 +294,7 @@
                                                                 {:port       port
                                                                  :ratio      pixel-ratio/ratio
                                                                  :image-name image-name
+                                                                 :clock      image-clock
                                                                  :key-uid    key-uid
                                                                  :theme      theme}
                                                                 avatar-opts)}))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21787

### Summary

* This PR attempts to fix an issue with account images not re-rendering after updating the profile image.
  * Currently this PR fixes the issue by associating a `clock` value to the identity images that are returned by status-go, because for some reason the clocks are defaulted to `0`.
  * Likely we'll need to update status-go to populate the image clocks before forwarding the results.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

* Profile images

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

WIP

<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

#### After Changes on iOS

https://github.com/user-attachments/assets/171d6565-5815-49dd-bb5b-6d0a0c22e6e6

status: ready <!-- Can be ready or wip -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that maybe impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
