### PR TITLE
fix_: add token and selected network on "Select network to receive" screen

### DIFF
--- a/src/status_im/contexts/wallet/bridge/bridge_to/style.cljs
+++ b/src/status_im/contexts/wallet/bridge/bridge_to/style.cljs
@@ -3,3 +3,11 @@
 (def content-container
   {:padding-horizontal 8})
 
+(def title-container
+  {:margin-horizontal 4})
+
+(def subtitle-container
+  {:flex-direction    :row
+   :margin-bottom     12
+   :margin-horizontal 20
+   :align-items       :center})

--- a/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
+++ b/src/status_im/contexts/wallet/bridge/bridge_to/view.cljs
@@ -4,45 +4,38 @@
     [quo.foundations.resources :as quo.resources]
     [quo.theme]
     [react-native.core :as rn]
+    [status-im.constants :as constants]
     [status-im.contexts.wallet.bridge.bridge-to.style :as style]
     [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im.contexts.wallet.common.utils :as utils]
-    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.setup.hot-reload :as hot-reload]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
 (defn- bridge-token-component
   []
-  (fn [{:keys [chain-id network-name]} {:keys [supported-networks] :as token}]
-    (let [network                               (rf/sub [:wallet/network-details-by-chain-id chain-id])
-          currency                              (rf/sub [:profile/currency])
-          currency-symbol                       (rf/sub [:profile/currency-symbol])
-          prices-per-token                      (rf/sub [:wallet/prices-per-token])
-          selected-network                      (rf/sub [:wallet/send-network])
-          {selected-network-chain-id :chain-id} selected-network
-          balance                               (utils/calculate-total-token-balance token [chain-id])
-          crypto-value                          (utils/get-standard-crypto-format token
-                                                                                  balance
-                                                                                  prices-per-token)
-          fiat-value                            (utils/calculate-token-fiat-value
-                                                 {:currency         currency
-                                                  :balance          balance
-                                                  :token            token
-                                                  :prices-per-token prices-per-token})
-          fiat-formatted                        (utils/fiat-formatted-for-ui currency-symbol
-                                                                             fiat-value)
-          token-available-on-network?           (network-utils/token-available-on-network?
-                                                 supported-networks
-                                                 chain-id)]
+  (fn [{:keys [chain-id network-name]} token]
+    (let [network          (rf/sub [:wallet/network-details-by-chain-id chain-id])
+          currency         (rf/sub [:profile/currency])
+          currency-symbol  (rf/sub [:profile/currency-symbol])
+          prices-per-token (rf/sub [:wallet/prices-per-token])
+          token-symbol     (rf/sub [:wallet/wallet-send-token-symbol])
+          balance          (utils/calculate-total-token-balance token [chain-id])
+          crypto-value     (utils/get-standard-crypto-format token
+                                                             balance
+                                                             prices-per-token)
+          fiat-value       (utils/calculate-token-fiat-value
+                            {:currency         currency
+                             :balance          balance
+                             :token            token
+                             :prices-per-token prices-per-token})
+          fiat-formatted   (utils/fiat-formatted-for-ui currency-symbol
+                                                        fiat-value)]
       [quo/network-list
        {:label         (name network-name)
         :network-image (quo.resources/get-network (:network-name network))
-        :token-value   (str crypto-value " " (:symbol token))
+        :token-value   (str crypto-value " " token-symbol)
         :fiat-value    fiat-formatted
-        :state         (if (and token-available-on-network? (not= chain-id selected-network-chain-id))
-                         :default
-                         :disabled)
         :on-press      #(rf/dispatch [:wallet/select-bridge-network
                                       {:network-chain-id chain-id
                                        :stack-id         :screen/wallet.bridge-to}])}])))
@@ -52,29 +45,49 @@
   (let [network-details  (rf/sub [:wallet/network-details])
         account          (rf/sub [:wallet/current-viewing-account])
         token            (rf/sub [:wallet/wallet-send-token])
+        network          (rf/sub [:wallet/send-network])
+        network-name     (:full-name network)
         token-symbol     (:symbol token)
         tokens           (:tokens account)
         mainnet          (first network-details)
-        layer-2-networks (rest network-details)
+        layer-2-networks (filter #(not= (:chain-id %) (:chain-id network))
+                                 (rest network-details))
         account-token    (some #(when (= token-symbol (:symbol %)) %) tokens)
         account-token    (when account-token
                            (assoc account-token
                                   :networks           (:networks token)
                                   :supported-networks (:supported-networks token)))
         bridge-to-title  (i18n/label :t/select-network-to-receive)]
-
     (hot-reload/use-safe-unmount #(rf/dispatch [:wallet/clean-bridge-to-selection]))
-
     [rn/view
      [account-switcher/view
       {:on-press            #(rf/dispatch [:navigate-back])
        :icon-name           :i/arrow-left
        :accessibility-label :top-bar
        :switcher-type       :select-account}]
-     [quo/page-top {:title bridge-to-title}]
-     [rn/view style/content-container
-      [bridge-token-component (assoc mainnet :network-name :t/mainnet) account-token]]
-
+     [quo/page-top
+      {:title           bridge-to-title
+       :container-style {:padding-vertical 0}}]
+     [rn/view {:style style/subtitle-container}
+      [quo/context-tag
+       {:token token-symbol
+        :label token-symbol
+        :size  24
+        :type  :token}]
+      [quo/text
+       {:size                :paragraph-2
+        :weight              :medium
+        :style               style/title-container
+        :accessibility-label :send-label}
+       (i18n/label :t/from)]
+      [quo/context-tag
+       {:network-name network-name
+        :type         :network
+        :network-logo (:source network)
+        :size         24}]]
+     (when (not= (:chain-id network) constants/ethereum-mainnet-chain-id)
+       [rn/view style/content-container
+        [bridge-token-component (assoc mainnet :network-name :t/mainnet) account-token]])
      [quo/divider-label (i18n/label :t/layer-2)]
      [rn/flat-list
       {:data                    layer-2-networks

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -408,7 +408,8 @@
             ;; If the token has a balance in only one account (or this was dispatched from the
             ;; account screen) and the network is already set, navigate forward in the bridge flow.
             (some? network)
-            [[:dispatch
+            [(when to-address [:dispatch [:wallet/switch-current-viewing-account to-address]])
+             [:dispatch
               [:wallet/wizard-navigate-forward
                {:current-screen stack-id
                 :start-flow?    start-flow?


### PR DESCRIPTION
fixes #21846 

### Summary

This PR matches design on "Select network to receive" screen on the bridge flow

![](https://github.com/user-attachments/assets/c060b5ef-ed25-4564-b12c-4bd2466e80fb)
![](https://github.com/user-attachments/assets/84525815-e765-4faf-aa3d-09bfaabfb88f)

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- wallet / transactions

### Steps to test

1. Navigate to the Bridge flow.
2. Select the account from which assets will be bridged.
3. Proceed to the "Select Network to Receive" screen.
4. Verify design looks as expected

status: ready