### PR TITLE
fix(wallet)_: Send flow for collectibles

### DIFF
--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -254,7 +254,6 @@
          ownership-status            (get ownership-status-by-address owner-address)
          collectibles                (->> collectibles
                                           data-store/rpc->collectibles
-                                          (map #(update % :ownership distinct))
                                           vec)
          pending-requests            (dec (get-in db [:wallet :ui :collectibles :pending-requests]))
          ;; check if collectibles are updating (never fetched and cached before) for this address
@@ -323,7 +322,9 @@
                                          (merge-with keep-not-empty-value
                                                      c
                                                      collectible)
-                                         (update c :ownership distinct))]
+                                         (update c
+                                                 :ownership
+                                                 collectible-utils/remove-duplicates-in-ownership))]
      (if collectible
        {:db (assoc-in db [:wallet :ui :collectible :details] merged-collectible)}
        (log/error "failed to get collectible details"

--- a/src/status_im/contexts/wallet/collectible/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/view.cljs
@@ -38,7 +38,15 @@
 
 (defn cta-buttons
   [{:keys [chain-id token-id contract-address collectible watch-only?]}]
-  (let [theme (quo.theme/use-theme)]
+  (let [theme         (quo.theme/use-theme)
+        on-press-send (rn/use-callback
+                       (fn []
+                         (rf/dispatch [:wallet/clean-send-data])
+                         (rf/dispatch
+                          [:wallet/set-collectible-to-send
+                           {:collectible    collectible
+                            :start-flow?    true
+                            :current-screen :screen/wallet.collectible}])))]
     [rn/view {:style style/buttons-container}
      (when-not watch-only?
        [quo/button
@@ -46,11 +54,7 @@
          :type            :outline
          :size            40
          :icon-left       :i/send
-         :on-press        #(rf/dispatch
-                            [:wallet/set-collectible-to-send
-                             {:collectible    collectible
-                              :start-flow?    true
-                              :current-screen :screen/wallet.collectible}])}
+         :on-press        on-press-send}
         (i18n/label :t/send)])
      [quo/button
       {:container-style  style/opensea-button

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -289,6 +289,7 @@
   [collectibles]
   (->> collectibles
        (cske/transform-keys transforms/->kebab-case-keyword)
+       (map #(update % :ownership collectible-utils/remove-duplicates-in-ownership))
        (map #(assoc % :unique-id (collectible-utils/get-collectible-unique-id %)))
        vec))
 

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -78,15 +78,16 @@
 
 (rf/reg-event-fx :wallet/clean-current-viewing-account
  (fn [{:keys [db]} [ignore-just-completed-transaction?]]
-   (let [{:keys [entry-point just-completed-transaction?]} (-> db :wallet :ui :send)
-         entry-point-wallet-home?                          (= entry-point :wallet-stack)]
+   (let [{:keys [entry-point just-completed-transaction?
+                 collectible-multiple-owners?]} (-> db :wallet :ui :send)
+         entry-point-wallet-home?               (= entry-point :wallet-stack)]
      {:db (cond-> db
             (and (not entry-point)
                  (not ignore-just-completed-transaction?)
                  (not just-completed-transaction?))
             (update :wallet dissoc :current-viewing-account-address)
 
-            entry-point-wallet-home?
+            (and entry-point-wallet-home? (not collectible-multiple-owners?))
             (update-in [:wallet :ui :send] dissoc :entry-point)
 
             (and entry-point-wallet-home?

--- a/src/status_im/contexts/wallet/send/events_test.cljs
+++ b/src/status_im/contexts/wallet/send/events_test.cljs
@@ -321,9 +321,10 @@
                                       :start-flow?    start-flow?
                                       :flow-id        :wallet-send-flow}]]]}]
         (reset! rf-db/app-db
-          {:wallet          {:ui {:send {:other-props :value
-                                         :tx-type     tx-type
-                                         :collectible collectible}}}
+          {:wallet          {:current-viewing-account-address "0x01"
+                             :ui                              {:send {:other-props :value
+                                                                      :tx-type     tx-type
+                                                                      :collectible collectible}}}
            :profile/profile {:test-networks-enabled? testnet-enabled?}})
         (is (match? expected-result
                     (dispatch [event-id
@@ -347,9 +348,10 @@
                                       :start-flow?    start-flow?
                                       :flow-id        :wallet-send-flow}]]]}]
         (reset! rf-db/app-db
-          {:wallet          {:ui {:send {:other-props :value
-                                         :tx-type     tx-type
-                                         :collectible collectible}}}
+          {:wallet          {:current-viewing-account-address "0x01"
+                             :ui                              {:send {:other-props :value
+                                                                      :tx-type     tx-type
+                                                                      :collectible collectible}}}
            :profile/profile {:test-networks-enabled? testnet-enabled?}})
         (is (match? expected-result
                     (dispatch [event-id

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -5,40 +5,56 @@
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [status-im.common.floating-button-page.view :as floating-button-page]
+    [status-im.contexts.wallet.collectible.utils :as collectible-utils]
     [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im.contexts.wallet.send.from.style :as style]
+    [status-im.setup.hot-reload :as hot-reload]
     [utils.i18n :as i18n]
     [utils.money :as money]
     [utils.re-frame :as rf]))
 
 (defn- on-account-press
-  [address network-details]
+  [address network-details collectible-tx?]
   (rf/dispatch [:wallet/select-from-account
                 {:address         address
                  :network-details network-details
                  :stack-id        :screen/wallet.select-from
-                 :start-flow?     true}]))
+                 :start-flow?     (not collectible-tx?)}]))
+
+(defn- on-close
+  []
+  (rf/dispatch [:wallet/clean-selected-collectible {:ignore-entry-point? true}])
+  (rf/dispatch [:wallet/clean-current-viewing-account]))
 
 (defn- render-fn
-  [item _ _ {:keys [network-details]}]
-  (let [has-balance (money/above-zero? (string/replace-first (:asset-pay-balance item) "<" ""))]
+  [item _ _ {:keys [network-details collectible-tx? collectible]}]
+  (let [account-address (:address item)
+        balance         (if collectible-tx?
+                          (collectible-utils/collectible-balance collectible account-address)
+                          (string/replace-first (:asset-pay-balance item) "<" ""))
+        has-balance?    (money/above-zero? balance)
+        asset-symbol    (if collectible-tx? "" (:asset-pay-symbol item))
+        asset-value     (if collectible-tx? (str balance) (:asset-pay-balance item))]
     [quo/account-item
-     {:type          (if has-balance :tag :default)
-      :on-press      #(on-account-press (:address item) network-details)
-      :state         (if has-balance :default :disabled)
-      :token-props   {:symbol (:asset-pay-symbol item)
-                      :value  (:asset-pay-balance item)}
-      :account-props (assoc item
-                            :address       (:formatted-address item)
-                            :full-address? true)}]))
+     {:type          (if has-balance? :tag :default)
+      :on-press      #(on-account-press account-address network-details collectible-tx?)
+      :state         (if has-balance? :default :disabled)
+      :token-props   {:symbol asset-symbol
+                      :value  asset-value}
+      :account-props item}]))
 
 (defn view
   []
-  (let [token-symbol    (rf/sub [:wallet/send-token-symbol])
+  (let [collectible-tx? (rf/sub [:wallet/send-tx-type-collectible?])
+        token-symbol    (rf/sub [:wallet/send-token-symbol])
         token           (rf/sub [:wallet/token-by-symbol-from-first-available-account-with-balance
                                  token-symbol])
-        accounts        (rf/sub [:wallet/accounts-with-balances token])
+        collectible     (rf/sub [:wallet/wallet-send-collectible])
+        accounts        (if collectible-tx?
+                          (rf/sub [:wallet/operable-accounts])
+                          (rf/sub [:wallet/accounts-with-balances token]))
         network-details (rf/sub [:wallet/network-details])]
+    (hot-reload/use-safe-unmount on-close)
     [floating-button-page/view
      {:footer-container-padding 0
       :header                   [account-switcher/view
@@ -52,6 +68,8 @@
       {:style                             style/accounts-list
        :content-container-style           style/accounts-list-container
        :data                              accounts
-       :render-data                       {:network-details network-details}
+       :render-data                       {:network-details network-details
+                                           :collectible-tx? collectible-tx?
+                                           :collectible     collectible}
        :render-fn                         render-fn
        :shows-horizontal-scroll-indicator false}]]))

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -168,6 +168,11 @@
  :-> :enough-assets?)
 
 (rf/reg-sub
+ :wallet/wallet-send-collectible
+ :<- [:wallet/wallet-send]
+ :-> :collectible)
+
+(rf/reg-sub
  :wallet/wallet-send-token
  :<- [:wallet/wallet-send]
  :<- [:wallet/network-details]
@@ -234,6 +239,12 @@
  :wallet/wallet-send-tx-type
  :<- [:wallet/wallet-send]
  :-> :tx-type)
+
+(rf/reg-sub
+ :wallet/send-tx-type-collectible?
+ :<- [:wallet/wallet-send-tx-type]
+ (fn [tx-type]
+   (send-utils/tx-type-collectible? tx-type)))
 
 (rf/reg-sub
  :wallet/keypairs


### PR DESCRIPTION
fixes #21727

### Summary

This PR fixes 

 - the send flow for collectibles (ERC721 and ERC1155)
 - picking the right balance of the ERC1155 in the send flow from the account page, based on the account viewing by the user
 - the balance of ERC1155 is sometimes incorrect if the collectible is present in more than one account of the user

https://github.com/user-attachments/assets/544e987b-048f-4284-9b87-c25c6a0d95f3


### Testing notes

This PR doesn't fix the balance of the collectible after it's been sent. It's handled in different issue: https://github.com/status-im/status-mobile/issues/21483.

### Platforms

- Android
- iOS

### Steps to test

##### Prerequisites: An account with ERC721 and ERC1155 collectibles

#### ERC721
- Open Status
- Navigate to Wallet tab > Collectibles
- Tap on any ERC721 and tap on Send
- Verify the account of the collectible is automatically selected
- Verify the user is taken to select the recipient

#### ERC1155
- Open Status
- Navigate to Wallet tab > Collectibles
- Tap on any ERC155 which is present in two accounts and tap on Send
- Verify the user is taken to select the account to send from

status: ready 


