### PR TITLE
chore: trade apk size to speed up launch time

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,6 +135,9 @@ def getEnvOrConfig = { varName ->
 }
 
 android {
+    androidResources {
+        noCompress += ["bundle"]
+    }
     ndkVersion rootProject.ext.ndkVersion
 
     buildToolsVersion rootProject.ext.buildToolsVersion


### PR DESCRIPTION
## Summary

This PR un compresses the android bundle which apparently improves Time to Interactivity by 400ms.
There is a slight tradeoff in bundle size and I want to measure that.

This technique was first discovered and accepted by RN team here : https://github.com/facebook/react-native/pull/49449

## Platforms
- Android

status: ready