### PR TITLE
Wrong address opening when attempt to edit a saved one

### DIFF
--- a/src/status_im/app/events.cljs
+++ b/src/status_im/app/events.cljs
@@ -5,30 +5,34 @@
     [utils.re-frame :as rf]))
 
 
-;; whenever we need to publish notification we override the old and increment id
 (rf/reg-event-fx
  :app/notify-user
- (fn [{:keys [db]} [message]]
-   (let [last-message-id (get-in db [:app :last-user-notification] 0)]
-     {:db (assoc-in db
+ (fn [{:keys [db]} [{:keys [text type] :as message}]]
+   (let [notification-id (-> db
+                             (get-in [:app :last-user-notification] 0)
+                             inc)]
+     {;; whenever we need to publish notification we override the old and increment id
+      :db (assoc-in db
            [:app :last-user-notification]
            (merge message
-                  {:id (inc last-message-id)}))})))
+                  {:id notification-id}))
+      ;; TODO: toasts are part of ui layer and they shouldn't be published here. Instead some part
+      ;; of ui should keep track of last user notification and generate toast
+      :fx [[:dispatch
+            [:toasts/upsert
+             {:type type
+              :text text}]]]})))
 
 (comment
   (rf/dispatch [:app/notify-user
                 {:type :positive
-                 :text "This is a test notification10"}])
+                 :text "This is a good news"}])
   (rf/dispatch [:app/notify-user
                 {:type :negative
-                 :text "This is a test notification2"}])
-
-
-
+                 :text "This is a bad news"}])
 
   (rf/dispatch [:toasts/upsert
                 {:type :positive
                  :text "This is a test notification3"}])
-
 )
 

--- a/src/status_im/app/events.cljs
+++ b/src/status_im/app/events.cljs
@@ -2,37 +2,130 @@
   (:require
     [status-im.infra.transform :as transform]
     [taoensso.timbre :as log]
-    [utils.re-frame :as rf]))
+    [utils.re-frame :as rf]
+    [re-frame.db :as rfdb]
+    [re-frame.db :as db]))
 
 
-(rf/reg-event-fx
- :app/notify-user
- (fn [{:keys [db]} [{:keys [text type] :as message}]]
-   (let [notification-id (-> db
-                             (get-in [:app :last-user-notification] 0)
-                             inc)]
-     {;; whenever we need to publish notification we override the old and increment id
-      :db (assoc-in db
-           [:app :last-user-notification]
-           (merge message
-                  {:id notification-id}))
-      ;; TODO: toasts are part of ui layer and they shouldn't be published here. Instead some part
-      ;; of ui should keep track of last user notification and generate toast
-      :fx [[:dispatch
-            [:toasts/upsert
-             {:type type
-              :text text}]]]})))
+(def navigation-effects-tree
+  {:uc-view-saved-addresses
+   {:on-start               [[:dispatch [:open-modal :screen/settings.saved-addresses]]]
+    :uc-add-saved-addresses {:on-start  [[:dispatch [:open-modal :screen/settings.add-address-to-save]]]
+                             :on-finish [[:dispatch [:navigate-back]]]}
+    :on-finish              [[:dispatch [:navigate-back]]]}})
+
+
+(def db-path-use-case-stack [:app :use-cases-stack])
+
+(defn use-cases
+  [db]
+  (get-in db db-path-use-case-stack '()))
+
+(defn current-use-case
+  [db]
+  (-> db
+      use-cases
+      first))
+
+(defn- navigation-effects-for-key
+  [db last-key]
+  (let [path (-> db
+                 use-cases
+                 reverse
+                 vec
+                 (conj last-key))]
+    (tap> {:in        :navigation-effects-for-key
+           :use-cases (use-cases db)})
+    (get-in navigation-effects-tree path)))
+
+(defn start-use-case-navigation-effects
+  [db]
+  (navigation-effects-for-key db :on-start))
+
+(defn finish-use-case-navigation-effects
+  [db]
+  (navigation-effects-for-key db :on-finish))
+
+
+(rf/reg-event-fx :app/start-use-case
+ (fn [{:keys [db]} [use-case-name]]
+   (let [new-db (update-in db db-path-use-case-stack conj use-case-name)]
+     #_(tap> {:in      :app/start-use-case
+              :effects (start-use-case-navigation-effects new-db)})
+     {:db new-db
+      :fx (start-use-case-navigation-effects new-db)})))
+
+(rf/reg-event-fx :app/finish-use-case
+ (fn [{:keys [db]} [use-case-to-finish]]
+   (let [new-db (update-in db db-path-use-case-stack rest)]
+     (if (= (current-use-case db) use-case-to-finish)
+       {:db new-db
+        :fx (finish-use-case-navigation-effects db)}
+       ;; TODO: kozieiev: replace with effect
+       (log/error "Attempt to finish use case that is not current:" use-case-to-finish)))))
+
+(rf/reg-event-fx :app/clear-use-cases-stack
+ (fn [{:keys [db]}]
+   {:db (assoc-in db db-path-use-case-stack '())}))
 
 (comment
-  (rf/dispatch [:app/notify-user
-                {:type :positive
-                 :text "This is a good news"}])
-  (rf/dispatch [:app/notify-user
-                {:type :negative
-                 :text "This is a bad news"}])
+  (rf/dispatch [:app/start-use-case :uc-save-address])
+  (rf/dispatch [:app/start-use-case :uc-edit-address])
+  (rf/dispatch [:app/finish-use-case :uc-edit-address])
+  (rf/dispatch [:app/finish-use-case :uc-save-address])
 
-  (rf/dispatch [:toasts/upsert
-                {:type :positive
-                 :text "This is a test notification3"}])
+
+  (rf/dispatch [:app/clear-use-cases-stack])
+
+  (rf/sub [:app/use-case-active? :uc-edit-address])
+  (rf/sub [:app/use-case-active? :uc-save-address])
+  (rf/sub [:app/current-use-case])
+  (rf/dispatch [:navigate-back])
+
+  (start-use-case-navigation-effects {:app {:use-cases-stack
+                                            '(:uc-view-saved-addresses :uc-add-saved-addresses)}})
+  (finish-use-case-navigation-effects {:app {:use-cases-stack
+                                             '(:uc-view-saved-addresses :uc-add-saved-addresses)}})
+
+  (use-cases {:app {:use-cases-stack
+                    '(:uc-view-saved-addresses :uc-add-saved-addresses)}})
+
+  (-> {:app {:use-cases-stack '(:uc-view-saved-addresses :uc-add-saved-addresses)}}
+      use-cases
+      reverse
+      vec
+      (conj :on-exit))
+
+
 )
 
+#_(rf/reg-event-fx
+   :app/notify-user
+   (fn [{:keys [db]} [{:keys [text type] :as message}]]
+     (let [notification-id (-> db
+                               (get-in [:app :last-user-notification :id] 0)
+                               inc)]
+       {;; whenever we need to publish notification we override the old and increment id
+        :db (assoc-in db
+             [:app :last-user-notification]
+             (merge message
+                    {:id notification-id}))
+        ;; TODO: toasts are part of ui layer and they shouldn't be published here. Instead some part
+        ;; of ui should keep track of last user notification and generate toast
+        :fx [#_[:dispatch
+                [:toasts/upsert
+                 {:type type
+                  :text text}]]]})))
+
+#_(comment
+    (rf/dispatch [:app/notify-user
+                  {:type :positive
+                   :text "This is a good news"}])
+    (rf/dispatch [:app/notify-user
+                  {:type :negative
+                   :text "This is a bad news"}])
+
+    (rf/dispatch [:toasts/upsert
+                  {:type :positive
+                   :text "This is a test notification3"}])
+  )

--- a/src/status_im/app/events.cljs
+++ b/src/status_im/app/events.cljs
@@ -5,42 +5,15 @@
     [utils.re-frame :as rf]))
 
 
-
+;; whenever we need to publish notification we override the old and increment id
 (rf/reg-event-fx
  :app/notify-user
  (fn [{:keys [db]} [message]]
-   {:db (assoc-in db [:app :last-user-notification] message)}))
-
-(rf/reg-event-fx
- :app/set-view-id
- (fn [{:keys [db]} [value]]
-   (let [new-db (assoc db :view-id value)]
-     (tap> {:in    :set-view-id
-            :value value})
-
-     {:db new-db})))
-
-(rf/reg-event-fx
- :app/inc-toast
- (fn [{:keys [db]} [opts]]
-   (let [{:keys [ordered toasts]} (:toasts db)
-         next-toast-number        (get-in db [:toasts :next-toast-number] 1)
-         id                       (or (:id opts)
-                                      (str "toast-" next-toast-number))
-         update?                  (some #(= % id) ordered)
-         ordered                  (if (not update?)
-                                    (conj ordered id)
-                                    ordered)
-         toasts                   (assoc toasts id (dissoc opts :id))]
-     (cond-> {:db (-> db
-                      (update :toasts assoc :ordered ordered :toasts toasts)
-                      (update :toasts dissoc :hide-toasts-timer-set))}
-
-       #_(and (not update?) (= (count ordered) 1))
-       #_(assoc :show-toasts [(:view-id db) (or (:theme opts) (:theme db))])
-
-       #_(not (:id opts))
-       #_(update-in [:db :toasts :next-toast-number] inc)))))
+   (let [last-message-id (get-in db [:app :last-user-notification] 0)]
+     {:db (assoc-in db
+           [:app :last-user-notification]
+           (merge message
+                  {:id (inc last-message-id)}))})))
 
 (comment
   (rf/dispatch [:app/notify-user
@@ -50,8 +23,6 @@
                 {:type :negative
                  :text "This is a test notification2"}])
 
-  (rf/dispatch [:app/set-view-id :test1])
-  (rf/dispatch [:app/set-view-id :test2])
 
 
 
@@ -59,16 +30,5 @@
                 {:type :positive
                  :text "This is a test notification3"}])
 
-  (rf/dispatch [:app/inc-toast
-                {:type :positive
-                 :text "This is a test notification4"}])
-
-  (rf/dispatch [:app/inc-toast
-                {:type :positive
-                 :text "This is a test notification5"}])
-
-  (rf/dispatch [:app/inc-toast
-                1])
-
-  (rf/sub [:app/last-user-notification]))
+)
 

--- a/src/status_im/app/events.cljs
+++ b/src/status_im/app/events.cljs
@@ -1,0 +1,74 @@
+(ns status-im.app.events
+  (:require
+    [status-im.infra.transform :as transform]
+    [taoensso.timbre :as log]
+    [utils.re-frame :as rf]))
+
+
+
+(rf/reg-event-fx
+ :app/notify-user
+ (fn [{:keys [db]} [message]]
+   {:db (assoc-in db [:app :last-user-notification] message)}))
+
+(rf/reg-event-fx
+ :app/set-view-id
+ (fn [{:keys [db]} [value]]
+   (let [new-db (assoc db :view-id value)]
+     (tap> {:in    :set-view-id
+            :value value})
+
+     {:db new-db})))
+
+(rf/reg-event-fx
+ :app/inc-toast
+ (fn [{:keys [db]} [opts]]
+   (let [{:keys [ordered toasts]} (:toasts db)
+         next-toast-number        (get-in db [:toasts :next-toast-number] 1)
+         id                       (or (:id opts)
+                                      (str "toast-" next-toast-number))
+         update?                  (some #(= % id) ordered)
+         ordered                  (if (not update?)
+                                    (conj ordered id)
+                                    ordered)
+         toasts                   (assoc toasts id (dissoc opts :id))]
+     (cond-> {:db (-> db
+                      (update :toasts assoc :ordered ordered :toasts toasts)
+                      (update :toasts dissoc :hide-toasts-timer-set))}
+
+       #_(and (not update?) (= (count ordered) 1))
+       #_(assoc :show-toasts [(:view-id db) (or (:theme opts) (:theme db))])
+
+       #_(not (:id opts))
+       #_(update-in [:db :toasts :next-toast-number] inc)))))
+
+(comment
+  (rf/dispatch [:app/notify-user
+                {:type :positive
+                 :text "This is a test notification10"}])
+  (rf/dispatch [:app/notify-user
+                {:type :negative
+                 :text "This is a test notification2"}])
+
+  (rf/dispatch [:app/set-view-id :test1])
+  (rf/dispatch [:app/set-view-id :test2])
+
+
+
+  (rf/dispatch [:toasts/upsert
+                {:type :positive
+                 :text "This is a test notification3"}])
+
+  (rf/dispatch [:app/inc-toast
+                {:type :positive
+                 :text "This is a test notification4"}])
+
+  (rf/dispatch [:app/inc-toast
+                {:type :positive
+                 :text "This is a test notification5"}])
+
+  (rf/dispatch [:app/inc-toast
+                1])
+
+  (rf/sub [:app/last-user-notification]))
+

--- a/src/status_im/common/toasts/events.cljs
+++ b/src/status_im/common/toasts/events.cljs
@@ -44,8 +44,8 @@
           effect                   {:db db}]
       (if empty-ordered?
         (-> effect
-            #_(update-in [:db :toasts] assoc :hide-toasts-timer-set true)
-            #_(assoc :dispatch-later [{:ms 500 :dispatch [:toasts/hide-with-check]}]))
+            (update-in [:db :toasts] assoc :hide-toasts-timer-set true)
+            (assoc :dispatch-later [{:ms 500 :dispatch [:toasts/hide-with-check]}]))
         effect))))
 
 (rf/defn close-all-toasts

--- a/src/status_im/common/toasts/events.cljs
+++ b/src/status_im/common/toasts/events.cljs
@@ -44,8 +44,8 @@
           effect                   {:db db}]
       (if empty-ordered?
         (-> effect
-            (update-in [:db :toasts] assoc :hide-toasts-timer-set true)
-            (assoc :dispatch-later [{:ms 500 :dispatch [:toasts/hide-with-check]}]))
+            #_(update-in [:db :toasts] assoc :hide-toasts-timer-set true)
+            #_(assoc :dispatch-later [{:ms 500 :dispatch [:toasts/hide-with-check]}]))
         effect))))
 
 (rf/defn close-all-toasts

--- a/src/status_im/common/toasts/style.cljs
+++ b/src/status_im/common/toasts/style.cljs
@@ -3,12 +3,13 @@
 
 (defn outmost-transparent-container
   []
-  {:elevation       2
-   :pointer-events  :box-none
-   :padding-top     (+ (safe-area/get-top) 6)
-   :flex-direction  :column
-   :justify-content :center
-   :align-items     :center})
+  {:elevation        2
+   :pointer-events   :box-none
+   :padding-top      (+ (safe-area/get-top) 6)
+   :flex-direction   :column
+   :justify-content  :center
+   :align-items      :center
+   :background-color :yellow})
 
 (def each-toast-container
   {:width         "100%"

--- a/src/status_im/common/toasts/view.cljs
+++ b/src/status_im/common/toasts/view.cljs
@@ -58,6 +58,8 @@
 
 (defn toasts
   []
+  (tap> {:in   :toasts
+         :data (rf/sub [:view-id])})
   (->> (rf/sub [:toasts])
        :ordered
        (into [rn/view {:style (style/outmost-transparent-container)}]

--- a/src/status_im/common/toasts/view.cljs
+++ b/src/status_im/common/toasts/view.cljs
@@ -58,9 +58,15 @@
 
 (defn toasts
   []
-  (tap> {:in   :toasts
-         :data (rf/sub [:view-id])})
+  (tap> {:in           :toasts
+         :data         (rf/sub [:view-id])
+         :notification (rf/sub [:app/last-user-notification])})
+  (rf/sub [:app/last-user-notification])
+  (rf/dispatch [:toasts/upsert
+                {:type :positive
+                 :text "This is a test notification3"}])
   (->> (rf/sub [:toasts])
+       #_(rf/sub [:app/last-user-notification])
        :ordered
        (into [rn/view {:style (style/outmost-transparent-container)}]
              (map #(with-meta [f-container %] {:key %})))))

--- a/src/status_im/common/toasts/view.cljs
+++ b/src/status_im/common/toasts/view.cljs
@@ -58,15 +58,7 @@
 
 (defn toasts
   []
-  (tap> {:in           :toasts
-         :data         (rf/sub [:view-id])
-         :notification (rf/sub [:app/last-user-notification])})
-  (rf/sub [:app/last-user-notification])
-  (rf/dispatch [:toasts/upsert
-                {:type :positive
-                 :text "This is a test notification3"}])
   (->> (rf/sub [:toasts])
-       #_(rf/sub [:app/last-user-notification])
        :ordered
        (into [rn/view {:style (style/outmost-transparent-container)}]
              (map #(with-meta [f-container %] {:key %})))))

--- a/src/status_im/contexts/chat/messenger/messages/transport/events.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/transport/events.cljs
@@ -21,7 +21,7 @@
     [status-im.contexts.chat.messenger.messages.pin.events :as messages.pin]
     [status-im.contexts.communities.events :as communities]
     [status-im.contexts.shell.activity-center.events :as activity-center]
-    [status-im.contexts.wallet.data-store :as wallet.data-store]
+    [status-im.infra.transform :as infra.transform]
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]))
 
@@ -220,10 +220,10 @@
                    current-visibility-status-clj)))
 
       (seq saved-addresses-js)
-      (let [saved-addresses (-> saved-addresses-js types/js->clj wallet.data-store/rpc->saved-addresses)]
+      (let [saved-addresses (-> saved-addresses-js types/js->clj infra.transform/rpc->saved-addresses)]
         (js-delete response-js "savedAddresses")
         (rf/merge cofx
-                  {:fx [[:dispatch [:wallet/reconcile-saved-addresses saved-addresses]]]}
+                  {:fx [[:dispatch [:domain/reconcile-saved-addresses saved-addresses]]]}
                   (process-next response-js sync-handler)))
 
       (seq ens-username-details-js)

--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -164,15 +164,12 @@
         on-press-continue                   (rn/use-callback
                                              (fn []
                                                (rf/dispatch
-                                                [:wallet/set-address-to-save
+                                                [:open-modal :screen/settings.save-address
                                                  {:address address
                                                   :ens     (when ens-name? address-or-ens)
-                                                  :ens?    ens-name?}])
-                                               (rf/dispatch
-                                                [:open-modal :screen/settings.save-address]))
+                                                  :ens?    ens-name?}]))
                                              [address ens-name? address-or-ens])]
     (rn/use-unmount #(rf/dispatch [:wallet/clean-scanned-address]))
-    (rn/use-mount #(rf/dispatch [:wallet/clear-address-to-save]))
     [quo/overlay {:type :shell}
      [floating-button-page/view
       {:footer-container-padding     0

--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -15,7 +15,8 @@
 
 (defn- navigate-back
   []
-  (rf/dispatch [:navigate-back]))
+  (rf/dispatch [:app/finish-use-case :uc-add-saved-addresses])
+  #_(rf/dispatch [:navigate-back]))
 
 (defn- validate-input
   [account-addresses saved-addresses user-input]
@@ -170,6 +171,10 @@
                                                   :ens?    ens-name?}]))
                                              [address ens-name? address-or-ens])]
     (rn/use-unmount #(rf/dispatch [:wallet/clean-scanned-address]))
+    #_(rn/use-effect (fn []
+                       (when (rf/sub [:app/use-case-active? :uc-add-saved-addresses])
+                         (rf/dispatch [:navigate-back])))
+                     [(rf/sub [:app/use-case-active? :uc-add-saved-addresses])])
     [quo/overlay {:type :shell}
      [floating-button-page/view
       {:footer-container-padding     0

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
@@ -143,18 +143,6 @@
 
 (rf/reg-event-fx :wallet/add-saved-address-failed add-saved-address-failed)
 
-(defn set-address-to-save
-  [{:keys [db]} [args]]
-  {:db (assoc-in db [:wallet :ui :saved-address] args)})
-
-(rf/reg-event-fx :wallet/set-address-to-save set-address-to-save)
-
-(defn clear-address-to-save
-  [{:keys [db]}]
-  {:db (update-in db [:wallet :ui] dissoc :saved-address)})
-
-(rf/reg-event-fx :wallet/clear-address-to-save clear-address-to-save)
-
 (defn check-remaining-capacity-for-saved-addresses
   [{:keys [db]} [{:keys [on-success on-error]}]]
   (let [test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))]

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
@@ -7,68 +7,31 @@
 
 (defn save-address
   [{:keys [db]}
-   [{:keys [address name customization-color on-success on-error ens]}]]
-  (let [test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))
-        address-to-save        {:address address
-                                :name    name
-                                :colorId customization-color
-                                :ens     ens
-                                :isTest  test-networks-enabled?}]
+   [{:keys [address name customization-color ens edit?]}]]
+  (let [on-error [:wallet/add-saved-address-failed]
+        on-success
+        (if edit?
+          [:wallet/edit-saved-address-success]
+          [:wallet/add-saved-address-success])
+        test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))
+        address-to-save {:address address
+                         :name    name
+                         :colorId customization-color
+                         :ens     ens
+                         :isTest  test-networks-enabled?}]
     {:fx [[:json-rpc/call
            [{:method     "wakuext_upsertSavedAddress"
              :params     [address-to-save]
              :on-success on-success
              :on-error   on-error}]]]}))
 
-(rf/reg-event-fx :wallet/save-address save-address)
-
-(defn- update-saved-addresses
-  [saved-addresses-db new-saved-addresses]
-  (reduce
-   (fn [acc {:keys [address removed? test?] :as saved-address}]
-     (let [db-key (if test? :test :prod)]
-       (if removed?
-         (update acc db-key dissoc address)
-         (assoc-in acc [db-key address] saved-address))))
-   (or saved-addresses-db
-       {:test {}
-        :prod {}})
-   new-saved-addresses))
-
-(defn reconcile-saved-addresses
-  [{:keys [db]} [saved-addresses]]
-  {:db (update-in db [:wallet :saved-addresses] update-saved-addresses saved-addresses)})
-
-(rf/reg-event-fx :wallet/reconcile-saved-addresses reconcile-saved-addresses)
-
-(defn get-saved-addresses-success
-  [_ [raw-saved-addresses]]
-  (let [saved-addresses (data-store/rpc->saved-addresses raw-saved-addresses)]
-    {:fx [[:dispatch [:wallet/reconcile-saved-addresses saved-addresses]]]}))
-
-(rf/reg-event-fx :wallet/get-saved-addresses-success get-saved-addresses-success)
-
-(defn saved-addresses-rpc-error
-  [_ [action error]]
-  (log/warn (str "[wallet] [saved-addresses] Failed to " action)
-            {:error error}))
-
-(rf/reg-event-fx :wallet/saved-addresses-rpc-error saved-addresses-rpc-error)
-
-(defn get-saved-addresses
-  [_]
-  {:fx [[:json-rpc/call
-         [{:method     "wakuext_getSavedAddresses"
-           :on-success [:wallet/get-saved-addresses-success]
-           :on-error   [:wallet/saved-addresses-rpc-error :get-saved-addresses]}]]]})
-
-(rf/reg-event-fx :wallet/get-saved-addresses get-saved-addresses)
+(rf/reg-event-fx :app/save-address save-address)
 
 (defn delete-saved-address-success
   [{:keys [db]} [{:keys [address test-networks-enabled? toast-message]}]]
   (let [db-key        (if test-networks-enabled? :test :prod)
         saved-address (get-in db [:wallet :saved-addresses db-key address])]
-    {:fx [[:dispatch [:wallet/reconcile-saved-addresses [(assoc saved-address :removed? true)]]]
+    {:fx [[:dispatch [:domain/reconcile-saved-addresses [(assoc saved-address :removed? true)]]]
           [:dispatch [:hide-bottom-sheet]]
           [:dispatch-later
            {:ms       100
@@ -106,8 +69,8 @@
 (rf/reg-event-fx :wallet/delete-saved-address delete-saved-address)
 
 (defn add-saved-address-success
-  [_ [toast-message]]
-  {:fx [[:dispatch [:wallet/get-saved-addresses]]
+  [_]
+  {:fx [[:dispatch [:infra/get-saved-addresses]]
         [:dispatch [:dismiss-modal :screen/settings.add-address-to-save]]
         [:dispatch [:dismiss-modal :screen/settings.save-address]]
         [:dispatch-later
@@ -115,13 +78,13 @@
           :dispatch [:toasts/upsert
                      {:type  :positive
                       :theme :dark
-                      :text  toast-message}]}]]})
+                      :text  (i18n/label :t/address-saved)}]}]]})
 
 (rf/reg-event-fx :wallet/add-saved-address-success add-saved-address-success)
 
 (defn edit-saved-address-success
   [_]
-  {:fx [[:dispatch [:wallet/get-saved-addresses]]
+  {:fx [[:dispatch [:infra/get-saved-addresses]]
         [:dispatch [:dismiss-modal :screen/settings.edit-saved-address]]
         [:dispatch-later
          {:ms       100
@@ -134,7 +97,7 @@
 
 (defn add-saved-address-failed
   [_ [error]]
-  {:fx [[:dispatch [:wallet/saved-addresses-rpc-error :add-save-address error]]
+  {:fx [[:dispatch [:infra/saved-addresses-rpc-error :add-save-address error]]
         [:dispatch
          [:toasts/upsert
           {:type  :negative

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
@@ -5,115 +5,97 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(defn save-address
-  [{:keys [db]}
-   [{:keys [address name customization-color ens edit?]}]]
-  (let [on-error [:wallet/add-saved-address-failed]
-        on-success
-        (if edit?
-          [:wallet/edit-saved-address-success]
-          [:wallet/add-saved-address-success])
-        test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))
-        address-to-save {:address address
-                         :name    name
-                         :colorId customization-color
-                         :ens     ens
-                         :isTest  test-networks-enabled?}]
-    {:fx [[:json-rpc/call
-           [{:method     "wakuext_upsertSavedAddress"
-             :params     [address-to-save]
-             :on-success on-success
-             :on-error   on-error}]]]}))
+(rf/reg-event-fx :app/save-address
+ (fn [{:keys [db]}
+      [{:keys [address name customization-color ens edit?]}]]
+   (let [on-success             (if edit?
+                                  [:wallet/edit-saved-address-success]
+                                  [:wallet/add-saved-address-success])
+         test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))
+         address-to-save        {:address address
+                                 :name    name
+                                 :colorId customization-color
+                                 :ens     ens
+                                 :isTest  test-networks-enabled?}]
+     {:fx [[:json-rpc/call
+            [{:method     "wakuext_upsertSavedAddress"
+              :params     [address-to-save]
+              :on-success on-success
+              :on-error   [:wallet/add-saved-address-failed]}]]]})))
 
-(rf/reg-event-fx :app/save-address save-address)
+(rf/reg-event-fx :wallet/delete-saved-address-success
+ (fn [{:keys [db]} [{:keys [address test-networks-enabled? toast-message]}]]
+   (let [db-key        (if test-networks-enabled? :test :prod)
+         saved-address (get-in db [:wallet :saved-addresses db-key address])]
+     {:fx [[:dispatch [:domain/reconcile-saved-addresses [(assoc saved-address :removed? true)]]]
+           [:dispatch [:hide-bottom-sheet]]
+           [:dispatch-later
+            {:ms       100
+             :dispatch [:toasts/upsert
+                        {:type  :positive
+                         :theme :dark
+                         :text  toast-message}]}]]})))
 
-(defn delete-saved-address-success
-  [{:keys [db]} [{:keys [address test-networks-enabled? toast-message]}]]
-  (let [db-key        (if test-networks-enabled? :test :prod)
-        saved-address (get-in db [:wallet :saved-addresses db-key address])]
-    {:fx [[:dispatch [:domain/reconcile-saved-addresses [(assoc saved-address :removed? true)]]]
-          [:dispatch [:hide-bottom-sheet]]
-          [:dispatch-later
-           {:ms       100
-            :dispatch [:toasts/upsert
-                       {:type  :positive
-                        :theme :dark
-                        :text  toast-message}]}]]}))
+(rf/reg-event-fx :wallet/delete-saved-address-failed
+ (fn [_ [error]]
+   {:fx [[:dispatch [:hide-bottom-sheet]]
+         [:dispatch-later
+          {:ms       100
+           :dispatch [:toasts/upsert
+                      {:type  :negative
+                       :theme :dark
+                       :text  error}]}]]}))
 
-(rf/reg-event-fx :wallet/delete-saved-address-success delete-saved-address-success)
+(rf/reg-event-fx :wallet/delete-saved-address
+ (fn [{:keys [db]} [{:keys [address toast-message]}]]
+   (let [test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))]
+     {:fx [[:json-rpc/call
+            [{:method     "wakuext_deleteSavedAddress"
+              :params     [address test-networks-enabled?]
+              :on-success [:wallet/delete-saved-address-success
+                           {:address                address
+                            :test-networks-enabled? test-networks-enabled?
+                            :toast-message          toast-message}]
+              :on-error   [:wallet/delete-saved-address-failed]}]]]})))
 
-(defn delete-saved-address-failed
-  [_ [error]]
-  {:fx [[:dispatch [:hide-bottom-sheet]]
-        [:dispatch-later
-         {:ms       100
-          :dispatch [:toasts/upsert
-                     {:type  :negative
-                      :theme :dark
-                      :text  error}]}]]})
+(rf/reg-event-fx :wallet/add-saved-address-success
+ (fn [_]
+   {:fx [[:dispatch [:infra/get-saved-addresses]]
+         [:dispatch [:dismiss-modal :screen/settings.add-address-to-save]]
+         [:dispatch [:dismiss-modal :screen/settings.save-address]]
+         [:dispatch-later
+          {:ms       100
+           :dispatch [:toasts/upsert
+                      {:type  :positive
+                       :theme :dark
+                       :text  (i18n/label :t/address-saved)}]}]]}))
 
-(rf/reg-event-fx :wallet/delete-saved-address-failed delete-saved-address-failed)
+(rf/reg-event-fx :wallet/edit-saved-address-success
+ (fn [_]
+   {:fx [[:dispatch [:infra/get-saved-addresses]]
+         [:dispatch [:dismiss-modal :screen/settings.edit-saved-address]]
+         [:dispatch-later
+          {:ms       100
+           :dispatch [:toasts/upsert
+                      {:type  :positive
+                       :theme :dark
+                       :text  (i18n/label :t/address-edited)}]}]]}))
 
-(defn delete-saved-address
-  [{:keys [db]} [{:keys [address toast-message]}]]
-  (let [test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))]
-    {:fx [[:json-rpc/call
-           [{:method     "wakuext_deleteSavedAddress"
-             :params     [address test-networks-enabled?]
-             :on-success [:wallet/delete-saved-address-success
-                          {:address                address
-                           :test-networks-enabled? test-networks-enabled?
-                           :toast-message          toast-message}]
-             :on-error   [:wallet/delete-saved-address-failed]}]]]}))
 
-(rf/reg-event-fx :wallet/delete-saved-address delete-saved-address)
-
-(defn add-saved-address-success
-  [_]
-  {:fx [[:dispatch [:infra/get-saved-addresses]]
-        [:dispatch [:dismiss-modal :screen/settings.add-address-to-save]]
-        [:dispatch [:dismiss-modal :screen/settings.save-address]]
-        [:dispatch-later
-         {:ms       100
-          :dispatch [:toasts/upsert
-                     {:type  :positive
-                      :theme :dark
-                      :text  (i18n/label :t/address-saved)}]}]]})
-
-(rf/reg-event-fx :wallet/add-saved-address-success add-saved-address-success)
-
-(defn edit-saved-address-success
-  [_]
-  {:fx [[:dispatch [:infra/get-saved-addresses]]
-        [:dispatch [:dismiss-modal :screen/settings.edit-saved-address]]
-        [:dispatch-later
-         {:ms       100
-          :dispatch [:toasts/upsert
-                     {:type  :positive
-                      :theme :dark
-                      :text  (i18n/label :t/address-edited)}]}]]})
-
-(rf/reg-event-fx :wallet/edit-saved-address-success edit-saved-address-success)
-
-(defn add-saved-address-failed
-  [_ [error]]
-  {:fx [[:dispatch [:infra/saved-addresses-rpc-error :add-save-address error]]
-        [:dispatch
-         [:toasts/upsert
-          {:type  :negative
-           :theme :dark
-           :text  error}]]]})
-
-(rf/reg-event-fx :wallet/add-saved-address-failed add-saved-address-failed)
-
-(defn check-remaining-capacity-for-saved-addresses
-  [{:keys [db]} [{:keys [on-success on-error]}]]
-  (let [test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))]
-    {:fx [[:json-rpc/call
-           [{:method     "wakuext_remainingCapacityForSavedAddresses"
-             :params     [test-networks-enabled?]
-             :on-success on-success
-             :on-error   on-error}]]]}))
+(rf/reg-event-fx :wallet/add-saved-address-failed
+ (fn [_ [error]]
+   {:fx [[:dispatch [:infra/saved-addresses-rpc-error :add-save-address error]]
+         [:dispatch
+          [:toasts/upsert
+           {:type  :negative
+            :theme :dark
+            :text  error}]]]}))
 
 (rf/reg-event-fx :wallet/check-remaining-capacity-for-saved-addresses
- check-remaining-capacity-for-saved-addresses)
+ (fn [{:keys [db]} [{:keys [on-success on-error]}]]
+   (let [test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))]
+     {:fx [[:json-rpc/call
+            [{:method     "wakuext_remainingCapacityForSavedAddresses"
+              :params     [test-networks-enabled?]
+              :on-success on-success
+              :on-error   on-error}]]]})))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events_test.cljs
@@ -12,7 +12,7 @@
           result-fx   (:fx effects)
           expected-fx [[:json-rpc/call
                         [{:method     "wakuext_getSavedAddresses"
-                          :on-success [:wallet/get-saved-addresses-success]
+                          :on-success [:infra/convert-saved-addresses]
                           :on-error   [:wallet/saved-addresses-rpc-error :get-saved-addresses]}]]]]
       (is (match? expected-fx result-fx)))))
 
@@ -56,10 +56,10 @@
 (deftest get-saved-addresses-success-test
   (let [cofx                {:db {}}
         raw-saved-addresses [saved-address-rpc-1]
-        effects             (events/get-saved-addresses-success cofx [raw-saved-addresses])
+        effects             (events/convert-saved-addresses cofx [raw-saved-addresses])
         saved-addresses     (data-store/rpc->saved-addresses raw-saved-addresses)
         result-fx           (:fx effects)
-        expected-fx         [[:dispatch [:wallet/reconcile-saved-addresses saved-addresses]]]]
+        expected-fx         [[:dispatch [:domain/reconcile-saved-addresses saved-addresses]]]]
     (is (match? expected-fx result-fx))))
 
 (deftest reconcile-saved-addresses-test
@@ -220,7 +220,7 @@
           toast-message "Address saved"
           effects       (events/add-saved-address-success cofx [toast-message])
           result-fx     (:fx effects)
-          expected-fx   [[:dispatch [:wallet/get-saved-addresses]]
+          expected-fx   [[:dispatch [:infra/get-saved-addresses]]
                          [:dispatch [:dismiss-modal :screen/settings.add-address-to-save]]
                          [:dispatch [:dismiss-modal :screen/settings.save-address]]
                          [:dispatch-later
@@ -238,7 +238,7 @@
           toast-message "Address edited"
           effects       (events/edit-saved-address-success cofx)
           result-fx     (:fx effects)
-          expected-fx   [[:dispatch [:wallet/get-saved-addresses]]
+          expected-fx   [[:dispatch [:infra/get-saved-addresses]]
                          [:dispatch [:dismiss-modal :screen/settings.edit-saved-address]]
                          [:dispatch-later
                           {:ms       100

--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -17,50 +17,48 @@
 
 (defn view
   []
-  (let [{:keys [edit?]} (rf/sub [:get-screen-params])
-        {:keys [address name customization-color ens ens?]}
-        (rf/sub [:wallet/saved-address])
+  (let [{:keys [address name customization-color ens
+                ens? edit?]}              (rf/sub [:get-screen-params])
         [address-label set-address-label] (rn/use-state (or name ""))
         [address-color set-address-color] (rn/use-state (or customization-color
                                                             (rand-nth colors/account-colors)))
-        placeholder (i18n/label :t/address-name)
-        address-text (rn/use-callback
-                      (fn []
-                        [quo/address-text
-                         {:full-address? true
-                          :address       address
-                          :format        :long}])
-                      [address])
-        on-press-save (rn/use-callback
-                       (fn []
-                         (rf/dispatch [:wallet/save-address
-                                       {:on-success
-                                        (if edit?
-                                          [:wallet/edit-saved-address-success]
-                                          [:wallet/add-saved-address-success
-                                           (i18n/label :t/address-saved)])
-                                        :on-error
-                                        [:wallet/add-saved-address-failed]
-                                        :name address-label
-                                        :ens (when ens? ens)
-                                        :address address
-                                        :customization-color address-color}]))
-                       [address address-label
-                        address-color])
-        data-item-props (rn/use-memo
-                         #(cond-> {:status          :default
-                                   :size            :default
-                                   :subtitle-type   :default
-                                   :label           :none
-                                   :blur?           true
-                                   :card?           true
-                                   :title           (i18n/label :t/address)
-                                   :subtitle        ens
-                                   :custom-subtitle address-text
-                                   :container-style style/data-item}
-                            ens?
-                            (dissoc :custom-subtitle))
-                         [ens ens? address-text])]
+        placeholder                       (i18n/label :t/address-name)
+        address-text                      (rn/use-callback
+                                           (fn []
+                                             [quo/address-text
+                                              {:full-address? true
+                                               :address       address
+                                               :format        :long}])
+                                           [address])
+        on-press-save                     (rn/use-callback
+                                           (fn []
+                                             (rf/dispatch [:wallet/save-address
+                                                           {:on-success
+                                                            (if edit?
+                                                              [:wallet/edit-saved-address-success]
+                                                              [:wallet/add-saved-address-success
+                                                               (i18n/label :t/address-saved)])
+                                                            :on-error
+                                                            [:wallet/add-saved-address-failed]
+                                                            :name address-label
+                                                            :ens (when ens? ens)
+                                                            :address address
+                                                            :customization-color address-color}]))
+                                           [address address-label
+                                            address-color])
+        data-item-props                   (rn/use-memo
+                                           #(cond-> {:status          :default
+                                                     :size            :default
+                                                     :subtitle-type   :default
+                                                     :blur?           true
+                                                     :card?           true
+                                                     :title           (i18n/label :t/address)
+                                                     :subtitle        ens
+                                                     :custom-subtitle address-text
+                                                     :container-style style/data-item}
+                                              ens?
+                                              (dissoc :custom-subtitle))
+                                           [ens ens? address-text])]
     [quo/overlay {:type :shell}
      [floating-button-page/view
       {:footer-container-padding     (if edit? (+ (safe-area/get-bottom) 12) 0)

--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -32,17 +32,11 @@
                                            [address])
         on-press-save                     (rn/use-callback
                                            (fn []
-                                             (rf/dispatch [:wallet/save-address
-                                                           {:on-success
-                                                            (if edit?
-                                                              [:wallet/edit-saved-address-success]
-                                                              [:wallet/add-saved-address-success
-                                                               (i18n/label :t/address-saved)])
-                                                            :on-error
-                                                            [:wallet/add-saved-address-failed]
-                                                            :name address-label
-                                                            :ens (when ens? ens)
-                                                            :address address
+                                             (rf/dispatch [:app/save-address
+                                                           {:edit?               edit?
+                                                            :name                address-label
+                                                            :ens                 (when ens? ens)
+                                                            :address             address
                                                             :customization-color address-color}]))
                                            [address address-label
                                             address-color])

--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -9,7 +9,7 @@
     [utils.re-frame :as rf]))
 
 (defn view
-  [{:keys [name address customization-color] :as opts}]
+  [{:keys [name address customization-color] :as address-details}]
   (let [open-send-flow                 (rn/use-callback
                                         (fn []
                                           (rf/dispatch [:wallet/init-send-flow-for-address
@@ -62,19 +62,20 @@
                                            {:theme   :dark
                                             :shell?  true
                                             :content (fn []
-                                                       [remove-address/view opts])}])
-                                        [opts])
+                                                       [remove-address/view address-details])}])
+                                        [address-details])
         open-show-address-qr           (rn/use-callback
                                         #(rf/dispatch [:open-modal
-                                                       :screen/settings.share-saved-address opts])
-                                        [opts])
+                                                       :screen/settings.share-saved-address
+                                                       address-details])
+                                        [address-details])
         open-edit-saved-address        (rn/use-callback
                                         (fn []
-                                          (rf/dispatch [:wallet/set-address-to-save opts])
                                           (rf/dispatch [:open-modal
                                                         :screen/settings.edit-saved-address
-                                                        {:edit? true}]))
-                                        [opts])]
+                                                        (merge {:edit? true}
+                                                               address-details)]))
+                                        [address-details])]
     [quo/action-drawer
      [[{:icon                :i/arrow-up
         :label               (i18n/label :t/send-to-user {:user name})

--- a/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/view.cljs
@@ -99,12 +99,15 @@
 
 (defn- navigate-back
   []
-  (rf/dispatch [:navigate-back]))
+  (rf/dispatch [:app/finish-use-case :uc-view-saved-addresses])
+  #_(rf/dispatch [:navigate-back]))
 
 (defn- add-address-to-save
   []
   (rf/dispatch [:wallet/check-remaining-capacity-for-saved-addresses
-                {:on-success #(rf/dispatch [:open-modal :screen/settings.add-address-to-save])
+                {:on-success (fn []
+                               (rf/dispatch [:app/start-use-case :uc-add-saved-addresses])
+                               #_(rf/dispatch [:open-modal :screen/settings.add-address-to-save]))
                  :on-error   #(rf/dispatch [:toasts/upsert
                                             {:type  :negative
                                              :theme :dark
@@ -151,6 +154,10 @@
                                                          :on-clear            on-clear-input
                                                          :customization-color customization-color}))
                                        [has-saved-addresses? customization-color search-text])]
+    #_(rn/use-effect (fn []
+                       (when (rf/sub [:app/use-case-active? :uc-view-saved-addresses])
+                         (rf/dispatch [:navigate-back])))
+                     [(rf/sub [:app/use-case-active? :uc-view-saved-addresses])])
     [quo/overlay
      {:type       :shell
       :top-inset? true}

--- a/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/wallet_options/view.cljs
@@ -7,7 +7,8 @@
 
 (defn open-saved-addresses-settings-modal
   []
-  (rf/dispatch [:open-modal :screen/settings.saved-addresses]))
+  (rf/dispatch [:app/start-use-case :uc-view-saved-addresses])
+  #_(rf/dispatch [:open-modal :screen/settings.saved-addresses]))
 
 (defn open-keypairs-and-accounts-settings-modal
   []

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -162,25 +162,7 @@
   (->> (map rpc->keypair keypairs)
        (sort-by #(if (= (:type %) :profile) 0 1))))
 
-(defn- add-keys-to-saved-address
-  [saved-address]
-  (assoc saved-address :ens? (not (string/blank? (:ens saved-address)))))
 
-(defn rpc->saved-address
-  [saved-address]
-  (-> saved-address
-      (set/rename-keys {:chainShortNames  :chain-short-names
-                        :isTest           :test?
-                        :createdAt        :created-at
-                        :colorId          :customization-color
-                        :mixedcaseAddress :mixedcase-address
-                        :removed          :removed?})
-      (update :customization-color (comp keyword string/lower-case))
-      add-keys-to-saved-address))
-
-(defn rpc->saved-addresses
-  [saved-addresses]
-  (map rpc->saved-address saved-addresses))
 
 (defn reconcile-keypairs
   [keypairs]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -577,7 +577,7 @@
          [:dispatch [:wallet/get-ethereum-chains]]
          [:dispatch [:wallet/get-accounts]]
          [:dispatch [:wallet/get-keypairs]]
-         [:dispatch [:wallet/get-saved-addresses]]
+         [:dispatch [:infra/get-saved-addresses]]
          (when (ff/enabled? ::ff/wallet.wallet-connect)
            [:dispatch-later [{:ms 500 :dispatch [:wallet-connect/init]}]])]}))
 

--- a/src/status_im/contexts/wallet/send/transaction_progress/view.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_progress/view.cljs
@@ -52,7 +52,7 @@
     (fn []
       (rn/use-effect
        (fn []
-         (rf/dispatch [:wallet/get-saved-addresses])))
+         (rf/dispatch [:infra/get-saved-addresses])))
       (let [transaction-details (rf/sub [:wallet/send-transaction-progress])]
         [floating-button-page/view
          {:footer-container-padding 0

--- a/src/status_im/db.cljs
+++ b/src/status_im/db.cljs
@@ -42,4 +42,5 @@
    :settings/change-password           {}
    :keycard                            {}
    :theme                              :dark
-   :app                                {:last-user-notification {}}})
+   :app                                {:use-cases-stack        '()
+                                        :last-user-notification {}}})

--- a/src/status_im/db.cljs
+++ b/src/status_im/db.cljs
@@ -41,4 +41,5 @@
    :stickers/packs-pending             #{}
    :settings/change-password           {}
    :keycard                            {}
-   :theme                              :dark})
+   :theme                              :dark
+   :app                                {:last-user-notification {}}})

--- a/src/status_im/domain/events.cljs
+++ b/src/status_im/domain/events.cljs
@@ -16,8 +16,6 @@
         :prod {}})
    new-saved-addresses))
 
-(defn reconcile-saved-addresses
-  [{:keys [db]} [saved-addresses]]
-  {:db (update-in db [:wallet :saved-addresses] update-saved-addresses saved-addresses)})
-
-(rf/reg-event-fx :domain/reconcile-saved-addresses reconcile-saved-addresses)
+(rf/reg-event-fx :domain/reconcile-saved-addresses
+ (fn [{:keys [db]} [saved-addresses]]
+   {:db (update-in db [:wallet :saved-addresses] update-saved-addresses saved-addresses)}))

--- a/src/status_im/domain/events.cljs
+++ b/src/status_im/domain/events.cljs
@@ -1,0 +1,23 @@
+(ns status-im.domain.events
+  (:require
+    [taoensso.timbre :as log]
+    [utils.re-frame :as rf]))
+
+(defn- update-saved-addresses
+  [saved-addresses-db new-saved-addresses]
+  (reduce
+   (fn [acc {:keys [address removed? test?] :as saved-address}]
+     (let [db-key (if test? :test :prod)]
+       (if removed?
+         (update acc db-key dissoc address)
+         (assoc-in acc [db-key address] saved-address))))
+   (or saved-addresses-db
+       {:test {}
+        :prod {}})
+   new-saved-addresses))
+
+(defn reconcile-saved-addresses
+  [{:keys [db]} [saved-addresses]]
+  {:db (update-in db [:wallet :saved-addresses] update-saved-addresses saved-addresses)})
+
+(rf/reg-event-fx :domain/reconcile-saved-addresses reconcile-saved-addresses)

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1,5 +1,6 @@
 (ns status-im.events
   (:require
+    status-im.app.events
     status-im.common.alert-banner.events
     status-im.common.alert.effects
     status-im.common.async-storage.effects
@@ -55,6 +56,8 @@
     status-im.contexts.wallet.swap.events
     status-im.contexts.wallet.wallet-connect.events.core
     [status-im.db :as db]
+    status-im.domain.events
+    status-im.infra.events
     status-im.navigation.effects
     status-im.navigation.events
     [utils.re-frame :as rf]))

--- a/src/status_im/infra/events.cljs
+++ b/src/status_im/infra/events.cljs
@@ -1,0 +1,30 @@
+(ns status-im.infra.events
+  (:require
+    [status-im.infra.transform :as transform]
+    [taoensso.timbre :as log]
+    [utils.re-frame :as rf]))
+
+(defn convert-saved-addresses
+  [_ [raw-saved-addresses]]
+  (let [saved-addresses (transform/rpc->saved-addresses raw-saved-addresses)]
+    {:fx [[:dispatch [:domain/reconcile-saved-addresses saved-addresses]]]}))
+
+(rf/reg-event-fx :infra/convert-saved-addresses convert-saved-addresses)
+
+(defn get-saved-addresses
+  [_]
+  {:fx [[:json-rpc/call
+         [{:method     "wakuext_getSavedAddresses"
+           :on-success [:infra/convert-saved-addresses]
+           :on-error   [:infra/saved-addresses-rpc-error :get-saved-addresses]}]]]})
+
+(rf/reg-event-fx :infra/get-saved-addresses get-saved-addresses)
+
+(defn saved-addresses-rpc-error
+  [_ [action error]]
+  (log/warn (str "[wallet] [saved-addresses] Failed to " action)
+            {:error error}))
+
+(rf/reg-event-fx :infra/saved-addresses-rpc-error saved-addresses-rpc-error)
+
+

--- a/src/status_im/infra/events.cljs
+++ b/src/status_im/infra/events.cljs
@@ -4,27 +4,22 @@
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]))
 
-(defn convert-saved-addresses
-  [_ [raw-saved-addresses]]
-  (let [saved-addresses (transform/rpc->saved-addresses raw-saved-addresses)]
-    {:fx [[:dispatch [:domain/reconcile-saved-addresses saved-addresses]]]}))
+(rf/reg-event-fx :infra/convert-saved-addresses
+ (fn [_ [raw-saved-addresses]]
+   (let [saved-addresses (transform/rpc->saved-addresses raw-saved-addresses)]
+     {:fx [[:dispatch [:domain/reconcile-saved-addresses saved-addresses]]]})))
 
-(rf/reg-event-fx :infra/convert-saved-addresses convert-saved-addresses)
 
-(defn get-saved-addresses
-  [_]
-  {:fx [[:json-rpc/call
-         [{:method     "wakuext_getSavedAddresses"
-           :on-success [:infra/convert-saved-addresses]
-           :on-error   [:infra/saved-addresses-rpc-error :get-saved-addresses]}]]]})
+(rf/reg-event-fx :infra/get-saved-addresses
+ (fn [_]
+   {:fx [[:json-rpc/call
+          [{:method     "wakuext_getSavedAddresses"
+            :on-success [:infra/convert-saved-addresses]
+            :on-error   [:infra/saved-addresses-rpc-error :get-saved-addresses]}]]]}))
 
-(rf/reg-event-fx :infra/get-saved-addresses get-saved-addresses)
-
-(defn saved-addresses-rpc-error
-  [_ [action error]]
-  (log/warn (str "[wallet] [saved-addresses] Failed to " action)
-            {:error error}))
-
-(rf/reg-event-fx :infra/saved-addresses-rpc-error saved-addresses-rpc-error)
+(rf/reg-event-fx :infra/saved-addresses-rpc-error
+ (fn [_ [action error]]
+   (log/warn (str "[wallet] [saved-addresses] Failed to " action)
+             {:error error})))
 
 

--- a/src/status_im/infra/transform.cljs
+++ b/src/status_im/infra/transform.cljs
@@ -1,0 +1,32 @@
+(ns status-im.infra.transform
+  (:require
+    [camel-snake-kebab.extras :as cske]
+    [clojure.set :as set]
+    [clojure.string :as string]
+    [status-im.constants :as constants]
+    [status-im.contexts.wallet.collectible.utils :as collectible-utils]
+    [status-im.contexts.wallet.send.utils :as send-utils]
+    [utils.collection :as utils.collection]
+    [utils.money :as money]
+    [utils.number :as utils.number]
+    [utils.transforms :as transforms]))
+
+(defn- add-keys-to-saved-address
+  [saved-address]
+  (assoc saved-address :ens? (not (string/blank? (:ens saved-address)))))
+
+(defn rpc->saved-address
+  [saved-address]
+  (-> saved-address
+      (set/rename-keys {:chainShortNames  :chain-short-names
+                        :isTest           :test?
+                        :createdAt        :created-at
+                        :colorId          :customization-color
+                        :mixedcaseAddress :mixedcase-address
+                        :removed          :removed?})
+      (update :customization-color (comp keyword string/lower-case))
+      add-keys-to-saved-address))
+
+(defn rpc->saved-addresses
+  [saved-addresses]
+  (map rpc->saved-address saved-addresses))

--- a/src/status_im/subs/app.cljs
+++ b/src/status_im/subs/app.cljs
@@ -1,0 +1,8 @@
+(ns status-im.subs.app
+  (:require
+    [re-frame.core :as rf]))
+
+(rf/reg-sub
+ :app/last-user-notification
+ :<- [:app]
+ :-> :last-user-notification)

--- a/src/status_im/subs/app.cljs
+++ b/src/status_im/subs/app.cljs
@@ -6,3 +6,21 @@
  :app/last-user-notification
  :<- [:app]
  :-> :last-user-notification)
+
+
+(rf/reg-sub
+ :app/use-cases
+ :<- [:app]
+ :-> :use-cases-stack)
+
+(rf/reg-sub
+ :app/current-use-case
+ :<- [:app/use-cases]
+ (fn [use-cases]
+   (first use-cases)))
+
+(rf/reg-sub
+ :app/use-case-active?
+ :<- [:app/use-cases]
+ (fn [use-cases [_sub-name use-case]]
+   (some #(= use-case %) use-cases)))

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -3,6 +3,7 @@
     [re-frame.core :as re-frame]
     status-im.subs.activity-center
     status-im.subs.alert-banner
+    status-im.subs.app
     status-im.subs.biometrics
     status-im.subs.bottom-sheet
     status-im.subs.chats
@@ -191,3 +192,8 @@
 
 ;;keycard
 (reg-root-key-sub :keycard :keycard)
+
+(reg-root-key-sub :ui :ui)
+(reg-root-key-sub :infra :infra)
+(reg-root-key-sub :app :app)
+(reg-root-key-sub :domain :domain)

--- a/src/status_im/ui/core.cljs
+++ b/src/status_im/ui/core.cljs
@@ -1,0 +1,11 @@
+(ns status-im.ui.core
+  (:require [re-frame.db :as rf.db]
+            [reagent.core :as reagent]
+            #_[utils.re-frame :as rf]
+            [utils.re-frame :as rf]))
+
+
+
+
+
+


### PR DESCRIPTION
fixes #22044

## Summary
Address editing fixed



### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

### Areas that may be impacted
[comment]: # (Optional. Specify if some specific areas need to be tested, such as 1-1 chats)

#### Functional

- wallet / transactions


## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Open Status
- navigate to profile/wallet/saved addresses
- Add new address
- Add another address
- Edit first address
- Make sure that correct data displayed on editing screen 


status: ready
