### PR TITLE
Fix for local re-frisk launch

### DIFF
--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -129,5 +129,5 @@
 ;; if you're using android simulator, I suggest set the env variable to "http://10.0.2.2:"
 (goog-define STATUS_BACKEND_SERVER_IMAGE_SERVER_URI_PREFIX "https://localhost:")
 
-(def re-frisk-host (get-config :RE_FRISK_HOST "http://localhost"))
+(def re-frisk-host (get-config :RE_FRISK_HOST "localhost"))
 (def re-frisk-port (get-config :RE_FRISK_PORT "4567"))


### PR DESCRIPTION

## Summary
PR #21805 broke local launching of `re-frisk`, this PR fixes it.

Reason of the problem - default value for server was `http://localhost` whereas it should be just `localhost` because `http` part will be added [internally by re-frisk](https://github.com/flexsurfer/re-frisk/blob/da20221fae4b5856ad58ff15f674fbbca0e28fe0/src/re_frisk_remote/core.cljs#L124).


### Platforms

- Android
- iOS
## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- run `make run-re-frisk`
- Open Status in simulator
- make sure re-frisk works on `localhost:4567` and shows app data

status: ready
