### PR TITLE
Fix swap error when the flow is finished

### DIFF
--- a/src/status_im/contexts/wallet/swap/utils.cljs
+++ b/src/status_im/contexts/wallet/swap/utils.cljs
@@ -67,8 +67,9 @@
 (defn updated-token-price
   "Returns the updated token price (number) from the routes."
   [token updated-prices]
-  (->> token
-       :symbol
-       string/lower-case
-       keyword
-       (get updated-prices)))
+  (some->> token
+           :symbol
+           string/lower-case
+           keyword
+           (get updated-prices)
+           (or 0)))

--- a/src/status_im/contexts/wallet/swap/utils.cljs
+++ b/src/status_im/contexts/wallet/swap/utils.cljs
@@ -67,9 +67,8 @@
 (defn updated-token-price
   "Returns the updated token price (number) from the routes."
   [token updated-prices]
-  (some->> token
-           :symbol
-           string/lower-case
-           keyword
-           (get updated-prices)
-           (or 0)))
+  (let [token-symbol (some-> token
+                             :symbol
+                             string/lower-case
+                             keyword)]
+    (get updated-prices token-symbol 0)))

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -371,10 +371,10 @@
  :<- [:wallet/swap-updated-token-prices-usd]
  (fn [[pay-token-price receive-token-price asset-to-pay token-prices]]
    (when (and token-prices asset-to-pay)
-     (some->> asset-to-pay
-              :decimals
-              (utils/token-exchange-rate receive-token-price pay-token-price)
-              (or 0)))))
+     (let [exchange-rate (some->> asset-to-pay
+                                  :decimals
+                                  (utils/token-exchange-rate receive-token-price pay-token-price))]
+       (or exchange-rate 0)))))
 
 (rf/reg-sub
  :wallet/swap-exchange-rate-fiat

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -371,9 +371,10 @@
  :<- [:wallet/swap-updated-token-prices-usd]
  (fn [[pay-token-price receive-token-price asset-to-pay token-prices]]
    (when (and token-prices asset-to-pay)
-     (->> asset-to-pay
-          :decimals
-          (utils/token-exchange-rate receive-token-price pay-token-price)))))
+     (some->> asset-to-pay
+              :decimals
+              (utils/token-exchange-rate receive-token-price pay-token-price)
+              (or 0)))))
 
 (rf/reg-sub
  :wallet/swap-exchange-rate-fiat


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #22259

## Summary
[comment]: # (Summarise the problem and how the pull request solves it)
The value was nil when the flow is finished. Added defaults, but we need to improve the cleanup of send/swap flows, since we cleanup before the components manage to un-mount.

[comment]: # (Can be ready or wip)
status: ready


<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that may be impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
