### PR TITLE
[#22029] fix: bridge button when there is single account

### DIFF
--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -435,15 +435,16 @@
 (rf/reg-event-fx
  :wallet/start-bridge
  (fn [{:keys [db]}]
-   (let [view-id (:view-id db)
-         address (get-in db [:wallet :current-viewing-account-address])]
-     (cond-> {:db (assoc-in db [:wallet :ui :send :tx-type] :tx/bridge)}
-       (or (= view-id :screen/wallet.accounts) address)
-       (assoc :fx
-              [[:dispatch
-                [:wallet/wizard-navigate-forward
-                 {:start-flow? true
-                  :flow-id     :wallet-bridge-flow}]]])))))
+   {:db (assoc-in db [:wallet :ui :send :tx-type] :tx/bridge)
+    :fx [[:dispatch
+          [:wallet/wizard-navigate-forward
+           {:start-flow? true
+            :flow-id     :wallet-bridge-flow}]]]}))
+
+(rf/reg-event-fx
+ :wallet/set-send-tx-type
+ (fn [{:keys [db]} [type]]
+   {:db (assoc-in db [:wallet :ui :send :tx-type] type)}))
 
 (rf/reg-event-fx :wallet/select-bridge-network
  (fn [{:keys [db]} [{:keys [network-chain-id stack-id]}]]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -435,9 +435,10 @@
 (rf/reg-event-fx
  :wallet/start-bridge
  (fn [{:keys [db]}]
-   (let [view-id (:view-id db)]
+   (let [view-id (:view-id db)
+         address (get-in db [:wallet :current-viewing-account-address])]
      (cond-> {:db (assoc-in db [:wallet :ui :send :tx-type] :tx/bridge)}
-       (= view-id :screen/wallet.accounts)
+       (or (= view-id :screen/wallet.accounts) address)
        (assoc :fx
               [[:dispatch
                 [:wallet/wizard-navigate-forward

--- a/src/status_im/contexts/wallet/home/view.cljs
+++ b/src/status_im/contexts/wallet/home/view.cljs
@@ -91,6 +91,9 @@
                                                               {:content buy-token/view}]))
         on-bridge-press       (rn/use-callback
                                (fn []
+                                 ;; For a single account, it starts the bridge flow immediately. For
+                                 ;; multiple accounts, it sets the transaction type and starts the
+                                 ;; bridge flow after account selection.
                                  (rf/dispatch [:wallet/clean-send-data])
                                  (when-not multiple-accounts?
                                    (rf/dispatch [:wallet/switch-current-viewing-account

--- a/src/status_im/contexts/wallet/home/view.cljs
+++ b/src/status_im/contexts/wallet/home/view.cljs
@@ -94,9 +94,10 @@
                                  (rf/dispatch [:wallet/clean-send-data])
                                  (when-not multiple-accounts?
                                    (rf/dispatch [:wallet/switch-current-viewing-account
-                                                 first-account-address]))
-                                 (rf/dispatch [:wallet/start-bridge])
+                                                 first-account-address])
+                                   (rf/dispatch [:wallet/start-bridge]))
                                  (when multiple-accounts?
+                                   (rf/dispatch [:wallet/set-send-tx-type :tx/bridge])
                                    (rf/dispatch [:open-modal :screen/wallet.select-from])))
                                [multiple-accounts? first-account-address])
         on-swap-press         (rn/use-callback


### PR DESCRIPTION
fixes #22029

## Summary
The user should be properly navigated to the Bridge Flow after tapping "Bridge".

### Areas that may be impacted

- Bridge flow

## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

1. Restore a user with one account.
2. Tap "Bridge" on the wallet main page.


status: ready

