### PR TITLE
Add seed phrase validation for keycard and status-go calls

### DIFF
--- a/src/status_im/contexts/keycard/effects.cljs
+++ b/src/status_im/contexts/keycard/effects.cljs
@@ -97,8 +97,12 @@
    (keycard/generate-mnemonic (keycard.utils/wrap-handlers args))))
 
 (rf/reg-fx :effects.keycard/generate-and-load-key
- (fn [args]
-   (keycard/generate-and-load-key (keycard.utils/wrap-handlers args))))
+ (fn [{:keys [mnemonic on-failure] :as args}]
+   (-> mnemonic
+       (native-module/validate-mnemonic)
+       (promesa/then #(keycard/generate-and-load-key
+                       (keycard.utils/wrap-handlers args)))
+       (promesa/catch on-failure))))
 
 (rf/reg-fx :effects.keycard/login-with-keycard
  (fn [{:keys [key-uid password whisper-private-key]}]

--- a/src/status_im/contexts/wallet/effects.cljs
+++ b/src/status_im/contexts/wallet/effects.cljs
@@ -24,10 +24,11 @@
                   string? mnemonic-phrase
                   coll?   (string/join " " mnemonic-phrase)
                   (log/error "Unexpected value " mnemonic-phrase))]
-     (native-module/create-account-from-mnemonic
-      {:MnemonicPhrase phrase
-       :paths          paths}
-      on-success))))
+     (-> phrase
+         (native-module/validate-mnemonic)
+         (promesa/then #(native-module/create-account-from-mnemonic
+                         {:MnemonicPhrase phrase :paths paths}
+                         on-success))))))
 
 (defn create-account-from-private-key
   [private-key]


### PR DESCRIPTION
### Summary

Add seed phrase validation for keycard and status-go calls

related issue: https://github.com/status-im/status-mobile/issues/22209#issuecomment-2703803206

PR don't need to be manually test, as its only adding small validation check for mnemonics. I will test it manually before merging
(done, [video 1](https://github.com/user-attachments/assets/42aeea36-41d3-42f2-ba92-c483cf9f131f), [video 2](https://github.com/user-attachments/assets/16247c98-2eb2-4847-b54d-ebda6787dd94))

status: ready