### PR TITLE
chore_: remove EncodeTransfer/EncodeFunctionCall/VerifyAccountPassword

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/AccountManager.kt
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/AccountManager.kt
@@ -204,24 +204,6 @@ class AccountManager(private val reactContext: ReactApplicationContext) : ReactC
     }
 
     @ReactMethod
-    fun verify(address: String, password: String, callback: Callback) {
-        val absRootDirPath = utils.getNoBackupDirectory()
-        val newKeystoreDir = utils.pathCombine(absRootDirPath, "keystore")
-
-        val jsonParams = JSONObject()
-        jsonParams.put("keyStoreDir", newKeystoreDir)
-        jsonParams.put("address", address) 
-        jsonParams.put("password", password)
-
-        StatusBackendClient.executeStatusGoRequestWithCallback(
-            endpoint = "VerifyAccountPasswordV2",
-            requestBody = jsonParams.toString(),
-            statusgoFunction = { Statusgo.verifyAccountPasswordV2(jsonParams.toString()) },
-            callback
-        )
-    }
-
-    @ReactMethod
     fun verifyDatabasePassword(keyUID: String, password: String, callback: Callback) {
         val jsonParams = JSONObject()
         jsonParams.put("keyUID", keyUID)

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/EncryptionUtils.kt
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/EncryptionUtils.kt
@@ -88,42 +88,6 @@ class EncryptionUtils(private val reactContext: ReactApplicationContext) : React
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
-    fun encodeTransfer(to: String, value: String): String? {
-        return try {
-            val params = JSONObject().apply {
-                put("to", to)
-                put("value", value)
-            }
-            StatusBackendClient.executeStatusGoRequestWithResult(
-                "EncodeTransferV2",
-                params.toString(),
-                { Statusgo.encodeTransferV2(params.toString()) }
-            )
-        } catch (e: JSONException) {
-            Log.e(TAG, "Error creating JSON for encodeTransfer: ${e.message}")
-            null
-        }
-    }
-
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    fun encodeFunctionCall(method: String, paramsJSON: String): String? {
-        return try {
-            val params = JSONObject().apply {
-                put("method", method)
-                put("paramsJSON", JSONObject(paramsJSON))
-            }
-            StatusBackendClient.executeStatusGoRequestWithResult(
-                "EncodeFunctionCallV2",
-                params.toString(),
-                { Statusgo.encodeFunctionCallV2(params.toString()) }
-            )
-        } catch (e: JSONException) {
-            Log.e(TAG, "Error creating JSON for encodeFunctionCall: ${e.message}")
-            null
-        }
-    }
-
-    @ReactMethod(isBlockingSynchronousMethod = true)
     fun decodeParameters(decodeParamJSON: String): String = 
         StatusBackendClient.executeStatusGoRequestWithResult(
             "DecodeParameters",

--- a/modules/react-native-status/ios/RCTStatus/AccountManager.m
+++ b/modules/react-native-status/ios/RCTStatus/AccountManager.m
@@ -195,36 +195,6 @@ RCT_EXPORT_METHOD(loginAccount:(NSString *)request) {
     }];
 }
 
-RCT_EXPORT_METHOD(verify:(NSString *)address
-        password:(NSString *)password
-        callback:(RCTResponseSenderBlock)callback) {
-#if DEBUG
-    NSLog(@"VerifyAccountPasswordV2() method called");
-#endif
-    NSURL *rootUrl = [Utils getRootUrl];
-    NSString *keystorePath = [rootUrl.path stringByAppendingPathComponent:@"keystore"];
-    
-    NSDictionary *params = @{
-        @"keyStoreDir": keystorePath,
-        @"address": address,
-        @"password": password
-    };
-    NSError *error;
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:params options:0 error:&error];
-    if (error) {
-        NSLog(@"Error creating JSON: %@", error);
-        return;
-    }
-    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    
-    [StatusBackendClient executeStatusGoRequestWithCallback:@"VerifyAccountPasswordV2"
-                                                     body:jsonString
-                                        statusgoFunction:^NSString *{
-        return StatusgoVerifyAccountPasswordV2(jsonString);
-    }
-                                                 callback:callback];
-}
-
 RCT_EXPORT_METHOD(verifyDatabasePassword:(NSString *)keyUID
         password:(NSString *)password
         callback:(RCTResponseSenderBlock)callback) {

--- a/modules/react-native-status/ios/RCTStatus/EncryptionUtils.m
+++ b/modules/react-native-status/ios/RCTStatus/EncryptionUtils.m
@@ -105,48 +105,6 @@ RCT_EXPORT_METHOD(convertToKeycardAccount:(NSString *)keyUID
                                                  callback:callback];
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(encodeTransfer:(NSString *)to
-                                     value:(NSString *)value) {
-    NSDictionary *params = @{
-        @"to": to,
-        @"value": value
-    };
-    NSError *error;
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:params options:0 error:&error];
-    if (error) {
-        NSLog(@"Error creating JSON: %@", [error localizedDescription]);
-        return nil;
-    }
-    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    
-    return [StatusBackendClient executeStatusGoRequestWithResult:@"EncodeTransferV2"
-                                                          body:jsonString
-                                              statusgoFunction:^NSString *{
-        return StatusgoEncodeTransferV2(jsonString);
-    }];
-}
-
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(encodeFunctionCall:(NSString *)method
-                                     paramsJSON:(NSString *)paramsJSON) {
-    NSDictionary *params = @{
-        @"method": method,
-        @"paramsJSON": paramsJSON
-    };
-    NSError *error;
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:params options:0 error:&error];
-    if (error) {
-        NSLog(@"Error creating JSON: %@", [error localizedDescription]);
-        return nil;
-    }
-    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    
-    return [StatusBackendClient executeStatusGoRequestWithResult:@"EncodeFunctionCallV2"
-                                                          body:jsonString
-                                              statusgoFunction:^NSString *{
-        return StatusgoEncodeFunctionCallV2(jsonString);
-    }];
-}
-
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(decodeParameters:(NSString *)decodeParamJSON) {
     return [StatusBackendClient executeStatusGoRequestWithResult:@"DecodeParameters"
                                                           body:decodeParamJSON

--- a/modules/react-native-status/nodejs/status.cpp
+++ b/modules/react-native-status/nodejs/status.cpp
@@ -389,86 +389,6 @@ void _StopCPUProfiling(const FunctionCallbackInfo<Value>& args) {
 
 }
 
-void _EncodeTransfer(const FunctionCallbackInfo<Value>& args) {
-	Isolate* isolate = args.GetIsolate();
-        Local<Context> context = isolate->GetCurrentContext();
-
-	if (args.Length() != 2) {
-		// Throw an Error that is passed back to JavaScript
-		isolate->ThrowException(Exception::TypeError(
-			String::NewFromUtf8Literal(isolate, "Wrong number of arguments for EncodeTransfer")));
-		return;
-	}
-
-	// Check the argument types
-
-	if (!args[0]->IsString()) {
-		isolate->ThrowException(Exception::TypeError(
-			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'to'")));
-		return;
-	}
-
-	if (!args[1]->IsString()) {
-    		isolate->ThrowException(Exception::TypeError(
-    			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'value'")));
-    		return;
-    	}
-
-
-	String::Utf8Value arg0Obj(isolate, args[0]->ToString(context).ToLocalChecked());
-	char *arg0 = *arg0Obj;
-	String::Utf8Value arg1Obj(isolate, args[1]->ToString(context).ToLocalChecked());
-    char *arg1 = *arg1Obj;
-
-	// Call exported Go function, which returns a C string
-	char *c = EncodeTransfer(arg0, arg1);
-
-	Local<String> ret = String::NewFromUtf8(isolate, c).ToLocalChecked();
-	args.GetReturnValue().Set(ret);
-	delete c;
-
-}
-
-void _EncodeFunctionCall(const FunctionCallbackInfo<Value>& args) {
-	Isolate* isolate = args.GetIsolate();
-        Local<Context> context = isolate->GetCurrentContext();
-
-	if (args.Length() != 2) {
-		// Throw an Error that is passed back to JavaScript
-		isolate->ThrowException(Exception::TypeError(
-			String::NewFromUtf8Literal(isolate, "Wrong number of arguments for EncodeFunctionCall")));
-		return;
-	}
-
-	// Check the argument types
-
-	if (!args[0]->IsString()) {
-		isolate->ThrowException(Exception::TypeError(
-			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'method'")));
-		return;
-	}
-
-	if (!args[1]->IsString()) {
-    		isolate->ThrowException(Exception::TypeError(
-    			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'paramsJSON'")));
-    		return;
-    	}
-
-
-	String::Utf8Value arg0Obj(isolate, args[0]->ToString(context).ToLocalChecked());
-	char *arg0 = *arg0Obj;
-	String::Utf8Value arg1Obj(isolate, args[1]->ToString(context).ToLocalChecked());
-    char *arg1 = *arg1Obj;
-
-	// Call exported Go function, which returns a C string
-	char *c = EncodeFunctionCall(arg0, arg1);
-
-	Local<String> ret = String::NewFromUtf8(isolate, c).ToLocalChecked();
-	args.GetReturnValue().Set(ret);
-	delete c;
-
-}
-
 void _DecodeParameters(const FunctionCallbackInfo<Value>& args) {
 	Isolate* isolate = args.GetIsolate();
         Local<Context> context = isolate->GetCurrentContext();
@@ -1380,53 +1300,6 @@ void _CallPrivateRPC(const FunctionCallbackInfo<Value>& args) {
 
 }
 
-void _VerifyAccountPassword(const FunctionCallbackInfo<Value>& args) {
-	Isolate* isolate = args.GetIsolate();
-        Local<Context> context = isolate->GetCurrentContext();
-
-	if (args.Length() != 3) {
-		// Throw an Error that is passed back to JavaScript
-		isolate->ThrowException(Exception::TypeError(
-			String::NewFromUtf8Literal(isolate, "Wrong number of arguments for VerifyAccountPassword")));
-		return;
-	}
-
-	// Check the argument types
-
-	if (!args[0]->IsString()) {
-		isolate->ThrowException(Exception::TypeError(
-			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'keyStoreDir'")));
-		return;
-	}
-	if (!args[1]->IsString()) {
-		isolate->ThrowException(Exception::TypeError(
-			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'address'")));
-		return;
-	}
-	if (!args[2]->IsString()) {
-		isolate->ThrowException(Exception::TypeError(
-			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'password'")));
-		return;
-	}
-
-
-	String::Utf8Value arg0Obj(isolate, args[0]->ToString(context).ToLocalChecked());
-	char *arg0 = *arg0Obj;
-	String::Utf8Value arg1Obj(isolate, args[1]->ToString(context).ToLocalChecked());
-	char *arg1 = *arg1Obj;
-	String::Utf8Value arg2Obj(isolate, args[2]->ToString(context).ToLocalChecked());
-	char *arg2 = *arg2Obj;
-
-	// Call exported Go function, which returns a C string
-	char *c = VerifyAccountPassword(arg0, arg1, arg2);
-
-	Local<String> ret = String::NewFromUtf8(isolate, c).ToLocalChecked();
-	args.GetReturnValue().Set(ret);
-	delete c;
-
-
-}
-
 void _SendTransactionWithSignature(const FunctionCallbackInfo<Value>& args) {
 	Isolate* isolate = args.GetIsolate();
         Local<Context> context = isolate->GetCurrentContext();
@@ -1992,8 +1865,6 @@ void init(Local<Object> exports) {
 	NODE_SET_METHOD(exports, "acceptTerms", _AcceptTerms);
 	NODE_SET_METHOD(exports, "fleets", _Fleets);
 	NODE_SET_METHOD(exports, "stopCPUProfiling", _StopCPUProfiling);
-	NODE_SET_METHOD(exports, "encodeTransfer", _EncodeTransfer);
-	NODE_SET_METHOD(exports, "encodeFunctionCall", _EncodeFunctionCall);
 	NODE_SET_METHOD(exports, "decodeParameters", _DecodeParameters);
 	NODE_SET_METHOD(exports, "hexToNumber", _HexToNumber);
 	NODE_SET_METHOD(exports, "numberToHex", _NumberToHex);
@@ -2017,7 +1888,6 @@ void init(Local<Object> exports) {
 	NODE_SET_METHOD(exports, "openAccounts", _OpenAccounts);
 	NODE_SET_METHOD(exports, "extractGroupMembershipSignatures", _ExtractGroupMembershipSignatures);
 	NODE_SET_METHOD(exports, "callPrivateRPC", _CallPrivateRPC);
-	NODE_SET_METHOD(exports, "verifyAccountPassword", _VerifyAccountPassword);
 	NODE_SET_METHOD(exports, "sendTransactionWithSignature", _SendTransactionWithSignature);
 	NODE_SET_METHOD(exports, "writeHeapProfile", _WriteHeapProfile);
 	NODE_SET_METHOD(exports, "addPeer", _AddPeer);

--- a/src/native_module/core.cljs
+++ b/src/native_module/core.cljs
@@ -170,12 +170,6 @@
                                                  :Bip39Passphrase password})
                                callback))
 
-(defn verify
-  "NOTE: beware, the password has to be sha3 hashed"
-  [address hashed-password callback]
-  (log/debug "[native-module] verify")
-  (.verify ^js (account-manager) address hashed-password callback))
-
 (defn set-soft-input-mode
   [mode]
   (log/debug "[native-module]  set-soft-input-mode")
@@ -387,16 +381,6 @@
 
     ;; in unknown scenarios we also consider the device rooted to avoid degrading security
     :else (callback true)))
-
-(defn encode-transfer
-  [to-norm amount-hex]
-  (log/debug "[native-module] encode-transfer")
-  (.encodeTransfer ^js (encryption) to-norm amount-hex))
-
-(defn encode-function-call
-  [method params]
-  (log/debug "[native-module] encode-function-call")
-  (.encodeFunctionCall ^js (encryption) method (types/clj->json params)))
 
 (defn decode-parameters
   [bytes-string types]

--- a/src/tests/test_utils.cljs
+++ b/src/tests/test_utils.cljs
@@ -44,9 +44,6 @@
     (fn [s] (.serializeLegacyKey native-status s))
     :setBlankPreviewFlag
     identity
-    :encodeTransfer
-    (fn [to-norm amount-hex]
-      (.encodeTransfer native-status to-norm amount-hex))
     :hexToNumber
     (fn [hex] (.hexToNumber native-status hex))
     :decodeParameters


### PR DESCRIPTION
There's no usages for `EncodeTransfer/EncodeFunctionCall/VerifyAccountPassword` in frontend, we need to clean corresponding v1 endpoints on status-go side as well since we have v2 implementations

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

status: ready