### PR TITLE
fix: allow auto-correct to update message text before sending message

### DIFF
--- a/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
@@ -30,7 +30,11 @@
         contact-customization-color (when (= chat-type constants/one-to-one-chat-type)
                                       (rf/sub [:contacts/contact-customization-color-by-address
                                                chat-id]))
-        on-press                    (rn/use-callback #(send-message input-ref edit btn-opacity) [edit])]
+        on-press                    (rn/use-callback
+                                     (fn []
+                                       (js/requestAnimationFrame
+                                        #(send-message input-ref edit btn-opacity)))
+                                     [edit])]
     (rn/use-effect (fn []
                      ;; Handle send button opacity animation and z-index when input content changes
                      (if (or (seq input-text) images?)

--- a/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
@@ -3,13 +3,14 @@
     [quo.core :as quo]
     [react-native.core :as rn]
     [react-native.reanimated :as reanimated]
+    [reagent.core :as reagent]
     [status-im.constants :as constants]
     [status-im.contexts.chat.messenger.composer.actions.image.view :as actions.image]
     [status-im.contexts.chat.messenger.composer.actions.style :as style]
     [utils.re-frame :as rf]))
 
 (defn send-message
-  [input-ref edit btn-opacity]
+  [{:keys [input-ref edit btn-opacity]}]
   (when @input-ref
     (.clear ^js @input-ref))
   (reanimated/animate btn-opacity 0)
@@ -17,6 +18,19 @@
   (rf/dispatch [:chat.ui/set-chat-input-text nil])
   (when-not (some? edit)
     (rf/dispatch [:chat.ui/scroll-to-bottom])))
+
+(defn send-message-next-tick
+  "This function uses `reagent/next-tick` to call the `send-message` function.
+   
+   The usage `reagent/next-tick` will effectively schedule the `send-message`
+   function to run after any final modifications have been to the text-input.
+
+   For example on iOS, tools like auto-correct will attempt to modify the
+   text-input when pressing the send button. Using `reagent/next-tick` allows
+   for that modification to happen and the related event dispatches to resolve
+   before call the `send-message` function."
+  [params]
+  (reagent/next-tick #(send-message params)))
 
 (defn send-button
   [input-ref edit]
@@ -31,9 +45,9 @@
                                       (rf/sub [:contacts/contact-customization-color-by-address
                                                chat-id]))
         on-press                    (rn/use-callback
-                                     (fn []
-                                       (js/requestAnimationFrame
-                                        #(send-message input-ref edit btn-opacity)))
+                                     #(send-message-next-tick {:edit        edit
+                                                               :input-ref   input-ref
+                                                               :btn-opacity btn-opacity})
                                      [edit])]
     (rn/use-effect (fn []
                      ;; Handle send button opacity animation and z-index when input content changes

--- a/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/actions/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [quo.core :as quo]
     [react-native.core :as rn]
+    [react-native.platform :as platform]
     [react-native.reanimated :as reanimated]
     [reagent.core :as reagent]
     [status-im.constants :as constants]
@@ -9,7 +10,7 @@
     [status-im.contexts.chat.messenger.composer.actions.style :as style]
     [utils.re-frame :as rf]))
 
-(defn send-message
+(defn send-message-now
   [{:keys [input-ref edit btn-opacity]}]
   (when @input-ref
     (.clear ^js @input-ref))
@@ -30,7 +31,12 @@
    for that modification to happen and the related event dispatches to resolve
    before call the `send-message` function."
   [params]
-  (reagent/next-tick #(send-message params)))
+  (reagent/next-tick #(send-message-now params)))
+
+(def send-message
+  (if platform/ios?
+    send-message-next-tick
+    send-message-now))
 
 (defn send-button
   [input-ref edit]
@@ -45,9 +51,9 @@
                                       (rf/sub [:contacts/contact-customization-color-by-address
                                                chat-id]))
         on-press                    (rn/use-callback
-                                     #(send-message-next-tick {:edit        edit
-                                                               :input-ref   input-ref
-                                                               :btn-opacity btn-opacity})
+                                     #(send-message {:edit        edit
+                                                     :input-ref   input-ref
+                                                     :btn-opacity btn-opacity})
                                      [edit])]
     (rn/use-effect (fn []
                      ;; Handle send button opacity animation and z-index when input content changes


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #21774

## Summary
[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to resolve an issue with the chat text-input when using auto-correct on iOS.
  * The initial issue mentioned in #21774 seems to be caused by auto-correct replacing the text after the message has been sent and the text-input cleared.
* This PR resolves the issue by allowing the auto-correct feature to change the text before sending the message.
  * This functionality seems to match what happens in other chat apps on iOS like Messages, Signal, and WhatsApp.

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

### Areas that may be impacted
[comment]: # (Optional. Specify if some specific areas need to be tested, such as 1-1 chats)

#### Functional

- 1-1 chats
- public chats
- group chats
- auto-correct in chat (iOS)

### Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Ensure auto-correct is enabled on device keyboard
- Open Status mobile app
- Open a chat
- Type a message with typo that is detected by auto-correct
  - For example, the message "Yesh" would be recommended to be "Yeah"
- Press the send message button
- Review which message text was sent in chat log

### Screen Capture after changes on iOS

https://github.com/user-attachments/assets/5bb82f45-1371-4128-978d-e4d730184aa1

[comment]: # (Can be ready or wip)
status: ready

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that may be impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
