### PR TITLE
chore(analytics): Simplify analytics testing

### DIFF
--- a/src/legacy/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/legacy/status_im/ui/screens/advanced_settings/views.cljs
@@ -6,6 +6,7 @@
     [legacy.status-im.ui.components.list.views :as list]
     [quo.core :as quo]
     [re-frame.core :as re-frame]
+    [react-native.clipboard :as clipboard]
     [status-im.config :as config]
     [status-im.feature-flags :as ff]
     [utils.i18n :as i18n]
@@ -17,7 +18,8 @@
            light-client-enabled?
            store-confirmations-enabled?
            current-fleet
-           peer-syncing-enabled?]}]
+           peer-syncing-enabled?
+           analytics-user-id]}]
   (keep
    identity
    [(when (ff/enabled? ::ff/app-monitoring.intentional-crash)
@@ -29,6 +31,12 @@
        :on-press            (fn []
                               (re-frame/dispatch [:app-monitoring/intended-panic
                                                   "status-mobile intentional panic"]))})
+    (when (ff/enabled? ::ff/analytics.copy-user-id)
+      {:size                :small
+       :title               "Copy analytics user ID"
+       :accessibility-label :copy-analytics-user-id
+       :on-press            (fn []
+                              (clipboard/set-string analytics-user-id))})
     {:size :small
      :title (i18n/label :t/log-level)
      :accessibility-label :log-level-settings-button
@@ -108,7 +116,8 @@
                   store-confirmations-enabled? [:profile/store-confirmations-enabled?]
                   current-log-level            [:log-level/current-log-level]
                   current-fleet                [:fleets/current-fleet]
-                  peer-syncing-enabled?        [:profile/peer-syncing-enabled?]]
+                  peer-syncing-enabled?        [:profile/peer-syncing-enabled?]
+                  analytics-user-id            [:centralized-metrics/user-id]]
     [:<>
      [quo/page-nav
       {:type       :title
@@ -123,6 +132,7 @@
                     :store-confirmations-enabled? store-confirmations-enabled?
                     :current-fleet                current-fleet
                     :dev-mode?                    false
-                    :peer-syncing-enabled?        peer-syncing-enabled?})
+                    :peer-syncing-enabled?        peer-syncing-enabled?
+                    :analytics-user-id            analytics-user-id})
        :key-fn    (fn [_ i] (str i))
        :render-fn render-item}]]))

--- a/src/status_im/contexts/profile/events.cljs
+++ b/src/status_im/contexts/profile/events.cljs
@@ -75,14 +75,15 @@
 (rf/reg-event-fx
  :profile/get-profiles-overview-success
  (fn [{:keys [db]}
-      [{accounts                        :accounts
-        {:keys [userConfirmed enabled]} :centralizedMetricsInfo}]]
+      [{accounts                               :accounts
+        {:keys [userConfirmed enabled userID]} :centralizedMetricsInfo}]]
    (let [profiles          (reduce-profiles accounts)
          profiles-key-uids (keys profiles)
          new-db            (cond-> db
                              :always
                              (assoc :centralized-metrics/user-confirmed? userConfirmed
-                                    :centralized-metrics/enabled?        enabled)
+                                    :centralized-metrics/enabled?        enabled
+                                    :centralized-metrics/user-id         userID)
 
                              (seq profiles)
                              (assoc :profile/profiles-overview profiles))]

--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -13,6 +13,7 @@
   {::community.edit-account-selection   (enabled-in-env? :FLAG_EDIT_ACCOUNT_SELECTION_ENABLED)
    ::community.view-token-requirements  (enabled-in-env? :FLAG_VIEW_TOKEN_REQUIREMENTS)
    ::app-monitoring.intentional-crash   (enabled-in-env? :FLAG_INTENTIONAL_CRASH_ENABLED)
+   ::analytics.copy-user-id             (enabled-in-env? :FLAG_ANALYTICS_COPY_USER_ID)
 
    ;; Feature toggled (off by default) because the desktop app disabled this
    ;; feature and we want both clients in sync. We keep the code because it

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -190,6 +190,7 @@
 ;; centralized-metrics
 (reg-root-key-sub :centralized-metrics/enabled? :centralized-metrics/enabled?)
 (reg-root-key-sub :centralized-metrics/user-confirmed? :centralized-metrics/user-confirmed?)
+(reg-root-key-sub :centralized-metrics/user-id :centralized-metrics/user-id)
 
 ;;keycard
 (reg-root-key-sub :keycard :keycard)

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v10.8.0",
-    "commit-sha1": "ba8fd51958686aea45e34e684ac925a4e65927f8",
-    "src-sha256": "0kqn5rkfsn7aqc2n2flqvkm6cc53ssk0mc1l84f4czg0paci0717"
+    "version": "v10.10.0",
+    "commit-sha1": "b1ff26dda7870d9ebdf26f33a76841653ec22d85",
+    "src-sha256": "1y9ylp4sh6q0bglasirfs1xl3xch9iny059inip3xy4gghw0h3nz"
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/21680

## Summary

status-go PR: https://github.com/status-im/status-go/pull/6385

This PR provides an alternative implementation to the one suggested in #21680 which is much simpler. The problem we are trying to resolve is that when QAs or even developers need to analyze events sent to MixPanel they cannot pinpoint exactly which events originated from their testing Status installation. Even if events end up in the _test_ project (which is not as noisy as prod MixPanel), it's still cumbersome to test if there are other people concurrently generating events (which can be the case while we are testing releases).

The solution is to allow us to filter events based on the so called MixPanel `User ID`, which in the case of Status, is a UUID generated once and which varies per installation. This PR adds a new option in the Advanced Settings behind a toggle, therefore **the feature is only available in PR builds** because feature flags are only accessible if `ENABLE_QUO_PREVIEW` is `1`.

## Additional notes

The original solution suggested in the issue is more flexible but more involved, where clients would be able to specify their own `UserID`, which in the future would be useful to support tracking certain events more anonymously by not tying them to the global installation ID (User ID).

## Areas that may be impacted

I don't anticipate any impact in the app.

## Steps to test

1. Create at least one profile or log in to an existing one.
2. Enable usage tracking in `Settings > Privacy and security`.
3. Go to `Settings > Feature flags` and enable `analytics > copy-user-id`.
4. Log out so that the app initialization kicks in.
5. Log in and go to `Settings > Advanced settings` and press on the option `Copy analytics User ID` to copy the User ID to the clipboard.
6. Verify events are being sent to MixPanel (see screenshot below as an example on how to filter).

<img src="https://github.com/user-attachments/assets/df1a9700-8129-478b-a110-b312132423fb" width="700" />

status: ready