### PR TITLE
[#21389] fix: display correct amount without rounding

### DIFF
--- a/src/status_im/contexts/wallet/common/utils.cljs
+++ b/src/status_im/contexts/wallet/common/utils.cljs
@@ -112,7 +112,8 @@
       zero-value?                    "0"
       (< token-units usd-cent-value) "0"
       :else                          (number/remove-trailing-zeroes
-                                      (.toFixed token-units standardized-decimals-count)))))
+                                      (number/format-decimal-fixed token-units
+                                                                   standardized-decimals-count)))))
 
 (defn add-token-symbol-to-crypto-balance
   [crypto-balance token-symbol]

--- a/src/utils/number.cljs
+++ b/src/utils/number.cljs
@@ -97,3 +97,18 @@
   [num decimal-count]
   (let [decimal-part (second (string/split (str num) #"\."))]
     (or (nil? decimal-part) (<= (count decimal-part) decimal-count))))
+
+(defn format-decimal-fixed
+  "Formats a number `n` to `decimal-places` without rounding.
+   - Ensures the exact number of decimal places (including trailing zeros).
+   - Does not round up or down, just trims excess decimals."
+  [n decimal-places]
+  (let [bn        (money/bignumber n)
+        scale     (money/bignumber (money/from-decimal decimal-places))
+        truncated (if (money/less-than bn 0)
+                    (Math/ceil (money/mul bn scale))
+                    (Math/floor (money/mul bn scale)))]
+    (-> truncated
+        (money/bignumber)
+        (money/div scale)
+        (money/to-fixed decimal-places))))

--- a/src/utils/number_test.cljs
+++ b/src/utils/number_test.cljs
@@ -88,3 +88,19 @@
 
     (is (true? (utils.number/valid-decimal-count? 1234567890.12 2)))
     (is (false? (utils.number/valid-decimal-count? 1234567890.12345 3)))))
+
+(deftest format-decimal-fixed-test
+  (testing "Format decimal numbers correctly without rounding"
+    (is (= "123.45" (utils.number/format-decimal-fixed "123.456" 2)))
+    (is (= "123.456" (utils.number/format-decimal-fixed "123.456" 3)))
+
+    (is (= "123.45600" (utils.number/format-decimal-fixed "123.456" 5)))
+    (is (= "123.000" (utils.number/format-decimal-fixed "123.000" 3)))
+
+    (is (= "123" (utils.number/format-decimal-fixed "123.999" 0)))
+
+    (is (= "-123.4" (utils.number/format-decimal-fixed "-123.456" 1)))
+    (is (= "-123.45" (utils.number/format-decimal-fixed "-123.456" 2)))
+
+    (is (= "0.0006" (utils.number/format-decimal-fixed "0.000650462672354754" 4)))
+    (is (= "999999999.999" (utils.number/format-decimal-fixed "999999999.999999" 3)))))


### PR DESCRIPTION
fixes #21389

## Summary

Display correct amount without rounding

### Areas that may be impacted

- Send and Bridge



## Steps to test

1. Recover a user with available assets that require rounding (e.g., 1.149 DAI in my case).
2. Go to the routes generation page in the send or bridge flow.
3. Check the max value displayed.


### Before
<img src="https://github.com/user-attachments/assets/f8983a52-9069-400c-b2e5-eda613c72c90" width="390px"/>

### Result 

https://github.com/user-attachments/assets/5cb5f5c9-f74f-46e2-b3a5-075ba1a2e587


status: ready
