### PR TITLE
Cl 22229 swap exchange rate conversion

### DIFF
--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -488,3 +488,13 @@
   (if (utils.address/supported-address? clipboard-text)
     (utils.address/extract-address-without-chains-info clipboard-text)
     clipboard-text))
+
+(defn token-exchange-rate
+  "Returns the exchange rate based on the token prices.
+   i.e. how many 'divisor' tokens is one 'divident' token."
+  ([divident-price divisor-price]
+   (token-exchange-rate divident-price divisor-price constants/min-token-decimals-to-display))
+  ([divident-price divisor-price divisor-token-decimals]
+   (-> (money/bignumber divident-price)
+       (money/div (money/bignumber divisor-price))
+       (number/to-fixed (min divisor-token-decimals constants/min-token-decimals-to-display)))))

--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -186,16 +186,17 @@
 
 (rf/reg-event-fx :wallet/swap-proposal-success
  (fn [{:keys [db]} [swap-proposal]]
-   (let [last-request-uuid (get-in db [:wallet :ui :swap :last-request-uuid])
-         amount-hex        (get-in db [:wallet :ui :swap :amount-hex])
-         asset-to-pay      (get-in db [:wallet :ui :swap :asset-to-pay])
-         asset-to-receive  (get-in db [:wallet :ui :swap :asset-to-receive])
-         network           (get-in db [:wallet :ui :swap :network])
-         initial-response? (get-in db [:wallet :ui :swap :initial-response?])
-         view-id           (:view-id db)
-         request-uuid      (:uuid swap-proposal)
-         best-routes       (:best swap-proposal)
-         error-response    (:error-response swap-proposal)]
+   (let [last-request-uuid    (get-in db [:wallet :ui :swap :last-request-uuid])
+         amount-hex           (get-in db [:wallet :ui :swap :amount-hex])
+         asset-to-pay         (get-in db [:wallet :ui :swap :asset-to-pay])
+         asset-to-receive     (get-in db [:wallet :ui :swap :asset-to-receive])
+         network              (get-in db [:wallet :ui :swap :network])
+         initial-response?    (get-in db [:wallet :ui :swap :initial-response?])
+         view-id              (:view-id db)
+         request-uuid         (:uuid swap-proposal)
+         best-routes          (:best swap-proposal)
+         updated-token-prices (:updated-prices swap-proposal)
+         error-response       (:error-response swap-proposal)]
      (when (and (= request-uuid last-request-uuid)
                 (or (and (empty? best-routes) error-response)
                     (and
@@ -207,6 +208,7 @@
                                :swap-proposal          (when-not (empty? best-routes)
                                                          (assoc (first best-routes) :uuid request-uuid))
                                :error-response         error-response
+                               :updated-token-prices   updated-token-prices
                                :loading-swap-proposal? false
                                :initial-response?      false)}
          (and initial-response? (seq best-routes))

--- a/src/status_im/contexts/wallet/swap/utils.cljs
+++ b/src/status_im/contexts/wallet/swap/utils.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.wallet.swap.utils
-  (:require [status-im.constants :as constants]
+  (:require [clojure.string :as string]
+            [status-im.constants :as constants]
             [status-im.contexts.wallet.common.utils.networks :as network-utils]
             [utils.i18n :as i18n]))
 
@@ -62,3 +63,12 @@
   [{:keys [networks]}]
   (when (= (count networks) 1)
     (first networks)))
+
+(defn updated-token-price
+  "Returns the updated token price (number) from the routes."
+  [token updated-prices]
+  (->> token
+       :symbol
+       string/lower-case
+       keyword
+       (get updated-prices)))

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -4,6 +4,7 @@
             [status-im.constants :as constants]
             [status-im.contexts.wallet.common.utils :as utils]
             [status-im.contexts.wallet.send.utils :as send-utils]
+            [status-im.contexts.wallet.swap.utils :as swap-utils]
             [utils.money :as money]
             [utils.number :as number]))
 
@@ -61,6 +62,11 @@
  :wallet/swap-asset-to-pay-token-symbol
  :<- [:wallet/swap-asset-to-pay]
  :-> :symbol)
+
+(rf/reg-sub
+ :wallet/swap-updated-token-prices
+ :<- [:wallet/swap]
+ :-> :updated-token-prices)
 
 (rf/reg-sub
  :wallet/swap-asset-to-pay-networks
@@ -336,40 +342,23 @@
 
 (rf/reg-sub
  :wallet/swap-exchange-rate-crypto
- :<- [:wallet/swap-proposal-amount-in]
  :<- [:wallet/swap-asset-to-pay]
- :<- [:wallet/swap-proposal-amount-out]
  :<- [:wallet/swap-asset-to-receive]
- (fn [[amount-in asset-to-pay amount-out asset-to-receive]]
-   (let [pay-token-decimals     (:decimals asset-to-pay)
-         receive-token-decimals (:decimals asset-to-receive)
-         amount-in-num          (some-> amount-in
-                                        (number/hex->whole pay-token-decimals)
-                                        (number/to-fixed pay-token-decimals)
-                                        (money/->bignumber))
-         amount-out-num         (some-> amount-out
-                                        (number/hex->whole receive-token-decimals)
-                                        (number/to-fixed receive-token-decimals)
-                                        (money/->bignumber))
-         exchange-rate          (when (and amount-in-num amount-out-num)
-                                  (money/div amount-in-num amount-out-num))
-         display-decimals       (min pay-token-decimals
-                                     constants/min-token-decimals-to-display)]
-     (when exchange-rate
-       (number/to-fixed exchange-rate display-decimals)))))
+ :<- [:wallet/swap-updated-token-prices]
+ (fn [[asset-to-pay asset-to-receive token-prices]]
+   (when (and token-prices asset-to-pay asset-to-receive)
+     (let [pay-price          (swap-utils/updated-token-price asset-to-pay token-prices)
+           receive-price      (swap-utils/updated-token-price asset-to-receive token-prices)
+           pay-token-decimals (:decimals asset-to-pay)]
+       (utils/token-exchange-rate receive-price pay-price pay-token-decimals)))))
 
 (rf/reg-sub
  :wallet/swap-exchange-rate-fiat
- :<- [:wallet/swap-exchange-rate-crypto]
- :<- [:wallet/swap-asset-to-pay]
- :<- [:profile/currency]
+ :<- [:wallet/swap-asset-to-receive]
+ :<- [:wallet/swap-updated-token-prices]
  :<- [:profile/currency-symbol]
- :<- [:wallet/prices-per-token]
- (fn [[swap-exchange-rate asset-to-pay currency currency-symbol prices-per-token]]
-   (when swap-exchange-rate
-     (let [fiat-value (utils/calculate-token-fiat-value
-                       {:currency         currency
-                        :balance          swap-exchange-rate
-                        :token            asset-to-pay
-                        :prices-per-token prices-per-token})]
-       (utils/fiat-formatted-for-ui currency-symbol fiat-value)))))
+ (fn [[asset-to-receive token-prices currency-symbol]]
+   (when (and asset-to-receive token-prices)
+     (->> token-prices
+          (swap-utils/updated-token-price asset-to-receive)
+          (utils/fiat-formatted-for-ui currency-symbol)))))

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -64,7 +64,7 @@
  :-> :symbol)
 
 (rf/reg-sub
- :wallet/swap-updated-token-prices
+ :wallet/swap-updated-token-prices-usd
  :<- [:wallet/swap]
  :-> :updated-token-prices)
 
@@ -340,25 +340,45 @@
                           :prices-per-token prices-per-token})]
      fee-in-fiat)))
 
+;; NOTE: updated route prices come only in USD (for now). When the router will
+;; allow to define the currency, we should use only the updated prices, but till
+;; then we fallback to `prices-per-token`
+(rf/reg-sub :wallet/swap-pay-token-price
+ :<- [:wallet/swap-asset-to-pay]
+ :<- [:profile/currency]
+ :<- [:wallet/swap-updated-token-prices-usd]
+ :<- [:wallet/prices-per-token]
+ (fn [[asset-to-pay currency updated-token-prices prices-per-token]]
+   (if (= currency constants/profile-default-currency)
+     (swap-utils/updated-token-price asset-to-pay updated-token-prices)
+     (utils/token-price-by-symbol prices-per-token (:symbol asset-to-pay) currency))))
+
+(rf/reg-sub :wallet/swap-receive-token-price
+ :<- [:wallet/swap-asset-to-receive]
+ :<- [:profile/currency]
+ :<- [:wallet/swap-updated-token-prices-usd]
+ :<- [:wallet/prices-per-token]
+ (fn [[asset-to-receive currency updated-token-prices prices-per-token]]
+   (if (= currency constants/profile-default-currency)
+     (swap-utils/updated-token-price asset-to-receive updated-token-prices)
+     (utils/token-price-by-symbol prices-per-token (:symbol asset-to-receive) currency))))
+
 (rf/reg-sub
  :wallet/swap-exchange-rate-crypto
+ :<- [:wallet/swap-pay-token-price]
+ :<- [:wallet/swap-receive-token-price]
  :<- [:wallet/swap-asset-to-pay]
- :<- [:wallet/swap-asset-to-receive]
- :<- [:wallet/swap-updated-token-prices]
- (fn [[asset-to-pay asset-to-receive token-prices]]
-   (when (and token-prices asset-to-pay asset-to-receive)
-     (let [pay-price          (swap-utils/updated-token-price asset-to-pay token-prices)
-           receive-price      (swap-utils/updated-token-price asset-to-receive token-prices)
-           pay-token-decimals (:decimals asset-to-pay)]
-       (utils/token-exchange-rate receive-price pay-price pay-token-decimals)))))
+ :<- [:wallet/swap-updated-token-prices-usd]
+ (fn [[pay-token-price receive-token-price asset-to-pay token-prices]]
+   (when (and token-prices asset-to-pay)
+     (->> asset-to-pay
+          :decimals
+          (utils/token-exchange-rate receive-token-price pay-token-price)))))
 
 (rf/reg-sub
  :wallet/swap-exchange-rate-fiat
- :<- [:wallet/swap-asset-to-receive]
- :<- [:wallet/swap-updated-token-prices]
+ :<- [:wallet/swap-receive-token-price]
  :<- [:profile/currency-symbol]
- (fn [[asset-to-receive token-prices currency-symbol]]
-   (when (and asset-to-receive token-prices)
-     (->> token-prices
-          (swap-utils/updated-token-price asset-to-receive)
-          (utils/fiat-formatted-for-ui currency-symbol)))))
+ (fn [[receive-token-price currency-symbol]]
+   (when receive-token-price
+     (utils/fiat-formatted-for-ui currency-symbol receive-token-price))))


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #22229 
fixes #22237

## Summary
Previously the exchange rate was calculated by dividing the amount out by the amount in. This can lead to inaccuracies if the price difference between the tokens is "big" due to rounding, resulting sometimes in the wrong token price and conversion rate. In this PR, we are calculating the exchange rate based on the updated token prices that we get with the route. This way the price and exchange rate will always be up-to-date.

_UPDATE: falling back to the `prices-per-token` if the profile currency is not USD (the router only sends USD for now)._

_UPDATE: This PR was merged to the release branch and reverted, hence the new PR. There's an additional commit which fixes a bug that was missed before._ 




[comment]: # (Can be ready or wip)
status: ready


<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that may be impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
