### PR TITLE
ci: fix Nix Cache Jenkins job

### DIFF
--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -8,7 +8,7 @@ pipeline {
     string(
       name: 'NIX_CACHE_HOST',
       description: 'FQDN of Nix binary cache host.',
-      defaultValue: params.NIX_CACHE_HOST ?: 'cache-01.do-ams3.nix.ci.statusim.net'
+      defaultValue: params.NIX_CACHE_HOST ?: 'cache-01.he-eu-hel1.ci.nix.status.im'
     )
     string(
       name: 'NIX_CACHE_USER',
@@ -18,8 +18,7 @@ pipeline {
   }
 
   environment {
-    /* we source .bash_profile to be able to use nix-store */
-    NIX_SSHOPTS = "-oStrictHostKeyChecking=no"
+    NIX_SSHOPTS = "-oStrictHostKeyChecking=accept-new"
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
     NIX_STORE_CMD = '/nix/var/nix/profiles/default/bin/nix-store'
     NIX_SSH_REMOTE = "ssh://${params.NIX_CACHE_USER}@${params.NIX_CACHE_HOST}?remote-program=${env.NIX_STORE_CMD}"
@@ -47,6 +46,7 @@ pipeline {
         arch = sh(script: 'arch', returnStdout: true).trim()
       } }
     }
+
     stage('Build status-go') {
       steps { script {
         def platforms = ['mobile.android', 'mobile.ios', 'library']
@@ -64,6 +64,7 @@ pipeline {
         }
       } }
     }
+
     stage('Build android jsbundle') {
       steps { script {
         /* Build/fetch deps required for jsbundle build. */
@@ -75,6 +76,7 @@ pipeline {
         )
       } }
     }
+
     stage('Build android deps') {
       steps { script {
         /* Allow for Android builds on Apple ARM. */
@@ -88,6 +90,7 @@ pipeline {
         )
       } }
     }
+
     stage('Build nix shell deps') {
       steps { script {
         def shells = ['android', 'ios', 'fastlane', 'keytool', 'clojure', 'gradle']
@@ -106,22 +109,28 @@ pipeline {
         }
       } }
     }
+
+    stage('Collect') {
+      steps { script {
+        nix.shell(
+          """
+            find /nix/store/ -mindepth 1 -maxdepth 1 \
+              | grep -v -e '.*.links\$' -e '.*.lock\$' -e '.*.drv\$' -e '.*.drv\$' -e '.*-status-mobile-.*' \
+              | nix path-info --stdin --recursive \
+              > "${WORKSPACE_TMP}/store-paths.txt"
+          """,
+          pure: false
+        )
+      } }
+    }
+
     stage('Upload') {
       steps { script {
         sshagent(credentials: ['nix-cache-ssh']) {
           nix.shell(
             """
-              find /nix/store/ -mindepth 1 -maxdepth 1 -type d \
-                -not -name "*.links" -and -not -name "*-status-mobile-*" \
-                -and -not -name "tmp-*" \
-                -print0 | xargs -0 nix-store -qR | sort -u > "${WORKSPACE_TMP}"/store-paths.txt
-            """,
-            pure: false
-          )
-          nix.shell(
-            """
-              nix-store --export < "${WORKSPACE_TMP}"/store-paths.txt | \\
-                ssh ${env.NIX_SSHOPTS} ${params.NIX_CACHE_USER}@${params.NIX_CACHE_HOST} ${env.NIX_STORE_CMD} --import
+              cat "${WORKSPACE_TMP}/store-paths.txt" \
+                | nix copy --stdin --to "${NIX_SSH_REMOTE}"
             """,
             pure: false
           )


### PR DESCRIPTION
Changes:

- Use `nix copy` instead of `nix-store --export` as it does not work.
- Use `--stdin` when possible to improve performance.
- Update Nix cache hostname.

Host moved in:
- https://github.com/status-im/infra-ci/issues/181