### PR TITLE
ci: fix nix-cache job

### DIFF
--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -109,10 +109,19 @@ pipeline {
     stage('Upload') {
       steps { script {
         sshagent(credentials: ['nix-cache-ssh']) {
-          nix.shell("""
+          nix.shell(
+            """
               find /nix/store/ -mindepth 1 -maxdepth 1 -type d \
-                -not -name '*.links' -and -not -name '*-status-mobile-*' \
-                | xargs nix copy --to ${NIX_SSH_REMOTE}
+                -not -name "*.links" -and -not -name "*-status-mobile-*" \
+                -and -not -name "tmp-*" \
+                -print0 | xargs -0 nix-store -qR | sort -u > "${WORKSPACE_TMP}"/store-paths.txt
+            """,
+            pure: false
+          )
+          nix.shell(
+            """
+              nix-store --export < "${WORKSPACE_TMP}"/store-paths.txt | \\
+                ssh ${env.NIX_SSHOPTS} ${params.NIX_CACHE_USER}@${params.NIX_CACHE_HOST} ${env.NIX_STORE_CMD} --import
             """,
             pure: false
           )


### PR DESCRIPTION
## Summary
The nix cache job was broken since the `nix` upgrade of `2.24.11`
This PR modifies the `nix copy` expression and breaks it down to use `nix-store --export`
I am guessing since nix copy is experimental in newer version of nix using flakes was expected along with it.

My changes in this branch were tested by manually building https://ci.infra.status.im/job/status-mobile/job/nix-cache/job/linux-x86_64/ job being pointed at `fix-nix-cache-job`

<img width="1213" alt="Screenshot 2025-02-27 at 10 26 06 AM" src="https://github.com/user-attachments/assets/e5ba9005-ab1f-42a5-9089-dcbfe431bb8f" />


## Testing notes
not required.

status: ready


