### PR TITLE
[WIP]: Fix chat screen navigation for placeholder screen in ios

### DIFF
--- a/src/status_im/contexts/chat/messenger/placeholder/view.cljs
+++ b/src/status_im/contexts/chat/messenger/placeholder/view.cljs
@@ -3,6 +3,7 @@
     [quo.core :as quo]
     [quo.theme]
     [react-native.core :as rn]
+    [react-native.platform :as platform]
     [status-im.contexts.chat.messenger.placeholder.style :as style]
     [utils.re-frame :as rf]))
 
@@ -21,5 +22,8 @@
      (when-not chat-exist?
        [quo/page-nav
         {:icon-name :i/arrow-left
-         :on-press  #(rf/dispatch [:navigate-back])}])
+         :on-press  (fn []
+                      (rf/dispatch [:navigate-back])
+                      (when platform/ios?
+                        (rf/dispatch [:chat/close])))}])
      [loading-skeleton]]))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21660#issuecomment-2736829030

### Summary
- In Ios we also need to close chat while calling navigate back (related [comment](https://github.com/status-im/status-mobile/blob/110f7c94da0fc04cbf15226057779f57c5e4bb54/src/status_im/contexts/chat/messenger/messages/navigation/view.cljs#L108)). We were already doing that for [navigation/view](https://github.com/status-im/status-mobile/blob/develop/src/status_im/contexts/chat/messenger/messages/navigation/view.cljs#L108) in chat screen, but not in placeholder screen.
- But for android we keep chat close in :navigate-back itself, to support hardware button.
- Why not use navigate-back for ios too? Because of this issue https://github.com/status-im/status-mobile/issues/21659, we can't rely on view-id in ios. (Original issue report where we faced view-id and chat problem - https://github.com/status-im/status-mobile/pull/21643#issuecomment-2488962044)

status: ready