### PR TITLE
fix: add version field to localSrc definition for go-mobile nix build

### DIFF
--- a/nix/status-go/source.nix
+++ b/nix/status-go/source.nix
@@ -14,7 +14,6 @@ let
     rev = "unknown";
     shortRev = rev;
     version = "unknown";
-    rawVersion = version;
     cleanVersion = version;
     goPackagePath = "github.com/${owner}/${repo}";
     # We use builtins.path so that we can name the resulting derivation,
@@ -44,7 +43,6 @@ let
     inherit (versionJSON) owner repo version;
     rev = versionJSON.commit-sha1;
     shortRev = strings.substring 0 7 rev;
-    rawVersion = versionJSON.version;
     cleanVersion = lib.sanitizeVersion versionJSON.version;
     # Need to pretend this is from status-im to let Go build it.
     goPackagePath = "github.com/status-im/${repo}";

--- a/nix/status-go/source.nix
+++ b/nix/status-go/source.nix
@@ -13,9 +13,9 @@ let
     repo = "status-go";
     rev = "unknown";
     shortRev = rev;
-    rawVersion = "develop";
-    version = rawVersion;
-    cleanVersion = rawVersion;
+    version = "unknown";
+    rawVersion = version;
+    cleanVersion = version;
     goPackagePath = "github.com/${owner}/${repo}";
     # We use builtins.path so that we can name the resulting derivation,
     # Normally the name would not be deterministic, taken from the checkout directory.

--- a/nix/status-go/source.nix
+++ b/nix/status-go/source.nix
@@ -14,6 +14,7 @@ let
     rev = "unknown";
     shortRev = rev;
     rawVersion = "develop";
+    version = rawVersion;
     cleanVersion = rawVersion;
     goPackagePath = "github.com/${owner}/${repo}";
     # We use builtins.path so that we can name the resulting derivation,


### PR DESCRIPTION
## Summary
* This PR attempts to fix the Go-Mobile builds in development when using the environment variable `STATUS_GO_SRC_OVERRIDE`.
  * Before this change an error would occur, for example:
    * ```
       error: attribute 'version' missing

       at /Users/seanstrom/Code/org-seanstrom/status-mobile/nix/status-go/mobile/build.nix:19:47:

           18|   # Fixes fatal: not a git repository (or any of the parent directories): .git
           19|   fakeGit = pkgs.writeScriptBin "git" "echo ${source.version}";
             |                                               ^
      ```

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

### Areas that may be impacted
[comment]: # (Optional. Specify if some specific areas need to be tested, such as 1-1 chats)

#### Non-functional

- Nix builds

[comment]: # (Can be ready or wip)
status: ready


<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that may be impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
