### PR TITLE
Fixed error on opening Advanced settings

### DIFF
--- a/src/legacy/status_im/events.cljs
+++ b/src/legacy/status_im/events.cljs
@@ -7,6 +7,7 @@
     legacy.status-im.chat.models.loading
     legacy.status-im.data-store.chats
     legacy.status-im.data-store.visibility-status-updates
+    legacy.status-im.ens.core
     legacy.status-im.fleet.core
     legacy.status-im.group-chats.core
     legacy.status-im.log-level.core

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -101,10 +101,22 @@
    public-key))
 
 (re-frame/reg-sub
+ :profile/light-client-enabled?
+ :<- [:profile/profile]
+ (fn [profile]
+   (get-in profile [:wakuv2-config :LightClient])))
+
+(re-frame/reg-sub
  :profile/store-confirmations-enabled?
  :<- [:profile/profile]
  (fn [profile]
    (get-in profile [:wakuv2-config :EnableStoreConfirmationForMessagesSent])))
+
+(re-frame/reg-sub
+ :profile/peer-syncing-enabled?
+ :<- [:profile/profile]
+ (fn [profile]
+   (:peer-syncing-enabled? profile)))
 
 (re-frame/reg-sub
  :profile/telemetry-enabled?


### PR DESCRIPTION

fixes ##21891

### Summary

During cleanup few events were incorrectly removed. Now they are brought back


#### Platforms


- Android
- iOS


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->


### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Open Advanced settings in profile
- make sure they are opening


### Before and after screenshots comparison

status: ready 
