### PR TITLE
chore(deps)_: get missing deps versions dynamically

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -143,6 +143,10 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17
     }
+    // Disable default lint checks to remove redundant lintVitalReportRelease task
+    lintOptions {
+        checkReleaseBuilds false
+    }
 
     // https://developer.android.com/studio/projects/install-ndk#vanilla_cmake
     externalNativeBuild {

--- a/nix/deps/gradle/deps_hack.sh
+++ b/nix/deps/gradle/deps_hack.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fallback versions for each dependency
+readonly FOOJAY_FALLBACK="0.5.0"
+readonly KOTLIN_FALLBACK="1.8.0"
+readonly TOOLS_FALLBACK="3.5.4"
+readonly HERMES_FALLBACK="0.73.5"
+
+GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
+cd "${GIT_ROOT}"
+
+get_version() {
+    local file="$1"
+    local pattern="$2"
+    local fallback="$3"
+    local version
+
+    if [[ ! -f "$file" ]]; then
+        echo "$fallback"
+        return 0
+    fi
+
+    version=$(grep "$pattern" "$file" 2>/dev/null | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+\.*[0-9]*" | tail -n1 || echo "$fallback")
+    echo "$version"
+}
+
+foojay_version=$(get_version "./node_modules/@react-native/gradle-plugin/settings.gradle.kts" "foojay.*version" "$FOOJAY_FALLBACK")
+kotlin_version=$(get_version "./node_modules/@react-native/gradle-plugin/gradle/libs.versions.toml" "kotlin =" "$KOTLIN_FALLBACK")
+tools_version=$(get_version "./patches/BlurView-build.gradle.patch" "gradle:" "$TOOLS_FALLBACK")
+hermes_version=$(get_version "./node_modules/react-native/ReactAndroid/gradle.properties" "VERSION_NAME" "$HERMES_FALLBACK")
+
+
+cat << EOF
+org.gradle.toolchains.foojay-resolver-convention:org.gradle.toolchains.foojay-resolver-convention.gradle.plugin:$foojay_version
+org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:$kotlin_version
+com.android.tools.build:gradle:$tools_version
+com.facebook.react:hermes-android:$hermes_version
+EOF

--- a/nix/deps/gradle/generate.sh
+++ b/nix/deps/gradle/generate.sh
@@ -38,16 +38,10 @@ function gen_deps_list() {
     echo -e "${CLR}Found ${GRN}$(wc -l < "${DEPS_LIST}")${RST} direct dependencies..."
 }
 
-# FIXME: Temporary fix for missing packages.
+# FIXME: Fix for missing packages.
 # https://github.com/status-im/status-mobile/issues/15447
 function add_deps_hack() {
-    echo -n \
-'org.gradle.toolchains.foojay-resolver-convention:org.gradle.toolchains.foojay-resolver-convention.gradle.plugin:0.5.0
-org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:1.8.0
-com.android.tools.build:gradle:3.5.4
-com.android.tools.lint:lint-gradle:31.1.1
-com.facebook.react:hermes-android:0.73.5' \
-        >> "${DEPS_LIST}"
+   "${CUR_DIR}/deps_versions.sh" >> "${DEPS_LIST}"
 }
 
 # Find download URLs for each dependency.

--- a/nix/deps/gradle/get_deps.sh
+++ b/nix/deps/gradle/get_deps.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # This script generates a list of dependencies for the main project and its
-# sub-projects defined using Gradle config files. It parses Gradle output of
-# 'dependencies' and 'buildEnvironment` tasks using AWK.
+# sub-projects defined using Gradle config files. It uses github-dependency-graph-gradle-plugin:
+# https://github.com/gradle/github-dependency-graph-gradle-plugin?tab=readme-ov-file#using-the-plugin-to-generate-dependency-reports
 
 set -Eeuo pipefail
 


### PR DESCRIPTION
Ref.: 
- https://github.com/status-im/status-mobile/issues/15447
- https://github.com/status-im/status-mobile/pull/21502

## Summary
To remove hardcoding of specific versions of missing gradle dependencies, we will use `get_versions.sh` to fetch them dynamically.

Also removed by default enabled `lintOption` which removes `lintVitalReportRelease` from gradle tasks and unnecessary lint dependency (credits to @siddarthkay).

## Testing notes
not needed since we only change fetching build dependencies in this PR

## Platforms
Android

status: ready