### PR TITLE
fix_: include assets only related to selected network on edit asset drawer on send and bridge flows

### DIFF
--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -22,7 +22,9 @@
 
 (defn select-asset-bottom-sheet
   [clear-input!]
-  (let [{preselected-token-symbol :symbol} (rf/sub [:wallet/wallet-send-token])]
+  (let [{preselected-token-symbol :symbol} (rf/sub [:wallet/wallet-send-token])
+        network                            (rf/sub [:wallet/send-network])
+        chain-id                           (:chain-id network)]
     [:<> ;; Need to be a `:<>` to keep `asset-list` scrollable.
      [quo/drawer-top
       {:title           (i18n/label :t/select-token)
@@ -31,6 +33,7 @@
       {:content-container-style  {:padding-horizontal 8
                                   :padding-bottom     8}
        :preselected-token-symbol preselected-token-symbol
+       :chain-ids                [chain-id]
        :on-token-press           (fn [token]
                                    (rf/dispatch [:wallet/edit-token-to-send token])
                                    (clear-input!))}]]))


### PR DESCRIPTION
fixes #21852 

### Summary

This PR fixes a follow up bug on send and bridge simplification that currently makes tokens related to all networks to appear when editing the token to send or bridge.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

1. Go to bridge/send setup flow
2. Tap asset to open "Select asset"  screen
3. Verify only tokens related to the selected network are included on the "Select asset" screen

status: ready