### PR TITLE
chore: remove reagent override because it is currently not effective

### DIFF
--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -35,6 +35,20 @@
 ;;;; re-frame RN setup
 (set! interop/next-tick js/setTimeout)
 
+;; Note: In the past we've configured reagent to run its batch rendering
+;; faster by overriding the next-tick function. This technique could be useful
+;; if we want to adjust the batch speed for different frame-rates since by
+;; default reagent tunes its batch rendering for 60FPS.
+;;
+;; For example, this code would have batches rendering as fast as possible
+;; (set! reagent.impl.batching/next-tick js/setImmediate)
+;;
+;; While this example would approximate 120FPS
+;; (set! reagent.impl.batching/next-tick #(js/setTimeout % 8))
+;;
+;; And under the hood this is what reagent will use for approximately 60FPS:
+;; (set! reagent.impl.batching/next-tick #(js/setTimeout % 16))
+
 (def adjust-resize 16)
 
 (defn is-hermes

--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -16,7 +16,6 @@
     [react-native.platform :as platform]
     [react-native.shake :as react-native-shake]
     [reagent.core]
-    [reagent.impl.batching :as batching]
     [status-im.common.log :as logging]
     [taoensso.timbre :as log]
     [status-im.common.universal-links :as universal-links]
@@ -35,7 +34,6 @@
 
 ;;;; re-frame RN setup
 (set! interop/next-tick js/setTimeout)
-(set! batching/fake-raf #(js/setTimeout % 0))
 
 (def adjust-resize 16)
 


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

## Summary
[comment]: # (Summarise the problem and how the pull request solves it)

* This PR removes an override for reagent's polyfill for requestAnimationFrame. Initially, the codebase used an override to configure to use a different polyfill, but now the override is not currently effective because of how the override is set. The `fake-raf` def is used by the `next-tick` def inside reagent, but both of those defs are evaluated before the override is set, meaning that the override does not take effect since we're not re-evaluating the next-tick def.

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

This change should not affect anything since it removes code that was not working, so it might be simplest to avoid manual testing unless it's just starting the app.

[comment]: # (Can be ready or wip)
status: ready


<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

- Specify potentially impacted user flows in _Areas that may be impacted*.
- Ensure that _Steps to test_ is filled in.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


-->
