### PR TITLE
fix(market): update status-go

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v10.8.0",
-    "commit-sha1": "ba8fd51958686aea45e34e684ac925a4e65927f8",
-    "src-sha256": "0kqn5rkfsn7aqc2n2flqvkm6cc53ssk0mc1l84f4czg0paci0717"
+    "version": "ab/issue-22203-only-increase-timeout",
+    "commit-sha1": "5b6643ffbece33883e4ac31922fa93fb9993801d",
+    "src-sha256": "03p7w9mss2gqxwx20m2870rsgjg0nc83vly2p2x832pbz7crfxr6"
 }


### PR DESCRIPTION
related status go PR https://github.com/status-im/status-go/pull/6392

* point status-go to ab/issue-22203-only-increase-timeout 
* increase http timeout from 5 seconds to 20 seconds (and introduce 5 second timeouts on dial, tls, headers) 
* increase overall market timeout to 60 seconds (since there are 5 retries + some requests may be executed in chunks) 

fixes #22203

The only worrying request is **FetchTokenDetails**, which may fail on limited network. Proper fix should include caching, I've tested with and without "3g" profile in network link conditioner:

## CryptoCompare API

| Method | Execution Time, unlimited and 780kbps (s) | Response Size |
|--------|-------------------|---------------|
| FetchHistoricalDailyPrices | 1 (2) | 6KB |
| FetchHistoricalHourlyPrices | 1 (1) | 4KB |
| FetchPrices | 1 (3) | 75B |
| **FetchTokenDetails** | 5 (292) | 21MB |
| FetchTokenMarketValues | 2 (2) | 5KB |

## CoinGecko API

| Method | Execution Time (s) | Response Size |
|--------|-------------------|---------------|
| FetchHistoricalDailyPrices(FetchHistoryMarketData) | 1 (3) | 72KB |
| FetchPlatforms | 2 (3) | 140KB |
| FetchPrices(FetchSimplePrice) | 1 (2) | 78B |
| **FetchTokenDetails**(FetchTokens) | 3 (32) | 2MB |
| FetchTokenMarketValues(FetchCoinsMarkets) | 1 (1) | 2KB |

On mobile it's used in https://github.com/status-im/status-mobile/blob/develop/src/status_im/contexts/wallet/tokens/rpc.cljs.
In the api.log from the ticket `fetchTokenDetails` is called 7 times (2 times after `2025-02-27T14:30:00.000Z`) 

(On desktop it's only used once in init->`supportedTokensListRetrieved`)