### PR TITLE
fix: swap fees are not displayed if route estimated time is nil

### DIFF
--- a/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
+++ b/src/status_im/contexts/wallet/swap/set_spending_cap/view.cljs
@@ -202,18 +202,17 @@
         :network-image (:source network)}]
       [data-item
        {:title    (i18n/label :t/max-fees)
-        :subtitle (if (and estimated-time approval-fees-formatted)
+        :subtitle (if approval-fees-formatted
                     approval-fees-formatted
                     (i18n/label :t/unknown))
         :loading? loading-swap-proposal?
         :size     :small}]
-      [data-item
-       {:title    (i18n/label :t/est-time)
-        :subtitle (if estimated-time
-                    (i18n/label :t/time-in-mins {:minutes (str estimated-time)})
-                    (i18n/label :t/unknown))
-        :loading? loading-swap-proposal?
-        :size     :small}]]]))
+      (when estimated-time
+        [data-item
+         {:title    (i18n/label :t/est-time)
+          :subtitle (i18n/label :t/time-in-mins {:minutes (str estimated-time)})
+          :loading? loading-swap-proposal?
+          :size     :small}])]]))
 
 (defn- slide-button
   []

--- a/src/status_im/contexts/wallet/swap/swap_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/swap/swap_confirmation/view.cljs
@@ -148,15 +148,14 @@
         max-slippage           (rf/sub [:wallet/swap-max-slippage])]
     [rn/view {:style style/details-container}
      [:<>
-      [data-item
-       {:title    (i18n/label :t/est-time)
-        :subtitle (if estimated-time
-                    (i18n/label :t/time-in-mins {:minutes (str estimated-time)})
-                    (i18n/label :t/unknown))
-        :loading? loading-swap-proposal?}]
+      (when estimated-time
+        [data-item
+         {:title    (i18n/label :t/est-time)
+          :subtitle (i18n/label :t/time-in-mins {:minutes (str estimated-time)})
+          :loading? loading-swap-proposal?}])
       [data-item
        {:title    (i18n/label :t/max-fees)
-        :subtitle (if (and estimated-time max-fees-formatted) max-fees-formatted (i18n/label :t/unknown))
+        :subtitle (if max-fees-formatted max-fees-formatted (i18n/label :t/unknown))
         :loading? loading-swap-proposal?}]
       [data-item
        {:title    (i18n/label :t/max-slippage)


### PR DESCRIPTION
fixes #21948

## Summary

This PR fixes fees for swap transactions not being properly displayed (approvals and swaps themselves) when estimated-time comes nil from status-go. Also hides Estimated time if it comes with a nil value.

### Before

![](https://github.com/user-attachments/assets/8a9ef4d9-1ec3-4bb2-8e56-61b7e240b715)

### After

![](https://github.com/user-attachments/assets/dc7fe195-8aa3-4956-8226-9222f6dc0412)
![](https://github.com/user-attachments/assets/8bfc2481-625a-4913-80d3-a8949b836530)

### Platforms

- Android
- iOS

### Areas that may be impacted

#### Functional

- wallet / transactions

## Steps to test

- Open Status
- Try to perform a Swap with an ERC-20 token that required approval
- Go to set spending cap confimation page
- Check max fee and estimated time
Also:
- Go to swap confirmation page
- Check max fee and estimated time


status: ready