### PR TITLE
deps: dynamically get gradle-lint version

### DIFF
--- a/nix/deps/gradle/deps_hack.sh
+++ b/nix/deps/gradle/deps_hack.sh
@@ -6,6 +6,7 @@ readonly FOOJAY_FALLBACK="0.5.0"
 readonly KOTLIN_FALLBACK="1.8.0"
 readonly TOOLS_FALLBACK="3.5.4"
 readonly HERMES_FALLBACK="0.73.5"
+readonly GRADLE_LINT_FALLBACK="31.1.1"
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 cd "${GIT_ROOT}"
@@ -25,16 +26,28 @@ get_version() {
     echo "$version"
 }
 
+# https://github.com/googlesamples/android-custom-lint-rules/blob/be672cd747ecf13844918e1afccadb935f856a72/docs/api-guide/example.md.html#L112-L129
+get_gradle_lint_version() {
+  gradlePluginVersion=$(get_version "./nix/pkgs/aapt2/default.nix" "version =" $GRADLE_LINT_FALLBACK)
+  major=$(echo "$gradlePluginVersion" | grep -o "^[0-9]*")
+  #  lintVersion = gradlePluginVersion + 23.0.0
+  major=$((major + 23))
+  minor=$(echo "$gradlePluginVersion" | grep -o "\.[0-9]*\." | grep -o "[0-9]*")
+  patch=$(echo "$gradlePluginVersion" | grep -o "[0-9]*$")
+
+  echo "$major.$minor.$patch"
+}
+
 foojay_version=$(get_version "./node_modules/@react-native/gradle-plugin/settings.gradle.kts" "foojay.*version" "$FOOJAY_FALLBACK")
 kotlin_version=$(get_version "./node_modules/@react-native/gradle-plugin/gradle/libs.versions.toml" "kotlin =" "$KOTLIN_FALLBACK")
 tools_version=$(get_version "./patches/BlurView-build.gradle.patch" "gradle:" "$TOOLS_FALLBACK")
 hermes_version=$(get_version "./node_modules/react-native/ReactAndroid/gradle.properties" "VERSION_NAME" "$HERMES_FALLBACK")
-
+lint_version=$(get_gradle_lint_version)
 
 cat << EOF
 org.gradle.toolchains.foojay-resolver-convention:org.gradle.toolchains.foojay-resolver-convention.gradle.plugin:$foojay_version
 org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:$kotlin_version
 com.android.tools.build:gradle:$tools_version
 com.facebook.react:hermes-android:$hermes_version
-com.android.tools.lint:lint-gradle:31.1.1
+com.android.tools.lint:lint-gradle:$lint_version
 EOF

--- a/nix/pkgs/aapt2/default.nix
+++ b/nix/pkgs/aapt2/default.nix
@@ -10,6 +10,7 @@ let
 
   pname = "aapt2";
   # Warning: This must be the same as gradlePluginVersion android/gradle.properties
+  # also referenced in nix/deps/gradle/deps_hack.sh
   version = "8.1.1-10154469";
 
   pkgPath = "com/android/tools/build/aapt2";


### PR DESCRIPTION
## Summary
This PR generates the gradle-lint dependency version according to the rules specified here in hack script : 
https://googlesamples.github.io/android-custom-lint-rules/api-guide.html

<img width="712" alt="Screenshot_2025-02-18_at_3 17 30_PM" src="https://github.com/user-attachments/assets/6b91f6b5-00c5-4da1-98e1-fb901c4a4519" />

## Testing notes
not needed, this is yet another build change

## Platforms
- Android

status: ready