### PR TITLE
feat: show swap proposal exchange rate

### DIFF
--- a/src/status_im/contexts/wallet/swap/setup_swap/style.cljs
+++ b/src/status_im/contexts/wallet/swap/setup_swap/style.cljs
@@ -1,4 +1,5 @@
-(ns status-im.contexts.wallet.swap.setup-swap.style)
+(ns status-im.contexts.wallet.swap.setup-swap.style
+  (:require [quo.foundations.colors :as colors]))
 
 (def container
   {:flex 1})
@@ -40,3 +41,22 @@
   {:height     :auto
    :min-height 40
    :max-height 62})
+
+(defn exchange-rate-loader
+  [theme]
+  {:margin-top       16
+   :width            72
+   :height           14
+   :border-radius    6
+   :background-color (colors/theme-colors colors/neutral-5 colors/neutral-90 theme)})
+
+(def exchange-rate-container
+  {:margin-top     16
+   :flex-direction :row})
+
+(def exchange-rate-crypto-label
+  {:color colors/neutral-50})
+
+(defn exchange-rate-fiat-label
+  [theme]
+  {:color (colors/theme-colors colors/neutral-40 colors/neutral-60 theme)})

--- a/translations/en.json
+++ b/translations/en.json
@@ -2566,6 +2566,7 @@
   "sun": "Sun",
   "swap": "Swap",
   "swap-details": "Swap details",
+  "swap-exchange-rate-in-crypto": "1 {{receive-token-symbol}} ≈ {{exchange-rate}} {{pay-token-symbol}}",
   "swap-failed": "Swap failed",
   "swapped-to": "Swapped {{pay-amount}} {{pay-token-symbol}} to {{receive-amount}} {{receive-token-symbol}}",
   "swapping-to": "Swapping {{pay-amount}} {{pay-token-symbol}} to {{receive-amount}} {{receive-token-symbol}}",


### PR DESCRIPTION
fixes #22037

## Summary

This PR adds swap conversion exchange rate to the swap proposal screen

![](https://github.com/user-attachments/assets/6f6e3569-6b6d-4028-98bb-a1bc06089a86)
![](https://github.com/user-attachments/assets/519c7ea3-9583-44fb-bda4-30a594001b5b)
![](https://github.com/user-attachments/assets/bbcdaff7-c20d-4fca-a92d-3ac766bcb066)

### Platforms

- Android
- iOS

### Areas that may be impacted

#### Functional

- wallet / transactions

## Steps to test

- Open Status
- Log in
- Initiate Swap flow
- Select asset to pay and asset to receive
- Insert a valid value
- Verify swap exchange rate is correctly shown

status: ready