### PR TITLE
[#21305] fix: sort assets by value and collectibles by name

### DIFF
--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -79,3 +79,10 @@
                      acc)))
                {})
        vals))
+
+(defn sort-collectibles-by-name
+  [collectibles]
+  (sort-by (fn [collectible]
+             (let [name (-> collectible :collectible-data :name)]
+               [(if (or (nil? name) (empty? name)) 1 0) name]))
+           collectibles))

--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -84,5 +84,5 @@
   [collectibles]
   (sort-by (fn [collectible]
              (let [name (-> collectible :collectible-data :name)]
-               [(if (or (nil? name) (empty? name)) 1 0) name]))
+               [(if (seq name) 0 1) name]))
            collectibles))

--- a/src/status_im/contexts/wallet/collectible/utils.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.wallet.collectible.utils
-  (:require [status-im.config :as config]
+  (:require [clojure.string :as string]
+            [status-im.config :as config]
             [status-im.constants :as constants]
             [status-im.contexts.wallet.common.utils.networks :as network-utils]
             [taoensso.timbre :as log]
@@ -83,6 +84,8 @@
 (defn sort-collectibles-by-name
   [collectibles]
   (sort-by (fn [collectible]
-             (let [name (-> collectible :collectible-data :name)]
-               [(if (seq name) 0 1) name]))
+             (let [name            (-> collectible :collectible-data :name)
+                   normalized-name (some-> name
+                                           string/lower-case)]
+               [(if (seq normalized-name) 0 1) normalized-name]))
            collectibles))

--- a/src/status_im/contexts/wallet/collectible/utils_test.cljs
+++ b/src/status_im/contexts/wallet/collectible/utils_test.cljs
@@ -44,3 +44,18 @@
                                                :token-id token-id
                                                :test-networks-enabled? true})
            "https://testnets.opensea.io/assets/optimism-sepolia/0xC/0xT"))))
+
+(deftest sort-collectibles-by-name-test
+  (testing "Sorts collectibles by name, moving nil or empty names to the end"
+    (let [collectibles        [{:collectible-data {:name "Alpha"}}
+                               {:collectible-data {:name nil}}
+                               {:collectible-data {:name "Beta"}}
+                               {:collectible-data {:name ""}}
+                               {:collectible-data {:name "Zeta"}}]
+          sorted-collectibles (utils/sort-collectibles-by-name collectibles)
+          expected            [{:collectible-data {:name "Alpha"}}
+                               {:collectible-data {:name "Beta"}}
+                               {:collectible-data {:name "Zeta"}}
+                               {:collectible-data {:name nil}}
+                               {:collectible-data {:name ""}}]]
+      (is (= sorted-collectibles expected)))))

--- a/src/status_im/contexts/wallet/common/asset_list/view.cljs
+++ b/src/status_im/contexts/wallet/common/asset_list/view.cljs
@@ -10,15 +10,11 @@
     token-name    :name
     total-balance :total-balance
     disabled?     :bridge-disabled?
+    fiat-value    :fiat-value
     :as           token}
    _ _
-   {:keys [currency currency-symbol on-token-press preselected-token-symbol prices-per-token]}]
-  (let [fiat-value       (utils/calculate-token-fiat-value
-                          {:currency         currency
-                           :balance          total-balance
-                           :token            token
-                           :prices-per-token prices-per-token})
-        crypto-formatted (utils/get-standard-crypto-format token total-balance prices-per-token)
+   {:keys [currency-symbol on-token-press preselected-token-symbol prices-per-token]}]
+  (let [crypto-formatted (utils/get-standard-crypto-format token total-balance prices-per-token)
         fiat-formatted   (utils/fiat-formatted-for-ui currency-symbol fiat-value)]
     [quo/token-network
      {:token       token-symbol
@@ -38,13 +34,11 @@
   (let [filtered-tokens  (rf/sub [:wallet/current-viewing-account-tokens-filtered
                                   {:query     search-text
                                    :chain-ids chain-ids}])
-        currency         (rf/sub [:profile/currency])
         currency-symbol  (rf/sub [:profile/currency-symbol])
         prices-per-token (rf/sub [:wallet/prices-per-token])]
     [gesture/flat-list
      {:data                         filtered-tokens
-      :render-data                  {:currency                 currency
-                                     :currency-symbol          currency-symbol
+      :render-data                  {:currency-symbol          currency-symbol
                                      :on-token-press           on-token-press
                                      :preselected-token-symbol preselected-token-symbol
                                      :prices-per-token         prices-per-token}

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -409,13 +409,15 @@
 
 (defn sort-tokens
   [tokens]
-  (let [priority #(get constants/token-sort-priority (:symbol %) ##Inf)]
-    (sort-by (juxt (comp - :balance) priority) tokens)))
+  (sort-by (comp - :balance) tokens))
+
+(defn sort-tokens-by-fiat-value
+  [tokens]
+  (sort-by (comp - :fiat-value) tokens))
 
 (defn sort-tokens-by-name
   [tokens]
-  (let [priority #(get constants/token-sort-priority (:symbol %) ##Inf)]
-    (sort-by (juxt :symbol priority) tokens)))
+  (sort-by :symbol tokens))
 
 (defn token-with-balance
   ([token networks]

--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -345,3 +345,33 @@
           expected []]
       (is (= (utils/get-accounts-with-token-balance accounts token)
              expected)))))
+
+(deftest sort-tokens-test
+  (testing "Sort tokens by balance in descending order"
+    (let [tokens   [{:symbol "BTC" :balance 2}
+                    {:symbol "ETH" :balance 5}
+                    {:symbol "DAI" :balance 10}]
+          expected [{:symbol "DAI" :balance 10}
+                    {:symbol "ETH" :balance 5}
+                    {:symbol "BTC" :balance 2}]]
+      (is (= (utils/sort-tokens tokens) expected)))))
+
+(deftest sort-tokens-by-fiat-value-test
+  (testing "Sort tokens by fiat value in descending order"
+    (let [tokens   [{:symbol "BTC" :fiat-value 50000}
+                    {:symbol "ETH" :fiat-value 15000}
+                    {:symbol "DAI" :fiat-value 1000}]
+          expected [{:symbol "BTC" :fiat-value 50000}
+                    {:symbol "ETH" :fiat-value 15000}
+                    {:symbol "DAI" :fiat-value 1000}]]
+      (is (= (utils/sort-tokens-by-fiat-value tokens) expected)))))
+
+(deftest sort-tokens-by-name-test
+  (testing "Sort tokens by symbol in ascending order"
+    (let [tokens   [{:symbol "ETH"}
+                    {:symbol "DAI"}
+                    {:symbol "BTC"}]
+          expected [{:symbol "BTC"}
+                    {:symbol "DAI"}
+                    {:symbol "ETH"}]]
+      (is (= (utils/sort-tokens-by-name tokens) expected)))))

--- a/src/status_im/subs/wallet/collectibles.cljs
+++ b/src/status_im/subs/wallet/collectibles.cljs
@@ -2,6 +2,7 @@
   (:require
     [clojure.string :as string]
     [re-frame.core :as re-frame]
+    [status-im.contexts.wallet.collectible.utils :as collectible-utils]
     [utils.collection]))
 
 (defn- filter-collectibles-in-chains
@@ -46,7 +47,10 @@
  :wallet/current-viewing-account-collectibles
  :<- [:wallet/current-viewing-account]
  (fn [current-account]
-   (-> current-account :collectibles add-collectibles-preview-url)))
+   (-> current-account
+       :collectibles
+       add-collectibles-preview-url
+       collectible-utils/sort-collectibles-by-name)))
 
 (re-frame/reg-sub
  :wallet/current-viewing-account-collectibles-in-selected-networks
@@ -71,7 +75,8 @@
           (apply interleave)
           (remove nil?)
           (utils.collection/distinct-by :id)
-          (add-collectibles-preview-url)))))
+          (add-collectibles-preview-url)
+          (collectible-utils/sort-collectibles-by-name)))))
 
 (re-frame/reg-sub
  :wallet/owned-collectibles-list-in-selected-networks


### PR DESCRIPTION
fixes #21305
also fixes #21636

and I believe it will close this https://github.com/status-im/status-mobile/issues/21636 as well. CC @alwx

## Summary
Assets are ordered in descending order of the fiat value on the 'select assets' and 'bridge' pages

- Default ordering should be by balance in descending order
- Collectibles should be by collection alphabetically in ascending order (A->Z)

### Areas that may be impacted

- collectible list tab
- asset list tab
- select asset and collectible screen


## Steps to test

1. Open account -> tap 'send' -> Go to 'select assets' page
2. Open account -> tap 'bridge' -> Go to 'bridge' page
3. Go to swap page -> open 'Asset to Pay', 'Asset to Receive' pages


### Result



https://github.com/user-attachments/assets/128317b7-b8fc-4d1d-9dc2-9582d52ce392



status: ready
