### PR TITLE
fix(wallet)_: Dismiss collectible details screen after a is TX placed

### DIFF
--- a/src/status_im/contexts/wallet/collectible/events.cljs
+++ b/src/status_im/contexts/wallet/collectible/events.cljs
@@ -303,7 +303,7 @@
            ;; By doing it, we skip a blink while visiting the collectible detail page.
            [:dispatch-later
             {:ms       17
-             :dispatch [:navigate-to :screen/wallet.collectible]}]]})))
+             :dispatch [:open-modal :screen/wallet.collectible]}]]})))
 
 (defn- keep-not-empty-value
   [old-value new-value]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -41,18 +41,18 @@
 (rf/reg-event-fx :wallet/navigate-to-account
  (fn [{:keys [db]} [address]]
    {:db (assoc-in db [:wallet :current-viewing-account-address] address)
-    :fx [[:dispatch [:navigate-to :screen/wallet.accounts address]]]}))
+    :fx [[:dispatch [:navigate-to :screen/wallet.accounts]]]}))
 
 (rf/reg-event-fx :wallet/navigate-to-account-within-stack
  (fn [{:keys [db]} [address]]
    {:db (assoc-in db [:wallet :current-viewing-account-address] address)
-    :fx [[:dispatch [:navigate-to-within-stack [:screen/wallet.accounts :shell-stack] address]]]}))
+    :fx [[:dispatch [:navigate-to-within-stack [:screen/wallet.accounts :shell-stack]]]]}))
 
 (rf/reg-event-fx :wallet/navigate-to-new-account
  (fn [{:keys [db]} [address]]
    {:db (assoc-in db [:wallet :current-viewing-account-address] address)
     :fx [[:dispatch [:hide-bottom-sheet]]
-         [:dispatch [:navigate-to :screen/wallet.accounts address]]
+         [:dispatch [:navigate-to :screen/wallet.accounts]]
          [:dispatch [:wallet/show-account-created-toast address]]]}))
 
 (rf/reg-event-fx :wallet/select-account-tab

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -633,6 +633,7 @@
 (rf/reg-event-fx :wallet/clean-up-transaction-flow
  (fn [_]
    {:fx [[:dispatch [:dismiss-modal :screen/wallet.transaction-confirmation]]
+         [:dispatch [:dismiss-modal :screen/wallet.collectible]]
          [:dispatch [:wallet/clean-scanned-address]]
          [:dispatch [:wallet/clean-local-suggestions]]
          [:dispatch [:wallet/clean-send-address]]

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -518,6 +518,7 @@
 
    {:name      :screen/wallet.collectible
     :metrics   {:track? true}
+    :options   {:modalPresentationStyle :overCurrentContext}
     :component wallet-collectible/view}
 
    {:name      :screen/wallet.edit-account


### PR DESCRIPTION
fixes #20701

## Summary

This PR fixes the user is not taken to the activity tab after the TX if the user enters the send flow from collectible details screen (inside the account)

## Review notes

This PR updates the opening of collectible details screen into the modal (correct navigation for the detail screen) and dismisses it on TX confirmation (just as we do for the send flow modal).

### Platforms

- Android
- iOS

## Steps to test

##### Prerequisites: A profile/account with collectibles

- Open Status
- Navigate to Wallet > Tap on an Account > Tap Collectible tab
- Tap on any collectible to open the details screen
- Open Send flow from it and complete the transaction
- Verify the collectible details screen is dismissed when the TX is placed and taken to the activity tab

status: ready

