### PR TITLE
[#22194] NFC prompt text not visible

### DIFF
--- a/src/status_im/contexts/keycard/nfc/sheets/view.cljs
+++ b/src/status_im/contexts/keycard/nfc/sheets/view.cljs
@@ -18,11 +18,16 @@
                :padding-horizontal 36
                :padding-vertical   30
                :background-color   (colors/theme-colors colors/white colors/neutral-95 theme)}}
-      [rn/text {:style {:font-size 26 :color "#9F9FA5" :margin-bottom 36}}
+      [rn/text
+       {:style {:font-size     26
+                :color         (colors/theme-colors "#8F8E94" "#9F9FA5" theme)
+                :margin-bottom 36}}
        (i18n/label :t/ready-to-scan)]
-      [rn/image
-       {:source (resources/get-image :nfc-prompt)}]
-      [rn/text {:style {:font-size 16 :color :white :margin-vertical 36}}
+      [rn/image {:source (resources/get-image :nfc-prompt)}]
+      [rn/text
+       {:style {:font-size       16
+                :color           (colors/theme-colors "#09101C" :white theme)
+                :margin-vertical 36}}
        (if connected?
          (i18n/label :t/connected-dont-move)
          (i18n/label :t/hold-phone-near-keycard))]
@@ -32,6 +37,12 @@
                     (rf/dispatch [:keycard/hide-connection-sheet]))
         :style    {:flex-direction :row}}
        [rn/view
-        {:style {:background-color "#8E8E93" :flex 1 :align-items :center :padding 18 :border-radius 10}}
-        [rn/text {:style {:color :white :font-size 16}}
+        {:style {:background-color (colors/theme-colors "#D5D4DB" "#8E8E93" theme)
+                 :flex             1
+                 :align-items      :center
+                 :padding          18
+                 :border-radius    10}}
+        [rn/text
+         {:style {:color     (colors/theme-colors "#09101C" :white theme)
+                  :font-size 16}}
          (i18n/label :t/cancel)]]]]]))


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #22194

## Summary
Fixes the implementation for the light theme, including:
- The button bg and text
- The color of "Ready to scan"
- The text not appearing.

Light theme look:
![image](https://github.com/user-attachments/assets/500b7485-0849-42ec-bd1d-e2866a0dd419)


### Platforms

- Android

status: ready