### PR TITLE
[#22248] fix: wallet tokens card padding

### DIFF
--- a/src/status_im/contexts/wallet/home/tabs/style.cljs
+++ b/src/status_im/contexts/wallet/home/tabs/style.cljs
@@ -1,4 +1,5 @@
 (ns status-im.contexts.wallet.home.tabs.style)
 
 (def container
-  {:flex 1})
+  {:padding-horizontal 8
+   :flex               1})


### PR DESCRIPTION
fixes #22248

## Summary
 
The margins on the wallet tokens needs adjustment

### Areas that may be impacted

- Assets and Collectibles alignment in home

### Result


<img src="https://github.com/user-attachments/assets/45869d5a-9663-47f9-b932-33719784da4a" width="390px" />


status: ready