### PR TITLE
chore_: specify kdfIterations explictly

### DIFF
--- a/src/status_im/contexts/profile/config.cljs
+++ b/src/status_im/contexts/profile/config.cljs
@@ -10,6 +10,7 @@
   []
   {;; Temporary fix until https://github.com/status-im/status-go/issues/3024 is resolved
    :wakuV2Nameserver              "8.8.8.8"
+   :kdfIterations                 3200
    :statusProxyEnabled            config/status-proxy-enabled?
    :statusProxyStageName          config/status-proxy-stage-name
    :statusProxyMarketUser         config/STATUS_BUILD_PROXY_USER


### PR DESCRIPTION
desktop and mobile have different values on param `kdfIterations`, it was bad to give default value(3200) on the status-go side which makes it hard to find out if we handled it well for mobile.

this change will make sure we pass kdfIterations explicitly when invoking `CreateAccountAndLogin` / `InputConnectionStringForBootstrappingV2` / `LoginAccount`

relate [comment1](https://github.com/status-im/status-go/pull/6338#discussion_r1952516072) 

cc @igor-sirotin 

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

status: ready
