### PR TITLE
[#21135] handle unsupported wallet address

### DIFF
--- a/src/status_im/contexts/shell/qr_reader/view.cljs
+++ b/src/status_im/contexts/shell/qr_reader/view.cljs
@@ -10,7 +10,6 @@
             [status-im.feature-flags :as ff]
             [utils.address :as utils-address]
             [utils.debounce :as debounce]
-            [utils.ethereum.eip.eip681 :as eip681]
             [utils.i18n :as i18n]
             [utils.url :as url]))
 
@@ -27,13 +26,6 @@
   [scanned-text]
   (let [index (string/index-of scanned-text "#")]
     (subs scanned-text (inc index))))
-
-(defn eip681-address?
-  [scanned-text]
-  (-> scanned-text
-      eip681/parse-uri
-      :address
-      boolean))
 
 (defn pairing-qr-code?
   [_]
@@ -88,10 +80,10 @@
       (debounce/debounce-and-dispatch [:generic-scanner/scan-success address] 300)
       (debounce/debounce-and-dispatch [:shell/change-tab :wallet-stack] 300))
 
-    (eip681-address? scanned-text)
+    (utils-address/eip-681-address? scanned-text)
     (do
-      (debounce/debounce-and-dispatch [:wallet-legacy/request-uri-parsed
-                                       (eip681/parse-uri scanned-text)]
+      (debounce/debounce-and-dispatch [:generic-scanner/scan-success
+                                       (utils-address/eip-681-address->eth-address scanned-text)]
                                       300)
       (debounce/debounce-and-dispatch [:shell/change-tab :wallet-stack] 300))
 

--- a/src/status_im/contexts/wallet/common/scan_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/scan_account/view.cljs
@@ -13,7 +13,7 @@
      {:title           (i18n/label :t/scan-qr)
       :subtitle        (i18n/label :t/scan-an-address-qr-code)
       :error-message   (i18n/label :t/oops-this-qr-does-not-contain-an-address)
-      :validate-fn     #(utils-address/supported-address? %)
+      :validate-fn     #(utils-address/supported-scan-address? %)
       :on-success-scan (fn [result]
                          (let [address (utils-address/supported-address->eth-address result)]
                            (when on-result (on-result address))

--- a/src/utils/address.cljs
+++ b/src/utils/address.cljs
@@ -2,7 +2,8 @@
   (:require
     [clojure.string :as string]
     [native-module.core :as native-module]
-    [utils.ethereum.eip.eip55 :as eip55]))
+    [utils.ethereum.eip.eip55 :as eip55]
+    [utils.ethereum.eip.eip681 :as eip681]))
 
 
 (def hex-prefix "0x")
@@ -105,10 +106,22 @@
   [address]
   (re-find regx-eip-3770-address address))
 
+(defn eip-681-address?
+  [scanned-text]
+  (-> scanned-text
+      eip681/parse-uri
+      :address
+      boolean))
+
 (defn supported-address?
   [s]
   (boolean (or (eip-3770-address? s)
                (metamask-address? s))))
+
+(defn supported-scan-address?
+  [s]
+  (boolean (or (eip-681-address? s)
+               (supported-address? s))))
 
 (defn metamask-address->eip-3770-address
   [metamask-address]
@@ -129,9 +142,18 @@
   [eip-3770-address]
   (extract-address-without-chains-info eip-3770-address))
 
+(defn eip-681-address->eth-address
+  [eip-681-address]
+  (-> eip-681-address
+      eip681/parse-uri
+      :address))
+
 (defn supported-address->eth-address
   [address]
   (cond
+    (eip-681-address? address)
+    (eip-681-address->eth-address address)
+
     (eip-3770-address? address)
     (eip-3770-address->eth-address address)
 


### PR DESCRIPTION
fixes #21135

### Summary

Convert all addresses down to plain eth address
The addresses should be fetched without prefixes and chain ids .

discussed with design [team](https://discord.com/channels/1210237582470807632/1217173176086302821/1279068522630353010)

#### Areas that maybe impacted

- Universal scan wallet QR
- Scanner in 'Send to' page


### Steps to test

- You can use QRs here to test with scanner https://github.com/status-im/status-mobile/issues/21135#issue-2491662656

### Result



https://github.com/user-attachments/assets/d0046ca9-eb61-4823-bc12-c9dbd5a0f817



status: ready