### PR TITLE
nix: replace yet another openjdk with headless version

### DIFF
--- a/nix/mobile/android/build.nix
+++ b/nix/mobile/android/build.nix
@@ -71,7 +71,7 @@ in stdenv.mkDerivation rec {
     };
   };
 
-  buildInputs = with pkgs; [ nodejs openjdk ];
+  buildInputs = with pkgs; [ nodejs openjdk_headless ];
   nativeBuildInputs = with pkgs; [ bash gradle unzip ]
     ++ lib.optionals stdenv.isDarwin [ file gnumake ];
 


### PR DESCRIPTION
Missed one in:
- https://github.com/status-im/status-mobile/pull/22197