### PR TITLE
[#21853] fix: check deeplink pending request after wallet connect loaded

### DIFF
--- a/src/react_native/wallet_connect.cljs
+++ b/src/react_native/wallet_connect.cljs
@@ -87,3 +87,11 @@
               event
               #(-> (bean/->clj %)
                    handler)))
+
+(defn unregister-handler
+  [{:keys [web3-wallet event handler]}]
+  (oops/ocall web3-wallet
+              "off"
+              event
+              #(-> (bean/->clj %)
+                   handler)))

--- a/src/status_im/common/universal_links.cljs
+++ b/src/status_im/common/universal_links.cljs
@@ -108,8 +108,7 @@
 (rf/defn handle-wallet-connect
   [_ uri]
   (log/info "universal-links: handle-wallet-connect" uri)
-  {:dispatch-later {:ms       1500
-                    :dispatch [:wallet-connect/on-scan-connection uri]}})
+  {:dispatch [:wallet-connect/process-deeplink uri]})
 
 (defn dispatch-url
   "Dispatch url so we can get access to re-frame/db"

--- a/src/status_im/contexts/profile/logout/events.cljs
+++ b/src/status_im/contexts/profile/logout/events.cljs
@@ -44,6 +44,7 @@
    {:db (assoc db :profile/logging-out? true)
     ;; We need to disable notifications before starting the logout process
     :fx [[:dispatch [:profile.logout/disable-notifications]]
+         [:dispatch [:wallet-connect/unregister-event-listeners]]
          [:dispatch-later
           {:ms       100
            :dispatch [:profile.logout/reset-state]}]]}))

--- a/src/status_im/contexts/wallet/wallet_connect/events/core.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/core.cljs
@@ -41,6 +41,19 @@
        (log/info "Re-Initialising WalletConnect SDK due to network change")
        {:fx [[:dispatch [:wallet-connect/init]]]}))))
 
+(defn- on-session-proposal
+  [data]
+  (rf/dispatch [:wallet-connect/on-session-proposal data]))
+
+(defn- on-session-request
+  [data]
+  (rf/dispatch [:wallet-connect/on-session-request data]))
+
+(defn- on-session-delete
+  [data]
+  (rf/dispatch [:wallet-connect/on-session-delete data]))
+
+
 (rf/reg-event-fx
  :wallet-connect/register-event-listeners
  (fn [{:keys [db]}]
@@ -48,15 +61,15 @@
      {:fx [[:effects.wallet-connect/register-event-listener
             [web3-wallet
              constants/wallet-connect-session-proposal-event
-             #(rf/dispatch [:wallet-connect/on-session-proposal %])]]
+             on-session-proposal]]
            [:effects.wallet-connect/register-event-listener
             [web3-wallet
              constants/wallet-connect-session-request-event
-             #(rf/dispatch [:wallet-connect/on-session-request %])]]
+             on-session-request]]
            [:effects.wallet-connect/register-event-listener
             [web3-wallet
              constants/wallet-connect-session-delete-event
-             #(rf/dispatch [:wallet-connect/on-session-delete %])]]]})))
+             on-session-delete]]]})))
 
 (rf/reg-event-fx
  :wallet-connect/unregister-event-listeners
@@ -65,15 +78,15 @@
      {:fx [[:effects.wallet-connect/unregister-event-listener
             [web3-wallet
              constants/wallet-connect-session-proposal-event
-             #(rf/dispatch [:wallet-connect/on-session-proposal %])]]
+             on-session-proposal]]
            [:effects.wallet-connect/unregister-event-listener
             [web3-wallet
              constants/wallet-connect-session-request-event
-             #(rf/dispatch [:wallet-connect/on-session-request %])]]
+             on-session-request]]
            [:effects.wallet-connect/unregister-event-listener
             [web3-wallet
              constants/wallet-connect-session-delete-event
-             #(rf/dispatch [:wallet-connect/on-session-delete %])]]]})))
+             on-session-delete]]]})))
 
 (rf/reg-event-fx
  :wallet-connect/on-init-fail

--- a/src/status_im/contexts/wallet/wallet_connect/events/core.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/core.cljs
@@ -28,9 +28,12 @@
  :wallet-connect/on-init-success
  (fn [{:keys [db]} [web3-wallet]]
    (log/info "WalletConnect SDK initialisation successful")
-   {:db (assoc db :wallet-connect/web3-wallet web3-wallet)
-    :fx [[:dispatch [:wallet-connect/register-event-listeners]]
-         [:dispatch [:wallet-connect/get-sessions]]]}))
+   (let [waiting-pair-url (get db :wallet-connect/waiting-pair-url)]
+     {:db (assoc db :wallet-connect/web3-wallet web3-wallet)
+      :fx [[:dispatch [:wallet-connect/register-event-listeners]]
+           [:dispatch [:wallet-connect/get-sessions]]
+           (when waiting-pair-url
+             [:dispatch [:wallet-connect/pair waiting-pair-url]])]})))
 
 (rf/reg-event-fx
  :wallet-connect/reload-on-network-change

--- a/src/status_im/contexts/wallet/wallet_connect/events/core.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/core.cljs
@@ -59,6 +59,23 @@
              #(rf/dispatch [:wallet-connect/on-session-delete %])]]]})))
 
 (rf/reg-event-fx
+ :wallet-connect/unregister-event-listeners
+ (fn [{:keys [db]}]
+   (let [web3-wallet (get db :wallet-connect/web3-wallet)]
+     {:fx [[:effects.wallet-connect/unregister-event-listener
+            [web3-wallet
+             constants/wallet-connect-session-proposal-event
+             #(rf/dispatch [:wallet-connect/on-session-proposal %])]]
+           [:effects.wallet-connect/unregister-event-listener
+            [web3-wallet
+             constants/wallet-connect-session-request-event
+             #(rf/dispatch [:wallet-connect/on-session-request %])]]
+           [:effects.wallet-connect/unregister-event-listener
+            [web3-wallet
+             constants/wallet-connect-session-delete-event
+             #(rf/dispatch [:wallet-connect/on-session-delete %])]]]})))
+
+(rf/reg-event-fx
  :wallet-connect/on-init-fail
  (fn [_ [error]]
    (log/error "Failed to initialize Wallet Connect"

--- a/src/status_im/contexts/wallet/wallet_connect/events/core.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/core.cljs
@@ -28,12 +28,10 @@
  :wallet-connect/on-init-success
  (fn [{:keys [db]} [web3-wallet]]
    (log/info "WalletConnect SDK initialisation successful")
-   (let [waiting-pair-url (get db :wallet-connect/waiting-pair-url)]
-     {:db (assoc db :wallet-connect/web3-wallet web3-wallet)
-      :fx [[:dispatch [:wallet-connect/register-event-listeners]]
-           [:dispatch [:wallet-connect/get-sessions]]
-           (when waiting-pair-url
-             [:dispatch [:wallet-connect/pair waiting-pair-url]])]})))
+   {:db (assoc db :wallet-connect/web3-wallet web3-wallet)
+    :fx [[:dispatch [:wallet-connect/register-event-listeners]]
+         [:dispatch [:wallet-connect/get-sessions]]
+         [:dispatch [:wallet-connect/pair-with-pending-deeplink]]]}))
 
 (rf/reg-event-fx
  :wallet-connect/reload-on-network-change

--- a/src/status_im/contexts/wallet/wallet_connect/events/effects.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/effects.cljs
@@ -35,6 +35,14 @@
      :handler     handler})))
 
 (rf/reg-fx
+ :effects.wallet-connect/unregister-event-listener
+ (fn [[web3-wallet wc-event handler]]
+   (wallet-connect/unregister-handler
+    {:web3-wallet web3-wallet
+     :event       wc-event
+     :handler     handler})))
+
+(rf/reg-fx
  :effects.wallet-connect/pair
  (fn [{:keys [web3-wallet url on-success on-fail]}]
    (when web3-wallet

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
@@ -15,14 +15,26 @@
  :wallet-connect/pair
  (fn [{:keys [db]} [url]]
    (let [web3-wallet (get db :wallet-connect/web3-wallet)]
+     {:fx [[:effects.wallet-connect/pair
+            {:web3-wallet web3-wallet
+             :url         url
+             :on-fail     #(log/error "Failed to pair with dApp" {:error %})
+             :on-success  #(log/info "dApp paired successfully")}]]})))
+
+(rf/reg-event-fx
+ :wallet-connect/process-deeplink
+ (fn [{:keys [db]} [url]]
+   (let [web3-wallet (get db :wallet-connect/web3-wallet)]
      (if web3-wallet
-       {:db (dissoc db :wallet-connect/waiting-pair-url)
-        :fx [[:effects.wallet-connect/pair
-              {:web3-wallet web3-wallet
-               :url         url
-               :on-fail     #(log/error "Failed to pair with dApp" {:error %})
-               :on-success  #(log/info "dApp paired successfully")}]]}
-       {:db (assoc db :wallet-connect/waiting-pair-url url)}))))
+       {:fx [[:dispatch [:wallet-connect/on-scan-connection url]]]}
+       {:db (assoc db :wallet-connect/pending-url url)}))))
+
+(rf/reg-event-fx
+ :wallet-connect/pair-with-pending-deeplink
+ (fn [{:keys [db]}]
+   (when-let [pending-url (get db :wallet-connect/pending-url)]
+     {:db (dissoc db :wallet-connect/pending-url)
+      :fx [[:dispatch [:wallet-connect/on-scan-connection pending-url]]]})))
 
 (rf/reg-event-fx
  :wallet-connect/on-scan-connection

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_proposals.cljs
@@ -15,11 +15,14 @@
  :wallet-connect/pair
  (fn [{:keys [db]} [url]]
    (let [web3-wallet (get db :wallet-connect/web3-wallet)]
-     {:fx [[:effects.wallet-connect/pair
-            {:web3-wallet web3-wallet
-             :url         url
-             :on-fail     #(log/error "Failed to pair with dApp" {:error %})
-             :on-success  #(log/info "dApp paired successfully")}]]})))
+     (if web3-wallet
+       {:db (dissoc db :wallet-connect/waiting-pair-url)
+        :fx [[:effects.wallet-connect/pair
+              {:web3-wallet web3-wallet
+               :url         url
+               :on-fail     #(log/error "Failed to pair with dApp" {:error %})
+               :on-success  #(log/info "dApp paired successfully")}]]}
+       {:db (assoc db :wallet-connect/waiting-pair-url url)}))))
 
 (rf/reg-event-fx
  :wallet-connect/on-scan-connection

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_responses.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_responses.cljs
@@ -121,22 +121,23 @@
                                                (get-in db [:wallet-connect/current-request :event]))]
      (let [method      (data-store/get-request-method event)
            web3-wallet (get db :wallet-connect/web3-wallet)]
-       {:db (assoc-in db [:wallet-connect/current-request :response-sent?] true)
-        :fx [[:effects.wallet-connect/respond-session-request
-              {:web3-wallet web3-wallet
-               :topic       topic
-               :id          id
-               :result      result
-               :error       error
-               :on-error    (fn [error]
-                              (log/error "Failed to send Wallet Connect response"
-                                         {:error                error
-                                          :method               method
-                                          :event                :wallet-connect/send-response
-                                          :wallet-connect-event event}))
-               :on-success  (fn []
-                              (rf/dispatch [:wallet-connect/redirect-to-dapp])
-                              (log/info "Successfully sent Wallet Connect response to dApp"))}]]}))))
+       (when web3-wallet
+         {:db (assoc-in db [:wallet-connect/current-request :response-sent?] true)
+          :fx [[:effects.wallet-connect/respond-session-request
+                {:web3-wallet web3-wallet
+                 :topic       topic
+                 :id          id
+                 :result      result
+                 :error       error
+                 :on-error    (fn [error]
+                                (log/error "Failed to send Wallet Connect response"
+                                           {:error                error
+                                            :method               method
+                                            :event                :wallet-connect/send-response
+                                            :wallet-connect-event event}))
+                 :on-success  (fn []
+                                (rf/dispatch [:wallet-connect/redirect-to-dapp])
+                                (log/info "Successfully sent Wallet Connect response to dApp"))}]]})))))
 
 (rf/reg-event-fx
  :wallet-connect/redirect-to-dapp

--- a/src/status_im/contexts/wallet/wallet_connect/events/session_responses.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/events/session_responses.cljs
@@ -121,23 +121,22 @@
                                                (get-in db [:wallet-connect/current-request :event]))]
      (let [method      (data-store/get-request-method event)
            web3-wallet (get db :wallet-connect/web3-wallet)]
-       (when web3-wallet
-         {:db (assoc-in db [:wallet-connect/current-request :response-sent?] true)
-          :fx [[:effects.wallet-connect/respond-session-request
-                {:web3-wallet web3-wallet
-                 :topic       topic
-                 :id          id
-                 :result      result
-                 :error       error
-                 :on-error    (fn [error]
-                                (log/error "Failed to send Wallet Connect response"
-                                           {:error                error
-                                            :method               method
-                                            :event                :wallet-connect/send-response
-                                            :wallet-connect-event event}))
-                 :on-success  (fn []
-                                (rf/dispatch [:wallet-connect/redirect-to-dapp])
-                                (log/info "Successfully sent Wallet Connect response to dApp"))}]]})))))
+       {:db (assoc-in db [:wallet-connect/current-request :response-sent?] true)
+        :fx [[:effects.wallet-connect/respond-session-request
+              {:web3-wallet web3-wallet
+               :topic       topic
+               :id          id
+               :result      result
+               :error       error
+               :on-error    (fn [error]
+                              (log/error "Failed to send Wallet Connect response"
+                                         {:error                error
+                                          :method               method
+                                          :event                :wallet-connect/send-response
+                                          :wallet-connect-event event}))
+               :on-success  (fn []
+                              (rf/dispatch [:wallet-connect/redirect-to-dapp])
+                              (log/info "Successfully sent Wallet Connect response to dApp"))}]]}))))
 
 (rf/reg-event-fx
  :wallet-connect/redirect-to-dapp


### PR DESCRIPTION
fixes #21853

### Summary

- "cannot read property" error is displayed on profiles list page
- Handle pending dapp pair request after wallet connect loaded successfully 

#### Areas that maybe impacted

- Dapps interactions

### Test Note 


Regarding the issue discussed in [PR #21833](https://github.com/status-im/status-mobile/pull/21833#issuecomment-2557013966), here’s an explanation of how dApp requests are handled and the current limitations:


### Handling dApp Requests
1. **Event Listener**  
   - The app registers an event listener to handle incoming dApp requests.  
   - However, this listener is only registered **after** the wallet screen loads. If a request is sent **before** the listener is active, it will not be processed.

2. **Deep Link**  
   - Currently, **pairing requests** from a dApp can be handled through deep links, where the dApp sends a URI containing the pairing information to the app.  
   - However, **sign requests** are **not** handled through deep links. This means any signing request (e.g., transactions or message signing) that is initiated via deep link will not work if user is not logged in already.   
   - If the app is launched through a deep link for a **pairing** request, the process works as expected, as shown in the video below.

3. **Push Notification** *(Not Yet Implemented)*  
   - Push notifications are intended to handle scenarios where the app is closed, and the request is sent to a different device.  
   - The issue in [PR #21833](https://github.com/status-im/status-mobile/pull/21833#issuecomment-2557013966) highlights this limitation. Currently, push notifications are not supported for **any type of request**.

for [PR #21833](https://github.com/status-im/status-mobile/pull/21833#issuecomment-2557013966) we can have a separate issue so i can discuss it with @clauxx and check for any solution.


### Steps to test
<!-- (Specify exact steps to test if there are such) -->

1. Connect to the Dapp(in my case Uniswap) using universal scanner
5. Log out
6. Make any transaction Using Dapp (approve or swap)



### Result


https://github.com/user-attachments/assets/75110d50-cddd-4364-859b-53f9c14481aa




status: ready
