### PR TITLE
feat(wallet)_: Remove EIP-3770 address format

### DIFF
--- a/src/quo/components/drawers/drawer_top/view.cljs
+++ b/src/quo/components/drawers/drawer_top/view.cljs
@@ -57,17 +57,10 @@
        :container-style style/keycard-icon}])])
 
 (defn- account-subtitle
-  [{:keys [networks theme blur? description]}]
-  (if networks
-    [address-text/view
-     {:networks networks
-      :address  description
-      :format   :short}]
-    [text/text
-     {:size   :paragraph-2
-      :weight :regular
-      :style  (style/description theme blur?)}
-     description]))
+  [{:keys [description]}]
+  [address-text/view
+   {:address description
+    :format  :short}])
 
 (defn- default-keypair-subtitle
   [{:keys [description theme blur?]}]
@@ -109,7 +102,7 @@
    description])
 
 (defn- subtitle
-  [{:keys [type theme blur? stored networks description community-name community-logo
+  [{:keys [type theme blur? stored description community-name community-logo
            context-tag-type account-name emoji customization-color full-name profile-picture context
            icon]}]
   (cond
@@ -121,8 +114,7 @@
 
     (= :account type)
     [account-subtitle
-     {:networks    networks
-      :theme       theme
+     {:theme       theme
       :blur?       blur?
       :description description}]
 
@@ -205,7 +197,7 @@
 (defn view
   [{:keys [title title-icon type description blur? community-name community-logo button-icon
            account-name emoji context-tag-type button-type container-style
-           on-button-press on-button-long-press profile-picture stored networks label full-name
+           on-button-press on-button-long-press profile-picture stored label full-name
            button-disabled? account-avatar-emoji account-avatar-type customization-color icon-avatar
            context icon]}]
   (let [theme (quo.theme/use-theme)]
@@ -233,7 +225,6 @@
         :theme               theme
         :blur?               blur?
         :stored              stored
-        :networks            networks
         :description         description
         :community-name      community-name
         :community-logo      community-logo

--- a/src/quo/components/inputs/address_input/view.cljs
+++ b/src/quo/components/inputs/address_input/view.cljs
@@ -53,7 +53,7 @@
     (colors/theme-colors colors/neutral-30 colors/neutral-60 theme)))
 
 (defn address-input
-  [{:keys [default-value blur? on-change-text on-blur on-focus on-clear on-scan
+  [{:keys [default-value blur? on-change-text on-blur on-focus on-clear on-scan on-paste
            on-detect-ens on-detect-address on-detect-unclassified address-regex ens-regex
            valid-ens-or-address? container-style]}]
   (let [theme                  (quo.theme/use-theme)
@@ -82,12 +82,13 @@
                                                (not ens?)
                                                on-detect-unclassified)
                                       (on-detect-unclassified text)))))
-        on-paste               (rn/use-callback
-                                (fn []
-                                  (clipboard/get-string
-                                   (fn [clipboard]
-                                     (when-not (empty? clipboard)
-                                       (on-change clipboard))))))
+        on-paste               (rn/use-callback #(if (fn? on-paste)
+                                                   (on-paste on-change)
+                                                   (clipboard/get-string
+                                                    (fn [clipboard]
+                                                      (when-not (empty? clipboard)
+                                                        (on-change clipboard)))))
+                                                [on-paste])
         on-clear               (rn/use-callback
                                 (fn []
                                   (on-change "")

--- a/src/quo/components/list_items/account_list_card/component_spec.cljs
+++ b/src/quo/components/list_items/account_list_card/component_spec.cljs
@@ -15,7 +15,6 @@
   (h/test "Test icon renders for ':action :icon'"
     (h/render-with-theme-provider [account-list-card/view
                                    {:account-props    account-props
-                                    :network          :ethereum
                                     :action           :icon
                                     :on-options-press (fn [])}])
     (h/is-truthy (h/get-by-label-text :icon))))

--- a/src/quo/components/list_items/account_list_card/view.cljs
+++ b/src/quo/components/list_items/account_list_card/view.cljs
@@ -12,7 +12,7 @@
     [schema.core :as schema]))
 
 (defn- internal-view
-  [{:keys [action blur? account-props networks on-press on-options-press]}]
+  [{:keys [action blur? account-props on-press on-options-press]}]
   (let [theme             (quo.theme/use-theme)
         [state set-state] (rn/use-state :default)
         on-press-in       (rn/use-callback #(set-state :pressed))
@@ -31,10 +31,9 @@
          :size   :paragraph-2}
         (:name account-props)]
        [address-text/view
-        {:blur?    blur?
-         :networks networks
-         :address  (:address account-props)
-         :format   :short}]]]
+        {:blur?   blur?
+         :address (:address account-props)
+         :format  :short}]]]
      (when (= action :icon)
        [rn/pressable {:on-press on-options-press}
         [icon/icon :i/options

--- a/src/quo/components/share/share_qr_code/component_spec.cljs
+++ b/src/quo/components/share/share_qr_code/component_spec.cljs
@@ -13,8 +13,6 @@
   {:type            :profile
    :profile-picture 123})
 
-(def wallet-props {:networks '(:ethereum)})
-
 (def text-press-event
   {:test-name           "Text pressed"
    :accessibility-label :share-qr-code-info-text
@@ -32,24 +30,6 @@
    :accessibility-label :link-to-profile
    :event-name          :press
    :callback-prop-key   :on-share-press})
-
-(def multichain-press-event
-  {:test-name           "Multichain tab pressed"
-   :accessibility-label :share-qr-code-multichain-tab
-   :event-name          :press
-   :callback-prop-key   :on-multichain-press})
-
-(def legacy-press-event
-  {:test-name           "Legacy tab pressed"
-   :accessibility-label :share-qr-code-legacy-tab
-   :event-name          :press
-   :callback-prop-key   :on-legacy-press})
-
-(def settings-press-event
-  {:test-name           "Settings pressed"
-   :accessibility-label :share-qr-code-settings
-   :event-name          :press
-   :callback-prop-key   :on-settings-press})
 
 (defn render-share-qr-code
   [props]
@@ -74,45 +54,22 @@
       (h/is-truthy (h/get-by-text qr-label)))
 
     (h/test "Wallet Legacy"
-      (render-share-qr-code (merge default-props
-                                   wallet-props
-                                   {:type    :wallet
-                                    :address :legacy}))
+      (render-share-qr-code (assoc default-props
+                                   :type
+                                   :wallet))
       (h/is-truthy (h/get-by-text qr-label)))
 
-    (h/test "Wallet multichain"
-      (render-share-qr-code (merge default-props
-                                   wallet-props
-                                   {:type    :wallet
-                                    :address :multichain}))
+    (h/test "Saved address"
+      (render-share-qr-code (assoc default-props
+                                   :type
+                                   :saved-address))
       (h/is-truthy (h/get-by-text qr-label)))
 
-    (h/test "Saved address legacy"
-      (render-share-qr-code (merge default-props
-                                   wallet-props
-                                   {:type    :saved-address
-                                    :address :legacy}))
-      (h/is-truthy (h/get-by-text qr-label)))
 
-    (h/test "Saved address multichain"
-      (render-share-qr-code (merge default-props
-                                   wallet-props
-                                   {:type    :saved-address
-                                    :address :multichain}))
-      (h/is-truthy (h/get-by-text qr-label)))
-
-    (h/test "Watched address legacy"
-      (render-share-qr-code (merge default-props
-                                   wallet-props
-                                   {:type    :watched-address
-                                    :address :legacy}))
-      (h/is-truthy (h/get-by-text qr-label)))
-
-    (h/test "Watched address multichain"
-      (render-share-qr-code (merge default-props
-                                   wallet-props
-                                   {:type    :watched-address
-                                    :address :multichain}))
+    (h/test "Watched address"
+      (render-share-qr-code (assoc default-props
+                                   :type
+                                   :watched-address))
       (h/is-truthy (h/get-by-text qr-label))))
 
   (h/describe "Fires all events for all types"
@@ -136,78 +93,27 @@
 
       (h/describe "Wallet Legacy"
         (test-fire-events
-         (merge default-props
-                wallet-props
-                {:type    :wallet
-                 :address :legacy
-                 :emoji   "👻"})
+         (assoc default-props
+                :type  :wallet
+                :emoji "👻")
          [text-press-event
           text-long-press-event
-          share-press-event
-          multichain-press-event
-          legacy-press-event]))
+          share-press-event]))
 
-      (h/describe "Wallet Multichain"
+      (h/describe "Saved Address"
         (test-fire-events
-         (merge default-props
-                wallet-props
-                {:type    :wallet
-                 :address :multichain
-                 :emoji   "👻"})
+         (assoc default-props
+                :type
+                :saved-address)
          [text-press-event
           text-long-press-event
-          share-press-event
-          legacy-press-event
-          multichain-press-event
-          settings-press-event]))
+          share-press-event]))
 
-      (h/describe "Saved Address Legacy"
+      (h/describe "Watched Address"
         (test-fire-events
-         (merge default-props
-                wallet-props
-                {:type    :saved-address
-                 :address :legacy})
+         (assoc default-props
+                :type  :watched-address
+                :emoji "👽")
          [text-press-event
           text-long-press-event
-          share-press-event
-          legacy-press-event
-          multichain-press-event]))
-
-      (h/describe "Saved Address Multichain"
-        (test-fire-events
-         (merge default-props
-                wallet-props
-                {:type :saved-address :address :multichain})
-         [text-press-event
-          text-long-press-event
-          share-press-event
-          legacy-press-event
-          multichain-press-event
-          settings-press-event]))
-
-      (h/describe "Watched Address Legacy"
-        (test-fire-events
-         (merge default-props
-                wallet-props
-                {:type    :watched-address
-                 :address :legacy
-                 :emoji   "👽"})
-         [text-press-event
-          text-long-press-event
-          share-press-event
-          legacy-press-event
-          multichain-press-event]))
-
-      (h/describe "Watched Address Multichain"
-        (test-fire-events
-         (merge default-props
-                wallet-props
-                {:type    :watched-address
-                 :address :multichain
-                 :emoji   "👽"})
-         [text-press-event
-          text-long-press-event
-          share-press-event
-          legacy-press-event
-          multichain-press-event
-          settings-press-event])))))
+          share-press-event])))))

--- a/src/quo/components/share/share_qr_code/schema.cljs
+++ b/src/quo/components/share/share_qr_code/schema.cljs
@@ -1,10 +1,4 @@
-(ns quo.components.share.share-qr-code.schema
-  (:require
-    [quo.foundations.resources :as resources]))
-
-(defn- valid-network?
-  [network]
-  (-> network resources/get-network boolean))
+(ns quo.components.share.share-qr-code.schema)
 
 (def ?base
   [:map
@@ -35,25 +29,9 @@
    [:type [:= :wallet]]
    [:emoji {:optional true} [:maybe ?emoji]]])
 
-(def ?address-multichain
-  [:map
-   [:address [:= :multichain]]
-   [:on-settings-press {:optional true} fn?]])
-
-(def ?address-base
-  [:merge
-   [:map
-    [:networks [:sequential [:fn valid-network?]]]
-    [:on-legacy-press {:optional true} [:maybe fn?]]
-    [:on-multichain-press {:optional true} [:maybe fn?]]
-    [:address [:enum :legacy :multichain]]]
-   [:multi {:dispatch :address}
-    [:multichain ?address-multichain]]])
-
 (def ?saved-address
   [:map
-   [:type [:= :saved-address]]
-   [:on-settings-press {:optional true} fn?]])
+   [:type [:= :saved-address]]])
 
 (def ?watched-address
   [:map
@@ -67,8 +45,8 @@
      [:multi {:dispatch :type}
       [:channel [:merge ?base ?channel]]
       [:profile [:merge ?base ?profile]]
-      [:wallet [:merge ?base ?address-base ?wallet]]
-      [:saved-address [:merge ?base ?address-base ?saved-address]]
-      [:watched-address [:merge ?base ?address-base ?watched-address]]]]]
+      [:wallet [:merge ?base ?wallet]]
+      [:saved-address [:merge ?base ?saved-address]]
+      [:watched-address [:merge ?base ?watched-address]]]]]
    :any])
 

--- a/src/quo/components/share/share_qr_code/view.cljs
+++ b/src/quo/components/share/share_qr_code/view.cljs
@@ -12,36 +12,11 @@
             [quo.components.share.qr-code.view :as qr-code]
             [quo.components.share.share-qr-code.schema :as component-schema]
             [quo.components.share.share-qr-code.style :as style]
-            [quo.components.tabs.tab.view :as tab]
-            [quo.components.wallet.address-text.view :as address-text]
             [quo.foundations.colors :as colors]
             [quo.theme]
             [react-native.core :as rn]
             [schema.core :as schema]
             [utils.i18n :as i18n]))
-
-(defn- header
-  [{:keys [on-legacy-press on-multichain-press address]}]
-  [rn/view {:style style/header-container}
-   [tab/view
-    {:accessibility-label         :share-qr-code-multichain-tab
-     :id                          :wallet-multichain-tab
-     :active-item-container-style style/header-tab-active
-     :item-container-style        style/header-tab-inactive
-     :size                        24
-     :active                      (= :multichain address)
-     :on-press                    on-multichain-press}
-    (i18n/label :t/multichain)]
-   [rn/view {:style style/space-between-tabs}]
-   [tab/view
-    {:accessibility-label         :share-qr-code-legacy-tab
-     :id                          :wallet-legacy-tab
-     :active-item-container-style style/header-tab-active
-     :item-container-style        style/header-tab-inactive
-     :size                        24
-     :active                      (= :legacy address)
-     :on-press                    on-legacy-press}
-    (i18n/label :t/legacy)]])
 
 (defn- info-label
   [share-qr-code-type]
@@ -86,35 +61,13 @@
      :on-long-press on-text-long-press}
     qr-data]])
 
-(defn- wallet-legacy-bottom
+(defn- wallet-bottom
   [{:keys [component-width qr-data on-text-press on-text-long-press]}]
   [info-text
    {:width         component-width
     :on-press      on-text-press
     :on-long-press on-text-long-press}
    qr-data])
-
-(defn wallet-multichain-bottom
-  [{:keys [component-width qr-data on-text-press on-text-long-press on-settings-press]}]
-  [rn/view
-   {:style style/wallet-multichain-container}
-   [info-text
-    {:width         component-width
-     :on-press      on-text-press
-     :on-long-press on-text-long-press}
-    [address-text/view
-     {:address       qr-data
-      :full-address? true
-      :weight        :regular
-      :size          :paragraph-1}]]
-   [button/button
-    {:icon-only?          true
-     :type                :grey
-     :background          :blur
-     :size                32
-     :accessibility-label :share-qr-code-settings
-     :on-press            on-settings-press}
-    :i/advanced]])
 
 (defn- header-icon
   [{:keys [share-qr-type customization-color emoji profile-picture full-name]}]
@@ -140,17 +93,9 @@
                                  :full-name           full-name}]
     nil))
 
-(defn- has-header?
-  [share-qr-type]
-  (case share-qr-type
-    (:wallet
-     :watched-address
-     :saved-address) true
-    false))
-
 (defn- share-qr-code
   [{:keys [share-qr-type qr-image-uri component-width customization-color full-name
-           profile-picture emoji on-share-press address]
+           profile-picture emoji on-share-press]
     :as   props}]
   [:<>
    [gradient-cover/view {:customization-color customization-color :height 463}]
@@ -168,8 +113,6 @@
          {:color           colors/white-opa-40
           :container-style style/watched-account-icon}])]
      [share-button {:on-press on-share-press}]]
-    (when (has-header? share-qr-type)
-      [header props])
     [quo.theme/provider :light
      [qr-code/view
       {:qr-image-uri        qr-image-uri
@@ -185,12 +128,12 @@
        :profile-picture     profile-picture
        :emoji               emoji}]]
     [rn/view {:style style/bottom-container}
-     (if (= share-qr-type :profile)
+     (case share-qr-type
+       :profile
        [profile-bottom props]
-       (case address
-         :legacy     [wallet-legacy-bottom props]
-         :multichain [wallet-multichain-bottom props]
-         nil))]]])
+       (:wallet :watched-address :saved-address)
+       [wallet-bottom props]
+       nil)]]])
 
 (defn- view-internal
   [{provided-width :width :as props}]

--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -34,6 +34,8 @@
 (def mainnet-chain-explorer-link "https://etherscan.io/address/")
 (def optimism-mainnet-chain-explorer-link "https://optimistic.etherscan.io/address/")
 (def arbitrum-mainnet-chain-explorer-link "https://arbiscan.io/address/")
+(def base-mainnet-chain-explorer-link "https://basescan.org/address/")
+(def base-sepolia-chain-explorer-link "https://sepolia.basescan.org/address/")
 (def sepolia-chain-explorer-link "https://sepolia.etherscan.io/address/")
 (def optimism-sepolia-chain-explorer-link "https://sepolia-optimistic.etherscan.io/address/")
 (def arbitrum-sepolia-chain-explorer-link "https://sepolia.arbiscan.io/address/")

--- a/src/status_im/contexts/preview/quo/list_items/account_list_card.cljs
+++ b/src/status_im/contexts/preview/quo/list_items/account_list_card.cljs
@@ -20,8 +20,6 @@
                                                 :type                :default
                                                 :name                "Trip to Vegas"
                                                 :address             "0x0ah...78b"}
-                             :networks         [{:network-name :ethereum :short-name "eth"}
-                                                {:network-name :optimism :short-name "oeth"}]
                              :action           :none
                              :on-press         (fn [] (js/alert "Item pressed"))
                              :on-options-press (fn [] (js/alert "Options pressed"))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
@@ -7,14 +7,13 @@
 
 (defn save-address
   [{:keys [db]}
-   [{:keys [address name customization-color on-success on-error chain-short-names ens]}]]
+   [{:keys [address name customization-color on-success on-error ens]}]]
   (let [test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))
-        address-to-save        {:address         address
-                                :name            name
-                                :colorId         customization-color
-                                :ens             ens
-                                :isTest          test-networks-enabled?
-                                :chainShortNames chain-short-names}]
+        address-to-save        {:address address
+                                :name    name
+                                :colorId customization-color
+                                :ens     ens
+                                :isTest  test-networks-enabled?}]
     {:fx [[:json-rpc/call
            [{:method     "wakuext_upsertSavedAddress"
              :params     [address-to-save]

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
@@ -174,24 +174,21 @@
           address                "0x3"
           ens                    "bobby.eth"
           customization-color    :yellow
-          chain-short-names      "eth:arb1:oeth:"
           args                   {:on-success          on-success
                                   :on-error            on-error
                                   :name                name
                                   :address             address
                                   :customization-color customization-color
-                                  :ens                 ens
-                                  :chain-short-names   chain-short-names}
+                                  :ens                 ens}
           effects                (events/save-address cofx [args])
           result-fx              (:fx effects)
           expected-fx            [[:json-rpc/call
                                    [{:method     "wakuext_upsertSavedAddress"
-                                     :params     [{:address         address
-                                                   :name            name
-                                                   :colorId         customization-color
-                                                   :ens             ens
-                                                   :isTest          test-networks-enabled?
-                                                   :chainShortNames chain-short-names}]
+                                     :params     [{:address address
+                                                   :name    name
+                                                   :colorId customization-color
+                                                   :ens     ens
+                                                   :isTest  test-networks-enabled?}]
                                      :on-success on-success
                                      :on-error   on-error}]]]]
       (is (match? expected-fx result-fx)))))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/share_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/share_address/view.cljs
@@ -4,9 +4,6 @@
     [react-native.core :as rn]
     [react-native.platform :as platform]
     [status-im.contexts.settings.wallet.saved-addresses.share-address.style :as style]
-    [status-im.contexts.wallet.common.utils :as utils]
-    [status-im.contexts.wallet.common.utils.networks :as network-utils]
-    [status-im.contexts.wallet.sheets.network-preferences.view :as network-preferences]
     [utils.i18n :as i18n]
     [utils.image-server :as image-server]
     [utils.re-frame :as rf]))
@@ -32,54 +29,18 @@
                              :message   address
                              :isNewTask true})}]))
 
-(defn- open-preferences
-  [{:keys [address color selected-networks set-selected-networks]}]
-  (let [on-save       (fn [chain-ids]
-                        (rf/dispatch [:hide-bottom-sheet])
-                        (set-selected-networks (map network-utils/id->network chain-ids)))
-        sheet-content (fn []
-                        [network-preferences/view
-                         {:description       (i18n/label
-                                              :t/saved-address-network-preference-selection-description)
-                          :button-label      (i18n/label :t/display)
-                          :blur?             true
-                          :selected-networks (set selected-networks)
-                          :account           {:address address
-                                              :color   color}
-                          :on-save           on-save}])]
-    (rf/dispatch [:show-bottom-sheet
-                  {:theme   :dark
-                   :shell?  true
-                   :content sheet-content}])))
-
 (defn view
   []
-  (let [{:keys [name address customization-color
-                network-preferences-names]}       (rf/sub [:get-screen-params])
-        [wallet-type set-wallet-type]             (rn/use-state :legacy)
-        [selected-networks set-selected-networks] (rn/use-state network-preferences-names)
-        on-settings-press                         (rn/use-callback
-                                                   #(open-preferences
-                                                     {:selected-networks     selected-networks
-                                                      :set-selected-networks set-selected-networks
-                                                      :address               address
-                                                      :color                 customization-color})
-                                                   [address customization-color selected-networks])
-        on-legacy-press                           (rn/use-callback #(set-wallet-type :legacy))
-        on-multichain-press                       (rn/use-callback #(set-wallet-type :multichain))
-        share-title                               (str name " " (i18n/label :t/address))
-        qr-url                                    (rn/use-memo #(utils/get-wallet-qr
-                                                                 {:wallet-type       wallet-type
-                                                                  :selected-networks selected-networks
-                                                                  :address           address})
-                                                               [wallet-type selected-networks address])
-        qr-media-server-uri                       (rn/use-memo
-                                                   #(image-server/get-qr-image-uri-for-any-url
-                                                     {:url         qr-url
-                                                      :port        (rf/sub [:mediaserver/port])
-                                                      :qr-size     qr-size
-                                                      :error-level :highest})
-                                                   [qr-url])]
+  (let [{:keys [name address customization-color]} (rf/sub [:get-screen-params])
+        share-title                                (str name " " (i18n/label :t/address))
+        qr-url                                     address
+        qr-media-server-uri                        (rn/use-memo
+                                                    #(image-server/get-qr-image-uri-for-any-url
+                                                      {:url         qr-url
+                                                       :port        (rf/sub [:mediaserver/port])
+                                                       :qr-size     qr-size
+                                                       :error-level :highest})
+                                                    [qr-url])]
     [quo/overlay
      {:type       :shell
       :top-inset? true}
@@ -95,13 +56,8 @@
       [rn/view {:style style/qr-wrapper}
        [quo/share-qr-code
         {:type                :saved-address
-         :address             wallet-type
          :qr-image-uri        qr-media-server-uri
          :qr-data             qr-url
-         :networks            selected-networks
          :on-share-press      #(share-action qr-url share-title)
          :full-name           name
-         :customization-color customization-color
-         :on-legacy-press     on-legacy-press
-         :on-multichain-press on-multichain-press
-         :on-settings-press   on-settings-press}]]]]))
+         :customization-color customization-color}]]]]))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.settings.wallet.saved-addresses.sheets.address-options.view
   (:require
-    [clojure.string :as string]
     [quo.core :as quo]
     [react-native.core :as rn]
     [react-native.platform :as platform]
@@ -10,18 +9,18 @@
     [utils.re-frame :as rf]))
 
 (defn view
-  [{:keys [name full-address chain-short-names address customization-color] :as opts}]
+  [{:keys [name address customization-color] :as opts}]
   (let [open-send-flow                 (rn/use-callback
                                         (fn []
                                           (rf/dispatch [:wallet/init-send-flow-for-address
-                                                        {:address full-address
+                                                        {:address address
                                                          :recipient
                                                          {:label name
                                                           :customization-color
                                                           customization-color
                                                           :recipient-type :saved-address}
                                                          :stack-id :screen/settings.saved-addresses}]))
-                                        [full-address name customization-color])
+                                        [name customization-color])
         open-eth-chain-explorer        (rn/use-callback
                                         #(rf/dispatch [:wallet/navigate-to-chain-explorer
                                                        {:address address
@@ -37,21 +36,26 @@
                                                        {:address address
                                                         :network constants/optimism-network-name}])
                                         [address])
+        open-base-chain-explorer       (rn/use-callback
+                                        #(rf/dispatch [:wallet/navigate-to-chain-explorer
+                                                       {:address address
+                                                        :network constants/base-network-name}])
+                                        [address])
         open-share                     (rn/use-callback
                                         #(rf/dispatch
                                           [:open-share
                                            {:options (if platform/ios?
                                                        {:activityItemSources
                                                         [{:placeholderItem {:type    :text
-                                                                            :content full-address}
+                                                                            :content address}
                                                           :item            {:default {:type :text
                                                                                       :content
-                                                                                      full-address}}
-                                                          :linkMetadata    {:title full-address}}]}
-                                                       {:title     full-address
-                                                        :message   full-address
+                                                                                      address}}
+                                                          :linkMetadata    {:title address}}]}
+                                                       {:title     address
+                                                        :message   address
                                                         :isNewTask true})}])
-                                        [full-address])
+                                        [address])
         open-remove-confirmation-sheet (rn/use-callback
                                         #(rf/dispatch
                                           [:show-bottom-sheet
@@ -83,20 +87,24 @@
         :blur?               true
         :on-press            open-eth-chain-explorer
         :accessibility-label :view-address-on-etherscan}
-       (when (string/includes? chain-short-names constants/optimism-short-name)
-         {:icon                :i/link
-          :right-icon          :i/external
-          :label               (i18n/label :t/view-address-on-optimistic)
-          :blur?               true
-          :on-press            open-oeth-chain-explorer
-          :accessibility-label :view-address-on-optimistic})
-       (when (string/includes? chain-short-names constants/arbitrum-short-name)
-         {:icon                :i/link
-          :right-icon          :i/external
-          :label               (i18n/label :t/view-address-on-arbiscan)
-          :blur?               true
-          :on-press            open-arb-chain-explorer
-          :accessibility-label :view-address-on-arbiscan})
+       {:icon                :i/link
+        :right-icon          :i/external
+        :label               (i18n/label :t/view-address-on-optimistic)
+        :blur?               true
+        :on-press            open-oeth-chain-explorer
+        :accessibility-label :view-address-on-optimistic}
+       {:icon                :i/link
+        :right-icon          :i/external
+        :label               (i18n/label :t/view-address-on-arbiscan)
+        :blur?               true
+        :on-press            open-arb-chain-explorer
+        :accessibility-label :view-address-on-arbiscan}
+       {:icon                :i/link
+        :right-icon          :i/external
+        :label               (i18n/label :t/view-address-on-basescan)
+        :blur?               true
+        :on-press            open-base-chain-explorer
+        :accessibility-label :view-address-on-basescan}
        {:icon                :i/share
         :on-press            open-share
         :label               (i18n/label :t/share-address)

--- a/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
@@ -33,9 +33,8 @@
       :container-style style/empty-container-style}]))
 
 (defn- saved-address
-  [{:keys [name address chain-short-names customization-color ens? ens network-preferences-names]}]
-  (let [full-address           (str chain-short-names address)
-        on-press-saved-address (rn/use-callback
+  [{:keys [name address customization-color ens? ens]}]
+  (let [on-press-saved-address (rn/use-callback
                                 #(rf/dispatch
                                   [:show-bottom-sheet
                                    {:theme           :dark
@@ -43,20 +42,16 @@
                                     :blur-background colors/bottom-sheet-background-blur
                                     :content         (fn []
                                                        [address-options/view
-                                                        {:address address
-                                                         :chain-short-names chain-short-names
-                                                         :full-address full-address
-                                                         :ens? ens?
-                                                         :ens ens
-                                                         :name name
-                                                         :network-preferences-names
-                                                         network-preferences-names
+                                                        {:address             address
+                                                         :ens?                ens?
+                                                         :ens                 ens
+                                                         :name                name
                                                          :customization-color customization-color}])}])
-                                [address chain-short-names full-address name customization-color])]
+                                [address name customization-color])]
     [quo/saved-address
      {:blur?           true
       :user-props      {:name                name
-                        :address             full-address
+                        :address             address
                         :ens                 (when ens? ens)
                         :customization-color customization-color
                         :blur?               true}

--- a/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
+++ b/src/status_im/contexts/shell/qr_reader/sheets/scanned_wallet_address.cljs
@@ -3,7 +3,6 @@
     [quo.core :as quo]
     [react-native.clipboard :as clipboard]
     [status-im.contexts.wallet.common.utils :as utils]
-    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -17,13 +16,12 @@
 
 (defn- send-to-address
   [address]
-  (let [[_ split-address] (network-utils/split-network-full-address address)]
-    (rf/dispatch
-     [:wallet/init-send-flow-for-address
-      {:address   address
-       :recipient {:recipient-type :address
-                   :label          (utils/get-shortened-address split-address)}
-       :stack-id  :wallet-select-address}])))
+  (rf/dispatch
+   [:wallet/init-send-flow-for-address
+    {:address   address
+     :recipient {:recipient-type :address
+                 :label          (utils/get-shortened-address address)}
+     :stack-id  :wallet-select-address}]))
 
 (defn view
   [address]

--- a/src/status_im/contexts/shell/share/wallet/component_spec.cljs
+++ b/src/status_im/contexts/shell/share/wallet/component_spec.cljs
@@ -11,45 +11,20 @@
         share-qr-code      (h/get-by-label-text :share-qr-code)]
     ;; Fires on-layout since it's needed to render the content
     (h/fire-event :layout share-qr-code #js {:nativeEvent #js {:layout #js {:width 500}}})
-    (rerender-fn [wallet-view/wallet-tab])
-    (h/fire-event :press (h/get-by-label-text :share-qr-code-legacy-tab))))
+    (rerender-fn [wallet-view/wallet-tab])))
 
 (h/describe "share wallet addresses"
   (h/setup-restorable-re-frame)
   (h/before-each
    (fn []
      (h/setup-subs {:dimensions/window-width 500
-                    :mediaserver/port 200
-                    :wallet/accounts [{:address "0x707f635951193ddafbb40971a0fcaab8a6415160"
-                                       :name    "Wallet One"
-                                       :emoji   "😆"
-                                       :color   :blue}]
-                    :wallet/preferred-chain-names-for-address #{:eth :oeth :arb1}})))
+                    :mediaserver/port        200
+                    :wallet/accounts         [{:address "0x707f635951193ddafbb40971a0fcaab8a6415160"
+                                               :name    "Wallet One"
+                                               :emoji   "😆"
+                                               :color   :blue}]})))
 
   (h/test "should display the wallet tab"
     (render-wallet-view)
-    (-> (h/expect (h/query-by-text "Wallet One"))
-        (h/is-truthy)))
-
-  (h/test "should display the legacy account"
-    (render-wallet-view)
-    (-> (h/wait-for #(h/get-by-label-text :share-qr-code-legacy-tab))
-        (.then (fn []
-                 (h/is-truthy (h/query-by-text "0x707f635951193ddafbb40971a0fcaab8a6415160"))
-                 (h/is-falsy (h/query-by-text "eth:"))))))
-
-  ;; NOTE: Fails with error below possibly due to Infura outage:
-  ;;    FAIL  ./status_im.contexts.shell.share.wallet.component_spec.js
-  ;;  ● share wallet addresses › should display the multichain account
-  ;;
-  ;;   No protocol method IDeref.-deref defined for type undefined
-  (h/test-skip "should display the multichain account"
-    (render-wallet-view)
-    (-> (h/wait-for #(h/get-by-label-text :share-qr-code-multichain-tab))
-        (.then (fn []
-                 (h/fire-event :press (h/get-by-label-text :share-qr-code-multichain-tab))
-                 (-> (h/wait-for #(h/get-by-label-text :share-qr-code-settings))
-                     (.then (fn []
-                              (h/is-truthy (h/get-by-text "eth:"))
-                              (h/is-truthy (h/get-by-text "oeth:"))
-                              (h/is-truthy (h/get-by-text "arb1:"))))))))))
+    (h/is-truthy (h/query-by-text "Wallet One"))
+    (h/is-truthy (h/query-by-text "0x707f635951193ddafbb40971a0fcaab8a6415160"))))

--- a/src/status_im/contexts/wallet/account/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/account/edit_account/view.cljs
@@ -7,8 +7,6 @@
             [status-im.contexts.wallet.common.screen-base.create-or-edit-account.view
              :as create-or-edit-account]
             [status-im.contexts.wallet.common.utils :as common.utils]
-            [status-im.contexts.wallet.sheets.network-preferences.view
-             :as network-preferences]
             [status-im.contexts.wallet.sheets.remove-account.view :as remove-account]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
@@ -55,15 +53,10 @@
                                              :updated-key :name
                                              :new-value   @edited-account-name}))]
     (fn []
-      (let [{:keys [name emoji address color watch-only? default-account?]
+      (let [{:keys [name emoji address color default-account?]
              :as   account}         (rf/sub [:wallet/current-viewing-account])
-            network-details         (rf/sub [:wallet/network-preference-details])
-            test-networks-enabled?  (rf/sub [:profile/test-networks-enabled?])
             other-account-names     (rf/sub [:wallet/accounts-names-without-current-account])
             other-emojis-and-colors (rf/sub [:wallet/accounts-emojis-and-colors-without-current-account])
-            network-preferences-key (if test-networks-enabled?
-                                      :test-preferred-chain-ids
-                                      :prod-preferred-chain-ids)
             account-name            (or @edited-account-name name)
             input-error             (or @emoji-color-error @name-error)
             button-disabled?        (or (string/blank? @edited-account-name)
@@ -108,23 +101,9 @@
            :size            :default
            :subtitle-type   :default
            :blur?           false
-           :right-icon      :i/advanced
            :card?           true
            :title           (i18n/label :t/address)
            :custom-subtitle (fn [] [quo/address-text
-                                    {:networks network-details
-                                     :address  address
-                                     :format   :long}])
-           :on-press        (fn []
-                              (rf/dispatch [:show-bottom-sheet
-                                            {:content
-                                             (fn []
-                                               [network-preferences/view
-                                                {:on-save     (fn [chain-ids]
-                                                                (rf/dispatch [:hide-bottom-sheet])
-                                                                (save-account
-                                                                 {:account     account
-                                                                  :updated-key network-preferences-key
-                                                                  :new-value   chain-ids}))
-                                                 :watch-only? watch-only?}])}]))
+                                    {:address address
+                                     :format  :long}])
            :container-style style/data-item}]]))))

--- a/src/status_im/contexts/wallet/add_account/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/add_address_to_watch/view.cljs
@@ -41,7 +41,9 @@
                             (rf/dispatch [:wallet/clean-scanned-address])))
         paste-on-input  #(clipboard/get-string
                           (fn [clipboard-text]
-                            (on-change-text clipboard-text)))]
+                            (-> clipboard-text
+                                utils.address/extract-address-without-chains-info
+                                on-change-text)))]
     (rn/use-effect (fn []
                      (when-not (string/blank? scanned-address)
                        (on-change-text scanned-address)))

--- a/src/status_im/contexts/wallet/common/utils/external_links.cljs
+++ b/src/status_im/contexts/wallet/common/utils/external_links.cljs
@@ -4,26 +4,32 @@
 
 (defn get-explorer-url-by-chain-id
   [chain-id]
-  (cond
-    (= chain-id constants/ethereum-mainnet-chain-id)
+  (condp = chain-id
+    constants/ethereum-mainnet-chain-id
     config/mainnet-chain-explorer-link
 
-    (= chain-id constants/arbitrum-mainnet-chain-id)
+    constants/arbitrum-mainnet-chain-id
     config/arbitrum-mainnet-chain-explorer-link
 
-    (= chain-id constants/optimism-mainnet-chain-id)
+    constants/optimism-mainnet-chain-id
     config/optimism-mainnet-chain-explorer-link
 
-    (= chain-id constants/ethereum-sepolia-chain-id)
+    constants/base-mainnet-chain-id
+    config/base-mainnet-chain-explorer-link
+
+    constants/ethereum-sepolia-chain-id
     config/sepolia-chain-explorer-link
 
-    (= chain-id constants/arbitrum-sepolia-chain-id)
+    constants/arbitrum-sepolia-chain-id
     config/arbitrum-sepolia-chain-explorer-link
 
-    (= chain-id constants/optimism-sepolia-chain-id)
+    constants/optimism-sepolia-chain-id
     config/optimism-sepolia-chain-explorer-link
 
-    :else config/mainnet-chain-explorer-link))
+    constants/base-sepolia-chain-id
+    config/base-sepolia-chain-explorer-link
+
+    config/mainnet-chain-explorer-link))
 
 (defn get-base-url-for-tx-details-by-chain-id
   [chain-id]

--- a/src/status_im/contexts/wallet/send/events_test.cljs
+++ b/src/status_im/contexts/wallet/send/events_test.cljs
@@ -298,10 +298,10 @@
 
 (h/deftest-event :wallet/select-send-address
   [event-id dispatch]
-  (let [address     "eth:arb1:0x01"
-        to-address  "0x01"
+  (let [address     "eth:arb1:0x707f635951193ddafbb40971a0fcaab8a6415160"
+        to-address  "0x707f635951193ddafbb40971a0fcaab8a6415160"
         recipient   {:type  :saved-address
-                     :label "0x01...23f"}
+                     :label "0x70...160"}
         stack-id    :screen/wallet.select-address
         start-flow? false
         tx-type     :tx/collectible-erc-721]

--- a/src/status_im/contexts/wallet/send/from/view.cljs
+++ b/src/status_im/contexts/wallet/send/from/view.cljs
@@ -14,15 +14,14 @@
     [utils.re-frame :as rf]))
 
 (defn- on-account-press
-  [address network-details general-flow? collectible-tx?]
+  [address general-flow? collectible-tx?]
   (when general-flow?
     (rf/dispatch [:wallet/clean-selected-token])
     (rf/dispatch [:wallet/clean-selected-collectible]))
   (rf/dispatch [:wallet/select-from-account
-                {:address         address
-                 :network-details network-details
-                 :stack-id        :screen/wallet.select-from
-                 :start-flow?     (not (or general-flow? collectible-tx?))}]))
+                {:address     address
+                 :stack-id    :screen/wallet.select-from
+                 :start-flow? (not (or general-flow? collectible-tx?))}]))
 
 (defn- on-close
   []
@@ -30,7 +29,7 @@
   (rf/dispatch [:wallet/clean-current-viewing-account]))
 
 (defn- render-fn
-  [item _ _ {:keys [general-flow? network-details collectible-tx? collectible]}]
+  [item _ _ {:keys [general-flow? collectible-tx? collectible]}]
   (let [account-address (:address item)
         balance         (cond
                           general-flow?   0
@@ -42,7 +41,7 @@
         asset-value     (if collectible-tx? (str balance) (:asset-pay-balance item))]
     [quo/account-item
      {:type          (if has-balance? :tag :default)
-      :on-press      #(on-account-press account-address network-details general-flow? collectible-tx?)
+      :on-press      #(on-account-press account-address general-flow? collectible-tx?)
       :state         (if (or has-balance? general-flow?) :default :disabled)
       :token-props   (when-not general-flow?
                        {:symbol asset-symbol
@@ -59,8 +58,7 @@
         collectible     (rf/sub [:wallet/wallet-send-collectible])
         accounts        (if (or general-flow? collectible-tx?)
                           (rf/sub [:wallet/operable-accounts])
-                          (rf/sub [:wallet/accounts-with-balances token]))
-        network-details (rf/sub [:wallet/network-details])]
+                          (rf/sub [:wallet/accounts-with-balances token]))]
     (hot-reload/use-safe-unmount on-close)
     [floating-button-page/view
      {:footer-container-padding 0
@@ -78,7 +76,6 @@
        :content-container-style           style/accounts-list-container
        :data                              accounts
        :render-data                       {:general-flow?   general-flow?
-                                           :network-details network-details
                                            :collectible-tx? collectible-tx?
                                            :collectible     collectible}
        :render-fn                         render-fn

--- a/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/tabs/view.cljs
@@ -10,23 +10,19 @@
     [utils.re-frame :as rf]))
 
 (defn other-account-item
-  [{:keys        [address color emoji network-preferences-names]
+  [{:keys        [address color emoji]
     account-name :name
     :as          account}]
-  (let [full-address (rf/sub [:wallet/account-address address network-preferences-names])]
-    [quo/account-item
-     {:account-props (assoc account
-                            :customization-color color
-                            :address             full-address
-                            :full-address?       true)
-      :on-press      (fn []
-                       (rf/dispatch [:wallet/select-send-address
-                                     {:address   address
-                                      :recipient {:recipient-type      :account
-                                                  :label               account-name
-                                                  :customization-color color
-                                                  :emoji               emoji}
-                                      :stack-id  :screen/wallet.select-address}]))}]))
+  [quo/account-item
+   {:account-props (assoc account :customization-color color)
+    :on-press      (fn []
+                     (rf/dispatch [:wallet/select-send-address
+                                   {:address   address
+                                    :recipient {:recipient-type      :account
+                                                :label               account-name
+                                                :customization-color color
+                                                :emoji               emoji}
+                                    :stack-id  :screen/wallet.select-address}]))}])
 
 (defn- my-accounts
   [theme]
@@ -64,20 +60,19 @@
             recent-recipients))))
 
 (defn- saved-address
-  [{:keys [name address chain-short-names customization-color ens? ens]}]
-  (let [full-address           (str chain-short-names address)
-        on-press-saved-address (rn/use-callback
+  [{:keys [name address customization-color ens? ens]}]
+  (let [on-press-saved-address (rn/use-callback
                                 #(rf/dispatch
                                   [:wallet/select-send-address
-                                   {:address   full-address
+                                   {:address   address
                                     :recipient {:label               name
                                                 :customization-color customization-color
                                                 :recipient-type      :saved-address}
                                     :stack-id  :screen/wallet.select-address}])
-                                [full-address])]
+                                [address])]
     [quo/saved-address
      {:user-props      {:name                name
-                        :address             full-address
+                        :address             address
                         :ens                 (when ens? ens)
                         :customization-color customization-color}
       :container-style {:margin-horizontal 8}

--- a/src/status_im/contexts/wallet/sheets/account_options/view.cljs
+++ b/src/status_im/contexts/wallet/sheets/account_options/view.cljs
@@ -9,7 +9,6 @@
             [react-native.gesture :as gesture]
             [react-native.platform :as platform]
             [reagent.core :as reagent]
-            [status-im.contexts.wallet.common.utils :as utils]
             [status-im.contexts.wallet.sheets.account-options.style :as style]
             [status-im.contexts.wallet.sheets.remove-account.view :as remove-account]
             [utils.i18n :as i18n]
@@ -35,10 +34,6 @@
   (let [{:keys [name color emoji address watch-only?
                 default-account?]} (rf/sub [:wallet/current-viewing-account])
         {:keys [derived-from]}     (rf/sub [:wallet/current-viewing-account-keypair])
-        network-preference-details (rf/sub [:wallet/network-preference-details])
-        multichain-address         (utils/get-multichain-address
-                                    network-preference-details
-                                    address)
         share-title                (i18n/label :t/share-address-title {:address name})]
     [rn/view
      {:on-layout #(reset! options-height (oops/oget % "nativeEvent.layout.height"))
@@ -57,7 +52,6 @@
      [quo/drawer-top
       (cond-> {:title                name
                :type                 :account
-               :networks             network-preference-details
                :description          address
                :account-avatar-emoji emoji
                :customization-color  color}
@@ -77,7 +71,7 @@
                                 (rf/dispatch [:toasts/upsert
                                               {:type :positive
                                                :text (i18n/label :t/address-copied)}])
-                                (clipboard/set-string multichain-address))}
+                                (clipboard/set-string address))}
         {:icon                :i/qr-code
          :accessibility-label :show-address-qr
          :label               (i18n/label :t/show-address-qr)
@@ -89,7 +83,7 @@
                                 (rf/dispatch [:hide-bottom-sheet])
                                 (js/setTimeout
                                  #(rf/dispatch [:wallet/share-account
-                                                {:title share-title :content multichain-address}])
+                                                {:title share-title :content address}])
                                  600))}
         (when-not (or default-account? (string/blank? derived-from))
           {:add-divider?        (not show-account-selector?)

--- a/src/utils/address.cljs
+++ b/src/utils/address.cljs
@@ -6,7 +6,8 @@
 
 
 (def hex-prefix "0x")
-;; EIP-3770 is a format used by Status and described here: https://eips.ethereum.org/EIPS/eip-3770
+;; EIP-3770 is a format used by Status until v2.32 and described here:
+;; https://eips.ethereum.org/EIPS/eip-3770
 (def regx-eip-3770-address #"^(?:(?:eth:|arb1:|oeth:)(?=:|))*0x[0-9a-fA-F]{40}$")
 (def regx-metamask-address #"^ethereum:(0x[0-9a-fA-F]{40})(?:@(0x1|0xa|0xa4b1))?$")
 (def regx-address-contains #"(?i)0x[a-fA-F0-9]{40}")

--- a/translations/en.json
+++ b/translations/en.json
@@ -2822,6 +2822,7 @@
   "via-card-or-bank": "Via card or bank",
   "view": "View",
   "view-address-on-arbiscan": "View address on Arbiscan",
+  "view-address-on-basescan": "View address on Basescan",
   "view-address-on-etherscan": "View address on Etherscan",
   "view-address-on-optimistic": "View address on Optimistic",
   "view-channel-members-and-details": "View channel members and details",


### PR DESCRIPTION
fixes #21958

## Summary

This PR:
 - removes EIP-3770 address format (with chain prefix) from the UI and displays/uses only the address
 - removes editing of preferred networks for an account and saved address
 - copy/paste functions will remove the chain prefix from the address (if any)
 - adds base chain explorer links to account and saved address

## Testing notes

A complete smoke testing of wallet is appreciated

This PR doesn't restrict the user from typing EIP-3770 address in the address inputs (send flow and saved address flow) as we supported it in earlier public releases. When user moves to next screen, it just ignores the prefix and takes only the address.

### Platforms

- Android
- iOS

## Steps to test

- Open Status
- Navigate to shell share and verify multi chain tab is not shown
- Navigate to the Wallet tab > tap on any account > open account switcher
- Verify the chain prefixes are not shown under each accounts and also with options such as copy and receive
- Navigate to edit account and verify the chain prefix is not shown and can not edit preferred networks
- Navigate to Saved addresses (`Profile > Wallet > Saved addresses`) 
- Verify the chain prefixes are not shown and can not edit preferred networks of it
- Verify the scanner ignores the chain prefix (General scanner and scanner on address inputs)
- Verify copy and paste functions ignores chain prefix in send flow and in add saved address flow

status: ready
