### PR TITLE
Fix quick transaction setting when bridging erc20 

### DIFF
--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -883,23 +883,35 @@
  (fn [{db :db} [value]]
    {:db (assoc-in db [:wallet :ui :send :tx-settings :nonce :current] value)}))
 
-(rf/reg-event-fx :wallet/quick-fee-mode-confirmed
- (fn [{db :db} [fee-mode]]
-   (let [gas-rate         (transaction-settings/tx-fee-mode->gas-rate fee-mode)
-         route            (first (get-in db [:wallet :ui :send :route]))
-         path-tx-identity (send-utils/path-identity route)
-         params           [path-tx-identity gas-rate]]
-     {:db (assoc-in db [:wallet :ui :send :custom-tx-settings :tx-fee-mode] fee-mode)
-      :fx [[:json-rpc/call
-            [{:method   "wallet_setFeeMode"
-              :params   params
-              :on-error (fn [error]
-                          (log/error "failed to set quick transaction settings"
-                                     {:event  :wallet/quick-fee-mode-confirmed
-                                      :error  (:message error)
-                                      :params params}))}]]
-           [:dispatch [:wallet/mark-user-tx-settings-for-deletion]]]})))
+(defn set-fee-mode-effect
+  [path-tx-identity gas-rate]
+  (let [params [path-tx-identity gas-rate]]
+    [:json-rpc/call
+     [{:method   "wallet_setFeeMode"
+       :params   params
+       :on-error (fn [error]
+                   (log/error "failed to set quick transaction settings"
+                              {:event  :wallet/quick-fee-mode-confirmed
+                               :error  (:message error)
+                               :params params}))}]]))
 
+(rf/reg-event-fx
+ :wallet/quick-fee-mode-confirmed
+ (fn [{db :db} [fee-mode]]
+   (let [gas-rate        (transaction-settings/tx-fee-mode->gas-rate fee-mode)
+         tx-type         (get-in db [:wallet :ui :send :tx-type])
+         route           (first (get-in db [:wallet :ui :send :route]))
+         ;; bridge consist from 2 transactions - approval and send, so we need to apply
+         ;; setting to both of them by making 2 calls
+         set-fee-effects (if (= tx-type :tx/bridge)
+                           [(set-fee-mode-effect (send-utils/path-identity route true) gas-rate)
+                            (set-fee-mode-effect (send-utils/path-identity route false) gas-rate)]
+                           [(set-fee-mode-effect (send-utils/path-identity route) gas-rate)])]
+     {:db (assoc-in db [:wallet :ui :send :custom-tx-settings :tx-fee-mode] fee-mode)
+      :fx (conj set-fee-effects
+                [:dispatch [:wallet/mark-user-tx-settings-for-deletion]])})))
+(comment
+  (send-utils/path-identity {:bridge-name "hello"} false))
 
 ;; There is a delay between the moment when user selected
 ;; custom settings and the moment when new route arrived

--- a/src/status_im/contexts/wallet/send/events.cljs
+++ b/src/status_im/contexts/wallet/send/events.cljs
@@ -910,8 +910,6 @@
      {:db (assoc-in db [:wallet :ui :send :custom-tx-settings :tx-fee-mode] fee-mode)
       :fx (conj set-fee-effects
                 [:dispatch [:wallet/mark-user-tx-settings-for-deletion]])})))
-(comment
-  (send-utils/path-identity {:bridge-name "hello"} false))
 
 ;; There is a delay between the moment when user selected
 ;; custom settings and the moment when new route arrived

--- a/src/status_im/contexts/wallet/send/utils.cljs
+++ b/src/status_im/contexts/wallet/send/utils.cljs
@@ -241,9 +241,11 @@
   (not (constants/bridge-assets token-symbol)))
 
 (defn path-identity
-  [path]
-  {:routerInputParamsUuid (:router-input-params-uuid path)
-   :pathName              (:bridge-name path)
-   :chainID               (get-in path [:from :chain-id])
-   :isApprovalTx          (:approval-required path)
-   :communityID           nil})
+  ([path]
+   (path-identity path (:approval-required path)))
+  ([path is-approval-tx?]
+   {:routerInputParamsUuid (:router-input-params-uuid path)
+    :pathName              (:bridge-name path)
+    :chainID               (get-in path [:from :chain-id])
+    :isApprovalTx          is-approval-tx?
+    :communityID           nil}))


### PR DESCRIPTION

fixes #22161


## Summary
Now quick transaction settings applied when user bridges erc20


https://github.com/user-attachments/assets/fc97fcb6-17f6-47a1-a621-c19396d01910



## Review notes
The root of problem is that Bridge actually contains from 2 transactions because erc20 tokens need approval. But in UI we do not reflect this, whereas `status-go` backend of quick transaction settings made with the idea that setting should be set separately for Approval tx and for Send tx.
To hide this implementation detail from user I call `SetFeeMode` endpoint 2 times for approval and send when user selects the setting.


### Platforms

- Android
- iOS

### Areas that may be impacted

#### Functional

- wallet / transactions
#### Non-functional

## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Open Status
- Start bridging erc20 transaction
- Make sure selected transaction settings applied


status: ready

