### PR TITLE
feat_: optimize endpoint calls when fetching balances

### DIFF
--- a/src/status_im/contexts/wallet/events_test.cljs
+++ b/src/status_im/contexts/wallet/events_test.cljs
@@ -116,20 +116,19 @@
         address-2 "0x2"]
     (reset! rf-db/app-db {:wallet {:accounts {address-1 {:address address-1}
                                               address-2 {:address address-2}}}})
-    (is (match? [[:dispatch [:wallet/get-wallet-token-for-account address-1]]
-                 [:dispatch [:wallet/get-wallet-token-for-account address-2]]]
+    (is (match? [[:dispatch [:wallet/get-wallet-token-for-accounts [address-1 address-2]]]]
                 (:fx (dispatch [event-id]))))))
 
-(h/deftest-event :wallet/get-wallet-token-for-account
+(h/deftest-event :wallet/get-wallet-token-for-accounts
   [event-id dispatch]
   (let [expected-effects {:db {:wallet {:ui {:tokens-loading {address true}}}}
                           :fx [[:json-rpc/call
                                 [{:method     "wallet_fetchOrGetCachedWalletBalances"
                                   :params     [[address] true]
-                                  :on-success [:wallet/store-wallet-token address]
-                                  :on-error   [:wallet/get-wallet-token-for-account-failed
-                                               address]}]]]}]
-    (is (match? expected-effects (dispatch [event-id address])))))
+                                  :on-success [:wallet/store-wallet-token [address]]
+                                  :on-error   [:wallet/get-wallet-token-for-accounts-failed
+                                               [address]]}]]]}]
+    (is (match? expected-effects (dispatch [event-id [address]])))))
 
 (h/deftest-event :wallet/reconcile-keypairs
   [event-id dispatch]


### PR DESCRIPTION
may fix #21804

### Summary

Not sure if related to [this Android freeze](https://github.com/status-im/status-mobile/issues/21799), but when we load all accounts balances either on initial login or pull to refresh, we fetch prices and market values once per account. That may be lot of redundant data to process if the user has accounts with many tokens. This PR optimizes the corresponding re-frame events to fetch all balances for all accounts in the same endpoint call, and also fetches prices and market values once per refresh.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

- Open Status
- Log in with a user with many accounts
- Verify initial wallet loading or pull to refresh is faster

status: ready