### PR TITLE
perf: enable -0fast optimisation flag in status-go

### DIFF
--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -48,6 +48,9 @@ in buildGoPackage rec {
   # TODO: try removing when go is upgraded to 1.22
   GODEBUG = "netdns=cgo+2";
 
+  # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-Ofast
+  CGO_CFLAGS = "-Ofast";
+
   # Sentry for status-go
   SENTRY_CONTEXT_NAME = "status-mobile";
   SENTRY_CONTEXT_VERSION = version;

--- a/nix/status-go/mobile/build.nix
+++ b/nix/status-go/mobile/build.nix
@@ -48,8 +48,8 @@ in buildGoPackage rec {
   # TODO: try removing when go is upgraded to 1.22
   GODEBUG = "netdns=cgo+2";
 
-  # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-Ofast
-  CGO_CFLAGS = "-Ofast";
+  # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-O3
+  CGO_CFLAGS = "-O3";
 
   # Sentry for status-go
   SENTRY_CONTEXT_NAME = "status-mobile";


### PR DESCRIPTION
fixes #16202

## Summary
Adds `-0fast` optimisation flag  to status-go.
Lets see if things actually speed up.

https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Options-That-Control-Optimization

Additional options include : 
- `01`
- `02`
- `03`

## Platforms
- Android
- iOS

## Non-functional
- performance improvements with status-go

status: ready
