### PR TITLE
feat: elevate and highlight wallet CTAs on wallet home screen

### DIFF
--- a/src/status_im/contexts/shell/share/view.cljs
+++ b/src/status_im/contexts/shell/share/view.cljs
@@ -11,56 +11,61 @@
 
 (defn- header
   []
-  [:<>
-   [rn/view {:style style/header-row}
-    [quo/button
-     {:icon-only?          true
-      :type                :grey
-      :background          :blur
-      :size                32
-      :accessibility-label :close-shell-share-tab
-      :container-style     style/header-button
-      :on-press            #(rf/dispatch [:navigate-back])}
-     :i/close]
-    [quo/button
-     {:icon-only?          true
-      :type                :grey
-      :background          :blur
-      :size                32
-      :accessibility-label :shell-scan-button
-      :on-press            (fn []
-                             (rf/dispatch [:navigate-back])
-                             (rf/dispatch [:open-modal :shell-qr-reader]))}
-     :i/scan]]
-   [quo/text
-    {:size   :heading-1
-     :weight :semi-bold
-     :style  style/header-heading}
-    (i18n/label :t/share)]])
+  (let [{:keys [status]} (rf/sub [:get-screen-params])]
+    [:<>
+     [rn/view {:style style/header-row}
+      [quo/button
+       {:icon-only?          true
+        :type                :grey
+        :background          :blur
+        :size                32
+        :accessibility-label :close-shell-share-tab
+        :container-style     style/header-button
+        :on-press            #(rf/dispatch [:navigate-back])}
+       :i/close]
+      [quo/button
+       {:icon-only?          true
+        :type                :grey
+        :background          :blur
+        :size                32
+        :accessibility-label :shell-scan-button
+        :on-press            (fn []
+                               (rf/dispatch [:navigate-back])
+                               (rf/dispatch [:open-modal :shell-qr-reader]))}
+       :i/scan]]
+     [quo/text
+      {:size   :heading-1
+       :weight :semi-bold
+       :style  style/header-heading}
+      (if (= :receive status)
+        (i18n/label :t/receive)
+        (i18n/label :t/share))]]))
 
 (defn- tab-content
-  [initial-tab]
-  (let [[selected-tab set-selected-tab] (rn/use-state initial-tab)]
+  []
+  (let [{:keys [initial-tab hide-tab-selector?]
+         :or   {initial-tab        :profile
+                hide-tab-selector? false}} (rf/sub [:get-screen-params])
+        [selected-tab set-selected-tab]    (rn/use-state initial-tab)]
     [rn/view {:style {:padding-top (safe-area/get-top)}}
      [header]
-     [rn/view {:style style/tabs-container}
-      [quo/segmented-control
-       {:size           28
-        :blur?          true
-        :on-change      set-selected-tab
-        :default-active selected-tab
-        :data           [{:id    :profile
-                          :label (i18n/label :t/profile)}
-                         {:id    :wallet
-                          :label (i18n/label :t/wallet)}]}]]
+     (when-not hide-tab-selector?
+       [rn/view {:style style/tabs-container}
+        [quo/segmented-control
+         {:size           28
+          :blur?          true
+          :on-change      set-selected-tab
+          :default-active selected-tab
+          :data           [{:id    :profile
+                            :label (i18n/label :t/profile)}
+                           {:id    :wallet
+                            :label (i18n/label :t/wallet)}]}]])
      (if (= selected-tab :wallet)
        [wallet-view/wallet-tab]
        [profile-view/profile-tab])]))
 
 (defn view
   []
-  (let [{:keys [initial-tab] :or {initial-tab :profile}} (rf/sub [:get-screen-params])]
-    [quo/overlay {:type :shell}
-     [rn/view
-      {:key :share}
-      [tab-content initial-tab]]]))
+  [quo/overlay {:type :shell}
+   [rn/view {:key :share}
+    [tab-content]]])

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -433,13 +433,17 @@
                                                    [:wallet/bridge-select-token
                                                     (assoc params :network network)]))}])}]]])})))
 
-(rf/reg-event-fx :wallet/start-bridge
+(rf/reg-event-fx
+ :wallet/start-bridge
  (fn [{:keys [db]}]
-   {:db (assoc-in db [:wallet :ui :send :tx-type] :tx/bridge)
-    :fx [[:dispatch
-          [:wallet/wizard-navigate-forward
-           {:start-flow? true
-            :flow-id     :wallet-bridge-flow}]]]}))
+   (let [view-id (:view-id db)]
+     (cond-> {:db (assoc-in db [:wallet :ui :send :tx-type] :tx/bridge)}
+       (= view-id :screen/wallet.accounts)
+       (assoc :fx
+              [[:dispatch
+                [:wallet/wizard-navigate-forward
+                 {:start-flow? true
+                  :flow-id     :wallet-bridge-flow}]]])))))
 
 (rf/reg-event-fx :wallet/select-bridge-network
  (fn [{:keys [db]} [{:keys [network-chain-id stack-id]}]]

--- a/src/status_im/contexts/wallet/home/style.cljs
+++ b/src/status_im/contexts/wallet/home/style.cljs
@@ -31,3 +31,8 @@
 (defn header-container
   [theme]
   {:background-color (colors/theme-colors colors/white colors/neutral-95 theme)})
+
+(def cta-buttons
+  {:padding-horizontal 20
+   :padding-bottom     13
+   :flex-direction     :row})

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -293,8 +293,9 @@
                    [:wallet :ui :send]
                    dissoc
                    :token
-                   :token-symbol :token-display-name
-                   :tx-type      :network)}))
+                   :token-symbol
+                   :token-display-name
+                   :network)}))
 
 (rf/reg-event-fx :wallet/clean-selected-collectible
  (fn [{:keys [db]} [{:keys [ignore-entry-point?]}]]
@@ -740,6 +741,7 @@
                                                                                   token-symbol
                                                                                   address)]
                                           (utils/token-with-balance token network-details)))
+         asset-selected?              (or collectible-tx? (some? token))
          bridge-tx?                   (= tx-type :tx/bridge)
          flow-id                      (if bridge-tx?
                                         :wallet-bridge-flow
@@ -762,7 +764,7 @@
             network      (assoc-in [:wallet :ui :send :network] network)
             token-symbol (assoc-in [:wallet :ui :send :token] token)
             bridge-tx?   (assoc-in [:wallet :ui :send :to-address] address))
-      :fx (if (or no-tx-type? (some? network) collectible-tx?)
+      :fx (if (or no-tx-type? (some? network) collectible-tx? (not asset-selected?))
             [[:dispatch [:wallet/switch-current-viewing-account address]]
              [:dispatch
               [:wallet/wizard-navigate-forward

--- a/src/status_im/contexts/wallet/send/events_test.cljs
+++ b/src/status_im/contexts/wallet/send/events_test.cljs
@@ -215,8 +215,7 @@
     (reset! rf-db/app-db
       {:wallet {:ui {:send {:other-props        :value
                             :token              "ETH"
-                            :token-display-name "ETH"
-                            :tx-type            :tx/collectible-erc-721}}}})
+                            :token-display-name "ETH"}}}})
     (is (match-strict? expected-db (:db (dispatch [event-id]))))))
 
 (h/deftest-event :wallet/clean-selected-collectible
@@ -497,12 +496,16 @@
         address     "0x01"
         network     {:chain-id 1}]
     (testing "when tx-type is :tx/bridge and token-symbol is nil"
-      (let [tx-type         :tx/bridge
+      (let [flow-id         :wallet-bridge-flow
+            tx-type         :tx/bridge
             expected-result {:db {:wallet {:ui {:send {:to-address address
                                                        :tx-type    tx-type}}}}
-                             :fx [[:dispatch [:dismiss-modal :screen/wallet.select-from]]
-                                  [:dispatch [:wallet/switch-current-viewing-account address]]
-                                  [:dispatch [:show-bottom-sheet {:content (m/pred fn?)}]]]}]
+                             :fx [[:dispatch [:wallet/switch-current-viewing-account address]]
+                                  [:dispatch
+                                   [:wallet/wizard-navigate-forward
+                                    {:current-screen stack-id
+                                     :start-flow?    start-flow?
+                                     :flow-id        flow-id}]]]}]
         (reset! rf-db/app-db {:wallet {:ui {:send {:tx-type tx-type}}}})
         (is (match? expected-result
                     (dispatch [event-id

--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -571,10 +571,15 @@
  (fn [{:keys [db]} [account]]
    (let [asset-to-pay     (get-in db [:wallet :ui :swap :asset-to-pay])
          asset-to-receive (get-in db [:wallet :ui :swap :asset-to-receive])]
-     {:fx [[:dispatch [:dismiss-modal :screen/wallet.swap-select-account]]
-           [:dispatch
-            [:wallet.swap/start
-             {:asset-to-pay     asset-to-pay
-              :asset-to-receive asset-to-receive
-              :open-new-screen? true
-              :from-account     account}]]]})))
+     {:fx (if asset-to-pay
+            [[:dispatch [:dismiss-modal :screen/wallet.swap-select-account]]
+             [:dispatch
+              [:wallet.swap/start
+               {:asset-to-pay     asset-to-pay
+                :asset-to-receive asset-to-receive
+                :open-new-screen? true
+                :from-account     account}]]]
+            [[:dispatch [:wallet/switch-current-viewing-account (:address account)]]
+             [:dispatch
+              [:navigate-to-within-stack
+               [:screen/wallet.swap-select-asset-to-pay :screen/wallet.swap-select-account]]]])})))

--- a/src/status_im/contexts/wallet/swap/select_account/view.cljs
+++ b/src/status_im/contexts/wallet/swap/select_account/view.cljs
@@ -11,16 +11,16 @@
     [utils.re-frame :as rf]))
 
 (defn- on-account-press
-  [account]
-  (rf/dispatch [:wallet.swap/start-from-account account]))
+  [account asset-to-pay]
+  (rf/dispatch [:wallet.swap/start-from-account account asset-to-pay]))
 
 (defn- render-fn
-  [item _ _]
+  [item _ _ {:keys [asset-to-pay]}]
   (let [has-balance (money/above-zero? (:asset-pay-balance item))]
     [quo/account-item
      {:type          (if has-balance :tag :default)
-      :on-press      #(on-account-press item)
-      :state         (if has-balance :default :disabled)
+      :on-press      #(on-account-press item asset-to-pay)
+      :state         (if (or has-balance (nil? asset-to-pay)) :default :disabled)
       :token-props   {:symbol (:asset-pay-symbol item)
                       :value  (:asset-pay-balance item)}
       :account-props (assoc item
@@ -49,5 +49,6 @@
       {:style                             style/accounts-list
        :content-container-style           style/accounts-list-container
        :data                              accounts
+       :render-data                       {:asset-to-pay asset-to-pay}
        :render-fn                         render-fn
        :shows-horizontal-scroll-indicator false}]]))


### PR DESCRIPTION
fixes #21976

## Summary

This PR adds wallet CTAs to our wallet home screen, and handle the case for each flow when they are initiated from the wallet home without any preselected token.

![](https://github.com/user-attachments/assets/abd40ccd-ef6b-4668-8289-54f56d8a4a7c)

### Platforms

- Android
- iOS

### Areas that may be impacted

## Steps to test

- Open Status
- Open wallet
- Tap Send / Bridge / Swap / Buy / Receive options
- Verify flows are working fine

We should also verify the current Send / Bridge / Swap / Buy / Receive flows where not broken by initiating them from different screens and actions.

status: ready