### PR TITLE
fix: prevent receiving routes for unsupported receiving chains on bridge flow

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v9.3.0",
-    "commit-sha1": "bec0c3733eb9629153bc3df3d6294cec6a23af09",
-    "src-sha256": "0vj9vhmlf8csnpy8b0xiny425yzpl4wj1z873igb5av5hqllabf3"
+    "version": "v10.0.0",
+    "commit-sha1": "dcce8e9b8aec04876b854eacb56d9de95fd96a59",
+    "src-sha256": "008z0wrf6slf32iy3navq4zznfy6lam72lpqhxqwl8705hk4a4mj"
 }


### PR DESCRIPTION
partially fixes #21964

status go https://github.com/status-im/status-go/tree/fix/check-bridge-to-chain-id

## Summary

Currently, if a token is not supported on our current bridge provider (Hop) for a given receiver network, the router still returns a valid route, but the transaction will fail. This PR introduces a fix on the status-go side where if the token is not supported on the receiving network, it won't return any route.

A complete fix would be to prevent the user to select a network to receive that is not supported for the selected token, but  that would require more complicated changes on status-go, so this is just a partial fix to prevent routes being found in such cases.

### Platforms

- Android
- iOS

### Areas that may be impacted

#### Functional

- wallet / transactions

## Steps to test

- Open Status
- Login
- Go to wallet
- Select an account
- Select bridge
- Select a token that Hop doesn't support for Base (like DAI or USDT)
- Select a network different from Base to bridge from
- Select Base as a network to bridge to
- Enter an amount
- Verify the router does not return a valid route, an error should be returned instead

status: ready