### PR TITLE
Check balance when changing tx fee settings

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v10.15.0",
-    "commit-sha1": "9dff1bc4925aa3773df1158e16707d6b54effb22",
-    "src-sha256": "0mc12wqz9cvf6ibrv41j7mx0i45899fms77bxb8mir3hzqmcx3k8"
+    "version": "v10.16.0",
+    "commit-sha1": "fa7db6f656d53838ddd8d0a4a0d5cba351536732",
+    "src-sha256": "04b1v3cm2877hv97sj6z3fipixar4vm1f0x9drkqcpj6ckw45jnx"
 }


### PR DESCRIPTION
https://github.com/status-im/status-go/compare/f0884d2f...2154185e

[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #22324 

## Summary
Relevant status-go PR https://github.com/status-im/status-go/pull/6429#pullrequestreview-2701891887

Added the balance check, so that when we get the suggested routes when changing the settings, we also get the "not enough balance" error. 

## Steps to test
1. Go to wallet
2. Try to send collectible from account that has no native token to pay the fees
3. See the "not enough balance" error on the send collectible confirmation screen
4. Change the tx fee setting
5. With the next route update, the "not enough balance" error should still be there (it would disappear before)

## Impacted areas
1. send collectible flow
2. send flow

[comment]: # (Can be ready or wip)
status: ready


### Risk


Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
