### PR TITLE
fix: handle network change for filter subs

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v8.1.0",
-    "commit-sha1": "df1c8788e42784ba3b8ed3e7c5bd3ea530028410",
-    "src-sha256": "1yxcswrj7p1m96lx795vbqlgjlmpkgzaw7l8f2k4ni3d7vmlklnw"
+    "version": "58707e787513f883ce3d42826e9989a3e71b9d4b",
+    "commit-sha1": "58707e787513f883ce3d42826e9989a3e71b9d4b",
+    "src-sha256": "1a4kkazy3qkpkgh88j41jqmlx9gwrv2f66b1dzlxqljg5v2f1d10"
 }


### PR DESCRIPTION
fixes filter not working when network switches from wifi to cellular. 
Corresponding status go PR https://github.com/status-im/status-go/pull/6232

### Summary

#### Platforms

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test

I would suggest testing network change (wifi to cellular, cellular to wifi etc) scenarios and reception of messages prior and after network change. Following are scenarios that should get validated

- start app when connected to wifi and switch to cellular by disabilng wifi
- start app when connected to Cellular only and switch on wifi
- switch between cellular and wifi multiple times to verify receiving messages


status: ready 

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

