### PR TITLE
Allow user to access recovery phrase after canceling 'Confirm Backup' drawer

### DIFF
--- a/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/view.cljs
@@ -64,7 +64,7 @@
    [button (assoc params :word (second options))]])
 
 (defn- complete-backup-sheet
-  [on-success]
+  [on-success on-try-again]
   (let [customization-color    (rf/sub [:profile/customization-color])
         [checked? set-checked] (rn/use-state false)]
     [:<>
@@ -88,7 +88,10 @@
        :button-two-label (i18n/label :t/cancel)
        :button-two-props {:type     :grey
                           :on-press (fn []
-                                      (rf/dispatch [:hide-bottom-sheet]))}}]]))
+                                      (rf/dispatch [:hide-bottom-sheet])
+                                      (when on-try-again
+                                        (rf/dispatch [:navigate-back])
+                                        (on-try-again)))}}]]))
 
 (defn view
   []
@@ -123,7 +126,8 @@
                                                                   {:theme   theme
                                                                    :shell?  shell?
                                                                    :content (fn [] [complete-backup-sheet
-                                                                                    on-success])}])))
+                                                                                    on-success
+                                                                                    on-try-again])}])))
                                                 (do
                                                   (when (> @incorrect-count 0)
                                                     (rf/dispatch [:show-bottom-sheet


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21903

### Video

https://github.com/user-attachments/assets/0cc59ffc-8567-46a7-b54d-c6dd8b7a14fa




status: ready