### PR TITLE
Quick transaction settings

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -443,7 +443,10 @@
 (def ^:const wallet-account-name-max-length 20)
 
 
+(def ^:const gas-rate-low 0)
 (def ^:const gas-rate-medium 1)
+(def ^:const gas-rate-high 2)
+(def ^:const gas-rate-custom 3)
 (def ^:const send-type-transfer 0)
 (def ^:const send-type-bridge 5)
 (def ^:const send-type-erc-721-transfer 6)

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -229,7 +229,8 @@
 
 (defn new->old-route-path
   [new-path]
-  (let [to-bignumber (fn [k] (-> new-path k money/bignumber))]
+  (let [to-bignumber                          (fn [k] (-> new-path k money/bignumber))
+        suggested-levels-for-max-fees-per-gas (:suggested-levels-for-max-fees-per-gas new-path)]
     {:approval-fee              (to-bignumber :approval-fee)
      :approval-l-1-fee          (to-bignumber :approval-l-1-fee)
      :bonder-fees               (to-bignumber :tx-bonder-fees)
@@ -238,35 +239,34 @@
      :amount-in-locked          (:amount-in-locked new-path)
      :amount-in                 (:amount-in new-path)
      :max-amount-in             (:max-amount-in new-path)
-     :gas-fees                  {:gas-price                "0"
-                                 :base-fee                 (send-utils/convert-to-gwei (:tx-base-fee
-                                                                                        new-path)
-                                                                                       precision)
+     :gas-fees                  {:gas-price "0"
+                                 :base-fee (send-utils/convert-to-gwei (:tx-base-fee
+                                                                        new-path)
+                                                                       precision)
                                  :max-priority-fee-per-gas (send-utils/convert-to-gwei (:tx-priority-fee
                                                                                         new-path)
                                                                                        precision)
-                                 :max-fee-per-gas-low      (send-utils/convert-to-gwei
-                                                            (get-in
-                                                             new-path
-                                                             [:suggested-levels-for-max-fees-per-gas
-                                                              :low])
-                                                            precision)
-                                 :max-fee-per-gas-medium   (send-utils/convert-to-gwei
-                                                            (get-in
-                                                             new-path
-                                                             [:suggested-levels-for-max-fees-per-gas
-                                                              :medium])
-                                                            precision)
-                                 :max-fee-per-gas-high     (send-utils/convert-to-gwei
-                                                            (get-in
-                                                             new-path
-                                                             [:suggested-levels-for-max-fees-per-gas
-                                                              :high])
-                                                            precision)
-                                 :l-1-gas-fee              (send-utils/convert-to-gwei (:tx-l-1-fee
-                                                                                        new-path)
-                                                                                       precision)
-                                 :eip-1559-enabled         true}
+                                 :l-1-gas-fee (send-utils/convert-to-gwei (:tx-l-1-fee
+                                                                           new-path)
+                                                                          precision)
+                                 :eip-1559-enabled true
+                                 :tx-max-fees-per-gas (send-utils/convert-to-gwei
+                                                       (:tx-max-fees-per-gas
+                                                        new-path)
+                                                       precision)
+                                 :suggested-gas-fees-for-setting
+                                 {:transaction-setting/normal (send-utils/convert-to-gwei
+                                                               (:low
+                                                                suggested-levels-for-max-fees-per-gas)
+                                                               precision)
+                                  :transaction-setting/fast   (send-utils/convert-to-gwei
+                                                               (:medium
+                                                                suggested-levels-for-max-fees-per-gas)
+                                                               precision)
+                                  :transaction-setting/urgent (send-utils/convert-to-gwei
+                                                               (:high
+                                                                suggested-levels-for-max-fees-per-gas)
+                                                               precision)}}
      :bridge-name               (:processor-name new-path)
      :amount-out                (:amount-out new-path)
      :approval-contract-address (:approval-contract-address new-path)
@@ -275,7 +275,8 @@
      :to                        (:to-chain new-path)
      :approval-amount-required  (:approval-amount-required new-path)
      ;;  :cost () ;; tbd not used on desktop
-     :gas-amount                (:tx-gas-amount new-path)}))
+     :gas-amount                (:tx-gas-amount new-path)
+     :router-input-params-uuid  (:router-input-params-uuid new-path)}))
 
 (defn tokens-never-loaded?
   [db]

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -5,6 +5,7 @@
     [clojure.string :as string]
     [status-im.constants :as constants]
     [status-im.contexts.wallet.collectible.utils :as collectible-utils]
+    [status-im.contexts.wallet.send.transaction-settings.core :as transaction-settings]
     [status-im.contexts.wallet.send.utils :as send-utils]
     [utils.collection :as utils.collection]
     [utils.money :as money]
@@ -255,18 +256,18 @@
                                                         new-path)
                                                        precision)
                                  :suggested-gas-fees-for-setting
-                                 {:transaction-setting/normal (send-utils/convert-to-gwei
-                                                               (:low
-                                                                suggested-levels-for-max-fees-per-gas)
-                                                               precision)
-                                  :transaction-setting/fast   (send-utils/convert-to-gwei
-                                                               (:medium
-                                                                suggested-levels-for-max-fees-per-gas)
-                                                               precision)
-                                  :transaction-setting/urgent (send-utils/convert-to-gwei
-                                                               (:high
-                                                                suggested-levels-for-max-fees-per-gas)
-                                                               precision)}}
+                                 {:tx-fee-mode/normal (send-utils/convert-to-gwei
+                                                       (:low
+                                                        suggested-levels-for-max-fees-per-gas)
+                                                       precision)
+                                  :tx-fee-mode/fast   (send-utils/convert-to-gwei
+                                                       (:medium
+                                                        suggested-levels-for-max-fees-per-gas)
+                                                       precision)
+                                  :tx-fee-mode/urgent (send-utils/convert-to-gwei
+                                                       (:high
+                                                        suggested-levels-for-max-fees-per-gas)
+                                                       precision)}}
      :bridge-name               (:processor-name new-path)
      :amount-out                (:amount-out new-path)
      :approval-contract-address (:approval-contract-address new-path)
@@ -276,7 +277,9 @@
      :approval-amount-required  (:approval-amount-required new-path)
      ;;  :cost () ;; tbd not used on desktop
      :gas-amount                (:tx-gas-amount new-path)
-     :router-input-params-uuid  (:router-input-params-uuid new-path)}))
+     :router-input-params-uuid  (:router-input-params-uuid new-path)
+     :tx-fee-mode               (transaction-settings/gas-rate->tx-fee-mode (:tx-gas-fee-mode
+                                                                             new-path))}))
 
 (defn tokens-never-loaded?
   [db]

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -6,10 +6,12 @@
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.data-store :as data-store]
+    [status-im.contexts.wallet.send.transaction-settings.core :as transaction-settings]
     [status-im.contexts.wallet.send.utils :as send-utils]
     [status-im.contexts.wallet.sheets.network-selection.view :as network-selection]
     [taoensso.timbre :as log]
     [utils.address]
+    [utils.i18n :as i18n]
     [utils.money :as utils.money]
     [utils.number]
     [utils.re-frame :as rf]
@@ -384,16 +386,100 @@
 (rf/reg-event-fx
  :wallet/set-token-amount-to-send
  (fn [{:keys [db]} [{:keys [amount stack-id start-flow?]}]]
+   {:db (assoc-in db [:wallet :ui :send :amount] amount)
+    :fx [[:dispatch
+          [:wallet/wizard-navigate-forward
+           {:current-screen stack-id
+            :start-flow?    start-flow?
+            :flow-id        :wallet-send-flow}]]]}))
+
+(rf/reg-event-fx
+ :wallet.send/auth-slider-completed
+ (fn [{:keys [db]}]
    (let [last-request-uuid (get-in db [:wallet :ui :send :last-request-uuid])]
-     {:db (-> db
-              (assoc-in [:wallet :ui :send :amount] amount)
-              (update-in [:wallet :ui :send] dissoc :transaction-for-signing))
+     {:db (update-in db [:wallet :ui :send] dissoc :transaction-for-signing)
       :fx [[:dispatch [:wallet/build-transactions-from-route {:request-uuid last-request-uuid}]]
            [:dispatch
-            [:wallet/wizard-navigate-forward
-             {:current-screen stack-id
-              :start-flow?    start-flow?
-              :flow-id        :wallet-send-flow}]]]})))
+            [:wallet.send/set-sign-transactions-callback-fx
+             [:dispatch
+              [:wallet/prepare-signatures-for-transactions :send]]]]]})))
+
+(defn log-transaction-signature-error
+  [error]
+  (log/error
+   "failed to prepare signatures for transactions"
+   {:event :wallet/prepare-signatures-for-transactions
+    :error error})
+  (rf/dispatch
+   [:toasts/upsert
+    {:id   :prepare-signatures-for-transactions-error
+     :type :negative
+     :text (:message error)}]))
+
+(defn- send-transactions-with-signatures
+  [tx-type signatures]
+  (rf/dispatch
+   [:wallet/send-router-transactions-with-signatures tx-type
+    signatures]))
+
+(rf/reg-event-fx
+ :wallet/send-router-transactions-with-signatures
+ (fn [{:keys [db]} [tx-type signatures]]
+   (let [transaction-for-signing (get-in db [:wallet :ui tx-type :transaction-for-signing])
+         signatures-map          (reduce (fn [acc {:keys [message signature]}]
+                                           (assoc acc
+                                                  message
+                                                  (send-utils/signature-rsv signature)))
+                                         {}
+                                         signatures)]
+     {:json-rpc/call [{:method     "wallet_sendRouterTransactionsWithSignatures"
+                       :params     [{:uuid       (get-in transaction-for-signing [:sendDetails :uuid])
+                                     :signatures signatures-map}]
+                       :on-success (fn []
+                                     (rf/dispatch [:hide-bottom-sheet]))
+                       :on-error   (fn [error]
+                                     (log/error "failed to send router transactions with signatures"
+                                                {:event :wallet/send-router-transactions-with-signatures
+                                                 :error error})
+                                     (rf/dispatch [:toasts/upsert
+                                                   {:id   :send-router-transactions-with-signatures-error
+                                                    :type :negative
+                                                    :text (:message error)}]))}]})))
+
+(rf/reg-event-fx
+ :wallet/prepare-signatures-for-transactions
+ (fn [{:keys [db]} [tx-type]]
+   (let [transaction-for-signing                (get-in db
+                                                        [:wallet :ui tx-type :transaction-for-signing])
+         signing-details                        (:signingDetails transaction-for-signing)
+         {:keys [hashes address signOnKeycard]} signing-details
+         send-tx-fn                             (partial send-transactions-with-signatures tx-type)]
+     (if signOnKeycard
+       {:fx [[:dispatch
+              [:standard-auth/authorize-with-keycard
+               {:on-complete (fn [pin]
+                               (rf/dispatch [:keycard/connect-and-sign-hashes
+                                             {:keycard-pin pin
+                                              :address     address
+                                              :hashes      hashes
+                                              :on-success  send-tx-fn
+                                              :on-failure  log-transaction-signature-error}]))}]]]}
+       {:fx [[:dispatch
+              [:standard-auth/authorize
+               {:on-auth-success   (fn [sha3-pwd]
+                                     (rf/dispatch [:wallet/standard-auth-autorization-success hashes
+                                                   address sha3-pwd send-tx-fn]))
+                :auth-button-label (i18n/label :t/confirm)}]]]}))))
+
+(rf/reg-event-fx
+ :wallet/standard-auth-autorization-success
+ (fn [_ [hashes address sha3-pwd send-tx-fn]]
+   {:fx [[:effects.wallet/sign-transaction-hashes
+          {:hashes     hashes
+           :address    address
+           :password   (security/safe-unmask-data sha3-pwd)
+           :on-success send-tx-fn
+           :on-error   log-transaction-signature-error}]]}))
 
 (rf/reg-event-fx
  :wallet/build-transaction-for-collectible-route
@@ -409,16 +495,14 @@
 (rf/reg-event-fx
  :wallet/set-token-amount-to-bridge
  (fn [{:keys [db]} [{:keys [amount stack-id start-flow?]}]]
-   (let [last-request-uuid (get-in db [:wallet :ui :send :last-request-uuid])]
-     {:db (-> db
-              (assoc-in [:wallet :ui :send :amount] amount)
-              (update-in [:wallet :ui :send] dissoc :transaction-for-signing))
-      :fx [[:dispatch [:wallet/build-transactions-from-route {:request-uuid last-request-uuid}]]
-           [:dispatch
-            [:wallet/wizard-navigate-forward
-             {:current-screen stack-id
-              :start-flow?    start-flow?
-              :flow-id        :wallet-bridge-flow}]]]})))
+   {:db (-> db
+            (assoc-in [:wallet :ui :send :amount] amount)
+            (update-in [:wallet :ui :send] dissoc :transaction-for-signing))
+    :fx [[:dispatch
+          [:wallet/wizard-navigate-forward
+           {:current-screen stack-id
+            :start-flow?    start-flow?
+            :flow-id        :wallet-bridge-flow}]]]}))
 
 (rf/reg-event-fx
  :wallet/clean-bridge-to-selection
@@ -670,66 +754,6 @@
                                                 :text (:message error)}]))}]}))
 
 (rf/reg-event-fx
- :wallet/prepare-signatures-for-transactions
- (fn [{:keys [db]} [type sha3-pwd]]
-   (let [{:keys [hashes address signOnKeycard]} (get-in db
-                                                        [:wallet :ui type :transaction-for-signing
-                                                         :signingDetails])
-         on-success                             (fn [signatures]
-                                                  (rf/dispatch
-                                                   [:wallet/send-router-transactions-with-signatures type
-                                                    signatures]))
-         on-error                               (fn [error]
-                                                  (log/error
-                                                   "failed to prepare signatures for transactions"
-                                                   {:event :wallet/prepare-signatures-for-transactions
-                                                    :error error})
-                                                  (rf/dispatch
-                                                   [:toasts/upsert
-                                                    {:id   :prepare-signatures-for-transactions-error
-                                                     :type :negative
-                                                     :text (:message error)}]))]
-     (if signOnKeycard
-       {:fx [[:dispatch
-              [:standard-auth/authorize-with-keycard
-               {:on-complete #(rf/dispatch [:keycard/connect-and-sign-hashes
-                                            {:keycard-pin %
-                                             :address     address
-                                             :hashes      hashes
-                                             :on-success  on-success
-                                             :on-failure  on-error}])}]]]}
-       {:fx [[:effects.wallet/sign-transaction-hashes
-              {:hashes     hashes
-               :address    address
-               :password   (security/safe-unmask-data sha3-pwd)
-               :on-success on-success
-               :on-error   on-error}]]}))))
-
-(rf/reg-event-fx
- :wallet/send-router-transactions-with-signatures
- (fn [{:keys [db]} [type signatures]]
-   (let [transaction-for-signing (get-in db [:wallet :ui type :transaction-for-signing])
-         signatures-map          (reduce (fn [acc {:keys [message signature]}]
-                                           (assoc acc
-                                                  message
-                                                  (send-utils/signature-rsv signature)))
-                                         {}
-                                         signatures)]
-     {:json-rpc/call [{:method     "wallet_sendRouterTransactionsWithSignatures"
-                       :params     [{:uuid       (get-in transaction-for-signing [:sendDetails :uuid])
-                                     :signatures signatures-map}]
-                       :on-success (fn []
-                                     (rf/dispatch [:hide-bottom-sheet]))
-                       :on-error   (fn [error]
-                                     (log/error "failed to send router transactions with signatures"
-                                                {:event :wallet/send-router-transactions-with-signatures
-                                                 :error error})
-                                     (rf/dispatch [:toasts/upsert
-                                                   {:id   :send-router-transactions-with-signatures-error
-                                                    :type :negative
-                                                    :text (:message error)}]))}]})))
-
-(rf/reg-event-fx
  :wallet/select-from-account
  (fn [{db :db} [{:keys [address stack-id network-details network start-flow?] :as params}]]
    (let [{:keys [token-symbol
@@ -817,35 +841,58 @@
 (rf/reg-event-fx
  :wallet/init-tx-settings
  (fn [{db :db}]
-   {:db (assoc-in db
-         [:wallet :ui :send :tx-settings]
-         {:max-base-fee   {:low     5
-                           :current 8.2
-                           :high    9}
-          :priority-fee   {:low     0.6
-                           :high    5.1
-                           :current 1.1}
-          :max-gas-amount {:low     30000
-                           :current 31000}
-          :nonce          {:last-transaction 21
-                           :current          22}})}))
+   {:db (-> db
+            (assoc-in [:wallet :ui :send :custom-tx-settings]
+                      {:max-base-fee   {:low     5
+                                        :current 8.2
+                                        :high    9}
+                       :priority-fee   {:low     0.6
+                                        :high    5.1
+                                        :current 1.1}
+                       :max-gas-amount {:low     30000
+                                        :current 31000}
+                       :nonce          {:last-transaction 21
+                                        :current          22}})
+            (assoc-in [:wallet :ui :send :confirmed-tx-setting] :transaction-setting/fast))}))
 
 (rf/reg-event-fx
  :wallet/set-max-base-fee
  (fn [{db :db} [value]]
-   {:db (assoc-in db [:wallet :ui :send :tx-settings :max-base-fee :current] value)}))
+   {:db (assoc-in db [:wallet :ui :send :custom-tx-settings :max-base-fee :current] value)}))
 
 (rf/reg-event-fx
  :wallet/set-priority-fee
  (fn [{db :db} [value]]
-   {:db (assoc-in db [:wallet :ui :send :tx-settings :priority-fee :current] value)}))
+   {:db (assoc-in db [:wallet :ui :send :custom-tx-settings :priority-fee :current] value)}))
 (rf/reg-event-fx
 
  :wallet/set-max-gas-amount
  (fn [{db :db} [value]]
-   {:db (assoc-in db [:wallet :ui :send :tx-settings :max-gas-amount :current] value)}))
+   {:db (assoc-in db [:wallet :ui :send :custom-tx-settings :max-gas-amount :current] value)}))
 
 (rf/reg-event-fx
  :wallet/set-nonce
  (fn [{db :db} [value]]
    {:db (assoc-in db [:wallet :ui :send :tx-settings :nonce :current] value)}))
+
+(rf/reg-event-fx :wallet/quick-transaction-settings-confirmed
+ (fn [{db :db} [confirmed-setting]]
+   (let [gas-rate         (transaction-settings/transaction-setting->gas-rate confirmed-setting)
+         route            (first (get-in db [:wallet :ui :send :route]))
+         path-tx-identity (send-utils/path-identity route)
+         params           [path-tx-identity gas-rate]]
+     {:db            (assoc-in db [:wallet :ui :send :confirmed-tx-setting] confirmed-setting)
+      :json-rpc/call [{:method   "wallet_setFeeMode"
+                       :params   params
+                       :on-error (fn [error]
+                                   (log/error "failed to set quick transaction settings"
+                                              {:event  :wallet/quick-transaction-settings-confirmed
+                                               :error  (:message error)
+                                               :params params}))}]})))
+
+
+(rf/reg-event-fx :wallet.send/set-sign-transactions-callback-fx
+ (fn [{:keys [db]} [callback-fx]]
+   {:db (assoc-in db
+         [:wallet :ui :send :sign-transactions-callback-fx]
+         callback-fx)}))

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -664,7 +664,10 @@
  :wallet/handle-suggested-routes
  (fn [{:keys [db]} [data]]
    (let [{send :send swap? :swap} (-> db :wallet :ui)
-         skip-processing-routes?  (:skip-processing-suggested-routes? send)]
+         skip-processing-routes?  (:skip-processing-suggested-routes? send)
+         clean-user-tx-settings?  (get-in db
+                                          [:wallet :ui :send :custom-tx-settings
+                                           :delete-on-routes-update?])]
      (when (or swap? (not skip-processing-routes?))
        (let [{error-code :code
               :as        error} (:ErrorResponse data)
@@ -675,13 +678,16 @@
            (log/error "failed to get suggested routes (async)"
                       {:event :wallet/handle-suggested-routes
                        :error error-message}))
-         {:fx [[:dispatch
-                (cond
-                  (and failure? swap?) [:wallet/swap-proposal-error error]
-                  failure?             [:wallet/suggested-routes-error error-message]
-                  swap?                [:wallet/swap-proposal-success (fix-routes data)]
-                  :else                [:wallet/suggested-routes-success (fix-routes data)
-                                        enough-assets?])]]})))))
+         (merge
+          (when clean-user-tx-settings?
+            {:db (update-in db [:wallet :ui :send] dissoc :custom-tx-settings)})
+          {:fx [[:dispatch
+                 (cond
+                   (and failure? swap?) [:wallet/swap-proposal-error error]
+                   failure?             [:wallet/suggested-routes-error error-message]
+                   swap?                [:wallet/swap-proposal-success (fix-routes data)]
+                   :else                [:wallet/suggested-routes-success (fix-routes data)
+                                         enough-assets?])]]}))))))
 
 (rf/reg-event-fx
  :wallet/transaction-success
@@ -852,8 +858,7 @@
                        :max-gas-amount {:low     30000
                                         :current 31000}
                        :nonce          {:last-transaction 21
-                                        :current          22}})
-            (assoc-in [:wallet :ui :send :confirmed-tx-setting] :transaction-setting/fast))}))
+                                        :current          22}}))}))
 
 (rf/reg-event-fx
  :wallet/set-max-base-fee
@@ -875,20 +880,32 @@
  (fn [{db :db} [value]]
    {:db (assoc-in db [:wallet :ui :send :tx-settings :nonce :current] value)}))
 
-(rf/reg-event-fx :wallet/quick-transaction-settings-confirmed
- (fn [{db :db} [confirmed-setting]]
-   (let [gas-rate         (transaction-settings/transaction-setting->gas-rate confirmed-setting)
+(rf/reg-event-fx :wallet/quick-fee-mode-confirmed
+ (fn [{db :db} [fee-mode]]
+   (let [gas-rate         (transaction-settings/tx-fee-mode->gas-rate fee-mode)
          route            (first (get-in db [:wallet :ui :send :route]))
          path-tx-identity (send-utils/path-identity route)
          params           [path-tx-identity gas-rate]]
-     {:db            (assoc-in db [:wallet :ui :send :confirmed-tx-setting] confirmed-setting)
-      :json-rpc/call [{:method   "wallet_setFeeMode"
-                       :params   params
-                       :on-error (fn [error]
-                                   (log/error "failed to set quick transaction settings"
-                                              {:event  :wallet/quick-transaction-settings-confirmed
-                                               :error  (:message error)
-                                               :params params}))}]})))
+     {:db (assoc-in db [:wallet :ui :send :custom-tx-settings :tx-fee-mode] fee-mode)
+      :fx [[:json-rpc/call
+            [{:method   "wallet_setFeeMode"
+              :params   params
+              :on-error (fn [error]
+                          (log/error "failed to set quick transaction settings"
+                                     {:event  :wallet/quick-fee-mode-confirmed
+                                      :error  (:message error)
+                                      :params params}))}]]
+           [:dispatch [:wallet/mark-user-tx-settings-for-deletion]]]})))
+
+
+;; There is a delay between the moment when user selected
+;; custom settings and the moment when new route arrived
+;; with those settings applied. During this delay
+;; we should keep user settings for ui. After new route
+;; arrived we should clean the settings.
+(rf/reg-event-fx :wallet/mark-user-tx-settings-for-deletion
+ (fn [{db :db}]
+   {:db (assoc-in db [:wallet :ui :send :custom-tx-settings :delete-on-routes-update?] true)}))
 
 
 (rf/reg-event-fx :wallet.send/set-sign-transactions-callback-fx

--- a/src/status_im/contexts/wallet/send/input_amount/view.cljs
+++ b/src/status_im/contexts/wallet/send/input_amount/view.cljs
@@ -72,11 +72,6 @@
 
     :else (rf/dispatch [:wallet/stop-and-clean-suggested-routes])))
 
-(defn- get-fee-formatted
-  [route]
-  (when-let [native-currency-symbol (-> route first :from :native-currency-symbol)]
-    (rf/sub [:wallet/wallet-send-fee-fiat-formatted native-currency-symbol])))
-
 (defn- insufficient-asset-amount?
   [{:keys [token-symbol owned-eth-token input-state limit-exceeded? enough-assets?]}]
   (let [eth-selected?              (= token-symbol (string/upper-case constants/mainnet-short-name))
@@ -172,7 +167,7 @@
                                           (empty? route)
                                           (not valid-input?))
         fee-formatted                 (when (or (not confirm-disabled?) not-enough-asset?)
-                                        (get-fee-formatted route))
+                                        (rf/sub [:wallet/wallet-send-fee-fiat-formatted]))
         handle-on-confirm             (fn [amount]
                                         (rf/dispatch [:wallet/set-token-amount-to-send
                                                       {:amount   amount

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -182,18 +182,17 @@
        [rn/activity-indicator {:style {:flex 1}}]
        route-loaded?
        [:<>
-        (when (ff/enabled? ::ff/wallet.transaction-params)
-          [quo/button
-           {:icon-only?          true
-            :type                :outline
-            :size                32
-            :inner-style         {:opacity 1}
-            :accessibility-label :advanced-button
-            :container-style     {:margin-right 8}
-            :on-press            #(rf/dispatch
-                                   [:show-bottom-sheet
-                                    {:content transaction-settings/settings-sheet}])}
-           :i/advanced])
+        [quo/button
+         {:icon-only?          true
+          :type                :outline
+          :size                32
+          :inner-style         {:opacity 1}
+          :accessibility-label :advanced-button
+          :container-style     {:margin-right 8}
+          :on-press            #(rf/dispatch
+                                 [:show-bottom-sheet
+                                  {:content transaction-settings/settings-sheet}])}
+         :i/advanced]
         [data-item
          {:title    (i18n/label :t/est-time)
           :subtitle (i18n/label :t/time-in-mins {:minutes (str estimated-time-min)})}]

--- a/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_confirmation/view.cljs
@@ -5,9 +5,10 @@
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
+    [status-im.common.biometric.utils :as biometric]
     [status-im.common.events-helper :as events-helper]
     [status-im.common.floating-button-page.view :as floating-button-page]
-    [status-im.common.standard-authentication.core :as standard-auth]
+    [status-im.constants :as constants]
     [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.send.transaction-confirmation.style :as style]
     [status-im.contexts.wallet.send.transaction-settings.view :as transaction-settings]
@@ -168,10 +169,9 @@
     :subtitle        subtitle}])
 
 (defn- transaction-details
-  [{:keys [estimated-time-min max-fees to-network route
-           transaction-type]}]
-  (let [route-loaded?             (and route (seq route))
-        loading-suggested-routes? (rf/sub [:wallet/wallet-send-loading-suggested-routes?])
+  [{:keys [estimated-time-min max-fees to-network
+           transaction-type route-loaded?]}]
+  (let [loading-suggested-routes? (rf/sub [:wallet/wallet-send-loading-suggested-routes?])
         amount                    (rf/sub [:wallet/send-total-amount-formatted])]
     [rn/view
      {:style (style/details-container
@@ -225,11 +225,7 @@
         estimated-time-min        (reduce + (map :estimated-time route))
         token-symbol              (or token-display-name
                                       (-> send-transaction-data :token :symbol))
-        first-route               (first route)
-        native-currency-symbol    (get-in first-route
-                                          [:from :native-currency-symbol])
-        fee-formatted             (rf/sub [:wallet/wallet-send-fee-fiat-formatted
-                                           native-currency-symbol])
+        fee-formatted             (rf/sub [:wallet/wallet-send-fee-fiat-formatted])
         account                   (rf/sub [:wallet/current-viewing-account])
         account-color             (:color account)
         bridge-to-network         (when bridge-to-chain-id
@@ -237,7 +233,6 @@
                                              bridge-to-chain-id]))
         loading-suggested-routes? (rf/sub
                                    [:wallet/wallet-send-loading-suggested-routes?])
-        transaction-for-signing   (rf/sub [:wallet/wallet-send-transaction-for-signing])
         from-account-props        {:customization-color account-color
                                    :size                32
                                    :emoji               (:emoji account)
@@ -249,20 +244,9 @@
         user-props                {:full-name to-address
                                    :address   (utils/get-shortened-address
                                                to-address)}
-        sign-on-keycard?          (get-in transaction-for-signing
-                                          [:signingDetails :signOnKeycard])]
+        biometric-auth?           (= (rf/sub [:auth-method]) constants/auth-method-biometric)
+        biometric-type            (rf/sub [:biometrics/supported-type])]
     (hot-reload/use-safe-unmount #(rf/dispatch [:wallet/clean-route-data-for-collectible-tx]))
-    ;; In token send flow we already have transaction built when
-    ;; we reach confirmation screen. But in send collectible flow
-    ;; routes request happens at the same time with navigation to
-    ;; confirmation screen. So we need to build the transaction as soon
-    ;; as route is available.
-    (rn/use-effect
-     (fn []
-       (when (and (send-utils/tx-type-collectible? transaction-type)
-                  first-route)
-         (rf/dispatch [:wallet/build-transaction-for-collectible-route])))
-     [first-route])
     (rn/use-mount
      (fn []
        (when (ff/enabled? ::ff/wallet.transaction-params)
@@ -283,27 +267,21 @@
                                     :to-network         bridge-to-network
                                     :theme              theme
                                     :route              route
-                                    :transaction-type   transaction-type}]
+                                    :transaction-type   transaction-type
+                                    :route-loaded?      (and route (seq route))}]
                                   (when (and (not loading-suggested-routes?) route (seq route))
-                                    [standard-auth/slide-button
-                                     {:size :size-48
-                                      :track-text (if (= transaction-type :tx/bridge)
-                                                    (i18n/label :t/slide-to-bridge)
-                                                    (i18n/label :t/slide-to-send))
-                                      :container-style {:z-index 2}
-                                      :disabled? (not transaction-for-signing)
+                                    [quo/slide-button
+                                     {:size                :size-48
+                                      :track-text          (if (= transaction-type :tx/bridge)
+                                                             (i18n/label :t/slide-to-bridge)
+                                                             (i18n/label :t/slide-to-send))
+                                      :container-style     {:z-index 2}
                                       :customization-color account-color
-                                      :auth-button-label (i18n/label :t/confirm)
-                                      :on-complete (when sign-on-keycard?
-                                                     #(rf/dispatch
-                                                       [:wallet/prepare-signatures-for-transactions
-                                                        :send
-                                                        ""]))
-                                      :on-auth-success
-                                      (fn [psw]
-                                        (rf/dispatch
-                                         [:wallet/prepare-signatures-for-transactions :send
-                                          psw]))}])]
+                                      :track-icon          (if biometric-auth?
+                                                             (biometric/get-icon-by-type biometric-type)
+                                                             :password)
+                                      :on-complete         #(rf/dispatch
+                                                             [:wallet.send/auth-slider-completed])}])]
        :gradient-cover?          true
        :customization-color      (:color account)}
       [rn/view

--- a/src/status_im/contexts/wallet/send/transaction_settings/core.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_settings/core.cljs
@@ -2,12 +2,22 @@
   (:require
     [status-im.constants :as constants]))
 
-(def default-transaction-setting :transaction-setting/fast)
+(def default-transaction-setting :tx-fee-mode/fast)
 
-(defn transaction-setting->gas-rate
-  [transaction-setting]
-  (case transaction-setting
-    :transaction-setting/normal constants/gas-rate-low
-    :transaction-setting/fast   constants/gas-rate-medium
-    :transaction-setting/urgent constants/gas-rate-high
+(defn tx-fee-mode->gas-rate
+  [tx-fee-mode]
+  (case tx-fee-mode
+    :tx-fee-mode/normal constants/gas-rate-low
+    :tx-fee-mode/fast   constants/gas-rate-medium
+    :tx-fee-mode/urgent constants/gas-rate-high
+    :tx-fee-mode/custom constants/gas-rate-custom
     constants/gas-rate-medium))
+
+(defn gas-rate->tx-fee-mode
+  [gas-rate]
+  (condp = gas-rate
+    constants/gas-rate-low    :tx-fee-mode/normal
+    constants/gas-rate-medium :tx-fee-mode/fast
+    constants/gas-rate-high   :tx-fee-mode/urgent
+    constants/gas-rate-custom :tx-fee-mode/custom
+    :tx-fee-mode/fast))

--- a/src/status_im/contexts/wallet/send/transaction_settings/core.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_settings/core.cljs
@@ -1,0 +1,13 @@
+(ns status-im.contexts.wallet.send.transaction-settings.core
+  (:require
+    [status-im.constants :as constants]))
+
+(def default-transaction-setting :transaction-setting/fast)
+
+(defn transaction-setting->gas-rate
+  [transaction-setting]
+  (case transaction-setting
+    :transaction-setting/normal constants/gas-rate-low
+    :transaction-setting/fast   constants/gas-rate-medium
+    :transaction-setting/urgent constants/gas-rate-high
+    constants/gas-rate-medium))

--- a/src/status_im/contexts/wallet/send/transaction_settings/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_settings/view.cljs
@@ -69,7 +69,10 @@
 (defn settings-sheet
   []
   (let [current-transaction-setting                   (rf/sub [:wallet/tx-fee-mode])
-        [transaction-setting set-transaction-setting] (rn/use-state current-transaction-setting)]
+        [transaction-setting set-transaction-setting] (rn/use-state current-transaction-setting)
+        set-normal                                    #(set-transaction-setting :tx-fee-mode/normal)
+        set-fast                                      #(set-transaction-setting :tx-fee-mode/fast)
+        set-urgent                                    #(set-transaction-setting :tx-fee-mode/urgent)]
     [rn/view
      [quo/drawer-top
       {:title (i18n/label :t/transaction-settings)}]
@@ -82,9 +85,16 @@
                :image             :emoji
                :description       :text
                :action            :selector
-               :action-props      {:type     :radio
-                                   :checked? (= :tx-fee-mode/normal transaction-setting)}
-               :on-press          #(set-transaction-setting :tx-fee-mode/normal)
+               :action-props      {:type      :radio
+                                   :checked?  (= :tx-fee-mode/normal transaction-setting)
+                                   ;; there is an UI isssue in quo/category, it has :on-press event
+                                   ;; and child radio button has own :on-change. If they are not set
+                                   ;; to the same action then we are getting inconsistent behaviour
+                                   ;; when user can click on settings item but cant on radio itself.
+                                   ;; So duplication is to prevent that until general fix is applied
+                                   ;; to quo/category
+                                   :on-change set-normal}
+               :on-press          set-normal
                :label             :text
                :preview-size      :size-32}
               {:title             (str (i18n/label :t/fast) "~40s")
@@ -94,9 +104,10 @@
                :image             :emoji
                :description       :text
                :action            :selector
-               :action-props      {:type     :radio
-                                   :checked? (= :tx-fee-mode/fast transaction-setting)}
-               :on-press          #(set-transaction-setting :tx-fee-mode/fast)
+               :action-props      {:type      :radio
+                                   :checked?  (= :tx-fee-mode/fast transaction-setting)
+                                   :on-change set-fast}
+               :on-press          set-fast
                :label             :text
                :preview-size      :size-32}
               {:title             (str (i18n/label :t/urgent) "~15s")
@@ -106,9 +117,10 @@
                :image             :emoji
                :description       :text
                :action            :selector
-               :action-props      {:type     :radio
-                                   :checked? (= :tx-fee-mode/urgent transaction-setting)}
-               :on-press          #(set-transaction-setting :tx-fee-mode/urgent)
+               :action-props      {:type      :radio
+                                   :checked?  (= :tx-fee-mode/urgent transaction-setting)
+                                   :on-change set-urgent}
+               :on-press          set-urgent
                :label             :text
                :preview-size      :size-32}
               (when (ff/enabled? ::ff/wallet.transaction-params)

--- a/src/status_im/contexts/wallet/send/transaction_settings/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_settings/view.cljs
@@ -66,60 +66,67 @@
        :button-one-label (i18n/label :t/confirm)}]]))
 
 (defn settings-sheet
-  [_]
-  (let [[selected-id set-selected-id] (rn/use-state :normal)]
+  []
+  (let [current-transaction-setting                   (rf/sub [:wallet/confirmed-tx-setting])
+        [transaction-setting set-transaction-setting] (rn/use-state current-transaction-setting)]
     [rn/view
      [quo/drawer-top
       {:title (i18n/label :t/transaction-settings)}]
      [quo/category
       {:list-type :settings
-       :data      [{:title             (str (i18n/label :t/normal) "~60s")
-                    :image-props       "🍿"
-                    :description-props {:text "€1.45"}
-                    :image             :emoji
-                    :description       :text
-                    :action            :selector
-                    :action-props      {:type     :radio
-                                        :checked? (= :normal selected-id)}
-                    :on-press          #(set-selected-id :normal)
-                    :label             :text
-                    :preview-size      :size-32}
-                   {:title             (str (i18n/label :t/fast) "~40s")
-                    :image-props       "🚗"
-                    :description-props {:text "€1.65"}
-                    :image             :emoji
-                    :description       :text
-                    :action            :selector
-                    :action-props      {:type     :radio
-                                        :checked? (= :fast selected-id)}
-                    :on-press          #(set-selected-id :fast)
-                    :label             :text
-                    :preview-size      :size-32}
-                   {:title             (str (i18n/label :t/urgent) "~15s")
-                    :image-props       "🚀"
-                    :description-props {:text "€1.85"}
-                    :image             :emoji
-                    :description       :text
-                    :action            :selector
-                    :action-props      {:type     :radio
-                                        :checked? (= :urgent selected-id)}
-                    :on-press          #(set-selected-id :urgent)
-                    :label             :text
-                    :preview-size      :size-32}
-                   {:title             (i18n/label :t/custom)
-                    :image-props       :i/edit
-                    :description-props {:text "Set your own fees and nonce"}
-                    :image             :icon
-                    :description       :text
-                    :action            :arrow
-                    :on-press          #(rf/dispatch
-                                         [:show-bottom-sheet
-                                          {:content custom-settings-sheet}])
-                    :label             :text
-                    :preview-size      :size-32}]}]
+       :data [{:title             (str (i18n/label :t/normal) "~60s")
+               :image-props       "🍿"
+               :description-props {:text (rf/sub [:wallet/wallet-send-transaction-setting-fiat-formatted
+                                                  :transaction-setting/normal])}
+               :image             :emoji
+               :description       :text
+               :action            :selector
+               :action-props      {:type     :radio
+                                   :checked? (= :transaction-setting/normal transaction-setting)}
+               :on-press          #(set-transaction-setting :transaction-setting/normal)
+               :label             :text
+               :preview-size      :size-32}
+              {:title             (str (i18n/label :t/fast) "~40s")
+               :image-props       "🚗"
+               :description-props {:text (rf/sub [:wallet/wallet-send-transaction-setting-fiat-formatted
+                                                  :transaction-setting/fast])}
+               :image             :emoji
+               :description       :text
+               :action            :selector
+               :action-props      {:type     :radio
+                                   :checked? (= :transaction-setting/fast transaction-setting)}
+               :on-press          #(set-transaction-setting :transaction-setting/fast)
+               :label             :text
+               :preview-size      :size-32}
+              {:title             (str (i18n/label :t/urgent) "~15s")
+               :image-props       "🚀"
+               :description-props {:text (rf/sub [:wallet/wallet-send-transaction-setting-fiat-formatted
+                                                  :transaction-setting/urgent])}
+               :image             :emoji
+               :description       :text
+               :action            :selector
+               :action-props      {:type     :radio
+                                   :checked? (= :transaction-setting/urgent transaction-setting)}
+               :on-press          #(set-transaction-setting :transaction-setting/urgent)
+               :label             :text
+               :preview-size      :size-32}
+              {:title             (i18n/label :t/custom)
+               :image-props       :i/edit
+               :description-props {:text "Set your own fees and nonce"}
+               :image             :icon
+               :description       :text
+               :action            :arrow
+               :on-press          #(rf/dispatch
+                                    [:show-bottom-sheet
+                                     {:content custom-settings-sheet}])
+               :label             :text
+               :preview-size      :size-32}]}]
      [quo/bottom-actions
       {:actions          :one-action
-       :button-one-props {:on-press #(rf/dispatch [:hide-bottom-sheet])}
+       :button-one-props {:on-press (fn []
+                                      (rf/dispatch [:wallet/quick-transaction-settings-confirmed
+                                                    transaction-setting])
+                                      (rf/dispatch [:hide-bottom-sheet]))}
        :button-one-label (i18n/label :t/confirm)}]]))
 
 (defn- hint

--- a/src/status_im/contexts/wallet/send/transaction_settings/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_settings/view.cljs
@@ -15,7 +15,8 @@
   (let [max-base-fee   (:current (rf/sub [:wallet/tx-settings-max-base-fee]))
         priority-fee   (:current (rf/sub [:wallet/tx-settings-priority-fee]))
         max-gas-amount (:current (rf/sub [:wallet/tx-settings-max-gas-amount]))
-        nonce          (:current (rf/sub [:wallet/tx-settings-nonce]))]
+        nonce          (:current (rf/sub [:wallet/tx-settings-nonce]))
+        account-color  (rf/sub [:wallet/current-viewing-account-color])]
     [rn/view
      [quo/drawer-top
       {:title (i18n/label :t/custom)}]
@@ -63,12 +64,14 @@
                     :preview-size      :size-32}]}]
      [quo/bottom-actions
       {:actions          :one-action
-       :button-one-props {:on-press #(rf/dispatch [:hide-bottom-sheet])}
+       :button-one-props {:on-press            #(rf/dispatch [:hide-bottom-sheet])
+                          :customization-color account-color}
        :button-one-label (i18n/label :t/confirm)}]]))
 
 (defn settings-sheet
   []
   (let [current-transaction-setting                   (rf/sub [:wallet/tx-fee-mode])
+        account-color                                 (rf/sub [:wallet/current-viewing-account-color])
         [transaction-setting set-transaction-setting] (rn/use-state current-transaction-setting)
         set-normal                                    #(set-transaction-setting :tx-fee-mode/normal)
         set-fast                                      #(set-transaction-setting :tx-fee-mode/fast)
@@ -85,15 +88,16 @@
                :image             :emoji
                :description       :text
                :action            :selector
-               :action-props      {:type      :radio
-                                   :checked?  (= :tx-fee-mode/normal transaction-setting)
+               :action-props      {:type                :radio
+                                   :checked?            (= :tx-fee-mode/normal transaction-setting)
+                                   :customization-color account-color
                                    ;; there is an UI isssue in quo/category, it has :on-press event
                                    ;; and child radio button has own :on-change. If they are not set
                                    ;; to the same action then we are getting inconsistent behaviour
                                    ;; when user can click on settings item but cant on radio itself.
                                    ;; So duplication is to prevent that until general fix is applied
                                    ;; to quo/category
-                                   :on-change set-normal}
+                                   :on-change           set-normal}
                :on-press          set-normal
                :label             :text
                :preview-size      :size-32}
@@ -104,9 +108,10 @@
                :image             :emoji
                :description       :text
                :action            :selector
-               :action-props      {:type      :radio
-                                   :checked?  (= :tx-fee-mode/fast transaction-setting)
-                                   :on-change set-fast}
+               :action-props      {:type                :radio
+                                   :checked?            (= :tx-fee-mode/fast transaction-setting)
+                                   :on-change           set-fast
+                                   :customization-color account-color}
                :on-press          set-fast
                :label             :text
                :preview-size      :size-32}
@@ -117,9 +122,10 @@
                :image             :emoji
                :description       :text
                :action            :selector
-               :action-props      {:type      :radio
-                                   :checked?  (= :tx-fee-mode/urgent transaction-setting)
-                                   :on-change set-urgent}
+               :action-props      {:type                :radio
+                                   :checked?            (= :tx-fee-mode/urgent transaction-setting)
+                                   :customization-color account-color
+                                   :on-change           set-urgent}
                :on-press          set-urgent
                :label             :text
                :preview-size      :size-32}
@@ -137,10 +143,11 @@
                  :preview-size      :size-32})]}]
      [quo/bottom-actions
       {:actions          :one-action
-       :button-one-props {:on-press (fn []
-                                      (rf/dispatch [:wallet/quick-fee-mode-confirmed
-                                                    transaction-setting])
-                                      (rf/dispatch [:hide-bottom-sheet]))}
+       :button-one-props {:on-press            (fn []
+                                                 (rf/dispatch [:wallet/quick-fee-mode-confirmed
+                                                               transaction-setting])
+                                                 (rf/dispatch [:hide-bottom-sheet]))
+                          :customization-color account-color}
        :button-one-label (i18n/label :t/confirm)}]]))
 
 (defn- hint

--- a/src/status_im/contexts/wallet/send/transaction_settings/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_settings/view.cljs
@@ -5,6 +5,7 @@
     [react-native.platform :as platform]
     [react-native.safe-area :as safe-area]
     [status-im.common.controlled-input.utils :as controlled-input]
+    [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -67,7 +68,7 @@
 
 (defn settings-sheet
   []
-  (let [current-transaction-setting                   (rf/sub [:wallet/confirmed-tx-setting])
+  (let [current-transaction-setting                   (rf/sub [:wallet/tx-fee-mode])
         [transaction-setting set-transaction-setting] (rn/use-state current-transaction-setting)]
     [rn/view
      [quo/drawer-top
@@ -77,54 +78,55 @@
        :data [{:title             (str (i18n/label :t/normal) "~60s")
                :image-props       "🍿"
                :description-props {:text (rf/sub [:wallet/wallet-send-transaction-setting-fiat-formatted
-                                                  :transaction-setting/normal])}
+                                                  :tx-fee-mode/normal])}
                :image             :emoji
                :description       :text
                :action            :selector
                :action-props      {:type     :radio
-                                   :checked? (= :transaction-setting/normal transaction-setting)}
-               :on-press          #(set-transaction-setting :transaction-setting/normal)
+                                   :checked? (= :tx-fee-mode/normal transaction-setting)}
+               :on-press          #(set-transaction-setting :tx-fee-mode/normal)
                :label             :text
                :preview-size      :size-32}
               {:title             (str (i18n/label :t/fast) "~40s")
                :image-props       "🚗"
                :description-props {:text (rf/sub [:wallet/wallet-send-transaction-setting-fiat-formatted
-                                                  :transaction-setting/fast])}
+                                                  :tx-fee-mode/fast])}
                :image             :emoji
                :description       :text
                :action            :selector
                :action-props      {:type     :radio
-                                   :checked? (= :transaction-setting/fast transaction-setting)}
-               :on-press          #(set-transaction-setting :transaction-setting/fast)
+                                   :checked? (= :tx-fee-mode/fast transaction-setting)}
+               :on-press          #(set-transaction-setting :tx-fee-mode/fast)
                :label             :text
                :preview-size      :size-32}
               {:title             (str (i18n/label :t/urgent) "~15s")
                :image-props       "🚀"
                :description-props {:text (rf/sub [:wallet/wallet-send-transaction-setting-fiat-formatted
-                                                  :transaction-setting/urgent])}
+                                                  :tx-fee-mode/urgent])}
                :image             :emoji
                :description       :text
                :action            :selector
                :action-props      {:type     :radio
-                                   :checked? (= :transaction-setting/urgent transaction-setting)}
-               :on-press          #(set-transaction-setting :transaction-setting/urgent)
+                                   :checked? (= :tx-fee-mode/urgent transaction-setting)}
+               :on-press          #(set-transaction-setting :tx-fee-mode/urgent)
                :label             :text
                :preview-size      :size-32}
-              {:title             (i18n/label :t/custom)
-               :image-props       :i/edit
-               :description-props {:text "Set your own fees and nonce"}
-               :image             :icon
-               :description       :text
-               :action            :arrow
-               :on-press          #(rf/dispatch
-                                    [:show-bottom-sheet
-                                     {:content custom-settings-sheet}])
-               :label             :text
-               :preview-size      :size-32}]}]
+              (when (ff/enabled? ::ff/wallet.transaction-params)
+                {:title             (i18n/label :t/custom)
+                 :image-props       :i/edit
+                 :description-props {:text "Set your own fees and nonce"}
+                 :image             :icon
+                 :description       :text
+                 :action            :arrow
+                 :on-press          #(rf/dispatch
+                                      [:show-bottom-sheet
+                                       {:content custom-settings-sheet}])
+                 :label             :text
+                 :preview-size      :size-32})]}]
      [quo/bottom-actions
       {:actions          :one-action
        :button-one-props {:on-press (fn []
-                                      (rf/dispatch [:wallet/quick-transaction-settings-confirmed
+                                      (rf/dispatch [:wallet/quick-fee-mode-confirmed
                                                     transaction-setting])
                                       (rf/dispatch [:hide-bottom-sheet]))}
        :button-one-label (i18n/label :t/confirm)}]]))

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -250,5 +250,6 @@
   [path]
   {:routerInputParamsUuid (:router-input-params-uuid path)
    :pathName              (:bridge-name path)
-   :chainID               (get-in path [:to :chain-id])
-   :isApprovalTx          (:approval-required path)})
+   :chainID               (get-in path [:from :chain-id])
+   :isApprovalTx          (:approval-required path)
+   :communityID           nil})

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -25,21 +25,42 @@
              transaction-hashes))
 
 (defn calculate-gas-fee
-  [data]
-  (let [gas-amount         (money/bignumber (get data :gas-amount))
-        gas-fees           (get data :gas-fees)
-        eip1559-enabled?   (get gas-fees :eip-1559-enabled)
-        optimal-price-gwei (money/bignumber (if eip1559-enabled?
-                                              (get gas-fees :max-fee-per-gas-medium)
-                                              (get gas-fees :gas-price)))
-        total-gas-fee-wei  (money/mul (money/->wei :gwei optimal-price-gwei) gas-amount)
-        l1-fee-wei         (money/->wei :gwei (get gas-fees :l-1-gas-fee))]
+  [{:keys [gas-amount gas-price l1-gas-fee]}]
+  (let [total-gas-fee-wei (money/mul (money/->wei :gwei gas-price) gas-amount)
+        l1-fee-wei        (money/->wei :gwei l1-gas-fee)]
     (money/add total-gas-fee-wei l1-fee-wei)))
 
-(defn calculate-full-route-gas-fee
+(defn path-gas-fee
+  [path]
+  (let [gas-amount       (money/bignumber (get path :gas-amount))
+        gas-fees         (get path :gas-fees)
+        eip1559-enabled? (get gas-fees :eip-1559-enabled)
+        gas-price        (money/bignumber (if eip1559-enabled?
+                                            (get gas-fees :tx-max-fees-per-gas)
+                                            (get gas-fees :gas-price)))
+        l1-gas-fee       (get gas-fees :l-1-gas-fee)]
+    (calculate-gas-fee {:gas-amount gas-amount
+                        :gas-price  gas-price
+                        :l1-gas-fee l1-gas-fee})))
+
+(defn path-gas-fee-for-custom-gas-price
+  [route gas-price]
+  (let [gas-amount (money/bignumber (get route :gas-amount))
+        gas-fees   (get route :gas-fees)
+        l1-gas-fee (get gas-fees :l-1-gas-fee)]
+    (calculate-gas-fee {:gas-amount gas-amount
+                        :gas-price  (money/bignumber gas-price)
+                        :l1-gas-fee l1-gas-fee})))
+
+(defn full-route-gas-fee
   "Sums all the routes fees in wei and then convert the total value to ether"
   [route]
-  (money/wei->ether (reduce money/add (map calculate-gas-fee route))))
+  (money/wei->ether (reduce money/add (map path-gas-fee route))))
+
+(defn full-route-gas-fee-for-custom-gas-price
+  "Sums all the routes fees in wei and then convert the total value to ether"
+  [route gas-price]
+  (money/wei->ether (reduce money/add (map #(path-gas-fee-for-custom-gas-price % gas-price) route))))
 
 (defn- path-amount-in
   [path]
@@ -224,3 +245,10 @@
   {:r (subs signature 0 64)
    :s (subs signature 64 128)
    :v (subs signature 128 130)})
+
+(defn path-identity
+  [path]
+  {:routerInputParamsUuid (:router-input-params-uuid path)
+   :pathName              (:bridge-name path)
+   :chainID               (get-in path [:to :chain-id])
+   :isApprovalTx          (:approval-required path)})

--- a/src/status_im/contexts/wallet/send/utils_test.cljs
+++ b/src/status_im/contexts/wallet/send/utils_test.cljs
@@ -178,21 +178,21 @@
 (deftest calculate-gas-fee-test
   (testing "EIP-1559 transaction without L1 fee"
     (let [data            {:gas-amount "23487"
-                           :gas-fees   {:max-fee-per-gas-medium "2.259274911"
-                                        :eip-1559-enabled       true
-                                        :l-1-gas-fee            "0"}}
+                           :gas-fees   {:tx-max-fees-per-gas "2.259274911"
+                                        :eip-1559-enabled    true
+                                        :l-1-gas-fee         "0"}}
           expected-result (money/bignumber "53063589834657")] ; This is in Wei
-      (is (money/equal-to (utils/calculate-gas-fee data)
+      (is (money/equal-to (utils/path-gas-fee data)
                           expected-result))))
 
   (testing "EIP-1559 transaction with L1 fee of 60,000 Gwei"
     (let [data            {:gas-amount "23487"
-                           :gas-fees   {:max-fee-per-gas-medium "2.259274911"
-                                        :eip-1559-enabled       true
-                                        :l-1-gas-fee            "60000"}}
+                           :gas-fees   {:tx-max-fees-per-gas "2.259274911"
+                                        :eip-1559-enabled    true
+                                        :l-1-gas-fee         "60000"}}
           expected-result (money/bignumber "113063589834657")] ; Added 60,000 Gwei in Wei to the
                                                                ; previous result
-      (is (money/equal-to (utils/calculate-gas-fee data)
+      (is (money/equal-to (utils/path-gas-fee data)
                           expected-result))))
 
   (testing "Non-EIP-1559 transaction with specified gas price"
@@ -202,48 +202,48 @@
                                         :l-1-gas-fee      "0"}}
           expected-result (money/bignumber "67471600217343")] ; This is in Wei, for the specified
                                                               ; gas amount and price
-      (is (money/equal-to (utils/calculate-gas-fee data)
+      (is (money/equal-to (utils/path-gas-fee data)
                           expected-result)))))
 
 (deftest calculate-full-route-gas-fee-test
   (testing "Route with a single EIP-1559 transaction, no L1 fees"
     (let [route           [{:gas-amount "23487"
-                            :gas-fees   {:max-fee-per-gas-medium "2.259274911"
-                                         :eip-1559-enabled       true
-                                         :l-1-gas-fee            "0"}}]
+                            :gas-fees   {:tx-max-fees-per-gas "2.259274911"
+                                         :eip-1559-enabled    true
+                                         :l-1-gas-fee         "0"}}]
           expected-result (money/bignumber "0.000053063589834657")] ; The Wei amount for the
                                                                     ; transaction, converted to
                                                                     ; Ether
-      (is (money/equal-to (utils/calculate-full-route-gas-fee route)
+      (is (money/equal-to (utils/full-route-gas-fee route)
                           expected-result))))
 
   (testing "Route with two EIP-1559 transactions, no L1 fees"
     (let [route           [{:gas-amount "23487"
-                            :gas-fees   {:max-fee-per-gas-medium "2.259274911"
-                                         :eip-1559-enabled       true
-                                         :l-1-gas-fee            "0"}}
+                            :gas-fees   {:tx-max-fees-per-gas "2.259274911"
+                                         :eip-1559-enabled    true
+                                         :l-1-gas-fee         "0"}}
                            {:gas-amount "23487"
-                            :gas-fees   {:max-fee-per-gas-medium "2.259274911"
-                                         :eip-1559-enabled       true
-                                         :l-1-gas-fee            "0"}}]
+                            :gas-fees   {:tx-max-fees-per-gas "2.259274911"
+                                         :eip-1559-enabled    true
+                                         :l-1-gas-fee         "0"}}]
           expected-result (money/bignumber "0.000106127179669314")] ; Sum of both transactions' Wei
                                                                     ; amounts, converted to Ether
-      (is (money/equal-to (utils/calculate-full-route-gas-fee route)
+      (is (money/equal-to (utils/full-route-gas-fee route)
                           expected-result))))
 
   (testing "Route with two EIP-1559 transactions, one with L1 fee of 60,000 Gwei"
     (let [route           [{:gas-amount "23487"
-                            :gas-fees   {:max-fee-per-gas-medium "2.259274911"
-                                         :eip-1559-enabled       true
-                                         :l-1-gas-fee            "0"}}
+                            :gas-fees   {:tx-max-fees-per-gas "2.259274911"
+                                         :eip-1559-enabled    true
+                                         :l-1-gas-fee         "0"}}
                            {:gas-amount "23487"
-                            :gas-fees   {:max-fee-per-gas-medium "2.259274911"
-                                         :eip-1559-enabled       true
-                                         :l-1-gas-fee            "60000"}}]
+                            :gas-fees   {:tx-max-fees-per-gas "2.259274911"
+                                         :eip-1559-enabled    true
+                                         :l-1-gas-fee         "60000"}}]
           expected-result (money/bignumber "0.000166127179669314")] ; Added 60,000 Gwei in Wei to
                                                                     ; the previous total and
                                                                     ; converted to Ether
-      (is (money/equal-to (utils/calculate-full-route-gas-fee route)
+      (is (money/equal-to (utils/full-route-gas-fee route)
                           expected-result)))))
 
 (deftest token-available-networks-for-suggested-routes-test

--- a/src/status_im/subs/wallet/send.cljs
+++ b/src/status_im/subs/wallet/send.cljs
@@ -207,14 +207,14 @@
 
 
 (rf/reg-sub
- :wallet/confirmed-tx-setting
- :<- [:wallet/wallet-send]
- :-> :confirmed-tx-setting)
-
-(rf/reg-sub
  :wallet/custom-tx-settings
  :<- [:wallet/wallet-send]
  :-> :custom-tx-settings)
+
+(rf/reg-sub
+ :wallet/tx-settings-fee-mode-user
+ :<- [:wallet/custom-tx-settings]
+ :-> :tx-fee-mode)
 
 (rf/reg-sub
  :wallet/tx-settings-max-base-fee
@@ -235,3 +235,10 @@
  :wallet/tx-settings-nonce
  :<- [:wallet/custom-tx-settings]
  :-> :nonce)
+
+(rf/reg-sub
+ :wallet/tx-fee-mode
+ :<- [:wallet/send-route]
+ :<- [:wallet/tx-settings-fee-mode-user]
+ (fn [[route value-set-by-user]]
+   (or value-set-by-user (:tx-fee-mode (first route)))))

--- a/src/status_im/subs/wallet/send.cljs
+++ b/src/status_im/subs/wallet/send.cljs
@@ -205,27 +205,33 @@
      {:crypto (str crypto-formatted " " (:symbol token))
       :fiat   fiat-formatted})))
 
+
 (rf/reg-sub
- :wallet/tx-settings
+ :wallet/confirmed-tx-setting
  :<- [:wallet/wallet-send]
- :-> :tx-settings)
+ :-> :confirmed-tx-setting)
+
+(rf/reg-sub
+ :wallet/custom-tx-settings
+ :<- [:wallet/wallet-send]
+ :-> :custom-tx-settings)
 
 (rf/reg-sub
  :wallet/tx-settings-max-base-fee
- :<- [:wallet/tx-settings]
+ :<- [:wallet/custom-tx-settings]
  :-> :max-base-fee)
 
 (rf/reg-sub
  :wallet/tx-settings-priority-fee
- :<- [:wallet/tx-settings]
+ :<- [:wallet/custom-tx-settings]
  :-> :priority-fee)
 
 (rf/reg-sub
  :wallet/tx-settings-max-gas-amount
- :<- [:wallet/tx-settings]
+ :<- [:wallet/custom-tx-settings]
  :-> :max-gas-amount)
 
 (rf/reg-sub
  :wallet/tx-settings-nonce
- :<- [:wallet/tx-settings]
+ :<- [:wallet/custom-tx-settings]
  :-> :nonce)

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -260,7 +260,7 @@
            token-for-fees      (first (filter #(= (string/lower-case (:symbol %))
                                                   (string/lower-case token-symbol-for-fees))
                                               tokens))
-           fee-in-native-token (send-utils/calculate-full-route-gas-fee [swap-proposal])
+           fee-in-native-token (send-utils/full-route-gas-fee [swap-proposal])
            fee-in-fiat         (utils/calculate-token-fiat-value
                                 {:currency         currency
                                  :balance          fee-in-native-token

--- a/src/status_im/subs/wallet/swap_test.cljs
+++ b/src/status_im/subs/wallet/swap_test.cljs
@@ -120,9 +120,9 @@
                    :approval-required        true
                    :approval-amount-required "0x10000"
                    :gas-amount               "25000"
-                   :gas-fees                 {:max-fee-per-gas-medium "4"
-                                              :eip-1559-enabled       true
-                                              :l-1-gas-fee            "0"}}
+                   :gas-fees                 {:tx-max-fees-per-gas "4"
+                                              :eip-1559-enabled    true
+                                              :l-1-gas-fee         "0"}}
    :error-response "Error"
    :loading-swap-proposal? false
    :max-slippage 0.5})

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -205,9 +205,10 @@
 
 (def route-data
   [{:gas-amount "25000"
-    :gas-fees   {:max-fee-per-gas-medium "4"
-                 :eip-1559-enabled       true
-                 :l-1-gas-fee            "0"}}])
+    :gas-fees   {:tx-max-fees-per-gas "4"
+                 :eip-1559-enabled    true
+                 :l-1-gas-fee         "0"}
+    :from       {:native-currency-symbol "ETH"}}])
 
 (h/deftest-sub :wallet/balances-in-selected-networks
   [sub-name]
@@ -938,9 +939,7 @@
            (assoc-in [:profile/profile :currency] :usd)
            (assoc-in [:profile/profile :currency-symbol] "$")))
 
-    (let [token-symbol-for-fees "ETH"
-          result                (rf/sub [sub-name token-symbol-for-fees])]
-      (is (match? result "$0.20")))))
+    (is (match? (rf/sub [sub-name]) "$0.20"))))
 
 (h/deftest-sub :wallet/zero-balance-in-all-non-watched-accounts?
   [sub-name]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v10.4.0",
-    "commit-sha1": "1bfb0cef022afc1484a410cb3e0097e7523bb705",
-    "src-sha256": "13cg07ld319g1fyaqpkjnpdw6iap389dwzwnh9g870ci8scpdy5m"
+    "version": "v10.5.0",
+    "commit-sha1": "5a7969593c98cd7906607042ee19c2386a673ec3",
+    "src-sha256": "0kqll98235p2nxkccvp0asrk9w5k0zmd7mywparnjfxv5cav8qmb"
 }


### PR DESCRIPTION
fixes #21019

## Summary
Quick transaction settings added. Now you can select normal/fast/urgent mode and see the estimated gas fee.

https://github.com/user-attachments/assets/5508e638-c55c-4f64-a1e3-c2c264b0e636


## Review notes
Adding quick transaction settings required changes in events flow. Before this PR our app was calling status-go function `BuildTransactionsFromRoute` at the moment when we navigated to transaction confirmation screen. This function stops the route updates, so the only thing we had to do is to sign the transactions.
But in order to allow user to change transaction settings we need to send changes to status-go and keep getting route updates with new fees. 
So the events order was changed. Now we navigate to transaction confirmation screen and still getting the routes update. But when user slides the sign button we:
- call `BuildTransactionsFromRoute`
- await for `wallet.router.sign-transactions` signal
- start authorization
- when authorized - sign transaction and send it to status-go

Along the way the authrization slider was refactored. **Update: authorization slider changes were reverted back to not interfere with current @clauxx refactoring of authorization process**


## Testing notes

This PR has changed the order of events during send/bridge, so they should be tested. 

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

### Areas that may be impacted
[comment]: # (Optional. Specify if some specific areas need to be tested, such as 1-1 chats)

#### Functional
- wallet / transactions



## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Open Status
- Go to send screen confirmation
- Press transaction settings button, make sure that different setting levels are in place and updating.
- Make sure that setting change affects the change of transaction fee (that happens not immediately but on the next update from status-go


status: ready

### Found Issues 

1. [incorrect fee option displayed as selected in "transaction settings" after navigating back to send set up page](https://github.com/status-im/status-mobile/issues/22103)  
   - [x] Fixed  (checked by dev)  
   - [x] Verified (checked by QA)

2. [Max fee not updated after inactivity on transaction confirmation page](https://github.com/status-im/status-mobile/issues/22104)  
   - [x] Fixed  (checked by dev)  
   - [x] Verified (checked by QA)  

3. ["Radio buttons are not responsive to direct taps](https://github.com/status-im/status-mobile/issues/22105)  
   - [x] Fixed  (checked by dev)  
   - [x] Verified (checked by QA)  

4. ["Confirm" button and radio buttons do not inherit selected account color](https://github.com/status-im/status-mobile/issues/22106)
   - [x] Fixed  (checked by dev)  
   - [x] Verified (checked by QA)

5. [Confirmation page does not match the visual design](https://github.com/status-im/status-mobile/issues/22107)
   - [ ] Fixed  (checked by dev)  
   - [ ] Verified (checked by QA)

6. [Routes are not built randomly](https://github.com/status-im/status-mobile/issues/22155)
   - [ ] Fixed  (checked by dev)  
   - [ ] Verified (checked by QA)

7. [Selected transaction setting is reset in bridge flow](https://github.com/status-im/status-mobile/issues/22161)
   - [ ] Fixed  (checked by dev)  
   - [ ] Verified (checked by QA)