### PR TITLE
fix Some of the message longtap options disappear until relogin after unmuting chat

### DIFF
--- a/src/status_im/contexts/chat/events.cljs
+++ b/src/status_im/contexts/chat/events.cljs
@@ -275,7 +275,8 @@
   {:events [:chat/unmute-chat-community]}
   [{:keys [db]} chat-id]
   (let [{:keys [community-id]} (get-in db [:chats chat-id])]
-    {:db (assoc-in db [:communities community-id :muted] false)}))
+    (when community-id
+      {:db (assoc-in db [:communities community-id :muted] false)})))
 
 (rf/defn mute-chat-failed
   {:events [:chat/mute-failed]}


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/22219

## Reviewer notes

- We added community with nil key in db

Consequences
- https://github.com/status-im/status-mobile/blob/11d66e5bc2ae41aada7411fceb00e41dbaa70e8e/src/status_im/subs/communities.cljs#L256
This subscription checks if a community exists using the community ID contained in the current chat. Since the chats were not community chats, it returned a nil community ID. However now we have a community with a nil key.

- https://github.com/status-im/status-mobile/blob/11d66e5bc2ae41aada7411fceb00e41dbaa70e8e/src/status_im/subs/chats.cljs#L216
This caused `current-chat-message-list-view-context` to return `:community? true`

- https://github.com/status-im/status-mobile/blob/11d66e5bc2ae41aada7411fceb00e41dbaa70e8e/src/status_im/contexts/chat/messenger/messages/drawers/view.cljs#L244
In drawer code, we show less actions when we have community? true but we are not member (of nil community)



status: ready