### PR TITLE
[#21797] Hide viewing community token requirements under a feature flag

### DIFF
--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -7,6 +7,7 @@
     [status-im.constants :as constants]
     [status-im.contexts.communities.actions.addresses-for-permissions.style :as style]
     [status-im.contexts.communities.actions.permissions-sheet.view :as permissions-sheet]
+    [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
     [utils.money :as money]
     [utils.re-frame :as rf]))
@@ -122,23 +123,23 @@
 (defn- page-top
   [{:keys [community-id identical-choices? can-edit-addresses?]}]
   (let [{:keys [name logo color]} (rf/sub [:communities/for-context-tag community-id])
-        has-permissions? (rf/sub [:communities/has-permissions? community-id])
-        confirm-discard-changes
-        (rn/use-callback
-         (fn []
-           (if identical-choices?
-             (rf/dispatch [:dismiss-modal :addresses-for-permissions])
-             (rf/dispatch [:show-bottom-sheet
-                           {:content (fn [] [confirm-discard-drawer
-                                             community-id])}])))
-         [identical-choices? community-id])
-
-        open-permission-sheet
-        (rn/use-callback (fn []
-                           (rf/dispatch [:show-bottom-sheet
-                                         {:content (fn [] [permissions-sheet/view
-                                                           community-id])}]))
-                         [community-id])]
+        has-permissions?          (rf/sub [:communities/has-permissions? community-id])
+        confirm-discard-changes   (rn/use-callback
+                                   (fn []
+                                     (if identical-choices?
+                                       (rf/dispatch [:dismiss-modal :addresses-for-permissions])
+                                       (rf/dispatch [:show-bottom-sheet
+                                                     {:content (fn []
+                                                                 [confirm-discard-drawer
+                                                                  community-id])}])))
+                                   [identical-choices? community-id])
+        open-permission-sheet     (rn/use-callback
+                                   (fn []
+                                     (rf/dispatch [:show-bottom-sheet
+                                                   {:content (fn []
+                                                               [permissions-sheet/view
+                                                                community-id])}]))
+                                   [community-id])]
     [:<>
      (when can-edit-addresses?
        [quo/page-nav
@@ -161,7 +162,7 @@
                  :community-name      name
                  :community-logo      logo
                  :customization-color color}
-          has-permissions?
+          (and has-permissions? (ff/enabled? ::ff/community.view-token-requirements))
           (assoc :button-icon     :i/info
                  :button-type     :grey
                  :on-button-press open-permission-sheet))])]))

--- a/src/status_im/contexts/communities/actions/community_options/view.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/view.cljs
@@ -40,7 +40,8 @@
    :right-icon          :i/chevron-right
    :accessibility-label :view-token-gating
    :on-press            #(rf/dispatch [:show-bottom-sheet
-                                       {:content                 (fn [] [permissions-sheet/view id])
+                                       {:content                 (fn []
+                                                                   [permissions-sheet/view id])
                                         :padding-bottom-override 16}])
    :label               (i18n/label :t/view-token-gating)})
 
@@ -146,7 +147,9 @@
   [{:keys [id join-pending? spectated? token-gated? intro-message test-networks-enabled?]}]
   (let [common   [(show-qr id) (share-community id)]
         specific (cond
-                   (and token-gated? (not test-networks-enabled?))
+                   (and token-gated?
+                        (not test-networks-enabled?)
+                        (ff/enabled? ::ff/community.view-token-requirements))
                    [(invite-contacts id) (view-token-gating id)]
 
                    token-gated?
@@ -172,7 +175,8 @@
   [{:keys [id token-gated? muted? muted-till color intro-message]}]
   [[(view-members id)
     (view-rules id intro-message)
-    (when token-gated? (view-token-gating id))
+    (when (and token-gated? (ff/enabled? ::ff/community.view-token-requirements))
+      (view-token-gating id))
     (when (ff/enabled? ::ff/community.edit-account-selection)
       (edit-shared-addresses id))
     (mark-as-read id)

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -11,13 +11,13 @@
 
 (def ^:private initial-flags
   {::community.edit-account-selection   (enabled-in-env? :FLAG_EDIT_ACCOUNT_SELECTION_ENABLED)
+   ::community.view-token-requirements  (enabled-in-env? :FLAG_VIEW_TOKEN_REQUIREMENTS)
 
    ;; Feature toggled (off by default) because the desktop app disabled this
    ;; feature and we want both clients in sync. We keep the code because it
    ;; works and we may re-enable it by default.
    ::profile-pictures-visibility        (enabled-in-env? :FLAG_PROFILE_PICTURES_VISIBILITY_ENABLED)
-   ::settings.import-all-keypairs       (enabled-in-env?
-                                         :FLAG_WALLET_SETTINGS_IMPORT_ALL_KEYPAIRS)
+   ::settings.import-all-keypairs       (enabled-in-env? :FLAG_WALLET_SETTINGS_IMPORT_ALL_KEYPAIRS)
    ::wallet.add-watched-address         (enabled-in-env? :FLAG_ADD_WATCHED_ADDRESS)
    ::wallet.advanced-sending            (enabled-in-env? :FLAG_ADVANCED_SENDING)
    ::wallet.assets-modal-hide           (enabled-in-env? :FLAG_ASSETS_MODAL_HIDE)


### PR DESCRIPTION
fixes #21797

### Summary

This PR hides the option to view token requirements for token gated communities by using a feature flag

status: ready