### PR TITLE
fix: transaction fails when signed from auto-restored derived account after seed phrase recovery with biometric authentication enabled

### DIFF
--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -862,14 +862,6 @@
        fee-formatted))))
 
 (rf/reg-sub
- :wallet/has-partially-operable-accounts?
- :<- [:wallet/accounts]
- (fn [accounts]
-   (->> accounts
-        (some #(= :partially (:operable %)))
-        boolean)))
-
-(rf/reg-sub
  :wallet/accounts-names
  :<- [:wallet/accounts]
  (fn [accounts]

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -942,20 +942,6 @@
           result                (rf/sub [sub-name token-symbol-for-fees])]
       (is (match? result "$0.20")))))
 
-(h/deftest-sub :wallet/has-partially-operable-accounts?
-  [sub-name]
-  (testing "returns false if there are no partially operable accounts"
-    (swap! rf-db/app-db
-      #(assoc-in % [:wallet :accounts] accounts))
-    (is (false? (rf/sub [sub-name]))))
-
-  (testing "returns true if there are partially operable accounts"
-    (swap! rf-db/app-db
-      #(assoc-in %
-        [:wallet :accounts]
-        (update accounts "0x2" assoc :operable :partially)))
-    (is (true? (rf/sub [sub-name])))))
-
 (h/deftest-sub :wallet/zero-balance-in-all-non-watched-accounts?
   [sub-name]
   (testing "returns true if the balance is zero in all non-watched accounts"

--- a/src/tests/integration_test/standard_auth_test.cljs
+++ b/src/tests/integration_test/standard_auth_test.cljs
@@ -17,6 +17,8 @@
 
 (defn auth-success-fixtures
   []
+  (rf/reg-fx :effects.standard-auth/on-auth-success
+   (fn [on-auth-success] (on-auth-success)))
   (rf/reg-fx :effects.biometric/check-if-available
    (fn [{:keys [on-success]}] (on-success)))
   (rf/reg-event-fx :biometric/authenticate
@@ -32,7 +34,7 @@
      (let [on-success-called? (atom false)
            args               (assoc default-args :on-auth-success #(reset! on-success-called? true))]
        (rf/dispatch [:standard-auth/authorize args])
-       (rf-test/wait-for [:standard-auth/on-biometric-success]
+       (rf-test/wait-for [:standard-auth/migrate-partially-operable-accounts]
          (is @on-success-called?))))))
 
 (defn auth-cancel-fixtures


### PR DESCRIPTION
fixes #22000 

## Summary

This PR fixes an issue where the on-auth-success function is passed to the :keychain/get-user-password event but is not called with the user's password when biometric authentication succeeds. As a result, authentication appeared successful, but transactions failed to go through, leading to confusing error toasts when confirming send or bridge transactions.

Additionally, this PR includes a safeguard for handling partially operable accounts, as identified during debugging (thanks @smohamedjavid for your findings).

### Platforms

- Android
- iOS

### Areas that may be impacted

#### Functional

- wallet / transactions

## Steps to test

- Check linked issue which contains specific steps on how to reproduce this issue.

status: ready