### PR TITLE
feat(wallet)_: Saved addresses limit

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -144,9 +144,9 @@
         on-change-text                      (rn/use-callback
                                              (fn [new-value]
                                                (let [trimmed-value (string/trim new-value)]
-                                                 (set-error (validate (string/lower-case trimmed-value)))
                                                  (set-address-or-ens trimmed-value)
                                                  (set-ens-address "")
+                                                 (set-error (validate (string/lower-case trimmed-value)))
                                                  (when (validation/ens-name? trimmed-value)
                                                    (debounce/debounce-and-dispatch
                                                     [:wallet/resolve-ens

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
@@ -154,3 +154,15 @@
   {:db (update-in db [:wallet :ui] dissoc :saved-address)})
 
 (rf/reg-event-fx :wallet/clear-address-to-save clear-address-to-save)
+
+(defn check-remaining-capacity-for-saved-addresses
+  [{:keys [db]} [{:keys [on-success on-error]}]]
+  (let [test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))]
+    {:fx [[:json-rpc/call
+           [{:method     "wakuext_remainingCapacityForSavedAddresses"
+             :params     [test-networks-enabled?]
+             :on-success on-success
+             :on-error   on-error}]]]}))
+
+(rf/reg-event-fx :wallet/check-remaining-capacity-for-saved-addresses
+ check-remaining-capacity-for-saved-addresses)

--- a/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
@@ -103,7 +103,13 @@
 
 (defn- add-address-to-save
   []
-  (rf/dispatch [:open-modal :screen/settings.add-address-to-save]))
+  (rf/dispatch [:wallet/check-remaining-capacity-for-saved-addresses
+                {:on-success #(rf/dispatch [:open-modal :screen/settings.add-address-to-save])
+                 :on-error   #(rf/dispatch [:toasts/upsert
+                                            {:type  :negative
+                                             :theme :dark
+                                             :text  (i18n/label
+                                                     :t/saved-addresses-limit-reached-toast)}])}]))
 
 (defn view
   []

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -5,7 +5,6 @@
     [clojure.string :as string]
     [status-im.constants :as constants]
     [status-im.contexts.wallet.collectible.utils :as collectible-utils]
-    [status-im.contexts.wallet.common.utils.networks :as network-utils]
     [status-im.contexts.wallet.send.utils :as send-utils]
     [utils.collection :as utils.collection]
     [utils.money :as money]
@@ -165,10 +164,7 @@
 
 (defn- add-keys-to-saved-address
   [saved-address]
-  (-> saved-address
-      (assoc :network-preferences-names
-             (network-utils/network-preference-prefix->network-names (:chain-short-names saved-address)))
-      (assoc :ens? (not (string/blank? (:ens saved-address))))))
+  (assoc saved-address :ens? (not (string/blank? (:ens saved-address)))))
 
 (defn rpc->saved-address
   [saved-address]

--- a/translations/en.json
+++ b/translations/en.json
@@ -2279,6 +2279,7 @@
   "saved-address-network-preference-selection-description": "Only change if you know which networks the address owner is happy to to receive funds on",
   "saved-address-removed": "Saved address removed",
   "saved-addresses": "Saved addresses",
+  "saved-addresses-limit-reached-toast": "Limit of 20 saved addresses reached. Remove a saved address to add a new one.",
   "saving-keys-to-device": "Saving keys to device...",
   "say-hi": "Say hi",
   "scan-an-account-qr-code": "Scan an account QR code",


### PR DESCRIPTION
fixes #22045

## Summary

This PR adds limit for adding saved addresses upto 20 to prevent any unwanted behaviour.

https://github.com/user-attachments/assets/db1c9946-7d4c-418d-8bd6-4d81e1d1b4b6


### Platforms

- Android
- iOS

## Steps to test

- Open Status
- Navigate to Profile > Wallet > Saved addresses
- Verify you can add upto 20 Saved addresses
- Verify a toast message is shown that the limit is reached if the user tries add more 

status: ready
