### PR TITLE
[#22206] fix: swap proposal keep sending update either after clean up

### DIFF
--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -249,15 +249,13 @@
 
 (rf/reg-event-fx :wallet/stop-get-swap-proposal
  (fn [{:keys [db]}]
-   (let [route-request-ongoing? (some? (get-in db [:wallet :ui :swap :last-request-uuid]))]
-     (when route-request-ongoing?
-       {:db            (update-in db [:wallet :ui :swap] dissoc :last-request-uuid)
-        :json-rpc/call [{:method   "wallet_stopSuggestedRoutesAsyncCalculation"
-                         :params   []
-                         :on-error (fn [error]
-                                     (log/error "failed to stop fetching swap proposals"
-                                                {:event :wallet/stop-get-swap-proposal
-                                                 :error error}))}]}))))
+   {:db            (update-in db [:wallet :ui :swap] dissoc :last-request-uuid)
+    :json-rpc/call [{:method   "wallet_stopSuggestedRoutesAsyncCalculation"
+                     :params   []
+                     :on-error (fn [error]
+                                 (log/error "failed to stop fetching swap proposals"
+                                            {:event :wallet/stop-get-swap-proposal
+                                             :error error}))}]}))
 
 (rf/reg-event-fx
  :wallet/clean-swap-proposal


### PR DESCRIPTION
fixes #22206

## Summary

swap proposal keep sending update either after clean up


### Areas that may be impacted

- Swap

**Precondition:**

1. The app should remain in the background for approximately 1 hour or more.
2. 1–2 profiles with assets should be added to the app.

### Reproduction

1. Resume the app from the background
2. `Login` to the Profile 1
3. Go to `Wallet` -> `Swap`
4. Choose networks and enter amount (no matter what data you choose)
5. Tap on `max slippage`
6. Do some changes there
7. Leave Swap and do a `log out`



status: ready