### PR TITLE
Improve activity loading to avoid sitations when activity tab becomes empty after auto-refresh or app backgrounding

### DIFF
--- a/src/status_im/contexts/wallet/common/activity_tab/view.cljs
+++ b/src/status_im/contexts/wallet/common/activity_tab/view.cljs
@@ -31,11 +31,20 @@
         on-end-reached (rn/use-callback
                         #(rf/dispatch
                           [:wallet/get-more-for-activities-filter-session]))]
-    (if (and (and (some? loading?) (false? loading?)) (empty? activity-list))
+    (cond
+      (and (empty? activity-list) loading?)
+      [quo/skeleton-list
+       {:content       :messages
+        :parent-height (:height (rn/get-window))
+        :animated?     false}]
+
+      (and (empty? activity-list) (false? loading?))
       [empty-tab/view
        {:title       (i18n/label :t/no-activity)
         :description (i18n/label :t/empty-tab-description)
         :image       (resources/get-themed-image :no-activity theme)}]
+
+      :else
       [rn/section-list
        {:sections                        activity-list
         :sticky-section-headers-enabled  false

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -57,11 +57,10 @@
 
 (rf/reg-event-fx :wallet/select-account-tab
  (fn [{:keys [db]} [tab]]
-   (let [activity-tab-selected? (= tab :activity)]
-     {:db (assoc-in db [:wallet :ui :account-page :active-tab] tab)
-      :fx [(if activity-tab-selected?
-             [:dispatch [:wallet/fetch-activities-for-current-account]]
-             [:dispatch [:wallet/stop-activity-filter-session]])]})))
+   {:db (assoc-in db [:wallet :ui :account-page :active-tab] tab)
+    :fx [(if (= tab :activity)
+           [:dispatch [:wallet/fetch-activities-for-current-account]]
+           [:dispatch [:wallet/stop-activity-filter-session]])]}))
 
 (rf/reg-event-fx :wallet/select-home-tab
  (fn [{:keys [db]} [tab]]


### PR DESCRIPTION
fixes #21792

### Summary
This PR fixes the issue with activity tab becoming empty + also makes the process of loading more visual. Also the PR includes a small cleanup.

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

status: ready
