### PR TITLE
fix(wallet)_: Send flow from saved address and QR scanner

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -13,19 +13,15 @@
   [{:keys [name full-address chain-short-names address customization-color] :as opts}]
   (let [open-send-flow                 (rn/use-callback
                                         (fn []
-                                          (rf/dispatch [:hide-bottom-sheet])
-                                          (rf/dispatch [:pop-to-root :shell-stack])
-                                          (js/setTimeout #(rf/dispatch [:wallet/select-send-address
-                                                                        {:address full-address
-                                                                         :recipient
-                                                                         {:label name
-                                                                          :customization-color
-                                                                          customization-color
-                                                                          :recipient-type :saved-address}
-                                                                         :stack-id :wallet-select-address
-                                                                         :start-flow? true}])
-                                                         400))
-                                        [full-address])
+                                          (rf/dispatch [:wallet/init-send-flow-for-address
+                                                        {:address full-address
+                                                         :recipient
+                                                         {:label name
+                                                          :customization-color
+                                                          customization-color
+                                                          :recipient-type :saved-address}
+                                                         :stack-id :screen/settings.saved-addresses}]))
+                                        [full-address name customization-color])
         open-eth-chain-explorer        (rn/use-callback
                                         #(rf/dispatch [:wallet/navigate-to-chain-explorer
                                                        {:address address

--- a/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
+++ b/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
@@ -2,6 +2,8 @@
   (:require
     [quo.core :as quo]
     [react-native.clipboard :as clipboard]
+    [status-im.contexts.wallet.common.utils :as utils]
+    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -13,16 +15,15 @@
                 {:type :positive
                  :text (i18n/label :t/address-copied)}]))
 
-#_(defn- send-to-address
-    [address]
-    (let [[_ split-address] (network-utils/split-network-full-address address)]
-      (rf/dispatch
-       [:wallet/select-send-address
-        {:address     address
-         :recipient   {:recipient-type :address
-                       :label          (utils/get-shortened-address split-address)}
-         :stack-id    :wallet-select-address
-         :start-flow? true}])))
+(defn- send-to-address
+  [address]
+  (let [[_ split-address] (network-utils/split-network-full-address address)]
+    (rf/dispatch
+     [:wallet/init-send-flow-for-address
+      {:address   address
+       :recipient {:recipient-type :address
+                   :label          (utils/get-shortened-address split-address)}
+       :stack-id  :wallet-select-address}])))
 
 (defn view
   [address]
@@ -33,13 +34,10 @@
        :accessibility-label :send-asset
        :label               (i18n/label :t/copy-address)
        :on-press            #(copy-address address)}
-      ;; Originally, the flow went to the send flow, but it has been removed to avoid bugs,
-      ;; please check https://github.com/status-im/status-mobile/issues/20972 for more context
-      ;; The previous code has been commented out to be reintroduced in the future easily.
-      #_{:icon                :i/send
-         :accessibility-label :send-asset
-         :label               (i18n/label :t/send-to-this-address)
-         :on-press            #(send-to-address address)}
+      {:icon                :i/send
+       :accessibility-label :send-asset
+       :label               (i18n/label :t/send-to-this-address)
+       :on-press            #(send-to-address address)}
       (when (ff/enabled? :ff/wallet.saved-addresses)
         {:icon                :i/save
          :accessibility-label :save-address

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -4,9 +4,9 @@
     [quo.core :as quo]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
+    [status-im.common.events-helper :as events-helper]
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.contexts.wallet.collectible.utils :as collectible-utils]
-    [status-im.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im.contexts.wallet.send.from.style :as style]
     [status-im.setup.hot-reload :as hot-reload]
     [utils.i18n :as i18n]
@@ -14,12 +14,15 @@
     [utils.re-frame :as rf]))
 
 (defn- on-account-press
-  [address network-details collectible-tx?]
+  [address network-details general-flow? collectible-tx?]
+  (when general-flow?
+    (rf/dispatch [:wallet/clean-selected-token])
+    (rf/dispatch [:wallet/clean-selected-collectible]))
   (rf/dispatch [:wallet/select-from-account
                 {:address         address
                  :network-details network-details
                  :stack-id        :screen/wallet.select-from
-                 :start-flow?     (not collectible-tx?)}]))
+                 :start-flow?     (not (or general-flow? collectible-tx?))}]))
 
 (defn- on-close
   []
@@ -27,40 +30,46 @@
   (rf/dispatch [:wallet/clean-current-viewing-account]))
 
 (defn- render-fn
-  [item _ _ {:keys [network-details collectible-tx? collectible]}]
+  [item _ _ {:keys [general-flow? network-details collectible-tx? collectible]}]
   (let [account-address (:address item)
-        balance         (if collectible-tx?
-                          (collectible-utils/collectible-balance collectible account-address)
-                          (string/replace-first (:asset-pay-balance item) "<" ""))
+        balance         (cond
+                          general-flow?   0
+                          collectible-tx? (collectible-utils/collectible-balance collectible
+                                                                                 account-address)
+                          :else           (string/replace-first (:asset-pay-balance item) "<" ""))
         has-balance?    (money/above-zero? balance)
         asset-symbol    (if collectible-tx? "" (:asset-pay-symbol item))
         asset-value     (if collectible-tx? (str balance) (:asset-pay-balance item))]
     [quo/account-item
      {:type          (if has-balance? :tag :default)
-      :on-press      #(on-account-press account-address network-details collectible-tx?)
-      :state         (if has-balance? :default :disabled)
-      :token-props   {:symbol asset-symbol
-                      :value  asset-value}
+      :on-press      #(on-account-press account-address network-details general-flow? collectible-tx?)
+      :state         (if (or has-balance? general-flow?) :default :disabled)
+      :token-props   (when-not general-flow?
+                       {:symbol asset-symbol
+                        :value  asset-value})
       :account-props item}]))
 
 (defn view
   []
-  (let [collectible-tx? (rf/sub [:wallet/send-tx-type-collectible?])
+  (let [general-flow?   (rf/sub [:wallet/send-general-flow?])
+        collectible-tx? (rf/sub [:wallet/send-tx-type-collectible?])
         token-symbol    (rf/sub [:wallet/send-token-symbol])
         token           (rf/sub [:wallet/token-by-symbol-from-first-available-account-with-balance
                                  token-symbol])
         collectible     (rf/sub [:wallet/wallet-send-collectible])
-        accounts        (if collectible-tx?
+        accounts        (if (or general-flow? collectible-tx?)
                           (rf/sub [:wallet/operable-accounts])
                           (rf/sub [:wallet/accounts-with-balances token]))
         network-details (rf/sub [:wallet/network-details])]
     (hot-reload/use-safe-unmount on-close)
     [floating-button-page/view
      {:footer-container-padding 0
-      :header                   [account-switcher/view
-                                 {:on-press      #(rf/dispatch [:navigate-back])
-                                  :margin-top    (safe-area/get-top)
-                                  :switcher-type :select-account}]}
+      :header                   [quo/page-nav
+                                 {:type       :no-title
+                                  :icon-name  :i/close
+                                  :on-press   events-helper/navigate-back
+                                  :margin-top (safe-area/get-top)
+                                  :background :blur}]}
      [quo/page-top
       {:title                     (i18n/label :t/from-label)
        :title-accessibility-label :title-label}]
@@ -68,7 +77,8 @@
       {:style                             style/accounts-list
        :content-container-style           style/accounts-list-container
        :data                              accounts
-       :render-data                       {:network-details network-details
+       :render-data                       {:general-flow?   general-flow?
+                                           :network-details network-details
                                            :collectible-tx? collectible-tx?
                                            :collectible     collectible}
        :render-fn                         render-fn

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -607,7 +607,8 @@
    {:name      :screen/wallet.select-asset
     :metrics   {:track?   true
                 :alias-id :wallet-send.select-asset}
-    :options   {:insets {:top? true}}
+    :options   {:modalPresentationStyle :overCurrentContext
+                :insets                 {:top? true}}
     :component wallet-select-asset/view}
 
    {:name      :screen/wallet.send-input-amount

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -247,6 +247,11 @@
    (send-utils/tx-type-collectible? tx-type)))
 
 (rf/reg-sub
+ :wallet/send-general-flow?
+ :<- [:wallet/wallet-send]
+ :-> :general-flow?)
+
+(rf/reg-sub
  :wallet/keypairs
  :<- [:wallet]
  :-> :keypairs)


### PR DESCRIPTION
fixes #21898
fixes #20878

### Summary

This PR:
 - fixes send flow from saved addresses
 - adds back send flow from general QR scanner

| Single Account | Multiple Accounts  | Entry from QR Scanner
| --- | --- | --- |
| <video src="https://github.com/user-attachments/assets/72ac7370-ecf2-4083-b187-8319d94664d3" />  | <video src="https://github.com/user-attachments/assets/41d88e9a-d43e-4162-9a1b-61ec49284efb" />  | <video src="https://github.com/user-attachments/assets/ffcdcefd-bbe0-4ea5-9e7e-945546b849ca" /> |


### Testing notes

A quick test of the send flow from the Wallet tab is appreciated

### Platforms

- Android
- iOS

### Steps to test

##### From Saved Addresses

- Open Status
- Navigate to `Profile > Wallet > Saved Addresses`
- Add a new saved address if it is empty
- Tap on any saved address and tap on `Send to <SAVED_ADDRESS_NAME>`
- Verify the user is taken to the account selection (`From`) page if the user has more than one operable accounts
- Verify the user is taken to the select asset page (default account) if the user has only one account
- Verify the routes are generated after asset selection and can be sent successfully

##### From QR Scanner

- Open Status
- Tap on scanner icon (`[-]`) on the profile navigation header
- Scan a valid address
- Verify the user is taken to the account selection (`From`) page if the user has more than one operable accounts
- Verify the user is taken to the select asset page (default account) if the user has only one account
- Verify the routes are generated after asset selection and can be sent successfully

status: ready