### PR TITLE
Wrong address opening when attempt to edit a saved one 

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -165,15 +165,12 @@
         on-press-continue                   (rn/use-callback
                                              (fn []
                                                (rf/dispatch
-                                                [:wallet/set-address-to-save
+                                                [:open-modal :screen/settings.save-address
                                                  {:address address
                                                   :ens     (when ens-name? address-or-ens)
-                                                  :ens?    ens-name?}])
-                                               (rf/dispatch
-                                                [:open-modal :screen/settings.save-address]))
+                                                  :ens?    ens-name?}]))
                                              [address ens-name? address-or-ens])]
     (rn/use-unmount #(rf/dispatch [:wallet/clean-scanned-address]))
-    (rn/use-mount #(rf/dispatch [:wallet/clear-address-to-save]))
     [quo/overlay {:type :shell}
      [floating-button-page/view
       {:footer-container-padding     0

--- a/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/events.cljs
@@ -143,18 +143,6 @@
 
 (rf/reg-event-fx :wallet/add-saved-address-failed add-saved-address-failed)
 
-(defn set-address-to-save
-  [{:keys [db]} [args]]
-  {:db (assoc-in db [:wallet :ui :saved-address] args)})
-
-(rf/reg-event-fx :wallet/set-address-to-save set-address-to-save)
-
-(defn clear-address-to-save
-  [{:keys [db]}]
-  {:db (update-in db [:wallet :ui] dissoc :saved-address)})
-
-(rf/reg-event-fx :wallet/clear-address-to-save clear-address-to-save)
-
 (defn check-remaining-capacity-for-saved-addresses
   [{:keys [db]} [{:keys [on-success on-error]}]]
   (let [test-networks-enabled? (boolean (get-in db [:profile/profile :test-networks-enabled?]))]

--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -17,50 +17,48 @@
 
 (defn view
   []
-  (let [{:keys [edit?]} (rf/sub [:get-screen-params])
-        {:keys [address name customization-color ens ens?]}
-        (rf/sub [:wallet/saved-address])
+  (let [{:keys [address name customization-color ens
+                ens? edit?]}              (rf/sub [:get-screen-params])
         [address-label set-address-label] (rn/use-state (or name ""))
         [address-color set-address-color] (rn/use-state (or customization-color
                                                             (rand-nth colors/account-colors)))
-        placeholder (i18n/label :t/address-name)
-        address-text (rn/use-callback
-                      (fn []
-                        [quo/address-text
-                         {:full-address? true
-                          :address       address
-                          :format        :long}])
-                      [address])
-        on-press-save (rn/use-callback
-                       (fn []
-                         (rf/dispatch [:wallet/save-address
-                                       {:on-success
-                                        (if edit?
-                                          [:wallet/edit-saved-address-success]
-                                          [:wallet/add-saved-address-success
-                                           (i18n/label :t/address-saved)])
-                                        :on-error
-                                        [:wallet/add-saved-address-failed]
-                                        :name address-label
-                                        :ens (when ens? ens)
-                                        :address address
-                                        :customization-color address-color}]))
-                       [address address-label
-                        address-color])
-        data-item-props (rn/use-memo
-                         #(cond-> {:status          :default
-                                   :size            :default
-                                   :subtitle-type   :default
-                                   :label           :none
-                                   :blur?           true
-                                   :card?           true
-                                   :title           (i18n/label :t/address)
-                                   :subtitle        ens
-                                   :custom-subtitle address-text
-                                   :container-style style/data-item}
-                            ens?
-                            (dissoc :custom-subtitle))
-                         [ens ens? address-text])]
+        placeholder                       (i18n/label :t/address-name)
+        address-text                      (rn/use-callback
+                                           (fn []
+                                             [quo/address-text
+                                              {:full-address? true
+                                               :address       address
+                                               :format        :long}])
+                                           [address])
+        on-press-save                     (rn/use-callback
+                                           (fn []
+                                             (rf/dispatch [:wallet/save-address
+                                                           {:on-success
+                                                            (if edit?
+                                                              [:wallet/edit-saved-address-success]
+                                                              [:wallet/add-saved-address-success
+                                                               (i18n/label :t/address-saved)])
+                                                            :on-error
+                                                            [:wallet/add-saved-address-failed]
+                                                            :name address-label
+                                                            :ens (when ens? ens)
+                                                            :address address
+                                                            :customization-color address-color}]))
+                                           [address address-label
+                                            address-color])
+        data-item-props                   (rn/use-memo
+                                           #(cond-> {:status          :default
+                                                     :size            :default
+                                                     :subtitle-type   :default
+                                                     :blur?           true
+                                                     :card?           true
+                                                     :title           (i18n/label :t/address)
+                                                     :subtitle        ens
+                                                     :custom-subtitle address-text
+                                                     :container-style style/data-item}
+                                              ens?
+                                              (dissoc :custom-subtitle))
+                                           [ens ens? address-text])]
     [quo/overlay {:type :shell}
      [floating-button-page/view
       {:footer-container-padding     (if edit? (+ (safe-area/get-bottom) 12) 0)

--- a/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/sheets/address_options/view.cljs
@@ -9,7 +9,7 @@
     [utils.re-frame :as rf]))
 
 (defn view
-  [{:keys [name address customization-color] :as opts}]
+  [{:keys [name address customization-color] :as address-details}]
   (let [open-send-flow                 (rn/use-callback
                                         (fn []
                                           (rf/dispatch [:wallet/init-send-flow-for-address
@@ -62,19 +62,20 @@
                                            {:theme   :dark
                                             :shell?  true
                                             :content (fn []
-                                                       [remove-address/view opts])}])
-                                        [opts])
+                                                       [remove-address/view address-details])}])
+                                        [address-details])
         open-show-address-qr           (rn/use-callback
                                         #(rf/dispatch [:open-modal
-                                                       :screen/settings.share-saved-address opts])
-                                        [opts])
+                                                       :screen/settings.share-saved-address
+                                                       address-details])
+                                        [address-details])
         open-edit-saved-address        (rn/use-callback
                                         (fn []
-                                          (rf/dispatch [:wallet/set-address-to-save opts])
                                           (rf/dispatch [:open-modal
                                                         :screen/settings.edit-saved-address
-                                                        {:edit? true}]))
-                                        [opts])]
+                                                        (merge {:edit? true}
+                                                               address-details)]))
+                                        [address-details])]
     [quo/action-drawer
      [[{:icon                :i/arrow-up
         :label               (i18n/label :t/send-to-user {:user name})


### PR DESCRIPTION
fixes #22044

## Summary
Address editing fixed


Uploading Screen Recording 2025-02-25 at 10.10.18.mov…



### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

### Areas that may be impacted
[comment]: # (Optional. Specify if some specific areas need to be tested, such as 1-1 chats)

#### Functional

- wallet / transactions


## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Open Status
- navigate to profile/wallet/saved addresses
- Add new address
- Add another address
- Edit first address
- Make sure that correct data displayed on editing screen 


status: ready
