### PR TITLE
fix(wallet)_: Assets unsupported for bridge appear as disabled on swap flow

### DIFF
--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -61,6 +61,7 @@
                              (rf/dispatch [:wallet/clean-send-data])
                              (rf/dispatch [:wallet/start-bridge]))
          :swap-action      (fn []
+                             (rf/dispatch [:wallet/clean-send-data])
                              (rf/dispatch [:wallet.tokens/get-token-list])
                              (rf/dispatch [:open-modal :screen/wallet.swap-select-asset-to-pay]))
          :bridge-disabled? testnet-mode?

--- a/src/status_im/contexts/wallet/common/token_value/view.cljs
+++ b/src/status_im/contexts/wallet/common/token_value/view.cljs
@@ -44,6 +44,7 @@
    :disabled?           (or testnet-mode? bridge-disabled?)
    :on-press            (fn []
                           (rf/dispatch [:hide-bottom-sheet])
+                          (rf/dispatch [:wallet/clean-send-data])
                           (rf/dispatch [:wallet/bridge-select-token params]))})
 
 (defn- action-swap
@@ -54,6 +55,7 @@
    :disabled?           testnet-mode?
    :on-press            (fn []
                           (rf/dispatch [:hide-bottom-sheet])
+                          (rf/dispatch [:wallet/clean-send-data])
                           (rf/dispatch [:wallet.swap/start
                                         {:asset-to-pay     (or token {:symbol token-symbol})
                                          :asset-to-receive asset-to-receive


### PR DESCRIPTION
fixes #21959

## Summary

This PR fixes assets unsupported for bridge appear as disabled on swap flow.

## Review notes

The bug is caused by leftover data (`:tx-type`) in app-db when the user leaves the bridge flow. We can add clean-up on the un-mount of those pages, but it will be time-consuming to identify as the user can enter from different entry points.
Cleaning up the send data when entering the swap flow is much better.


### Platforms

- Android
- iOS

## Steps to test

- Open Status
- Navigate to Wallet Tab
- Long press on any asset supported for the bridge and enter the bridge flow 
- Navigate back to the home screen
- Navigate to any account with assets not supported by the bridge
- Tap on Swap
- Verify all the assets are shown without disabled state

status: ready


