### PR TITLE
chore: update status-go with identity images fixes

### DIFF
--- a/src/status_im/contexts/profile/edit/header/events.cljs
+++ b/src/status_im/contexts/profile/edit/header/events.cljs
@@ -5,11 +5,9 @@
             [utils.re-frame :as rf]))
 
 (rf/reg-event-fx :profile/update-local-picture
- (fn [{:keys [db now]} [images]]
+ (fn [{:keys [db]} [images]]
    {:db (if images
-          (assoc-in db
-           [:profile/profile :images]
-           (map #(assoc % :clock now) images))
+          (assoc-in db [:profile/profile :images] images)
           (update db :profile/profile dissoc :images))}))
 
 (rf/reg-event-fx :profile/edit-profile-picture-success

--- a/src/status_im/contexts/profile/settings/events.cljs
+++ b/src/status_im/contexts/profile/settings/events.cljs
@@ -129,10 +129,8 @@
            [:dispatch [:hide-bottom-sheet]]]})))
 
 (rf/reg-event-fx :profile.settings/update-local-picture
- (fn [{:keys [db now]} [images]]
-   {:db (assoc-in db
-         [:profile/profile :images]
-         (map #(assoc % :clock now) images))}))
+ (fn [{:keys [db]} [images]]
+   {:db (assoc-in db [:profile/profile :images] images)}))
 
 (rf/reg-event-fx :profile.settings/mnemonic-was-shown
  (fn [_]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v8.1.0",
-    "commit-sha1": "df1c8788e42784ba3b8ed3e7c5bd3ea530028410",
-    "src-sha256": "1yxcswrj7p1m96lx795vbqlgjlmpkgzaw7l8f2k4ni3d7vmlklnw"
+    "version": "v9.0.0",
+    "commit-sha1": "59caca61960752c464cf21de99103c8649dfb0c5",
+    "src-sha256": "008qmdkgf9vxpz0q57his9wmlkahykcnyrq6qbcpjqfvk55cq5gr"
 }


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes https://github.com/status-im/status-mobile/issues/21787
related status-go PR: https://github.com/status-im/status-go/pull/6239

## Summary
[comment]: # (Summarise the problem and how the pull request solves it)

* This PR is a continuation of the work done here: https://github.com/status-im/status-mobile/pull/21830
  * Previously we were generating our own `clock` timestamps inside the app when updating a profile image, but now we're relying on a fix from within status-go.

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

### Areas that may be impacted
[comment]: # (Optional. Specify if some specific areas need to be tested, such as 1-1 chats)

#### Functional

- Settings - Profile - Updating Profile Picture

## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Open Status mobile app
- Navigate to the Settings screen
- Navigate to the Edit Profile screen
- Press the profile image and choose a profile picture
- After successfully choosing a profile image, repeat the last step and choose a different profile image

[comment]: # (Can be ready or wip)
status: ready


<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that may be impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->

### Screen Capture


https://github.com/user-attachments/assets/169a18f4-08d3-4eeb-a491-9d34ac4c598f


