### PR TITLE
[#21919] fix: remove on-ramp provider description and reinstate mecuryo

### DIFF
--- a/src/status_im/contexts/wallet/sheets/buy_token/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/buy_token/view.cljs
@@ -7,7 +7,7 @@
             [utils.re-frame :as rf]))
 
 (defn- crypto-on-ramp-item
-  [{:keys [name description fees logo-url site-url recurrent-site-url urls-need-parameters]
+  [{:keys [name fees logo-url site-url recurrent-site-url urls-need-parameters]
     :as   provider}
    _
    _
@@ -22,18 +22,16 @@
                       (rn/open-url (if (= tab :recurrent) recurrent-site-url site-url))))
                   [site-url recurrent-site-url tab])]
     [quo/settings-item
-     {:title             name
-      :description       :text
-      :description-props {:text description}
-      :tag               :context
-      :tag-props         {:icon    :i/fees
-                          :context fees}
-      :action            :arrow
-      :action-props      {:alignment :flex-start
-                          :icon      :i/external}
-      :image             :icon-avatar
-      :image-props       {:icon logo-url}
-      :on-press          open-url}]))
+     {:title        name
+      :tag          :context
+      :tag-props    {:icon    :i/fees
+                     :context fees}
+      :action       :arrow
+      :action-props {:alignment :flex-start
+                     :icon      :i/external}
+      :image        :icon-avatar
+      :image-props  {:icon logo-url}
+      :on-press     open-url}]))
 
 (def ^:private tabs
   [{:id    :one-time

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v9.1.0",
-    "commit-sha1": "4ec885a91f2857a30d1838213000f0a5a91fd52a",
-    "src-sha256": "1fkvhazv7v2vyqpffx3r4p3aii5ai464nx2pdfgn6b6gmb24bxdq"
+    "version": "v9.2.0",
+    "commit-sha1": "41743c6ca0bb0a1ff4510bfa3575948d477e6284",
+    "src-sha256": "1awd04bsxkglbgd0nk5mdz2sm17pxkcj47hfslczsppww7yhmc9n"
 }


### PR DESCRIPTION
fixes #21919
fixes #21916

status-go PR: https://github.com/status-im/status-go/pull/6250

## Summary
Reinstate Mercuryo and remove on-ramp provider description 

### Areas that may be impacted

- Buy asset modal

## Steps to test

1. Go to a wallet account
2. Click on Buy

### Result
<img src="https://github.com/user-attachments/assets/5860623a-61e6-45c2-9e0f-19239b8b319a" width="390px" />


status: ready