### PR TITLE
chore: add ci lint job for checking commit titles for `donotmerge`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,6 +330,9 @@ lint-fix: ##@test Run code style checks and fix issues
 	sh scripts/lint/trailing-newline.sh --fix && \
 	node_modules/.bin/prettier --write .
 
+lint-commits:
+	@sh scripts/lint/donotmerge-git-commits.sh
+
 shadow-server: export TARGET := clojure
 shadow-server:##@ Start shadow-cljs in server mode for watching
 	yarn shadow-cljs server

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -79,6 +79,11 @@ pipeline {
         }
       }
     }
+    stage('Commit Checks') {
+      steps {
+        make('lint-commits')
+      }
+    }
   }
   post {
     success { script { github.notifyPR(true) } }

--- a/scripts/lint/donotmerge-git-commits.sh
+++ b/scripts/lint/donotmerge-git-commits.sh
@@ -6,7 +6,10 @@ BASE_BRANCH="${CHANGE_TARGET:-$DEFAULT_BASE_BRANCH}"
 FEATURE_BRANCH="${CHANGE_BRANCH:-$(git branch --show-current)}"
 
 if [[ -n "$CI" && "$CI" == "true" ]]; then
-    COMMITS=$(git log HEAD --oneline)
+    # Configuring remote origin for CI to resolve origin branches when comparing commits
+    git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+    git fetch origin "${BASE_BRANCH}:${BASE_BRANCH}"
+    COMMITS=$(git log "${BASE_BRANCH}"..HEAD --oneline)
 else
     COMMITS=$(git log "${BASE_BRANCH}".."${FEATURE_BRANCH}" --oneline)
 fi

--- a/scripts/lint/donotmerge-git-commits.sh
+++ b/scripts/lint/donotmerge-git-commits.sh
@@ -6,12 +6,12 @@ BASE_BRANCH="${CHANGE_TARGET:-$DEFAULT_BASE_BRANCH}"
 FEATURE_BRANCH="${CHANGE_BRANCH:-$(git branch --show-current)}"
 
 if [[ -n "$CI" && "$CI" == "true" ]]; then
-    # Configuring remote origin for CI to resolve origin branches when comparing commits
+    # The default Jenkins refspec does not accept branches other than the one from PR.
     git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
     git fetch origin "${BASE_BRANCH}:${BASE_BRANCH}"
-    COMMITS=$(git log "${BASE_BRANCH}"..HEAD --oneline)
+    COMMITS=$(git log "${BASE_BRANCH}..HEAD" --oneline)
 else
-    COMMITS=$(git log "${BASE_BRANCH}".."${FEATURE_BRANCH}" --oneline)
+    COMMITS=$(git log "${BASE_BRANCH}..${FEATURE_BRANCH}" --oneline)
 fi
 
 echo "checking for ${DO_NOT_MERGE_KEYWORD} commits"

--- a/scripts/lint/donotmerge-git-commits.sh
+++ b/scripts/lint/donotmerge-git-commits.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+DO_NOT_MERGE_KEYWORD="donotmerge"
+DEFAULT_BASE_BRANCH="develop"
+BASE_BRANCH="${CHANGE_TARGET:-$DEFAULT_BASE_BRANCH}"
+FEATURE_BRANCH="${CHANGE_BRANCH:-$(git branch --show-current)}"
+
+if [[ -n "$CI" && "$CI" == "true" ]]; then
+    COMMITS=$(git log HEAD --oneline)
+else
+    COMMITS=$(git log "${BASE_BRANCH}".."${FEATURE_BRANCH}" --oneline)
+fi
+
+echo "checking for ${DO_NOT_MERGE_KEYWORD} commits"
+if echo "${COMMITS}" | grep $DO_NOT_MERGE_KEYWORD; then
+    echo "found ${DO_NOT_MERGE_KEYWORD} commits"
+    exit 1
+fi


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

## Summary

* This PR attempts to add a new CI lint check for commit titles that contain `donotmerge`, so that we can prevent accidental merges of file changes that should be not be merged but need to be modified temporarily for testing.
  * For example, sometimes we need to update the `VERSION` file so that we can create test release builds, but we rarely want to update the version file to the temporary version number that we'll use for testing a PR release build.

## Review notes

* For some reason, I was unable to correctly get the CI environment to retrieve the set of commits that are being merged into develop, so I had to retrieve the entire history. This is not ideal, but I found no work around at the time, and decided that I'll yield to some help. I'll include more details in the review comments for the code.

## Testing notes

* We can test the lint rule by pushing a git commit with `donotmerge` present in the commit title.

[comment]: # (Can be ready or wip)
status: ready


<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that may be impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
