### PR TITLE
ci: upgrade go to 1.22

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -53,25 +53,14 @@ in {
   xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
     versions = ["16.0" "16.1" "16.2"];
   };
-  go = super.go_1_21;
+  go = super.go_1_22;
   clang = super.clang_15;
-  buildGoPackage = super.buildGo121Package;
-  buildGoModule = super.buildGo121Module;
-  gomobile = (super.gomobile.overrideAttrs (old: {
-    patches = [
-      (self.fetchurl { # https://github.com/golang/mobile/pull/84
-        url = "https://github.com/golang/mobile/commit/f20e966e05b8f7e06bed500fa0da81cf6ebca307.patch";
-        sha256 = "sha256-TZ/Yhe8gMRQUZFAs9G5/cf2b9QGtTHRSObBFD5Pbh7Y=";
-      })
-      (self.fetchurl { # https://github.com/golang/go/issues/58426
-        url = "https://github.com/golang/mobile/commit/406ed3a7b8e44dc32844953647b49696d8847d51.patch";
-        sha256 = "sha256-dqbYukHkQEw8npOkKykOAzMC3ot/Y4DEuh7fE+ptlr8=";
-      })
-    ];
-  })).override {
-    # FIXME: No Android SDK packages for aarch64-darwin.
-    withAndroidPkgs = stdenv.system != "aarch64-darwin";
+  buildGoPackage = super.buildGo122Package;
+  buildGoModule = super.buildGo122Module;
+  gomobile = callPackage ./pkgs/gomobile {
+    #FIXME: No Android SDK packages for aarch64-darwin.
     androidPkgs = self.androidEnvCustom.compose;
+    withAndroidPkgs = stdenv.system != "aarch64-darwin";
   };
 
   # Android environment

--- a/nix/pkgs/gomobile/default.nix
+++ b/nix/pkgs/gomobile/default.nix
@@ -1,0 +1,85 @@
+{
+  stdenv,
+  lib,
+  fetchgit,
+  fetchurl,
+  buildGo122Module,
+  zlib,
+  makeWrapper,
+  xcodeenv,
+  androidenv,
+  xcodeWrapperArgs ? { },
+  xcodeWrapper ? xcodeenv.composeXcodeWrapper xcodeWrapperArgs,
+  withAndroidPkgs ? stdenv.system != "aarch64-darwin",
+  androidPkgs ? (
+    androidenv.composeAndroidPackages {
+      includeNDK = true;
+    }
+  ),
+}:
+buildGo122Module {
+  pname = "gomobile";
+  version = "0-unstable-2024-12-13";
+
+  src = fetchgit {
+    name = "gomobile";
+    url = "https://go.googlesource.com/mobile";
+    rev = "a87c1cf6cf463f0d4476cfe0fcf67c2953d76e7c";
+    hash = "sha256-7j4rdmCZMC8tn4vAsC9x/mMNkom/+Tl7uAY+5gkSvfY=";
+  };
+
+  vendorHash = "sha256-6ycxEDEE0/i6Lxo0gb8wq3U2U7Q49AJj+PdzSl57wwI=";
+
+  CGO_ENABLED = "1";
+
+  subPackages = [
+    "bind"
+    "cmd/gobind"
+    "cmd/gomobile"
+  ];
+
+  # Fails with: go: cannot find GOROOT directory
+  doCheck = false;
+
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcodeWrapper ];
+
+  # Prevent a non-deterministic temporary directory from polluting the resulting object files
+  postPatch = ''
+    substituteInPlace cmd/gomobile/env.go --replace-quiet \
+      'tmpdir, err = ioutil.TempDir("", "gomobile-work-")' \
+      'tmpdir = filepath.Join(os.Getenv("NIX_BUILD_TOP"), "gomobile-work")'
+    substituteInPlace cmd/gomobile/init.go --replace-quiet \
+      'tmpdir, err = ioutil.TempDir(gomobilepath, "work-")' \
+      'tmpdir = filepath.Join(os.Getenv("NIX_BUILD_TOP"), "work")'
+
+    # To fix unable to import bind: no Go package in golang.org/x/mobile/bind
+    substituteInPlace cmd/gomobile/init.go --replace \
+      'golang.org/x/mobile/cmd/gobind@latest' \
+      'golang.org/x/mobile/cmd/gobind'
+  '';
+
+  # Necessary for GOPATH when using gomobile.
+  postInstall = ''
+    mkdir -p $out/src/golang.org/x
+    ln -s $src $out/src/golang.org/x/mobile
+  '';
+
+  postFixup = ''
+    for prog in gomobile gobind; do
+      wrapProgram $out/bin/$prog \
+        --suffix GOPATH : $out \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ zlib ]}" \
+        ${lib.optionalString withAndroidPkgs ''
+          --prefix PATH : "${androidPkgs.androidsdk}/bin" \
+          --set-default ANDROID_HOME "${androidPkgs.androidsdk}/libexec/android-sdk"
+        ''}
+    done
+  '';
+
+  meta = {
+    description = "Tool for building and running mobile apps written in Go";
+    homepage = "https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile";
+    license = with lib.licenses; [ bsd3 ];
+    maintainers = with lib.maintainers; [ jakubgs ];
+  };
+}

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v10.0.0",
-    "commit-sha1": "dcce8e9b8aec04876b854eacb56d9de95fd96a59",
-    "src-sha256": "008z0wrf6slf32iy3navq4zznfy6lam72lpqhxqwl8705hk4a4mj"
+    "version": "v10.2.0",
+    "commit-sha1": "901c9688f21740d13b76345d67bc384a94fc9f30",
+    "src-sha256": "0sknsscmdc67k17c6rxssic7gjc0q7hwwpidz352f2axsqhhzh7a"
 }


### PR DESCRIPTION
## Summary

- This PR upgrades `go` to `1.22`
- Brings in `gomobile` latest derivation at master of `nixpkgs` : https://github.com/NixOS/nixpkgs/commit/f5abef98e8b8c9f9e6da4bdab63f8be1e57ea8c0
- points to status-go changes where `go` is also upgraded to `1.22` -> https://github.com/status-im/status-go/pull/6258

## Testing notes
Please test thoroughly.

## Areas that may be impacted
- 1-1 chats
- public chats
- group chats
- account recovery
- networks
- mailservers

## Platforms
- Android
- iOS

status: ready

related: https://github.com/status-im/status-go/issues/6254