### PR TITLE
feat(messenger): Add option to copy active message ID

### DIFF
--- a/src/status_im/contexts/chat/messenger/messages/drawers/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/drawers/view.cljs
@@ -95,10 +95,10 @@
 
 (defn get-actions
   [{:keys [outgoing content pinned-by outgoing-status deleted? deleted-for-me? content-type
-           bridge-message]
+           bridge-message message-id]
     :as   message-data}
    {:keys [able-to-send-message? community? community-member? can-delete-message-for-everyone?
-           message-pin-enabled group-chat group-admin?]}]
+           message-pin-enabled group-chat group-admin? debug-log-level?]}]
   (let [edit-message?        (and (or community-member? (not community?))
                                   outgoing
                                   (not (or deleted? deleted-for-me?))
@@ -152,6 +152,14 @@
              :accessibility-label :copy-text
              :icon                :i/copy
              :id                  :copy})
+
+      debug-log-level?
+      (conj {:type                :main
+             :on-press            #(clipboard/set-string message-id)
+             :label               (i18n/label :t/copy-message-id)
+             :accessibility-label :copy-message-id
+             :icon                :i/copy
+             :id                  :copy-message-id})
 
       pin-message?
       (conj {:type                :main

--- a/src/status_im/subs/chats.cljs
+++ b/src/status_im/subs/chats.cljs
@@ -217,7 +217,8 @@
  :<- [:chats/current-chat-chat-view]
  :<- [:communities/current-community]
  :<- [:multiaccount/public-key]
- (fn [[current-chat current-community current-public-key] [_ in-pinned-view?]]
+ :<- [:log-level/debug?]
+ (fn [[current-chat current-community current-public-key debug-log-level?] [_ in-pinned-view?]]
    (let [{:keys [group-chat chat-id public? admins space-keeper able-to-send-message?]}
          current-chat
 
@@ -244,6 +245,7 @@
       :community?                       community?
       :community-admin?                 community-admin?
       :current-public-key               current-public-key
+      :debug-log-level?                 debug-log-level?
       :space-keeper                     space-keeper
       :chat-id                          chat-id
       :in-pinned-view?                  (boolean in-pinned-view?)

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -169,6 +169,11 @@
  (fn [multiaccount]
    (get multiaccount :log-level)))
 
+(re-frame/reg-sub :log-level/debug?
+ :<- [:log-level/current-log-level]
+ (fn [level]
+   (= "DEBUG" level)))
+
 (re-frame/reg-sub
  :dapps-address
  :<- [:profile/profile]
@@ -309,4 +314,3 @@
  :<- [:profile/profile]
  (fn [profile]
    (not (boolean (seq (:mnemonic profile))))))
-

--- a/translations/en.json
+++ b/translations/en.json
@@ -539,6 +539,7 @@
   "copy-address": "Copy address",
   "copy-all-details": "Copy all details",
   "copy-info": "Copy info",
+  "copy-message-id": "Copy message ID",
   "copy-qr": "Copy code",
   "copy-text": "Copy text",
   "copy-to-clipboard": "Copy",


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/21984

## Summary

Add option to copy message ID when long pressing on a chat message. Similar to how it's implemented in the desktop client, the option is only visible if the user enables the DEBUG log level.

<img src="https://github.com/user-attachments/assets/df30f999-5aee-48b8-bfac-fccd9288a272" width="350" />

## Areas that may be impacted

- Chat

## Steps to test

1. In _Advanced settings_, choose log level DEBUG.
2. Login with same profile.
3. Long press on any message, you should see the option `Copy message ID`.

cc @churik 