### PR TITLE
Typo fix post-mortem.md

### DIFF
--- a/doc/post-mortem.md
+++ b/doc/post-mortem.md
@@ -1,4 +1,4 @@
-This document MUST be updated everytime a PR has been identified has the source of a bug in develop. The post mortem analysis MUST include: the CAUSE of the bug, the RESOLUTION PROCESS and PREVENTION MEASURES.
+This document MUST be updated every time a PR has been identified has the source of a bug in develop. The post mortem analysis MUST include: the CAUSE of the bug, the RESOLUTION PROCESS and PREVENTION MEASURES.
 
 
 # "sql: no rows in result set" error on iOS login


### PR DESCRIPTION
# Typo Fix in `post-mortem.md`

## Description
This PR fixes a minor typo in the `post-mortem.md` document:
- Changed "everytime" to "every time" for grammatical correctness.

## Changes
- Corrected the typo from "everytime" to "every time" in the `post-mortem.md` file.

## Context
This update ensures clarity and adherence to proper grammar in documentation.

## Checklist
- [x] I have reviewed the updated content to ensure accuracy.
- [x] Documentation remains consistent and clear after this update.
- [ ] No additional changes or issues are introduced by this PR.

## Additional Notes
- This is a minor fix with no impact on the functionality or codebase.
- Please let me know if further improvements to the document are necessary.

