### PR TITLE
Fix for overlapping icons on the authentication slider

### DIFF
--- a/src/quo/components/buttons/slide_button/style.cljs
+++ b/src/quo/components/buttons/slide_button/style.cljs
@@ -37,6 +37,7 @@
     :align-items     :center
     :left            0
     :top             0
+    :transform       [{:translate-x 0}]
     :flex-direction  :row
     :justify-content :space-around}])
 


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #22230 
By @alwx 

This PR is already in release - https://github.com/status-im/status-mobile/pull/22243

## Summary
The icons no longer overlap!

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

status: ready