### PR TITLE
fix(wallet)_: collectible route cleanup on navigating back from TX confirmation page

### DIFF
--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -2,14 +2,15 @@
   (:require [status-im.config :as config]
             [status-im.constants :as constants]
             [status-im.contexts.wallet.common.utils.networks :as network-utils]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [utils.number :as utils.number]))
 
 (defn collectible-balance
   ([{:keys [ownership]} address]
-   (let [balance (some #(when (= address (:address %))
-                          (js/parseInt (:balance %)))
-                       ownership)]
-     (if (js/Number.isNaN balance) 0 balance))))
+   (->> ownership
+        (some #(when (= address (:address %))
+                 (:balance %)))
+        utils.number/parse-int)))
 
 (def supported-collectible-types
   #{"image/jpeg"


### PR DESCRIPTION
fixes #21882

### Summary

This PR fixes routes not cleaned properly (`Context Canceled` and `No Routes Found` errors thrown on generating the next route) when the user navigates back from the TX confirmation screen using the device's back button/gesture.

### Platforms

- Android
- iOS

### Steps to test

##### Prerequisite: A wallet account with multiple collectibles

- Open Status
- Navigate to the Wallet Tab
- Tap any collectible and enter the Send flow
- Complete the flow until the TX confirmation screen
- Navigate back using the device's back button or gesture
- Try to complete the flow again (reaching the TX confirmation page)
- Verify the `Context Canceled` and `No Routes Found` error messages are not shown

status: ready
