### PR TITLE
nix: use openjdk_headless to avoid pulling GTK

### DIFF
--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -8,7 +8,7 @@ rec {
 
   shell = mkShell {
     buildInputs = with pkgs; [
-      openjdk
+      openjdk_headless
       gradle
       lsof  # used in start-react-native.sh
       flock # used in nix/scripts/node_modules.sh

--- a/nix/mobile/jsbundle/default.nix
+++ b/nix/mobile/jsbundle/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
           ];
         };
     };
-  buildInputs = with pkgs; [ clojure nodejs bash git openjdk];
+  buildInputs = with pkgs; [ clojure nodejs bash git openjdk_headless ];
   phases = [
     "unpackPhase" "secretsPhase" "patchPhase"
     "configurePhase" "buildPhase" "installPhase"

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -49,7 +49,7 @@ in {
   nodejs = super.nodejs_20;
   ruby = super.ruby_3_1;
   yarn = super.yarn.override { nodejs = super.nodejs_20; };
-  openjdk = super.openjdk17_headless;
+  openjdk_headless = super.openjdk17_headless;
   xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
     versions = ["16.0" "16.1" "16.2"];
   };

--- a/nix/pkgs/android-sdk/shell.nix
+++ b/nix/pkgs/android-sdk/shell.nix
@@ -1,8 +1,8 @@
-{ mkShell, openjdk, androidPkgs }:
+{ mkShell, openjdk_headless, androidPkgs }:
 
 mkShell {
   name = "android-sdk-shell";
-  buildInputs = [ openjdk ];
+  buildInputs = [ openjdk_headless ];
 
   shellHook = ''
     export ANDROID_HOME="${androidPkgs.sdk}"

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -19,7 +19,7 @@ let
     # for calling clojure targets in CI or Makefile
     clojure = mkShell {
       buildInputs = with pkgs; [
-        clojure flock maven openjdk
+        clojure flock maven openjdk_headless
         # lint specific utilities
         babashka clj-kondo clojure-lsp ripgrep zprint
       ];
@@ -61,7 +61,7 @@ let
 
     # for 'scripts/generate-keystore.sh'
     keytool = mkShell {
-      buildInputs = with pkgs; [ openjdk apksigner ];
+      buildInputs = with pkgs; [ openjdk_headless apksigner ];
     };
 
     # for targets needing 'adb', 'apkanalyzer' and other SDK/NDK tools

--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -1,5 +1,5 @@
 { callPackage, lib, buildGoPackage, pkgs
-, androidPkgs, openjdk, gomobile, xcodeWrapper, removeReferencesTo
+, androidPkgs, openjdk_headless, gomobile, xcodeWrapper, removeReferencesTo
 , go-bindata, mockgen, protobuf3_20, protoc-gen-go
 , meta
 , source
@@ -32,7 +32,7 @@ in buildGoPackage rec {
   extraSrcPaths = [ gomobile ];
   nativeBuildInputs = [
     gomobile removeReferencesTo go-bindata mockgen protoc-gen-go protobuf3_20 fakeGit
-  ] ++ optional isAndroid openjdk
+  ] ++ optional isAndroid openjdk_headless
     ++ optional isIOS xcodeWrapper;
 
   ldflags = goBuildLdFlags;


### PR DESCRIPTION
This saves a whole bunch of downloading.

In theory.