### PR TITLE
[#21483] fix: update collectible amounts after sending

### DIFF
--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -308,7 +308,7 @@
          ;; We delay the navigation because we need re-frame to update the DB on time.
          ;; By doing it, we skip a blink while visiting the collectible detail page.
          [:dispatch-later
-          {:ms       17
+          {:ms       20
            :dispatch [:open-modal :screen/wallet.collectible]}]]}))
 
 (rf/reg-event-fx

--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -346,17 +346,10 @@
                   {:event    :wallet/get-collectible-details-done
                    :response response})))))
 
-(defn group-collectibles-by-ownership-address
-  [collectible]
-  (->> (:ownership collectible)
-       (map (fn [{:keys [address]}]
-              [address collectible]))
-       (into {})))
-
 (rf/reg-event-fx
  :wallet/update-collectibles-data
  (fn [{:keys [db]} [collectible]]
-   (let [collectibles-by-address (group-collectibles-by-ownership-address collectible)]
+   (let [collectibles-by-address (collectible-utils/group-collectibles-by-ownership-address collectible)]
      {:db (update-in db
                      [:wallet :accounts]
                      #(reduce-kv

--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -70,7 +70,7 @@
    (let [current-collectible-idx (get-in db [:wallet :accounts account :current-collectible-idx] 0)
          collectibles-filter     nil
          data-type               (collectible-data-types :header)
-         fetch-criteria          {:fetch-type            (fetch-type :fetch-if-not-cached)
+         fetch-criteria          {:fetch-type            (fetch-type :fetch-if-cache-old)
                                   :max-cache-age-seconds max-cache-age-seconds}
          chain-ids               (chain/chain-ids db)
          request-params          [request-id
@@ -171,16 +171,19 @@
 
 (rf/reg-event-fx
  :wallet/collectible-ownership-update-finished
- (fn [{:keys [db]} [{:keys [accounts chainId]}]]
+ (fn [{:keys [db]} [{:keys [accounts chainId message]}]]
    (let [address            (first accounts)
          pending-chain-ids  (get-in db [:wallet :ui :collectibles :updating address])
          updated-chain-ids  (disj pending-chain-ids chainId)
-         all-chain-updated? (and (some? pending-chain-ids) (empty? updated-chain-ids))]
+         all-chain-updated? (and (some? pending-chain-ids) (empty? updated-chain-ids))
+         collectible-id     (data-store/rpc->collectible-id message)]
      {:db (cond-> db
             (some? pending-chain-ids)
             (assoc-in [:wallet :ui :collectibles :updating address] updated-chain-ids))
       :fx [(when all-chain-updated?
-             [:dispatch [:wallet/request-collectibles-for-account address]])]})))
+             [:dispatch [:wallet/request-collectibles-for-account address]])
+           (when collectible-id
+             [:dispatch [:wallet/get-collectibles-by-unique-id-async collectible-id]])]})))
 
 (defn- update-collectibles-in-account
   [existing-collectibles updated-collectibles]
@@ -282,28 +285,33 @@
       [{{collectible-id :id :as collectible} :collectible
         aspect-ratio                         :aspect-ratio
         gradient-color                       :gradient-color}]]
+   {:db (assoc-in db
+         [:wallet :ui :collectible]
+         {:details        collectible
+          :aspect-ratio   aspect-ratio
+          :gradient-color gradient-color})
+    :fx [[:dispatch [:wallet/get-collectibles-by-unique-id-async collectible-id]]
+         ;; We delay the navigation because we need re-frame to update the DB on time.
+         ;; By doing it, we skip a blink while visiting the collectible detail page.
+         [:dispatch-later
+          {:ms       17
+           :dispatch [:open-modal :screen/wallet.collectible]}]]}))
+
+(rf/reg-event-fx
+ :wallet/get-collectibles-by-unique-id-async
+ (fn [_ [collectible-id]]
    (let [request-id               0
          collectible-id-converted (cske/transform-keys transforms/->PascalCaseKeyword collectible-id)
          data-type                (collectible-data-types :details)
          request-params           [request-id [collectible-id-converted] data-type]]
-     {:db (assoc-in db
-           [:wallet :ui :collectible]
-           {:details        collectible
-            :aspect-ratio   aspect-ratio
-            :gradient-color gradient-color})
-      :fx [[:json-rpc/call
+     {:fx [[:json-rpc/call
             [{:method   "wallet_getCollectiblesByUniqueIDAsync"
               :params   request-params
               :on-error (fn [error]
                           (log/error "failed to request collectible"
                                      {:event  :wallet/navigate-to-collectible-details
                                       :error  error
-                                      :params request-params}))}]]
-           ;; We delay the navigation because we need re-frame to update the DB on time.
-           ;; By doing it, we skip a blink while visiting the collectible detail page.
-           [:dispatch-later
-            {:ms       17
-             :dispatch [:open-modal :screen/wallet.collectible]}]]})))
+                                      :params request-params}))}]]]})))
 
 (defn- keep-not-empty-value
   [old-value new-value]
@@ -318,18 +326,49 @@
                                                             (transforms/json->clj message))
          {[collectible] :collectibles} response
          known-collectible-info        (get-in db [:wallet :ui :collectible :details])
+         current-account-address       (get-in db [:wallet :current-viewing-account-address])
+         total-owned                   (collectible-utils/collectible-balance collectible
+                                                                              current-account-address)
          merged-collectible            (as-> known-collectible-info c
                                          (merge-with keep-not-empty-value
                                                      c
                                                      collectible)
                                          (update c
                                                  :ownership
-                                                 collectible-utils/remove-duplicates-in-ownership))]
+                                                 collectible-utils/remove-duplicates-in-ownership))
+         updated-collectible           (assoc merged-collectible
+                                              :total-owned
+                                              total-owned)]
      (if collectible
-       {:db (assoc-in db [:wallet :ui :collectible :details] merged-collectible)}
+       {:db (assoc-in db [:wallet :ui :collectible :details] updated-collectible)
+        :fx [[:dispatch [:wallet/update-collectibles-data updated-collectible]]]}
        (log/error "failed to get collectible details"
                   {:event    :wallet/get-collectible-details-done
                    :response response})))))
+
+(defn group-collectibles-by-ownership-address
+  [collectible]
+  (->> (:ownership collectible)
+       (map (fn [{:keys [address]}]
+              [address collectible]))
+       (into {})))
+
+(rf/reg-event-fx
+ :wallet/update-collectibles-data
+ (fn [{:keys [db]} [collectible]]
+   (let [collectibles-by-address (group-collectibles-by-ownership-address collectible)]
+     {:db (update-in db
+                     [:wallet :accounts]
+                     #(reduce-kv
+                       (fn [accounts address updated-collectibles]
+                         (if (contains? accounts address)
+                           (update-in accounts
+                                      [address :collectibles]
+                                      update-collectibles-in-account
+                                      [updated-collectibles])
+                           accounts))
+                       %
+                       collectibles-by-address))})))
 
 (rf/reg-event-fx
  :wallet/clear-collectible-details

--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -183,7 +183,21 @@
       :fx [(when all-chain-updated?
              [:dispatch [:wallet/request-collectibles-for-account address]])
            (when collectible-id
-             [:dispatch [:wallet/get-collectibles-by-unique-id-async collectible-id]])]})))
+             (let [collectible-unique-id (collectible-utils/get-collectible-unique-id {:id
+                                                                                       collectible-id})
+                   pending-collectible?  (-> db
+                                             (get-in [:wallet :ui :collectibles :pending])
+                                             (contains? collectible-unique-id))]
+               (when pending-collectible?
+                 [:dispatch
+                  [:wallet/update-pending-collectible-details collectible-id
+                   collectible-unique-id]])))]})))
+
+(rf/reg-event-fx
+ :wallet/update-pending-collectible-details
+ (fn [{:keys [db]} [collectible-id collectible-unique-id]]
+   {:db (update-in db [:wallet :ui :collectibles :pending] dissoc collectible-unique-id)
+    :fx [[:dispatch [:wallet/get-collectibles-by-unique-id-async collectible-id]]]}))
 
 (defn- update-collectibles-in-account
   [existing-collectibles updated-collectibles]

--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -6,7 +6,7 @@
             [taoensso.timbre :as log]
             [utils.number :as utils.number]))
 
-(defn total-collectible-balance
+(defn- total-collectible-balance
   ([ownership]
    (reduce (fn [total {:keys [balance]}]
              (+ total (or (js/parseInt balance) 0)))
@@ -89,6 +89,13 @@
                      acc)))
                {})
        vals))
+
+(defn group-collectibles-by-ownership-address
+  [collectible]
+  (->> (:ownership collectible)
+       (map (fn [{:keys [address]}]
+              [address collectible]))
+       (into {})))
 
 (defn sort-collectibles-by-name
   [collectibles]

--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -6,12 +6,21 @@
             [taoensso.timbre :as log]
             [utils.number :as utils.number]))
 
+(defn total-collectible-balance
+  ([ownership]
+   (reduce (fn [total {:keys [balance]}]
+             (+ total (or (js/parseInt balance) 0)))
+           0
+           ownership)))
+
 (defn collectible-balance
   ([{:keys [ownership]} address]
-   (->> ownership
-        (some #(when (= address (:address %))
-                 (:balance %)))
-        utils.number/parse-int)))
+   (let [balance (if address
+                   (some #(when (= address (:address %))
+                            (:balance %))
+                         ownership)
+                   (total-collectible-balance ownership))]
+     (utils.number/parse-int balance))))
 
 (def supported-collectible-types
   #{"image/jpeg"

--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -9,7 +9,7 @@
 (defn- total-collectible-balance
   ([ownership]
    (reduce (fn [total {:keys [balance]}]
-             (+ total (or (js/parseInt balance) 0)))
+             (+ total (or (utils.number/parse-int balance) 0)))
            0
            ownership)))
 

--- a/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/collectibles_tab/view.cljs
@@ -7,8 +7,7 @@
     [status-im.contexts.wallet.collectible.utils :as utils]
     [status-im.contexts.wallet.common.collectibles-tab.style :as style]
     [status-im.contexts.wallet.common.empty-tab.view :as empty-tab]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+    [utils.i18n :as i18n]))
 
 (defn- loading-collectible-item
   [_ index]
@@ -82,9 +81,9 @@
       ;; 1. If possible, move `collectibles-data` calculation to a subscription
       ;; 2. Optimization: do not recalculate all the collectibles, process only the new ones
       (let [collectibles-data (map
-                               (fn [{:keys [ownership] :as collectible}]
-                                 (let [total-owned (rf/sub [:wallet/total-owned-collectible ownership
-                                                            current-account-address])]
+                               (fn [collectible]
+                                 (let [total-owned (utils/collectible-balance collectible
+                                                                              current-account-address)]
                                    (assoc collectible
                                           :total-owned   total-owned
                                           :on-long-press on-collectible-long-press

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -300,7 +300,7 @@
         keypair              (get keypairs selected-keypair-uid)]
     (boolean (seq (:keycards keypair)))))
 
-(defn transform-collectible
+(defn- transform-collectible
   [{:keys [added updated removed]}]
   (let [entry (first (remove nil? (concat added updated removed)))]
     (when entry

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -299,3 +299,17 @@
         selected-keypair-uid (get-in db [:wallet :ui :create-account :selected-keypair-uid])
         keypair              (get keypairs selected-keypair-uid)]
     (boolean (seq (:keycards keypair)))))
+
+(defn transform-collectible
+  [{:keys [added updated removed]}]
+  (let [entry (first (remove nil? (concat added updated removed)))]
+    (when entry
+      {:contract-id {:chain-id (:chainID (:contractID entry))
+                     :address  (:address (:contractID entry))}
+       :token-id    (str (:tokenID entry))})))
+
+(defn rpc->collectible-id
+  [collectible]
+  (-> collectible
+      transforms/json->clj
+      transform-collectible))

--- a/src/status_im/contexts/wallet/data_store_test.cljs
+++ b/src/status_im/contexts/wallet/data_store_test.cljs
@@ -265,3 +265,13 @@
   (testing "returns false when db does not contain wallet data"
     (let [db {}]
       (is (false? (sut/selected-keypair-keycard? db))))))
+
+(deftest rpc->collectible-id-test
+  (testing "Transforms JSON with `updated` key into collectible ID"
+    (let
+      [json
+       "{\"updated\": [{\"contractID\": {\"chainID\": 222, \"address\": \"0x123456\"}, \"tokenID\": 77}]}"
+       expected {:contract-id {:chain-id 222
+                               :address  "0x123456"}
+                 :token-id    "77"}]
+      (is (= expected (sut/rpc->collectible-id json))))))

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -398,8 +398,12 @@
 (rf/reg-event-fx
  :wallet/build-transaction-for-collectible-route
  (fn [{:keys [db]}]
-   (let [last-request-uuid (get-in db [:wallet :ui :send :last-request-uuid])]
-     {:db (update-in db [:wallet :ui :send] dissoc :transaction-for-signing)
+   (let [last-request-uuid     (get-in db [:wallet :ui :send :last-request-uuid])
+         collectible-unique-id (get-in db [:wallet :ui :send :collectible :unique-id])]
+     {:db (->
+            db
+            (update-in [:wallet :ui :send] dissoc :transaction-for-signing)
+            (assoc-in [:wallet :ui :collectibles :pending collectible-unique-id] true))
       :fx [[:dispatch [:wallet/build-transactions-from-route {:request-uuid last-request-uuid}]]]})))
 
 (rf/reg-event-fx


### PR DESCRIPTION
fixes #21483

### Summary

Multicollectible amount is not updated after transaction until relogin

#### Areas that maybe impacted

- Send collectible



### Steps to test

1. Send multicollectible from Account A to internal Account B
2. See if collectible amount has been updated after pull to refresh

### Note for Test
As you can see in the video, receiving the updated balance may take some time (in my case, approximately 50 seconds). Once a signal confirming the ownership transfer is received, the balance will be updated accordingly

### Result

https://github.com/user-attachments/assets/5b171042-a413-4971-9aa6-bad3885fd53f

status: ready



