### PR TITLE
nix: add fake git to status-go build derivation

### DIFF
--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -1,4 +1,4 @@
-{ callPackage, lib, buildGoPackage
+{ callPackage, lib, buildGoPackage, pkgs
 , androidPkgs, openjdk, gomobile, xcodeWrapper, removeReferencesTo
 , go-bindata, mockgen, protobuf3_20, protoc-gen-go
 , meta
@@ -15,6 +15,8 @@ let
   isIOS = platform == "ios";
   isAndroid = platform == "android";
   enforceXCodeAvailable = callPackage ./enforceXCodeAvailable.nix { };
+  # Fixes fatal: not a git repository (or any of the parent directories): .git
+  fakeGit = pkgs.writeScriptBin "git" "echo ${source.version}";
 
 in buildGoPackage rec {
   pname = source.repo;
@@ -29,7 +31,7 @@ in buildGoPackage rec {
 
   extraSrcPaths = [ gomobile ];
   nativeBuildInputs = [
-    gomobile removeReferencesTo go-bindata mockgen protoc-gen-go protobuf3_20
+    gomobile removeReferencesTo go-bindata mockgen protoc-gen-go protobuf3_20 fakeGit
   ] ++ optional isAndroid openjdk
     ++ optional isIOS xcodeWrapper;
 


### PR DESCRIPTION
## Summary

This PR adds a script that overrides `git` to echo version required by `status-go` derivation.
Also fixes error messages like this when building `status-go` :  
```
fatal: not a git repository (or any of the parent directories): .git
```

These messages can be often misleading to some developers.

## Testing notes
not required, this PR just fixes a warning.

## Platforms
- Android
- iOS

status: ready
