### PR TITLE
fix(wallet)_: Address or ENS - Paste button behaviour

### DIFF
--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -7,6 +7,7 @@
     [react-native.safe-area :as safe-area]
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.contexts.settings.wallet.saved-addresses.add-address-to-save.style :as style]
+    [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.common.validation :as validation]
     [utils.address :as utils-address]
     [utils.debounce :as debounce]
@@ -159,7 +160,7 @@
                                                (fn [clipboard-text]
                                                  (when-not (string/blank? clipboard-text)
                                                    (-> clipboard-text
-                                                       utils-address/extract-address-without-chains-info
+                                                       utils/on-paste-address-or-ens
                                                        on-change-text)))))
         on-press-continue                   (rn/use-callback
                                              (fn []

--- a/src/status_im/contexts/wallet/add_account/add_address_to_watch/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/add_address_to_watch/view.cljs
@@ -7,6 +7,7 @@
     [reagent.core :as reagent]
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.contexts.wallet.add-account.add-address-to-watch.style :as style]
+    [status-im.contexts.wallet.common.utils :as utils]
     [status-im.contexts.wallet.common.validation :as validation]
     [status-im.subs.wallet.add-account.address-to-watch]
     [utils.address :as utils-address]
@@ -42,7 +43,7 @@
         paste-on-input  #(clipboard/get-string
                           (fn [clipboard-text]
                             (-> clipboard-text
-                                utils.address/extract-address-without-chains-info
+                                utils/on-paste-address-or-ens
                                 on-change-text)))]
     (rn/use-effect (fn []
                      (when-not (string/blank? scanned-address)

--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -4,6 +4,7 @@
             [status-im.common.qr-codes.view :as qr-codes]
             [status-im.constants :as constants]
             [status-im.contexts.wallet.common.utils.networks :as network-utils]
+            [utils.address]
             [utils.money :as money]
             [utils.number :as number]
             [utils.string]))
@@ -479,3 +480,11 @@
       (filter (fn [{:keys [tokens]}]
                 (some positive-balance-in-any-chain? tokens))
               operable-account))))
+
+(defn on-paste-address-or-ens
+  "Check if the clipboard has any valid address and extract the address without any chain info.
+  If it does not contain an valid address or it is ENS, return the clipboard text as it is"
+  [clipboard-text]
+  (if (utils.address/supported-address? clipboard-text)
+    (utils.address/extract-address-without-chains-info clipboard-text)
+    clipboard-text))

--- a/src/status_im/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im/contexts/wallet/send/select_address/view.cljs
@@ -61,7 +61,7 @@
                                   (fn [clipboard]
                                     (when-not (empty? clipboard)
                                       (-> clipboard
-                                          utils-address/extract-address-without-chains-info
+                                          utils/on-paste-address-or-ens
                                           on-change)))))
         :ens-regex             constants/regx-ens
         :scanned-value         (or (when recipient-plain-address? send-address) scanned-address)


### PR DESCRIPTION
fixes #22228

## Summary

This PR fixes the paste button behaviour for address or ENS on the Wallet.

### Platforms

- Android
- iOS


## Steps to test

- Open Status
- Navigate to Wallet tab > Account > Send flow
- Copy a valid EIP-3770 address
- Tap on the `Paste` button and verify the chain info is removed
- Copy an invalid EIP-3770 or normal valid address or ENS
- Tap on the `Paste` button and verify the address is added into the input
- Copy any random text
- Tap on the `Paste` button and verify the clipboard text is added into input

status: ready
