### PR TITLE
Fixes activities list cleaning after unsuccessful activites request from status-go

### DIFF
--- a/src/status_im/contexts/wallet/common/activity_tab/constants.cljs
+++ b/src/status_im/contexts/wallet/common/activity_tab/constants.cljs
@@ -14,6 +14,10 @@
 (def ^:const wallet-activity-token-type-erc-721 2)
 (def ^:const wallet-activity-token-type-erc-1155 3)
 
+(def ^:const activity-request-success 1)
+(def ^:const activity-request-task-cancelled 2)
+(def ^:const activity-request-failed 3)
+
 (def ^:const wallet-activity-status->name
   {wallet-activity-status-failed    :failed
    wallet-activity-status-pending   :pending

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "parsing-best-route-fix",
-    "commit-sha1": "002cd8c48d87d1b368c8b1bc9f4b974f8b841853",
+    "version": "v10.7.0+hotfix.3",
+    "commit-sha1": "37fd3a28aface4e4d6f75191b43c0496b0e3e861",
     "src-sha256": "01zwasnqvizl15vsarw2bqv4g1avcjn141mn4g0v9rzb8cg87c42"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v10.7.0+hotfix.2",
-    "commit-sha1": "595dc68e9ff5e6e57364818098616a97b83eabd5",
-    "src-sha256": "04dsmz70h3i738bj3i3ba8bckpw61vxb56m8sc4qw8agc9pdaxc0"
+    "version": "parsing-best-route-fix",
+    "commit-sha1": "002cd8c48d87d1b368c8b1bc9f4b974f8b841853",
+    "src-sha256": "01zwasnqvizl15vsarw2bqv4g1avcjn141mn4g0v9rzb8cg87c42"
 }


### PR DESCRIPTION

## Summary
This is a mobile-side part of the #22265
After bridging L1->L2 retrieving of activities fails in `status-go`. While `status-go` will have own fix, there is also a problem on mobile side - we do not check the error code that activities request returned. As a result we are clearing existing activities but we do not have an updated list.

## Review notes
Now we check error code and do not clean old data if there is no new.

## Testing notes
This is mobile-only fix. When `status-go` fix merged we can bump the status-go version in this PR and merge all it once in release branch.

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

### Areas that may be impacted
[comment]: # (Optional. Specify if some specific areas need to be tested, such as 1-1 chats)

#### Functional


- wallet / transactions



## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- perform few send transactions
- perform DAI bridge transaction
- make sure activities list wasn't cleared



status: ready

