### PR TITLE
fix Keyboard overlaps suggestion bar and validation errors

### DIFF
--- a/src/status_im/common/enter_seed_phrase/style.cljs
+++ b/src/status_im/common/enter_seed_phrase/style.cljs
@@ -31,7 +31,7 @@
    :margin-bottom   2})
 
 (def input-container
-  {:height            120
+  {:flex              1
    :margin-top        12
    :margin-horizontal -20})
 

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -1048,7 +1048,8 @@
 
     {:name      :screen/use-recovery-phrase-dark
      :metrics   {:track? true}
-     :options   {:theme :dark}
+     :options   {:theme                  :dark
+                 :modalPresentationStyle :fullScreen}
      :component enter-seed-phrase/view}
 
     {:name      :screen/profile.profiles


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21622

### Summary

- According to [Figma](https://www.figma.com/design/YGm3igIOAcwMqUVJWCJ6f1/Keycard-UX?node-id=121-19239&node-type=frame&t=EIFHDwgfg8qc60pT-0), the recovery screen should be displayed in fullscreen, as we have in the onboarding, not as a [pageSheet](https://wix.github.io/react-native-navigation/api/options-root#modalpresentationstyle). Using the pagesheet modal caused issues because the "Enter Seed Phrase" screen was developed based on the fullscreen design.

- Hardcoding the input form height caused issues when the screen was not in fullscreen mode.

### Video
https://github.com/user-attachments/assets/806855b5-19b7-4618-b235-2e91dd3ff8c3

status: ready