### PR TITLE
chore_: move android logs from download dir to private app data folder

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/Utils.kt
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/Utils.kt
@@ -39,14 +39,7 @@ class Utils(private val reactContext: ReactApplicationContext) : ReactContextBas
     }
 
     fun getPublicStorageDirectory(): File? {
-        StatusBackendClient.getInstance()?.let { client ->
-            if (client.serverEnabled && client.rootDataDir != null) {
-                return File(client.rootDataDir!!)
-            }
-        }
-        // Environment.getExternalStoragePublicDirectory doesn't work as expected on Android Q
-        // https://developer.android.com/reference/android/os/Environment#getExternalStoragePublicDirectory(java.lang.String)
-        return reactContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+        return File(getNoBackupDirectory(), "logs")
     }
 
     fun getKeyUID(json: String): String {


### PR DESCRIPTION
With this PR, all log files in Android will be stored in private app data folder for new Status account.

relate [comment](https://github.com/status-im/status-go/pull/6334#issuecomment-2667375118)

## Testing notes
Pls check log files are there when send log via email.
Old log files won't be included anymore when send log.

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android

## Steps to test
[comment]: #  (Specify exact steps to test if there are such)
- Open Status
- Shake device
- Report a bug
- Submit by email with logs archive


[comment]: # (Can be ready or wip)
status: ready
