### PR TITLE
[#22249] fix: display 24-hour amount change instead of current price

### DIFF
--- a/src/status_im/contexts/wallet/common/utils_test.cljs
+++ b/src/status_im/contexts/wallet/common/utils_test.cljs
@@ -375,3 +375,11 @@
                     {:symbol "DAI"}
                     {:symbol "ETH"}]]
       (is (= (utils/sort-tokens-by-name tokens) expected)))))
+
+(deftest calculate-token-fiat-change-test
+  (testing "Calculate token fiat change"
+    (is (= (utils/calculate-token-fiat-change 100 10) 10.0))
+    (is (= (utils/calculate-token-fiat-change 200 -5) 10.0))
+    (is (= (utils/calculate-token-fiat-change 50 0) 0.0))
+    (is (= (utils/calculate-token-fiat-change 100 -100) 100.0))
+    (is (= (utils/calculate-token-fiat-change 0.001 0.1) 0.000001))))


### PR DESCRIPTION
fixes #22249

## Summary

display 24-hour amount change instead of current price


### Areas that may be impacted

- Asset List in home and account view

### Result 


<img src="https://github.com/user-attachments/assets/95e13d8c-c558-4a45-8eaa-d25f4004309c"  width="390px"/>

status: ready
