### PR TITLE
perf: optimize fetch token details calls

### DIFF
--- a/src/status_im/contexts/wallet/account/view.cljs
+++ b/src/status_im/contexts/wallet/account/view.cljs
@@ -62,7 +62,6 @@
                              (rf/dispatch [:wallet/start-bridge]))
          :swap-action      (fn []
                              (rf/dispatch [:wallet/clean-send-data])
-                             (rf/dispatch [:wallet.tokens/get-token-list])
                              (rf/dispatch [:open-modal :screen/wallet.swap-select-asset-to-pay]))
          :bridge-disabled? testnet-mode?
          :swap-disabled?   testnet-mode?}])

--- a/src/status_im/contexts/wallet/home/view.cljs
+++ b/src/status_im/contexts/wallet/home/view.cljs
@@ -106,7 +106,6 @@
         on-swap-press         (rn/use-callback
                                (fn []
                                  (rf/dispatch [:wallet/clean-send-data])
-                                 (rf/dispatch [:wallet.tokens/get-token-list])
                                  (when-not multiple-accounts?
                                    (rf/dispatch [:wallet/switch-current-viewing-account
                                                  first-account-address]))


### PR DESCRIPTION
fixes #22276

## Summary

This PR optimizes calls to fetch token details endpoints.

- Remove event dispatches to `:wallet.tokens/get-token-list` when initiating swap and send flows
- Event is only called on wallet initialization
- Prices are now only re-fetched when we receive `wallet-tick-reload` signal

### Platforms

- Android
- iOS

### Areas that may be impacted

#### Functional

- wallet / transactions

## Steps to test

- Open Status
- Log in
- Test asset selection lists on swap / send flows

status: ready