### PR TITLE
[WIP] feat: show 1 year gains on portfolio on the wallet account page

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -494,3 +494,5 @@
 
 (def ^:const pre-login-log-level-key "pre-login-log-level")
 (def ^:const report-email "error-reports@status.im")
+
+(def ^:const time-interval-1-year 3)

--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -44,6 +44,9 @@
        :current-value       formatted-balance
        :account-name        name
        :account             (if watch-only? :watched-address :default)
+       :time-frame          :one-year
+       :percentage-change   "2.5%"
+       :metrics             :positive
        :customization-color color}]
      (when (ff/enabled? ::ff/wallet.graph)
        [quo/wallet-graph {:time-frame :empty}])

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -17,6 +17,7 @@
     [status-im.contexts.wallet.db :as db]
     [status-im.contexts.wallet.db-path :as db-path]
     [status-im.contexts.wallet.item-types :as item-types]
+    [status-im.contexts.wallet.networks.config :as networks.config]
     [status-im.contexts.wallet.networks.db :as networks.db]
     status-im.contexts.wallet.networks.events
     [status-im.contexts.wallet.send.utils :as send-utils]
@@ -293,22 +294,25 @@
 
 (rf/reg-event-fx
  :wallet/get-balance-history-for-all-tokens
- (fn [_ {:keys [addresses symbols time-interval]}]
-   {:fx [(map (fn [token-symbol]
-                [:dispatch
-                 [:wallet/get-balance-history-for-token
-                  {:addresses     addresses
-                   :token-symbol  token-symbol
-                   :time-interval time-interval}]])
-              symbols)]}))
+ (fn [_ [{:keys [addresses symbols time-interval]}]]
+   {:fx (into []
+              (map (fn [token-symbol]
+                     [:dispatch
+                      [:wallet/get-balance-history-for-token
+                       {:addresses     addresses
+                        :token-symbol  token-symbol
+                        :time-interval time-interval}]])
+                   symbols))}))
 
 (rf/reg-event-fx
  :wallet/get-balance-history-for-token
- (fn [{:keys [db]} {:keys [addresses token-symbol time-interval]}]
+ (fn [{:keys [db]} [{:keys [addresses token-symbol time-interval]}]]
    (let [testnet-mode?   (get-in db [:profile/profile :test-networks-enabled?])
          currency-symbol (get-in db [:profile/profile :currency-symbol])
          chain-ids       (vec
-                          (if testnet-mode? constants/sepolia-chain-ids constants/mainnet-chain-ids))]
+                          (if testnet-mode?
+                            (keys networks.config/testnets)
+                            (keys networks.config/mainnets)))]
      {:fx [[:json-rpc/call
             [{:method     "wallet_getBalanceHistory"
               :params     [chain-ids addresses token-symbol currency-symbol time-interval]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -287,50 +287,43 @@
              :on-success [:wallet.tokens/store-prices]
              :on-error   [:wallet.tokens/fetch-prices-failed]}]
            [:dispatch
-            [:wallet/get-balance-history-for-all-tokens
+            [:wallet/get-balance-history-for-all-accounts
              {:addresses     addresses
               :symbols       symbols
               :time-interval constants/time-interval-1-year}]]]})))
 
 (rf/reg-event-fx
- :wallet/get-balance-history-for-all-tokens
+ :wallet/get-balance-history-for-all-accounts
  (fn [_ [{:keys [addresses symbols time-interval]}]]
    {:fx (into []
-              (map (fn [token-symbol]
+              (map (fn [address]
                      [:dispatch
-                      [:wallet/get-balance-history-for-token
-                       {:addresses     addresses
-                        :token-symbol  token-symbol
+                      [:wallet/get-balance-history-for-account
+                       {:address       address
+                        :token-symbols symbols
                         :time-interval time-interval}]])
-                   symbols))}))
+                   addresses))}))
 
 (rf/reg-event-fx
- :wallet/get-balance-history-for-token
- (fn [{:keys [db]} [{:keys [addresses token-symbol time-interval]}]]
+ :wallet/get-balance-history-for-account
+ (fn [{:keys [db]} [{:keys [address token-symbols time-interval]}]]
    (let [testnet-mode?   (get-in db [:profile/profile :test-networks-enabled?])
-         currency-symbol (get-in db [:profile/profile :currency-symbol])
+         currency-symbol (get-in db [:profile/profile :currency])
          chain-ids       (vec
                           (if testnet-mode?
                             (keys networks.config/testnets)
                             (keys networks.config/mainnets)))]
      {:fx [[:json-rpc/call
-            [{:method     "wallet_getBalanceHistory"
-              :params     [chain-ids addresses token-symbol currency-symbol time-interval]
-              :on-success [:wallet/store-balance-history-for-token addresses token-symbol time-interval]
+            [{:method     "wallet_getAggregateBalanceHistory"
+              :params     [chain-ids address token-symbols currency-symbol time-interval]
+              :on-success [:wallet/store-balance-history-for-account address]
               :on-error   [:wallet/log-rpc-error
                            {:event :wallet/get-balance-history-for-token}]}]]]})))
 
 (rf/reg-event-fx
- :wallet/store-balance-history-for-token
- (fn [{:keys [db]} [addresses token-symbol time-interval balances]]
-   {:db (-> db
-            ((fn [db]
-               (reduce (fn [db address]
-                         (assoc-in db
-                          [:wallet :accounts address :historical-balances token-symbol time-interval]
-                          balances))
-                       db
-                       addresses))))}))
+ :wallet/store-balance-history-for-account
+ (fn [{:keys [db]} [address balances]]
+   {:db (assoc-in db [:wallet :accounts address :historical-balances] balances)}))
 
 (rf/reg-event-fx
  :wallet/get-last-wallet-token-update-if-needed

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -284,7 +284,49 @@
             {:symbols    symbols
              :currencies [constants/profile-default-currency profile-currency]
              :on-success [:wallet.tokens/store-prices]
-             :on-error   [:wallet.tokens/fetch-prices-failed]}]]})))
+             :on-error   [:wallet.tokens/fetch-prices-failed]}]
+           [:dispatch
+            [:wallet/get-balance-history-for-all-tokens
+             {:addresses     addresses
+              :symbols       symbols
+              :time-interval constants/time-interval-1-year}]]]})))
+
+(rf/reg-event-fx
+ :wallet/get-balance-history-for-all-tokens
+ (fn [_ {:keys [addresses symbols time-interval]}]
+   {:fx [(map (fn [token-symbol]
+                [:dispatch
+                 [:wallet/get-balance-history-for-token
+                  {:addresses     addresses
+                   :token-symbol  token-symbol
+                   :time-interval time-interval}]])
+              symbols)]}))
+
+(rf/reg-event-fx
+ :wallet/get-balance-history-for-token
+ (fn [{:keys [db]} {:keys [addresses token-symbol time-interval]}]
+   (let [testnet-mode?   (get-in db [:profile/profile :test-networks-enabled?])
+         currency-symbol (get-in db [:profile/profile :currency-symbol])
+         chain-ids       (vec
+                          (if testnet-mode? constants/sepolia-chain-ids constants/mainnet-chain-ids))]
+     {:fx [[:json-rpc/call
+            [{:method     "wallet_getBalanceHistory"
+              :params     [chain-ids addresses token-symbol currency-symbol time-interval]
+              :on-success [:wallet/store-balance-history-for-token addresses token-symbol time-interval]
+              :on-error   [:wallet/log-rpc-error
+                           {:event :wallet/get-balance-history-for-token}]}]]]})))
+
+(rf/reg-event-fx
+ :wallet/store-balance-history-for-token
+ (fn [{:keys [db]} [addresses token-symbol time-interval balances]]
+   {:db (-> db
+            ((fn [db]
+               (reduce (fn [db address]
+                         (assoc-in db
+                          [:wallet :accounts address :historical-balances token-symbol time-interval]
+                          balances))
+                       db
+                       addresses))))}))
 
 (rf/reg-event-fx
  :wallet/get-last-wallet-token-update-if-needed

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v10.24.0",
-    "commit-sha1": "d8f56e82625bf3dce0faea7294305bdbd895c50a",
-    "src-sha256": "135bnb586a176xlp8l0d85zf93lb9ln7s8zw5v0c4h6x1hr5s9fn"
+    "version": "feat/account-aggregate-balance",
+    "commit-sha1": "3d36da2d5507c1be52bc7a4fbd09584b6a36494c",
+    "src-sha256": "0ajfz8hzdywprb0dd0izrzmsnz0zdqbgph7srb9qv9lgy1a80gfx"
 }


### PR DESCRIPTION
fixes #21478 

## Summary

This PR adds the annual portfolio gain to the wallet account page

### Platforms

- Android
- iOS

### Areas that may be impacted

#### Functional

- wallet / transactions

## Steps to test

- Open Status
- Log in
- Open wallet
- Go to an account screen
- Verify the annual portfolio gains/losses are shown as expected

status: wip