### PR TITLE
Allow users to view the recovery phrase again when creating a profile for an empty keycard

### DIFF
--- a/src/status_im/contexts/keycard/create/events.cljs
+++ b/src/status_im/contexts/keycard/create/events.cljs
@@ -20,6 +20,10 @@
   (rf/dispatch [:navigate-back])
   (rf/dispatch [:open-modal :screen/confirm-backup
                 {:masked-seed-phrase masked-seed-phrase
+                 :on-try-again       #(rf/dispatch [:open-modal :screen/backup-recovery-phrase-dark
+                                                    {:on-success         backup-recovery-phrase-success
+                                                     :masked-seed-phrase masked-seed-phrase
+                                                     :revealed?          true}])
                  :on-success         #(rf/dispatch [:keycard/create.phrase-backed-up
                                                     masked-seed-phrase])}]))
 

--- a/src/status_im/contexts/keycard/create/events.cljs
+++ b/src/status_im/contexts/keycard/create/events.cljs
@@ -22,7 +22,10 @@
                 {:masked-seed-phrase masked-seed-phrase
                  :on-try-again       #(rf/dispatch [:open-modal :screen/backup-recovery-phrase-dark
                                                     {:on-success         backup-recovery-phrase-success
-                                                     :masked-seed-phrase masked-seed-phrase
+                                                     :masked-seed-phrase (->> masked-seed-phrase
+                                                                              security/safe-unmask-data
+                                                                              (string/join " ")
+                                                                              security/mask-data)
                                                      :revealed?          true}])
                  :on-success         #(rf/dispatch [:keycard/create.phrase-backed-up
                                                     masked-seed-phrase])}]))

--- a/src/status_im/contexts/keycard/migrate/events.cljs
+++ b/src/status_im/contexts/keycard/migrate/events.cljs
@@ -57,6 +57,13 @@
   (rf/dispatch [:navigate-back])
   (rf/dispatch [:open-modal :screen/confirm-backup
                 {:masked-seed-phrase masked-seed-phrase
+                 :on-try-again       #(rf/dispatch [:open-modal :screen/backup-recovery-phrase-dark
+                                                    {:on-success         backup-recovery-phrase-success
+                                                     :masked-seed-phrase (->> masked-seed-phrase
+                                                                              security/safe-unmask-data
+                                                                              (string/join " ")
+                                                                              security/mask-data)
+                                                     :revealed?          true}])
                  :on-success         #(rf/dispatch [:keycard/migration.phrase-backed-up])}]))
 
 (rf/reg-event-fx :keycard/migration.get-phrase

--- a/src/status_im/contexts/profile/backup_recovery_phrase/view.cljs
+++ b/src/status_im/contexts/profile/backup_recovery_phrase/view.cljs
@@ -44,22 +44,23 @@
 
 (defn view
   []
-  (let [step-labels                             [:t/backup-step-1 :t/backup-step-2 :t/backup-step-3
-                                                 :t/backup-step-4]
-        checked?                                (reagent/atom
-                                                 {:0 false
-                                                  :1 false
-                                                  :2 false
-                                                  :3 false})
-        revealed?                               (reagent/atom false)
-        customization-color                     (rf/sub [:profile/customization-color])
-        {:keys [on-success masked-seed-phrase]} (rf/sub [:get-screen-params])
-        seed-phrase                             (reagent/atom (if masked-seed-phrase
-                                                                (->
-                                                                  (security/safe-unmask-data
-                                                                   masked-seed-phrase)
-                                                                  (string/split #"\s"))
-                                                                []))]
+  (let [step-labels         [:t/backup-step-1 :t/backup-step-2 :t/backup-step-3
+                             :t/backup-step-4]
+        checked?            (reagent/atom
+                             {:0 false
+                              :1 false
+                              :2 false
+                              :3 false})
+        {:keys [on-success masked-seed-phrase
+                revealed?]} (rf/sub [:get-screen-params])
+        revealed?           (reagent/atom revealed?)
+        customization-color (rf/sub [:profile/customization-color])
+        seed-phrase         (reagent/atom (if masked-seed-phrase
+                                            (->
+                                              (security/safe-unmask-data
+                                               masked-seed-phrase)
+                                              (string/split #"\s"))
+                                            []))]
     (fn []
       (let [theme (quo.theme/use-theme)]
         (rn/use-mount
@@ -108,8 +109,7 @@
             [quo/bottom-actions
              {:actions          :one-action
               :button-one-label (i18n/label :t/i-have-written)
-              :button-one-props {:disabled?           (some false? (vals @checked?))
-                                 :customization-color customization-color
+              :button-one-props {:customization-color customization-color
                                  :on-press            #(on-success (security/mask-data @seed-phrase))}}]
             [quo/text
              {:size  :paragraph-2

--- a/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/view.cljs
@@ -31,7 +31,7 @@
     [(subvec result 0 2) (subvec result 2 4)]))
 
 (defn- cheat-warning
-  []
+  [on-try-again]
   (let [customization-color (rf/sub [:profile/customization-color])]
     [:<>
      [quo/drawer-top {:title (i18n/label :t/do-not-cheat)}]
@@ -42,6 +42,8 @@
       {:button-one-label (i18n/label :t/see-recovery-phrase-again)
        :button-one-props {:customization-color customization-color
                           :on-press            (fn []
+                                                 (when on-try-again
+                                                   (on-try-again))
                                                  (rf/dispatch [:hide-bottom-sheet])
                                                  (rf/dispatch [:navigate-back]))}}]]))
 
@@ -95,6 +97,7 @@
         incorrect-count              (reagent/atom 0)
         show-error?                  (reagent/atom false)
         {:keys [on-success
+                on-try-again
                 masked-seed-phrase]} (rf/sub [:get-screen-params])
         unmasked-seed-phrase         (security/safe-unmask-data masked-seed-phrase)
         random-phrase                (reagent/atom [])]
@@ -121,7 +124,9 @@
                                                 (do
                                                   (when (> @incorrect-count 0)
                                                     (rf/dispatch [:show-bottom-sheet
-                                                                  {:content cheat-warning}]))
+                                                                  {:content (fn []
+                                                                              [cheat-warning
+                                                                               on-try-again])}]))
                                                   (reset! incorrect-count (inc @incorrect-count))
                                                   (reset! show-error? true))))]
           [rn/view {:style {:flex 1}}

--- a/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/view.cljs
@@ -42,10 +42,10 @@
       {:button-one-label (i18n/label :t/see-recovery-phrase-again)
        :button-one-props {:customization-color customization-color
                           :on-press            (fn []
-                                                 (when on-try-again
-                                                   (on-try-again))
                                                  (rf/dispatch [:hide-bottom-sheet])
-                                                 (rf/dispatch [:navigate-back]))}}]]))
+                                                 (rf/dispatch [:navigate-back])
+                                                 (when on-try-again
+                                                   (on-try-again)))}}]]))
 
 (defn- button
   [{:keys [word margin-right on-press]}]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/22002

status: ready