### PR TITLE
Refactoring: removed duplications in swap rf-db access paths

### DIFF
--- a/src/status_im/contexts/wallet/buy_crypto/events.cljs
+++ b/src/status_im/contexts/wallet/buy_crypto/events.cljs
@@ -1,13 +1,14 @@
 (ns status-im.contexts.wallet.buy-crypto.events
   (:require [re-frame.core :as rf]
             [react-native.core :as rn]
+            [status-im.contexts.wallet.db :as db]
             [status-im.contexts.wallet.sheets.buy-network-selection.view :as buy-network-selection]
             [status-im.contexts.wallet.sheets.select-asset.view :as select-asset]
             [utils.i18n :as i18n]))
 
 (rf/reg-event-fx :wallet.buy-crypto/select-provider
  (fn [{:keys [db]} [{:keys [account provider recurrent?]}]]
-   (let [swap-network (get-in db [:wallet :ui :swap :network])]
+   (let [swap-network (db/get-in db [db/swap :network])]
      {:db (-> db
               (assoc-in [:wallet :ui :buy-crypto :account] account)
               (assoc-in [:wallet :ui :buy-crypto :provider] provider)

--- a/src/status_im/contexts/wallet/db.cljs
+++ b/src/status_im/contexts/wallet/db.cljs
@@ -1,5 +1,49 @@
 (ns status-im.contexts.wallet.db
-  (:require [status-im.constants :as constants]))
+  (:require [clojure.core :as core]
+            [status-im.constants :as constants])
+  (:refer-clojure :exclude [assoc-in get-in update-in]))
+
+(def swap [:wallet :ui :swap])
+
+(defn- flatten-path
+  "Receives a vector of vals and flattens them
+  (flatten-path [:a [:b :c]]) returns [:a :b :c]
+  (flatten-path [[:a] [:b :c]]) returns [:a :b :c]"
+  [ks]
+  (loop [elements ks
+         result   []]
+    (let [v (first elements)]
+      (if-not v
+        result
+        (if (sequential? v)
+          (recur (rest elements) (into result v))
+          (recur (rest elements) (conj result v)))))))
+
+(defn assoc-in
+  "Version of assoc-in that can receive vectors as parts of the path.
+  Example:
+  (def swap [:wallet :ui :swap])
+  (assoc-in db [swap :some-key] \"value\")"
+  [m ks v]
+  (core/assoc-in m (flatten-path ks) v))
+
+(defn update-in
+  "Version of update-in that can receive vectors as parts of the path.
+  Example:
+  (def swap [:wallet :ui :swap])
+  (update-in db [swap :some-key] \"value\")"
+  [m ks & args]
+  (apply core/update-in m (flatten-path ks) args))
+
+(defn get-in
+  "Version of get-in that can receive vectors as parts of the path.
+  Example:
+  (def swap [:wallet :ui :swap])
+  (update-in db [swap :some-key] \"value\")"
+  ([m ks not-found]
+   (core/get-in m (flatten-path ks) not-found))
+  ([m ks]
+   (core/get-in m (flatten-path ks) nil)))
 
 (def network-filter-defaults
   {:selector-state    :default

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -786,7 +786,7 @@
  (fn [{:keys [db]}
       [{sent-transactions :sentTransactions
         send-details      :sendDetails}]]
-   (let [swap? (get-in db [:wallet :ui :swap])]
+   (let [swap? (get-in db db/swap)]
      {:fx [[:dispatch
             (if-let [error-response (:errorResponse send-details)]
               [(if swap?

--- a/src/status_im/contexts/wallet/signals.cljs
+++ b/src/status_im/contexts/wallet/signals.cljs
@@ -2,6 +2,7 @@
   (:require
     [oops.core :as oops]
     [status-im.constants :as constants]
+    [status-im.contexts.wallet.db :as db]
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]
     [utils.transforms :as transforms]))
@@ -19,7 +20,7 @@
                                         :pending
                                         (= tx-status constants/transaction-status-failed)
                                         :failed)
-         swap-approval-transaction-id (get-in db [:wallet :ui :swap :approval-transaction-id])
+         swap-approval-transaction-id (db/get-in db [db/swap :approval-transaction-id])
          swap-approval-transaction?   (= swap-approval-transaction-id tx-hash)
          swap-transaction-ids         (get-in db [:wallet :swap-transaction-ids])
          swap-transaction?            (and swap-transaction-ids

--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -2,6 +2,7 @@
   (:require [re-frame.core :as rf]
             [status-im.constants :as constants]
             [status-im.contexts.wallet.common.utils :as utils]
+            [status-im.contexts.wallet.db :as db]
             [status-im.contexts.wallet.send.utils :as send-utils]
             [status-im.contexts.wallet.sheets.network-selection.view :as network-selection]
             [status-im.contexts.wallet.swap.utils :as swap-utils]
@@ -35,11 +36,11 @@
                                     (swap-utils/select-network asset-to-pay))
          start-point            (if open-new-screen? :action-menu :swap-button)]
      {:db (-> db
-              (assoc-in [:wallet :ui :swap :asset-to-pay] asset-to-pay)
-              (assoc-in [:wallet :ui :swap :asset-to-receive] asset-to-receive)
-              (assoc-in [:wallet :ui :swap :network] network')
-              (assoc-in [:wallet :ui :swap :launch-screen] view-id)
-              (assoc-in [:wallet :ui :swap :start-point] start-point))
+              (db/assoc-in [db/swap :asset-to-pay] asset-to-pay)
+              (db/assoc-in [db/swap :asset-to-receive] asset-to-receive)
+              (db/assoc-in [db/swap :network] network')
+              (db/assoc-in [db/swap :launch-screen] view-id)
+              (db/assoc-in [db/swap :start-point] start-point))
       :fx (if (and multi-account-balance? root-screen? (not from-account))
             [[:dispatch [:open-modal :screen/wallet.swap-select-account]]]
             (if network'
@@ -75,10 +76,10 @@
 
 (rf/reg-event-fx :wallet.swap/select-asset-to-pay
  (fn [{:keys [db]} [{:keys [token]}]]
-   (let [previous-token (get-in db [:wallet :ui :swap :asset-to-pay])
-         network        (get-in db [:wallet :ui :swap :network])]
+   (let [previous-token (db/get-in db [db/swap :asset-to-pay])
+         network        (db/get-in db [db/swap :network])]
      {:db (update-in db
-                     [:wallet :ui :swap]
+                     db/swap
                      #(-> %
                           (assoc :asset-to-pay token)
                           (dissoc :amount
@@ -97,9 +98,9 @@
 
 (rf/reg-event-fx :wallet.swap/select-asset-to-receive
  (fn [{:keys [db]} [{:keys [token]}]]
-   (let [previous-token (get-in db [:wallet :ui :swap :asset-to-receive])
-         network        (get-in db [:wallet :ui :swap :network])]
-     {:db (assoc-in db [:wallet :ui :swap :asset-to-receive] token)
+   (let [previous-token (db/get-in db [db/swap :asset-to-receive])
+         network        (db/get-in db [db/swap :network])]
+     {:db (db/assoc-in db [db/swap :asset-to-receive] token)
       :fx [[:dispatch
             [:centralized-metrics/track :metric/swap-asset-to-receive-changed
              {:network        (:chain-id network)
@@ -108,21 +109,21 @@
 
 (rf/reg-event-fx :wallet.swap/set-default-slippage
  (fn [{:keys [db]}]
-   {:db (assoc-in db [:wallet :ui :swap :max-slippage] constants/default-slippage)}))
+   {:db (db/assoc-in db [db/swap :max-slippage] constants/default-slippage)}))
 
 (rf/reg-event-fx :wallet.swap/set-max-slippage
  (fn [{:keys [db]} [max-slippage]]
-   {:db (assoc-in db [:wallet :ui :swap :max-slippage] (number/parse-float max-slippage))}))
+   {:db (db/assoc-in db [db/swap :max-slippage] (number/parse-float max-slippage))}))
 
 (rf/reg-event-fx :wallet.swap/set-loading-swap-proposal
  (fn [{:keys [db]}]
-   {:db (assoc-in db [:wallet :ui :swap :loading-swap-proposal?] true)}))
+   {:db (db/assoc-in db [db/swap :loading-swap-proposal?] true)}))
 
 (rf/reg-event-fx :wallet/start-get-swap-proposal
  (fn [{:keys [db]} [{:keys [amount-in amount-out clean-approval-transaction?]}]]
    (let [wallet-address          (get-in db [:wallet :current-viewing-account-address])
          {:keys [asset-to-pay asset-to-receive
-                 network]}       (get-in db [:wallet :ui :swap])
+                 network]}       (get-in db db/swap)
          test-networks-enabled?  (get-in db [:profile/profile :test-networks-enabled?])
          networks                ((if test-networks-enabled? :test :prod)
                                   (get-in db [:wallet :networks]))
@@ -160,7 +161,7 @@
                                     amount-in (assoc :amountIn amount-in-hex))]]
      (when-let [amount (or amount-in amount-out)]
        {:db            (update-in db
-                                  [:wallet :ui :swap]
+                                  db/swap
                                   #(cond-> %
                                      :always
                                      (assoc
@@ -186,12 +187,12 @@
 
 (rf/reg-event-fx :wallet/swap-proposal-success
  (fn [{:keys [db]} [swap-proposal]]
-   (let [last-request-uuid    (get-in db [:wallet :ui :swap :last-request-uuid])
-         amount-hex           (get-in db [:wallet :ui :swap :amount-hex])
-         asset-to-pay         (get-in db [:wallet :ui :swap :asset-to-pay])
-         asset-to-receive     (get-in db [:wallet :ui :swap :asset-to-receive])
-         network              (get-in db [:wallet :ui :swap :network])
-         initial-response?    (get-in db [:wallet :ui :swap :initial-response?])
+   (let [last-request-uuid    (db/get-in db [db/swap :last-request-uuid])
+         amount-hex           (db/get-in db [db/swap :amount-hex])
+         asset-to-pay         (db/get-in db [db/swap :asset-to-pay])
+         asset-to-receive     (db/get-in db [db/swap :asset-to-receive])
+         network              (db/get-in db [db/swap :network])
+         initial-response?    (db/get-in db [db/swap :initial-response?])
          view-id              (:view-id db)
          request-uuid         (:uuid swap-proposal)
          best-routes          (:best swap-proposal)
@@ -203,7 +204,7 @@
                      (pos? (count best-routes))
                      (= (:amount-in (first best-routes)) amount-hex))))
        (cond-> {:db (update-in db
-                               [:wallet :ui :swap]
+                               db/swap
                                assoc
                                :swap-proposal          (when-not (empty? best-routes)
                                                          (assoc (first best-routes) :uuid request-uuid))
@@ -243,15 +244,15 @@
 (rf/reg-event-fx :wallet/swap-proposal-error
  (fn [{:keys [db]} [error-response]]
    {:db (-> db
-            (update-in [:wallet :ui :swap] dissoc :route :swap-proposal)
-            (assoc-in [:wallet :ui :swap :loading-swap-proposal?] false)
-            (assoc-in [:wallet :ui :swap :error-response] error-response))
+            (db/update-in db/swap dissoc :route :swap-proposal)
+            (db/assoc-in [db/swap :loading-swap-proposal?] false)
+            (db/assoc-in [db/swap :error-response] error-response))
     :fx [[:dispatch
           [:centralized-metrics/track :metric/swap-proposal-failed {:error (:code error-response)}]]]}))
 
 (rf/reg-event-fx :wallet/stop-get-swap-proposal
  (fn [{:keys [db]}]
-   {:db            (update-in db [:wallet :ui :swap] dissoc :last-request-uuid)
+   {:db            (update-in db db/swap dissoc :last-request-uuid)
     :json-rpc/call [{:method   "wallet_stopSuggestedRoutesAsyncCalculation"
                      :params   []
                      :on-error (fn [error]
@@ -268,7 +269,7 @@
                                  :loading-swap-proposal?]
                           clean-amounts?              (conj :amount :amount-hex)
                           clean-approval-transaction? (conj :approval-transaction-id :approved-amount))]
-     {:db (apply update-in db [:wallet :ui :swap] dissoc keys-to-dissoc)
+     {:db (apply update-in db db/swap dissoc keys-to-dissoc)
       :fx [[:dispatch [:wallet/stop-get-swap-proposal]]]})))
 
 (rf/reg-event-fx :wallet/clean-swap
@@ -288,8 +289,8 @@
      {:db (cond-> db
             :always                     (assoc-in [:wallet :transactions]
                                          (merge wallet-transactions transaction-details))
-            :always                     (assoc-in [:wallet :ui :swap :transaction-ids] transaction-ids)
-            approval-transaction?       (assoc-in [:wallet :ui :swap :approval-transaction-id]
+            :always                     (db/assoc-in [db/swap :transaction-ids] transaction-ids)
+            approval-transaction?       (db/assoc-in [db/swap :approval-transaction-id]
                                          transaction-id)
             (not approval-transaction?) (assoc-in [:wallet :swap-transaction-ids]
                                          (if swap-transaction-ids
@@ -299,7 +300,7 @@
 (rf/reg-event-fx :wallet.swap/approve-transaction-update
  (fn [{:keys [db]} [{:keys [status]}]]
    (let [{:keys [amount asset-to-pay swap-proposal
-                 network]}                (get-in db [:wallet :ui :swap])
+                 network]}                (get-in db db/swap)
          provider-name                    (:bridge-name swap-proposal)
          token-symbol                     (:symbol asset-to-pay)
          swap-chain-id                    (:chain-id network)
@@ -333,9 +334,9 @@
                                          :provider-name provider-name
                                          :account-name  account-name}))}]]]}
          transaction-confirmed?
-         (assoc :db (assoc-in db [:wallet :ui :swap :approved-amount] amount))
+         (assoc :db (db/assoc-in db [db/swap :approved-amount] amount))
          (not transaction-confirmed?)
-         (assoc :db (update-in db [:wallet :ui :swap] dissoc :approval-transaction-id)))))))
+         (assoc :db (update-in db db/swap dissoc :approval-transaction-id)))))))
 
 (rf/reg-event-fx
  :wallet.swap/swap-transaction-update
@@ -373,7 +374,7 @@
  :wallet.swap/flip-assets
  (fn [{:keys [db]}]
    (let [{:keys [asset-to-pay asset-to-receive
-                 swap-proposal amount network]} (get-in db [:wallet :ui :swap])
+                 swap-proposal amount network]} (get-in db db/swap)
          receive-token-decimals                 (:decimals asset-to-receive)
          amount-out                             (when swap-proposal (:amount-out swap-proposal))
          receive-amount                         (when amount-out
@@ -381,7 +382,7 @@
                                                       (number/hex->whole receive-token-decimals)
                                                       (money/to-fixed receive-token-decimals)))]
      {:db (update-in db
-                     [:wallet :ui :swap]
+                     db/swap
                      #(-> %
                           (assoc
                            :asset-to-pay     asset-to-receive
@@ -407,13 +408,13 @@
 (rf/reg-event-fx
  :wallet.swap/set-sign-transactions-callback-fx
  (fn [{:keys [db]} [callback-fx]]
-   {:db (assoc-in db [:wallet :ui :swap :sign-transactions-callback-fx] callback-fx)}))
+   {:db (db/assoc-in db [db/swap :sign-transactions-callback-fx] callback-fx)}))
 
 (rf/reg-event-fx
  :wallet.swap/review-swap
  (fn [{:keys [db]}]
    {:db (-> db
-            (update-in [:wallet :ui :swap] dissoc :transaction-for-signing))
+            (update-in db/swap dissoc :transaction-for-signing))
     :fx [[:dispatch
           [:navigate-to-within-stack
            [:screen/wallet.swap-confirmation
@@ -422,8 +423,8 @@
 (rf/reg-event-fx
  :wallet/prepare-signatures-for-swap-transactions
  (fn [{:keys [db]}]
-   (let [last-request-uuid (get-in db [:wallet :ui :swap :last-request-uuid])
-         max-slippage      (get-in db [:wallet :ui :swap :max-slippage])]
+   (let [last-request-uuid (db/get-in db [db/swap :last-request-uuid])
+         max-slippage      (db/get-in db [db/swap :max-slippage])]
      {:fx [[:dispatch
             [:wallet/build-transactions-from-route
              {:request-uuid last-request-uuid
@@ -447,7 +448,7 @@
  (fn [{:keys [db]} [transaction-id]]
    {:db (-> db
             (assoc-in [:wallet :transactions transaction-id :status] :pending)
-            (assoc-in [:wallet :ui :swap :approval-transaction-id] transaction-id))}))
+            (db/assoc-in [db/swap :approval-transaction-id] transaction-id))}))
 
 (rf/reg-event-fx
  :wallet.swap/transaction-success
@@ -458,7 +459,7 @@
                  asset-to-receive
                  network
                  amount]
-          :as   swap}           (get-in db [:wallet :ui :swap])
+          :as   swap}           (get-in db db/swap)
          swap-chain-id          (:chain-id network)
          token-id-from          (:symbol asset-to-pay)
          token-id-to            (:symbol asset-to-receive)
@@ -517,7 +518,7 @@
          {:keys [asset-to-pay
                  asset-to-receive
                  network]
-          :as   swap}       (get-in db [:wallet :ui :swap])
+          :as   swap}       (get-in db db/swap)
          swap-chain-id      (:chain-id network)
          token-id-from      (:symbol asset-to-pay)
          token-id-to        (:symbol asset-to-receive)
@@ -542,7 +543,7 @@
  :wallet.swap/clean-up-transaction-flow
  (fn [{:keys [db]}]
    (let [transactions       (get-in db [:wallet :transactions])
-         swap               (get-in db [:wallet :ui :swap])
+         swap               (get-in db db/swap)
          approval-required? (transaction-approval-required? transactions swap)]
      {:db (update-in db [:wallet :ui] dissoc :swap)
       :fx [[:dispatch
@@ -563,8 +564,8 @@
 
 (rf/reg-event-fx :wallet.swap/start-from-account
  (fn [{:keys [db]} [account]]
-   (let [asset-to-pay     (get-in db [:wallet :ui :swap :asset-to-pay])
-         asset-to-receive (get-in db [:wallet :ui :swap :asset-to-receive])]
+   (let [asset-to-pay     (db/get-in db [db/swap :asset-to-pay])
+         asset-to-receive (db/get-in db [db/swap :asset-to-receive])]
      {:fx (if asset-to-pay
             [[:dispatch [:dismiss-modal :screen/wallet.swap-select-account]]
              [:dispatch

--- a/src/status_im/contexts/wallet/swap/events.cljs
+++ b/src/status_im/contexts/wallet/swap/events.cljs
@@ -2,14 +2,15 @@
   (:require [re-frame.core :as rf]
             [status-im.constants :as constants]
             [status-im.contexts.wallet.common.utils :as utils]
-            [status-im.contexts.wallet.db :as db]
+            [status-im.contexts.wallet.db :as db :refer [assoc-in get-in update-in]]
             [status-im.contexts.wallet.send.utils :as send-utils]
             [status-im.contexts.wallet.sheets.network-selection.view :as network-selection]
             [status-im.contexts.wallet.swap.utils :as swap-utils]
             [taoensso.timbre :as log]
             [utils.i18n :as i18n]
             [utils.money :as money]
-            [utils.number :as number]))
+            [utils.number :as number])
+  (:refer-clojure :exclude [assoc-in get-in update-in]))
 
 (rf/reg-event-fx :wallet.swap/start
  (fn [{:keys [db]} [{:keys [network asset-to-receive open-new-screen? from-account] :as data}]]
@@ -36,11 +37,11 @@
                                     (swap-utils/select-network asset-to-pay))
          start-point            (if open-new-screen? :action-menu :swap-button)]
      {:db (-> db
-              (db/assoc-in [db/swap :asset-to-pay] asset-to-pay)
-              (db/assoc-in [db/swap :asset-to-receive] asset-to-receive)
-              (db/assoc-in [db/swap :network] network')
-              (db/assoc-in [db/swap :launch-screen] view-id)
-              (db/assoc-in [db/swap :start-point] start-point))
+              (assoc-in [db/swap :asset-to-pay] asset-to-pay)
+              (assoc-in [db/swap :asset-to-receive] asset-to-receive)
+              (assoc-in [db/swap :network] network')
+              (assoc-in [db/swap :launch-screen] view-id)
+              (assoc-in [db/swap :start-point] start-point))
       :fx (if (and multi-account-balance? root-screen? (not from-account))
             [[:dispatch [:open-modal :screen/wallet.swap-select-account]]]
             (if network'
@@ -76,8 +77,8 @@
 
 (rf/reg-event-fx :wallet.swap/select-asset-to-pay
  (fn [{:keys [db]} [{:keys [token]}]]
-   (let [previous-token (db/get-in db [db/swap :asset-to-pay])
-         network        (db/get-in db [db/swap :network])]
+   (let [previous-token (get-in db [db/swap :asset-to-pay])
+         network        (get-in db [db/swap :network])]
      {:db (update-in db
                      db/swap
                      #(-> %
@@ -98,9 +99,9 @@
 
 (rf/reg-event-fx :wallet.swap/select-asset-to-receive
  (fn [{:keys [db]} [{:keys [token]}]]
-   (let [previous-token (db/get-in db [db/swap :asset-to-receive])
-         network        (db/get-in db [db/swap :network])]
-     {:db (db/assoc-in db [db/swap :asset-to-receive] token)
+   (let [previous-token (get-in db [db/swap :asset-to-receive])
+         network        (get-in db [db/swap :network])]
+     {:db (assoc-in db [db/swap :asset-to-receive] token)
       :fx [[:dispatch
             [:centralized-metrics/track :metric/swap-asset-to-receive-changed
              {:network        (:chain-id network)
@@ -109,15 +110,15 @@
 
 (rf/reg-event-fx :wallet.swap/set-default-slippage
  (fn [{:keys [db]}]
-   {:db (db/assoc-in db [db/swap :max-slippage] constants/default-slippage)}))
+   {:db (assoc-in db [db/swap :max-slippage] constants/default-slippage)}))
 
 (rf/reg-event-fx :wallet.swap/set-max-slippage
  (fn [{:keys [db]} [max-slippage]]
-   {:db (db/assoc-in db [db/swap :max-slippage] (number/parse-float max-slippage))}))
+   {:db (assoc-in db [db/swap :max-slippage] (number/parse-float max-slippage))}))
 
 (rf/reg-event-fx :wallet.swap/set-loading-swap-proposal
  (fn [{:keys [db]}]
-   {:db (db/assoc-in db [db/swap :loading-swap-proposal?] true)}))
+   {:db (assoc-in db [db/swap :loading-swap-proposal?] true)}))
 
 (rf/reg-event-fx :wallet/start-get-swap-proposal
  (fn [{:keys [db]} [{:keys [amount-in amount-out clean-approval-transaction?]}]]
@@ -187,12 +188,12 @@
 
 (rf/reg-event-fx :wallet/swap-proposal-success
  (fn [{:keys [db]} [swap-proposal]]
-   (let [last-request-uuid    (db/get-in db [db/swap :last-request-uuid])
-         amount-hex           (db/get-in db [db/swap :amount-hex])
-         asset-to-pay         (db/get-in db [db/swap :asset-to-pay])
-         asset-to-receive     (db/get-in db [db/swap :asset-to-receive])
-         network              (db/get-in db [db/swap :network])
-         initial-response?    (db/get-in db [db/swap :initial-response?])
+   (let [last-request-uuid    (get-in db [db/swap :last-request-uuid])
+         amount-hex           (get-in db [db/swap :amount-hex])
+         asset-to-pay         (get-in db [db/swap :asset-to-pay])
+         asset-to-receive     (get-in db [db/swap :asset-to-receive])
+         network              (get-in db [db/swap :network])
+         initial-response?    (get-in db [db/swap :initial-response?])
          view-id              (:view-id db)
          request-uuid         (:uuid swap-proposal)
          best-routes          (:best swap-proposal)
@@ -244,9 +245,9 @@
 (rf/reg-event-fx :wallet/swap-proposal-error
  (fn [{:keys [db]} [error-response]]
    {:db (-> db
-            (db/update-in db/swap dissoc :route :swap-proposal)
-            (db/assoc-in [db/swap :loading-swap-proposal?] false)
-            (db/assoc-in [db/swap :error-response] error-response))
+            (update-in db/swap dissoc :route :swap-proposal)
+            (assoc-in [db/swap :loading-swap-proposal?] false)
+            (assoc-in [db/swap :error-response] error-response))
     :fx [[:dispatch
           [:centralized-metrics/track :metric/swap-proposal-failed {:error (:code error-response)}]]]}))
 
@@ -289,8 +290,8 @@
      {:db (cond-> db
             :always                     (assoc-in [:wallet :transactions]
                                          (merge wallet-transactions transaction-details))
-            :always                     (db/assoc-in [db/swap :transaction-ids] transaction-ids)
-            approval-transaction?       (db/assoc-in [db/swap :approval-transaction-id]
+            :always                     (assoc-in [db/swap :transaction-ids] transaction-ids)
+            approval-transaction?       (assoc-in [db/swap :approval-transaction-id]
                                          transaction-id)
             (not approval-transaction?) (assoc-in [:wallet :swap-transaction-ids]
                                          (if swap-transaction-ids
@@ -334,7 +335,7 @@
                                          :provider-name provider-name
                                          :account-name  account-name}))}]]]}
          transaction-confirmed?
-         (assoc :db (db/assoc-in db [db/swap :approved-amount] amount))
+         (assoc :db (assoc-in db [db/swap :approved-amount] amount))
          (not transaction-confirmed?)
          (assoc :db (update-in db db/swap dissoc :approval-transaction-id)))))))
 
@@ -408,7 +409,7 @@
 (rf/reg-event-fx
  :wallet.swap/set-sign-transactions-callback-fx
  (fn [{:keys [db]} [callback-fx]]
-   {:db (db/assoc-in db [db/swap :sign-transactions-callback-fx] callback-fx)}))
+   {:db (assoc-in db [db/swap :sign-transactions-callback-fx] callback-fx)}))
 
 (rf/reg-event-fx
  :wallet.swap/review-swap
@@ -423,8 +424,8 @@
 (rf/reg-event-fx
  :wallet/prepare-signatures-for-swap-transactions
  (fn [{:keys [db]}]
-   (let [last-request-uuid (db/get-in db [db/swap :last-request-uuid])
-         max-slippage      (db/get-in db [db/swap :max-slippage])]
+   (let [last-request-uuid (get-in db [db/swap :last-request-uuid])
+         max-slippage      (get-in db [db/swap :max-slippage])]
      {:fx [[:dispatch
             [:wallet/build-transactions-from-route
              {:request-uuid last-request-uuid
@@ -448,7 +449,7 @@
  (fn [{:keys [db]} [transaction-id]]
    {:db (-> db
             (assoc-in [:wallet :transactions transaction-id :status] :pending)
-            (db/assoc-in [db/swap :approval-transaction-id] transaction-id))}))
+            (assoc-in [db/swap :approval-transaction-id] transaction-id))}))
 
 (rf/reg-event-fx
  :wallet.swap/transaction-success
@@ -564,8 +565,8 @@
 
 (rf/reg-event-fx :wallet.swap/start-from-account
  (fn [{:keys [db]} [account]]
-   (let [asset-to-pay     (db/get-in db [db/swap :asset-to-pay])
-         asset-to-receive (db/get-in db [db/swap :asset-to-receive])]
+   (let [asset-to-pay     (get-in db [db/swap :asset-to-pay])
+         asset-to-receive (get-in db [db/swap :asset-to-receive])]
      {:fx (if asset-to-pay
             [[:dispatch [:dismiss-modal :screen/wallet.swap-select-account]]
              [:dispatch

--- a/src/status_im/subs/wallet/swap_test.cljs
+++ b/src/status_im/subs/wallet/swap_test.cljs
@@ -2,6 +2,7 @@
   (:require
     [cljs.test :refer [is testing]]
     [re-frame.db :as rf-db]
+    [status-im.contexts.wallet.db :as db]
     [status-im.subs.root]
     [status-im.subs.wallet.collectibles]
     [test-helpers.unit :as h]
@@ -131,7 +132,7 @@
   [sub-name]
   (testing "Return the wallet/ui/swap node"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? swap-data (rf/sub [sub-name])))))
 
@@ -139,7 +140,7 @@
   [sub-name]
   (testing "Return swap asset-to-pay"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? (swap-data :asset-to-pay) (rf/sub [sub-name])))))
 
@@ -147,7 +148,7 @@
   [sub-name]
   (testing "Return swap asset-to-receive"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? (swap-data :asset-to-receive) (rf/sub [sub-name])))))
 
@@ -155,7 +156,7 @@
   [sub-name]
   (testing "Return asset-to-pay token symbol"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? "SNT" (rf/sub [sub-name])))))
 
@@ -163,7 +164,7 @@
   [sub-name]
   (testing "Return the available networks for the swap asset-to-pay"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? networks (rf/sub [sub-name])))))
 
@@ -173,7 +174,7 @@
     (swap! rf-db/app-db
       #(-> %
            (assoc :currencies currencies)
-           (assoc-in [:wallet :ui :swap] swap-data)
+           (assoc-in db/swap swap-data)
            (assoc-in [:wallet :tokens :prices-per-token] prices-per-token-low)))
     (is (match? {:crypto "1 SNT" :fiat "$0.03"} (rf/sub [sub-name 1])))))
 
@@ -181,7 +182,7 @@
   [sub-name]
   (testing "Return the current swap network"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? (swap-data :network) (rf/sub [sub-name])))))
 
@@ -189,7 +190,7 @@
   [sub-name]
   (testing "Return the swap error response"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? (swap-data :error-response) (rf/sub [sub-name])))))
 
@@ -197,7 +198,7 @@
   [sub-name]
   (testing "Return the max slippage for the swap"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? 0.5 (rf/sub [sub-name])))))
 
@@ -205,7 +206,7 @@
   [sub-name]
   (testing "Return if swap is loading the swap proposal"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (false? (rf/sub [sub-name])))))
 
@@ -213,7 +214,7 @@
   [sub-name]
   (testing "Return the swap proposal"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? (swap-data :swap-proposal) (rf/sub [sub-name])))))
 
@@ -221,7 +222,7 @@
   [sub-name]
   (testing "Return the amount out in the swap proposal"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? "0x10000" (rf/sub [sub-name])))))
 
@@ -229,7 +230,7 @@
   [sub-name]
   (testing "Return if approval is required in the swap proposal"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (true? (rf/sub [sub-name])))))
 
@@ -237,7 +238,7 @@
   [sub-name]
   (testing "Return the approval amount required in the swap proposal"
     (swap! rf-db/app-db assoc-in
-      [:wallet :ui :swap]
+      db/swap
       swap-data)
     (is (match? "0x10000" (rf/sub [sub-name])))))
 
@@ -248,7 +249,7 @@
       #(-> %
            (assoc-in [:wallet :accounts] accounts-with-tokens)
            (assoc-in [:wallet :current-viewing-account-address] "0x1")
-           (assoc-in [:wallet :ui :swap] swap-data)
+           (assoc-in db/swap swap-data)
            (assoc-in [:currencies] currencies)
            (assoc-in [:profile/profile :currency] :usd)
            (assoc-in [:profile/profile :currency-symbol] "$")


### PR DESCRIPTION
## Summary
### Problem
We duplicate same `rf-db` path sections multiple times in our codebase. For example `:wallet :ui :swap` in code sections similar to this one:
```clojure
              (assoc-in [:wallet :ui :swap :asset-to-pay] asset-to-pay)
              (assoc-in [:wallet :ui :swap :asset-to-receive] asset-to-receive)
              (assoc-in [:wallet :ui :swap :network] network')
              (assoc-in [:wallet :ui :swap :launch-screen] view-id)
              (assoc-in [:wallet :ui :swap :start-point] start-point)
```              

That means that any database refactoring will be a pain. In fact it is the same problem as sprinkling some magic constant around the code - tons of places will need to change if constants changed.

Lets check how things are with the send constants:
![Screenshot 2025-03-13 at 14 37 38](https://github.com/user-attachments/assets/1bdd8359-8a3c-416a-adb2-2b9394f9e642)
**124 occurences!**

### Decision
This PR reimplements `(assoc-in)`, `(get-in)` and `(update-in)` such that they can receive path vector that contains another vectors.
Example:


in: db.cljs:
```clojure
(def swap [:wallet :ui :swap])

(defn assoc-in ...)
```

in events.cljs:
```clojure
              (assoc-in [db/swap :asset-to-pay] asset-to-pay)
              (assoc-in [db/swap :asset-to-receive] asset-to-receive)
              (assoc-in [db/swap :network] network')
              (assoc-in [db/swap :launch-screen] view-id)
              (assoc-in [db/swap :start-point] start-point)
```

With these changes we 

## Review notes
This PR only introduces constant for `swap` db path. If you will find it useful the approach can be spreaded to more code areas

## Testing notes
Swaps internals changed, they need testing

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

### Areas that may be impacted
[comment]: # (Optional. Specify if some specific areas need to be tested, such as 1-1 chats)

#### Functional

- wallet / transactions


## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Open Status
- Do some swaps
- Step 3, etc.


[comment]: # (Can be ready or wip)
status: ready

