### PR TITLE
Fix keycard login flow options while usign empty keycard

### DIFF
--- a/src/status_im/contexts/keycard/error/view.cljs
+++ b/src/status_im/contexts/keycard/error/view.cljs
@@ -23,6 +23,7 @@
 (defn view
   []
   (let [error                       (rf/sub [:keycard/application-info-error])
+        logged-in?                  (rf/sub [:multiaccount/logged-in?])
         {:keys [title description]} (get titles error)]
     [:<>
      [quo/page-nav
@@ -37,21 +38,31 @@
       [quo/section-label
        {:section (i18n/label :t/what-you-can-do) :container-style {:padding-vertical 8}}]
       (if (= error :keycard/error.keycard-empty)
-        [quo/settings-item
-         {:title             (i18n/label :t/use-backup-keycard)
-          :image             :icon
-          :image-props       :i/placeholder
-          :action            :arrow
-          :description       :text
-          :description-props {:text (i18n/label :t/create-backup-profile-keycard)}
-          :on-press          (fn []
-                               (rf/dispatch [:show-bottom-sheet
-                                             {:content
-                                              (fn []
-                                                [backup.view/sheet
-                                                 {:on-continue
-                                                  (rf/dispatch
-                                                   [:keycard/backup.create-or-enter-pin])}])}]))}]
+        (if logged-in?
+          [quo/settings-item
+           {:title             (i18n/label :t/use-backup-keycard)
+            :image             :icon
+            :image-props       :i/placeholder
+            :action            :arrow
+            :description       :text
+            :description-props {:text (i18n/label :t/create-backup-profile-keycard)}
+            :on-press          (fn []
+                                 (rf/dispatch [:show-bottom-sheet
+                                               {:content
+                                                (fn []
+                                                  [backup.view/sheet
+                                                   {:on-continue
+                                                    (rf/dispatch
+                                                     [:keycard/backup.create-or-enter-pin])}])}]))}]
+          [quo/settings-item
+           {:title             (i18n/label :t/create-new-profile)
+            :image             :icon
+            :image-props       :i/profile
+            :action            :arrow
+            :description       :text
+            :description-props {:text (i18n/label :t/new-key-pair-keycard)}
+            :on-press          (fn []
+                                 (rf/dispatch [:keycard/create.get-phrase]))}])
         [:<>
          (when (or (= error :keycard/error.keycard-frozen)
                    (= error :keycard/error.keycard-locked))

--- a/src/status_im/navigation/effects.cljs
+++ b/src/status_im/navigation/effects.cljs
@@ -164,9 +164,9 @@
                                                                                  theme)})
                                                options
                                                (when sheet?
-                                                 options/sheet-options))}}]}})
-        (state/navigation-state-push {:id   component
-                                      :type :modal})))))
+                                                 options/sheet-options))}}]}})))
+    (state/navigation-state-push {:id   component
+                                  :type :modal})))
 
 (rf/reg-fx :open-modal-fx open-modal)
 


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/22024
fixes https://github.com/status-im/status-mobile/issues/22181

https://github.com/status-im/status-mobile/issues/22024#issuecomment-2679140503

>  I think at this point we are okay to show Create profile button to go with implementation shown in your video OR redirect user to "Backup recovery phrase flow" as it matches our current implementation of Create profile flow.

### Video

https://github.com/user-attachments/assets/c5d7fcc9-ef0f-450d-9a09-5fb235d44d94




status: ready