### PR TITLE
Backend server doc added to readme

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -16,6 +16,7 @@
 - [Patching](patching.md)
 - [Creating a pixel perfect UI](pixel-perfection.md)
 - [Contributing to status-go](status-go-changes.md)
+- [Status Backend Server](use-status-backend-server.md)
 - [Malli schemas (recorded demo)](https://www.youtube.com/watch?v=SlRio70aYVI) ([slides](files/forging-code-with-schemas-sep-2023-slides.pdf))
 
 ## Testing


### PR DESCRIPTION

## Summary
Backend server doc added to Readme because it is the fastest way to navigate to it.


status: ready
