### PR TITLE
Implement screen-id and improve get-screen-params

### DIFF
--- a/src/legacy/status_im/browser/core.cljs
+++ b/src/legacy/status_im/browser/core.cljs
@@ -395,7 +395,7 @@
   (rf/merge (assoc-in cofx [:db :browser/options :yielding-control?] false)
             (browser.permissions/send-response-to-bridge permission message-id true data)
             (browser.permissions/process-next-permission dapp-name)
-            (navigation/navigate-back)))
+            (navigation/navigate-back nil)))
 
 (rf/defn handle-canceled-qr-code
   {:events [:browser.bridge.callback/qr-code-canceled]}

--- a/src/legacy/status_im/browser/permissions.cljs
+++ b/src/legacy/status_im/browser/permissions.cljs
@@ -86,7 +86,7 @@
   [cofx dapp]
   (rf/merge cofx
             (revoke-permissions dapp)
-            (navigation/navigate-back)))
+            (navigation/navigate-back nil)))
 
 (rf/defn clear-dapps-permissions
   [{:keys [db]}]

--- a/src/legacy/status_im/communities/core.cljs
+++ b/src/legacy/status_im/communities/core.cljs
@@ -30,7 +30,7 @@
   {:events [::people-invited]}
   [cofx response-js]
   (rf/merge cofx
-            (navigation/navigate-back)
+            (navigation/navigate-back nil)
             (handle-response response-js)))
 
 (rf/defn member-banned

--- a/src/legacy/status_im/ens/core.cljs
+++ b/src/legacy/status_im/ens/core.cljs
@@ -363,4 +363,4 @@
                  :preferred-name
                  (first new-names)
                  {}))
-              (navigation/navigate-back))))
+              (navigation/navigate-back nil))))

--- a/src/legacy/status_im/qr_scanner/core.cljs
+++ b/src/legacy/status_im/qr_scanner/core.cljs
@@ -31,7 +31,7 @@
   {:events [:qr-scanner.callback/scan-qr-code-cancel]}
   [cofx opts]
   (rf/merge cofx
-            (navigation/navigate-back)
+            (navigation/navigate-back nil)
             (when-let [handler (:cancel-handler opts)]
               (fn [] {:dispatch [handler opts]}))))
 
@@ -39,7 +39,7 @@
   [cofx {:keys [url]}]
   (rf/merge cofx
             {:browser/show-browser-selection url}
-            (navigation/navigate-back)))
+            (navigation/navigate-back nil)))
 
 (defn own-public-key?
   [{:keys [profile/profile]} public-key]
@@ -68,7 +68,7 @@
       (and public-key (not own))
       (rf/merge cofx
                 {:dispatch [:chat.ui/show-profile public-key ens-name]}
-                (navigation/navigate-back))
+                (navigation/navigate-back nil))
 
       :else
       {:effects.utils/show-popup {:title      (i18n/label :t/unable-to-read-this-code)

--- a/src/legacy/status_im/ui/screens/communities/members.cljs
+++ b/src/legacy/status_im/ui/screens/communities/members.cljs
@@ -7,8 +7,8 @@
     [legacy.status-im.ui.components.react :as react]
     [legacy.status-im.ui.components.topbar :as topbar]
     [legacy.status-im.ui.components.unviewed-indicator :as unviewed-indicator]
+    [quo.theme]
     [react-native.core :as rn]
-    [reagent.core :as reagent]
     [status-im.constants :as constants]
     [status-im.contexts.profile.utils :as profile.utils]
     [utils.i18n :as i18n]
@@ -108,9 +108,11 @@
        :title (i18n/label :t/membership-requests)}]
      [quo/separator {:style {:margin-vertical 8}}]]))
 
-(defn members
+(defn view
   []
-  (let [{:keys [community-id]} (rf/sub [:get-screen-params])]
+  (let [{:keys [community-id]} (quo.theme/use-screen-params)]
+    (rn/use-mount
+     #(rf/dispatch [:community/fetch-requests-to-join community-id]))
     (fn []
       (let [my-public-key (rf/sub [:multiaccount/public-key])
             {:keys [permissions
@@ -137,13 +139,3 @@
                          :admin?            admin}
            :key-fn      identity
            :render-fn   render-member}]]))))
-
-(defn legacy-members-container
-  []
-  (reagent/create-class
-   {:display-name        "community-members-view"
-    :component-did-mount (fn []
-                           (rf/dispatch [:community/fetch-requests-to-join
-                                         (get (rf/sub [:get-screen-params])
-                                              :community-id)]))
-    :reagent-render      members}))

--- a/src/legacy/status_im/ui/screens/screens.cljs
+++ b/src/legacy/status_im/ui/screens/screens.cljs
@@ -46,9 +46,9 @@
     :component progress/progress}
 
    ;;COMMUNITY
-   {:name      :legacy-community-members
+   {:name      :screen/legacy-community-members
     :options   {:insets {:top? true}}
-    :component members/legacy-members-container}
+    :component members/view}
 
 
    ;;SETTINGS

--- a/src/legacy/status_im/waku/core.cljs
+++ b/src/legacy/status_im/waku/core.cljs
@@ -122,7 +122,7 @@
   [cofx id]
   (rf/merge cofx
             (delete id)
-            (navigation/navigate-back)))
+            (navigation/navigate-back nil)))
 
 (rf/defn toggle-light-client
   {:events [:wakuv2.ui/toggle-light-client]}

--- a/src/quo/components/notifications/activity_log/view.cljs
+++ b/src/quo/components/notifications/activity_log/view.cljs
@@ -146,7 +146,7 @@
 
 (defmethod footer-item-view :status
   [{:keys [label subtype blur? theme]} _ _]
-  [quo.theme/provider theme
+  [quo.theme/provider {:theme theme}
    [status-tags/status-tag
     {:size   :small
      :label  label

--- a/src/quo/components/notifications/notification/view.cljs
+++ b/src/quo/components/notifications/notification/view.cljs
@@ -80,7 +80,7 @@
                         [avatar-container
                          {:multiline? (and header body)}
                          user-avatar])]
-    [quo.theme/provider theme
+    [quo.theme/provider {:theme theme}
      [notification-container
       {:avatar          avatar
        :header          header

--- a/src/quo/components/notifications/toast/view.cljs
+++ b/src/quo/components/notifications/toast/view.cljs
@@ -6,7 +6,7 @@
     [quo.components.markdown.text :as text]
     [quo.components.notifications.count-down-circle :as count-down-circle]
     [quo.components.notifications.toast.style :as style]
-    [quo.theme :as quo.theme]
+    [quo.theme]
     [react-native.core :as rn]
     [utils.i18n :as i18n]))
 
@@ -81,7 +81,7 @@
                                 :i/incorrect
                                 :i/incorrect-dark)
                     :neutral  icon)]
-    [quo.theme/provider theme
+    [quo.theme/provider {:theme theme}
      [toast-container
       {:left            (cond user
                               [user-avatar/user-avatar user]

--- a/src/quo/components/share/share_qr_code/view.cljs
+++ b/src/quo/components/share/share_qr_code/view.cljs
@@ -113,7 +113,7 @@
          {:color           colors/white-opa-40
           :container-style style/watched-account-icon}])]
      [share-button {:on-press on-share-press}]]
-    [quo.theme/provider :light
+    [quo.theme/provider {:theme :light}
      [qr-code/view
       {:qr-image-uri        qr-image-uri
        :size                (style/qr-code-size component-width)
@@ -144,7 +144,7 @@
         props                 (-> props
                                   (assoc :component-width (or provided-width calculated-width))
                                   (clojure.set/rename-keys {:type :share-qr-type}))]
-    [quo.theme/provider :dark
+    [quo.theme/provider {:theme :dark}
      [rn/view
       {:accessibility-label :share-qr-code
        :style               style/outer-container

--- a/src/quo/components/wallet/network_routing/component_spec.cljs
+++ b/src/quo/components/wallet/network_routing/component_spec.cljs
@@ -1,7 +1,7 @@
 (ns quo.components.wallet.network-routing.component-spec
   (:require [oops.core :as oops]
             [quo.components.wallet.network-routing.view :as network-routing]
-            quo.theme
+            [quo.theme]
             [reagent.core :as reagent]
             [test-helpers.component :as h]))
 
@@ -22,7 +22,7 @@
         ;; Fires on-layout callback since the total width is required
         (h/fire-event :layout component #js {:nativeEvent #js {:layout #js {:width 1000}}})
         ;; Update props to trigger rerender, otherwise it won't be updated
-        (rerender-fn [quo.theme/provider :light
+        (rerender-fn [quo.theme/provider {:theme :light}
                       [network-routing/view (assoc default-props :requesting-data? true)]])
         ;; Check number of networks rendered
         (->> (js->clj (h/query-all-by-label-text :network-routing-bar))

--- a/src/quo/theme.cljs
+++ b/src/quo/theme.cljs
@@ -1,16 +1,30 @@
 (ns quo.theme
   (:require
     ["react" :as react]
+    [oops.core :as oops]
     [react-native.core :as rn]))
 
-(defonce ^:private theme-context (react/createContext :light))
+(defonce ^:private context (react/createContext nil))
 
 (defn provider
-  [theme & children]
-  (into [:> (.-Provider theme-context) {:value theme}]
+  [data & children]
+  (into [:> (.-Provider context) {:value #js {:cljData data}}]
         children))
 
 (defn use-theme
   "A hook that returns the current theme keyword."
   []
-  (keyword (rn/use-context theme-context)))
+  (if-let [data (rn/use-context context)]
+    (:theme (oops/oget data :cljData))
+    :light))
+
+(defn use-screen-id
+  "A hook that returns the current screen id."
+  []
+  (when-let [data (rn/use-context context)]
+    (:screen-id (oops/oget data :cljData))))
+
+(defn use-screen-params
+  []
+  (when-let [data (rn/use-context context)]
+    (:screen-params (oops/oget data :cljData))))

--- a/src/status_im/common/emoji_picker/view.cljs
+++ b/src/status_im/common/emoji_picker/view.cljs
@@ -4,7 +4,7 @@
     [oops.core :as oops]
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
-    [quo.theme :as quo.theme]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
     [react-native.platform :as platform]
@@ -14,8 +14,7 @@
     [status-im.common.emoji-picker.style :as style]
     [status-im.common.emoji-picker.utils :as emoji-picker.utils]
     [utils.debounce :as debounce]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+    [utils.i18n :as i18n]))
 
 (defn- on-press-category
   [{:keys [id index active-category scroll-ref]}]
@@ -171,7 +170,7 @@
 
 (defn view
   [_]
-  (let [{:keys [on-select]}       (rf/sub [:get-screen-params])
+  (let [{:keys [on-select]}       (quo.theme/use-screen-params)
         scroll-ref                (atom nil)
         set-scroll-ref            #(reset! scroll-ref %)
         search-text               (reagent/atom "")

--- a/src/status_im/common/enter_seed_phrase/view.cljs
+++ b/src/status_im/common/enter_seed_phrase/view.cljs
@@ -5,6 +5,7 @@
     [oops.core :as oops]
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
@@ -238,7 +239,7 @@
 
 (defn view
   []
-  (let [{:keys [on-success onboarding-flow?]} (rf/sub [:get-screen-params])]
+  (let [{:keys [on-success onboarding-flow?]} (quo.theme/use-screen-params)]
     (rn/use-unmount
      (fn []
        (rf/dispatch [:enter-seed-phrase/clear-error])

--- a/src/status_im/common/home/top_nav/view.cljs
+++ b/src/status_im/common/home/top_nav/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [cljs-time.core :as t]
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [status-im.common.home.top-nav.style :as style]
     [status-im.constants :as constants]
@@ -47,8 +48,8 @@
                                            ; https://github.com/status-im/status-mobile/issues/17102
                                            :unread-indicator/new  :mention
                                            nil)
-        view-id                          (rf/sub [:view-id])
-        initial-share-tab                (if (= :wallet-stack view-id) :wallet :profile)]
+        screen-id                        (quo.theme/use-screen-id)
+        initial-share-tab                (if (= :wallet-stack screen-id) :wallet :profile)]
     [quo/top-nav
      {:avatar-on-press          #(rf/dispatch [:open-modal :settings])
       :scan-on-press            #(rf/dispatch [:open-modal :shell-qr-reader])

--- a/src/status_im/common/lightbox/view.cljs
+++ b/src/status_im/common/lightbox/view.cljs
@@ -3,6 +3,7 @@
     [clojure.string :as string]
     [oops.core :as oops]
     [quo.foundations.colors :as colors]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
     [react-native.orientation :as orientation]
@@ -140,7 +141,7 @@
 (defn- f-lightbox
   []
   (let [{:keys [images index bottom-text-component on-options-press]}
-        (rf/sub [:get-screen-params])
+        (quo.theme/use-screen-params)
         props
         (utils/init-props)
         state

--- a/src/status_im/common/pdf_viewer/view.cljs
+++ b/src/status_im/common/pdf_viewer/view.cljs
@@ -1,14 +1,14 @@
 (ns status-im.common.pdf-viewer.view
   (:require
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.pdf-viewer :as pdf-viewer]
-    [status-im.common.events-helper :as events-helper]
-    [utils.re-frame :as rf]))
+    [status-im.common.events-helper :as events-helper]))
 
 (defn view
   []
-  (let [{:keys [uri pdf-viewer-props]} (rf/sub [:get-screen-params])]
+  (let [{:keys [uri pdf-viewer-props]} (quo.theme/use-screen-params)]
     [rn/view {:style {:flex 1}}
      [quo/page-nav
       {:icon-name           :i/close

--- a/src/status_im/contexts/chat/group/details/view.cljs
+++ b/src/status_im/contexts/chat/group/details/view.cljs
@@ -53,7 +53,7 @@
   (let [theme                      (quo.theme/use-theme)
         selected-participants      (rf/sub [:group-chat/selected-participants])
         deselected-members         (rf/sub [:group-chat/deselected-members])
-        chat-id                    (rf/sub [:get-screen-params :screen/group-add-manage-members])
+        chat-id                    (quo.theme/use-screen-params)
         {:keys [admins] :as group} (rf/sub [:chats/chat-by-id chat-id])
         current-pk                 (rf/sub [:multiaccount/public-key])
         admin?                     (get admins current-pk)]
@@ -124,7 +124,7 @@
 
 (defn view
   []
-  (let [chat-id         (rf/sub [:get-screen-params :screen/group-details])
+  (let [chat-id         (quo.theme/use-screen-params)
         {:keys [admins chat-id chat-name color muted contacts image]
          :as   group}   (rf/sub [:chats/chat-by-id chat-id])
         members         (rf/sub [:contacts/group-members-sections chat-id])

--- a/src/status_im/contexts/chat/group/update/view.cljs
+++ b/src/status_im/contexts/chat/group/update/view.cljs
@@ -1,12 +1,13 @@
 (ns status-im.contexts.chat.group.update.view
   (:require
+    [quo.theme :as quo.theme]
     [status-im.contexts.chat.group.common.group-edit :as group-edit]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
 (defn view
   [{:keys [close]}]
-  (let [chat-id                         (rf/sub [:get-screen-params :screen/group-update])
+  (let [chat-id                         (quo.theme/use-screen-params)
         {:keys [chat-name color image]} (rf/sub [:chats/chat-by-id chat-id])
         contacts                        (rf/sub [:contacts/contacts-by-chat chat-id])]
     [group-edit/view

--- a/src/status_im/contexts/chat/home/view.cljs
+++ b/src/status_im/contexts/chat/home/view.cljs
@@ -115,22 +115,23 @@
                                               :shared-value scroll-shared-value})}])))
 
 (defn- on-new-message-press
-  []
-  (let [main-event [:show-bottom-sheet {:content chat.actions.view/new-chat}]]
+  [screen-id]
+  (let [main-event [:show-bottom-sheet {:content chat.actions.view/new-chat :screen-id screen-id}]]
     (rf/dispatch [:profile/check-profile-update-prompt main-event])))
 
 (defn- banner-data
   [profile-link]
-  {:title-props
-   {:beta?               true
-    :label               (i18n/label :t/messages)
-    :handler             on-new-message-press
-    :accessibility-label :new-chat-button}
-   :card-props
-   {:on-press    #(rf/dispatch [:open-share {:options {:url profile-link}}])
-    :banner      (resources/get-image :invite-friends)
-    :title       (i18n/label :t/invite-friends-to-status)
-    :description (i18n/label :t/share-invite-link)}})
+  (let [screen-id (quo.theme/use-screen-id)]
+    {:title-props
+     {:beta?               true
+      :label               (i18n/label :t/messages)
+      :handler             #(on-new-message-press screen-id)
+      :accessibility-label :new-chat-button}
+     :card-props
+     {:on-press    #(rf/dispatch [:open-share {:options {:url profile-link}}])
+      :banner      (resources/get-image :invite-friends)
+      :title       (i18n/label :t/invite-friends-to-status)
+      :description (i18n/label :t/share-invite-link)}}))
 
 (defn view
   []

--- a/src/status_im/contexts/chat/messenger/messages/navigation/view.cljs
+++ b/src/status_im/contexts/chat/messenger/messages/navigation/view.cljs
@@ -91,6 +91,7 @@
   (let [{:keys [chat-id chat-type]
          :as   chat}           (rf/sub [:chats/current-chat-chat-view])
         top-insets             (safe-area/get-top)
+        screen-id              (quo.theme/use-screen-id)
         navigation-view-height (+ top-insets messages.constants/top-bar-height)]
     [rn/view {:style (style/navigation-view navigation-view-height)}
      [header-background
@@ -103,13 +104,7 @@
         :background          :blur
         :size                32
         :accessibility-label :back-button
-        :on-press            (fn []
-                               (rf/dispatch [:navigate-back])
-                               ;; In IOS view-id might be incorrect (if screen closed using swipe),
-                               ;; so we can't rely on `:navigate-back` to close the chat.
-                               ;; https://github.com/status-im/status-mobile/pull/21643#issuecomment-248896204451
-                               (when platform/ios?
-                                 (rf/dispatch [:chat/close])))}
+        :on-press            #(rf/dispatch [:navigate-back screen-id])}
        (if (= chat-type constants/community-chat-type) :i/arrow-left :i/close)]
       [header-content-container chat]
       [quo/button

--- a/src/status_im/contexts/chat/messenger/placeholder/view.cljs
+++ b/src/status_im/contexts/chat/messenger/placeholder/view.cljs
@@ -16,10 +16,11 @@
 (defn view
   [on-layout-done?]
   (let [theme       (quo.theme/use-theme)
+        screen-id   (quo.theme/use-screen-id)
         chat-exist? (rf/sub [:chats/current-chat-exist?])]
     [rn/view {:style (style/container theme @on-layout-done?)}
      (when-not chat-exist?
        [quo/page-nav
         {:icon-name :i/arrow-left
-         :on-press  #(rf/dispatch [:navigate-back])}])
+         :on-press  #(rf/dispatch [:navigate-back screen-id])}])
      [loading-skeleton]]))

--- a/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
@@ -54,7 +54,7 @@
 
 (defn view
   []
-  (let [{id :community-id}                (rf/sub [:get-screen-params])
+  (let [{id :community-id}                (quo.theme/use-screen-params)
         {:keys [name images joined]}      (rf/sub [:communities/community id])
         has-permissions?                  (rf/sub [:communities/has-permissions? id])
         airdrop-account                   (rf/sub [:communities/airdrop-account id])

--- a/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [clojure.string :as string]
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
     [status-im.constants :as constants]
@@ -250,7 +251,7 @@
 
 (defn view
   []
-  (let [{id :community-id} (rf/sub [:get-screen-params])
+  (let [{id :community-id} (quo.theme/use-screen-params)
 
         color (rf/sub [:communities/community-color id])
 

--- a/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
+++ b/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.communities.actions.airdrop-addresses.view
   (:require
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
     [status-im.common.not-implemented :as not-implemented]
@@ -39,7 +40,7 @@
 
 (defn view
   []
-  (let [{id :community-id}        (rf/sub [:get-screen-params])
+  (let [{id :community-id}        (quo.theme/use-screen-params)
         {:keys [name logo color]} (rf/sub [:communities/for-context-tag id])
         accounts                  (rf/sub [:communities/accounts-to-reveal id])
         airdrop-address           (rf/sub [:communities/airdrop-address id])

--- a/src/status_im/contexts/communities/actions/channel_view_details/view.cljs
+++ b/src/status_im/contexts/communities/actions/channel_view_details/view.cljs
@@ -77,8 +77,7 @@
 
 (defn view
   []
-  (let [{:keys [chat-id community-id]} (rf/sub [:get-screen-params
-                                                :screen/chat.view-channel-members-and-details])
+  (let [{:keys [chat-id community-id]} (quo.theme/use-screen-params)
         {:keys [description chat-name emoji muted chat-type color]
          :as   chat}                   (rf/sub [:chats/chat-by-id chat-id])
         pins-count                     (rf/sub [:chats/pin-messages-count chat-id])

--- a/src/status_im/contexts/communities/actions/community_options/view.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/view.cljs
@@ -22,7 +22,7 @@
   {:icon                :i/members
    :accessibility-label :view-members
    :label               (i18n/label :t/view-members)
-   :on-press            #(hide-sheet-and-dispatch [:navigate-to :legacy-community-members
+   :on-press            #(hide-sheet-and-dispatch [:navigate-to :screen/legacy-community-members
                                                    {:community-id id}])})
 
 (defn view-rules

--- a/src/status_im/contexts/communities/actions/invite_contacts/view.cljs
+++ b/src/status_im/contexts/communities/actions/invite_contacts/view.cljs
@@ -53,7 +53,7 @@
   [{:keys [public-key]
     :as   item}]
   (let [user-selected?         (rf/sub [:is-contact-selected? public-key])
-        {:keys [id]}           (rf/sub [:get-screen-params])
+        {:keys [id]}           (quo.theme/use-screen-params)
         community-members-keys (set (rf/sub [:communities/community-members id]))
         community-member?      (boolean (community-members-keys public-key))
         on-toggle              (fn []
@@ -77,7 +77,7 @@
     (rn/use-unmount #(rf/dispatch [:group-chat/clear-contacts]))
     (let [theme                   (quo.theme/use-theme)
           customization-color     (rf/sub [:profile/customization-color])
-          {:keys [id]}            (rf/sub [:get-screen-params])
+          {:keys [id]}            (quo.theme/use-screen-params)
           contacts                (rf/sub [:contacts/filtered-active-sections])
           selected                (rf/sub [:group/selected-contacts])
           {:keys [name images]}   (rf/sub [:communities/community id])

--- a/src/status_im/contexts/communities/actions/share_community/view.cljs
+++ b/src/status_im/contexts/communities/actions/share_community/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.fast-image :as fast-image]
     [react-native.platform :as platform]
@@ -18,7 +19,7 @@
 
 (defn view
   []
-  (let [params                     (rf/sub [:get-screen-params])
+  (let [params                     (quo.theme/use-screen-params)
         ;; NOTE(seanstrom): We need to store these screen params for when the modal closes
         ;; because the screen params will be cleared.
         {:keys [url community-id]} @(rn/use-ref-atom params)

--- a/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
+++ b/src/status_im/contexts/communities/actions/share_community_channel/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.communities.actions.share-community-channel.view
   (:require
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [status-im.common.qr-codes.view :as qr-codes]
@@ -13,7 +14,7 @@
 (defn view
   []
   (fn []
-    (let [params                          (rf/sub [:get-screen-params])
+    (let [params                          (quo.theme/use-screen-params)
           ;; NOTE(seanstrom): We need to store these screen params for when the modal closes
           ;; because the screen params will be cleared.
           {:keys [url chat-id]}           @(rn/use-ref-atom params)

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -364,6 +364,6 @@
 
 (defn view
   [id]
-  (let [id (or id (rf/sub [:get-screen-params :community-overview]))]
+  (let [id (or id (quo.theme/use-screen-params))]
     [rn/view {:style style/community-overview-container}
      [community-card-page-view id]]))

--- a/src/status_im/contexts/keycard/authorise/view.cljs
+++ b/src/status_im/contexts/keycard/authorise/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.keycard.authorise.view
   (:require [quo.core :as quo]
+            [quo.theme]
             [react-native.core :as rn]
             [status-im.common.events-helper :as events-helper]
             [status-im.common.resources :as resources]
@@ -12,7 +13,7 @@
   (let [profile-name         (rf/sub [:profile/name])
         profile-picture      (rf/sub [:profile/image])
         customization-color  (rf/sub [:profile/customization-color])
-        {:keys [on-success]} (rf/sub [:get-screen-params])]
+        {:keys [on-success]} (quo.theme/use-screen-params)]
     [:<>
      [quo/page-nav
       {:icon-name :i/close

--- a/src/status_im/contexts/keycard/backup/view.cljs
+++ b/src/status_im/contexts/keycard/backup/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.keycard.backup.view
   (:require [quo.core :as quo]
+            [quo.theme]
             [react-native.core :as rn]
             [status-im.common.events-helper :as events-helper]
             [status-im.common.resources :as resources]
@@ -9,7 +10,7 @@
 
 (defn ready-to-add
   []
-  (let [{:keys [on-press]} (rf/sub [:get-screen-params])]
+  (let [{:keys [on-press]} (quo.theme/use-screen-params)]
     [:<>
      [quo/page-nav
       {:icon-name :i/close
@@ -44,7 +45,7 @@
 
 (defn not-empty-view
   []
-  (let [{:keys [on-press]} (rf/sub [:get-screen-params])]
+  (let [{:keys [on-press]} (quo.theme/use-screen-params)]
     [:<>
      [quo/page-nav
       {:icon-name :i/close

--- a/src/status_im/contexts/keycard/check/view.cljs
+++ b/src/status_im/contexts/keycard/check/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.keycard.check.view
   (:require [quo.core :as quo]
+            [quo.theme]
             [react-native.core :as rn]
             [status-im.common.events-helper :as events-helper]
             [status-im.common.resources :as resources]
@@ -28,7 +29,7 @@
 
 (defn view
   []
-  (let [{:keys [on-press]} (rf/sub [:get-screen-params])]
+  (let [{:keys [on-press]} (quo.theme/use-screen-params)]
     [:<>
      [quo/page-nav
       {:icon-name  :i/arrow-left

--- a/src/status_im/contexts/keycard/create/view.cljs
+++ b/src/status_im/contexts/keycard/create/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.keycard.create.view
   (:require [quo.core :as quo]
+            [quo.theme]
             [react-native.core :as rn]
             [status-im.common.events-helper :as events-helper]
             [status-im.common.resources :as resources]
@@ -18,7 +19,7 @@
 
 (defn ready-to-add
   []
-  (let [{:keys [on-continue]} (rf/sub [:get-screen-params])]
+  (let [{:keys [on-continue]} (quo.theme/use-screen-params)]
     [:<>
      [quo/page-nav
       {:icon-name  :i/close
@@ -42,7 +43,7 @@
 
 (defn ready-to-generate
   []
-  (let [{:keys [on-continue]} (rf/sub [:get-screen-params])]
+  (let [{:keys [on-continue]} (quo.theme/use-screen-params)]
     [:<>
      [quo/page-nav
       {:icon-name :i/close
@@ -61,7 +62,7 @@
 
 (defn not-empty-view
   []
-  (let [{:keys [on-login]} (rf/sub [:get-screen-params])]
+  (let [{:keys [on-login]} (quo.theme/use-screen-params)]
     [:<>
      [quo/page-nav
       {:icon-name :i/close
@@ -97,7 +98,7 @@
 
 (defn empty-view
   []
-  (let [{:keys [on-create on-import]} (rf/sub [:get-screen-params])]
+  (let [{:keys [on-create on-import]} (quo.theme/use-screen-params)]
     [:<>
      [quo/page-nav
       {:icon-name :i/close

--- a/src/status_im/contexts/keycard/pin/create/view.cljs
+++ b/src/status_im/contexts/keycard/pin/create/view.cljs
@@ -1,15 +1,15 @@
 (ns status-im.contexts.keycard.pin.create.view
   (:require [clojure.string :as string]
             [quo.core :as quo]
+            [quo.theme]
             [react-native.core :as rn]
             [status-im.common.events-helper :as events-helper]
             [status-im.constants :as constants]
-            [utils.i18n :as i18n]
-            [utils.re-frame :as rf]))
+            [utils.i18n :as i18n]))
 
 (defn view
   []
-  (let [{:keys [on-complete title repeat-stage-title]} (rf/sub [:get-screen-params])
+  (let [{:keys [on-complete title repeat-stage-title]} (quo.theme/use-screen-params)
         [pin set-pin]                                  (rn/use-state "")
         [first-pin set-first-pin]                      (rn/use-state "")
         [error? set-error]                             (rn/use-state false)

--- a/src/status_im/contexts/keycard/pin/enter/view.cljs
+++ b/src/status_im/contexts/keycard/pin/enter/view.cljs
@@ -1,14 +1,14 @@
 (ns status-im.contexts.keycard.pin.enter.view
   (:require [quo.core :as quo]
+            [quo.theme]
             [react-native.core :as rn]
             [status-im.common.events-helper :as events-helper]
             [status-im.contexts.keycard.pin.view :as keycard.pin]
-            [utils.i18n :as i18n]
-            [utils.re-frame :as rf]))
+            [utils.i18n :as i18n]))
 
 (defn view
   []
-  (let [{:keys [on-complete title]} (rf/sub [:get-screen-params])]
+  (let [{:keys [on-complete title]} (quo.theme/use-screen-params)]
     [rn/view {:style {:padding-bottom 12 :flex 1}}
      [quo/page-nav
       {:icon-name :i/close

--- a/src/status_im/contexts/onboarding/share_usage/view.cljs
+++ b/src/status_im/contexts/onboarding/share_usage/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.onboarding.share-usage.view
   (:require
     [quo.core :as quo]
+    [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [status-im.common.events-helper :as events-helper]
@@ -26,7 +27,7 @@
 (defn view
   []
   (let [insets           (safe-area/get-insets)
-        next-screen      (:next-screen (rf/sub [:get-screen-params :screen/onboarding.share-usage]))
+        next-screen      (:next-screen (quo.theme/use-screen-params))
         share-usage-data (rn/use-callback #(share-usage-data-fn true next-screen))
         maybe-later      (rn/use-callback #(share-usage-data-fn false next-screen))]
     [rn/view {:style style/page}

--- a/src/status_im/contexts/preview/quo/notifications/activity_logs.cljs
+++ b/src/status_im/contexts/preview/quo/notifications/activity_logs.cljs
@@ -174,7 +174,7 @@
           {:flex    1
            :padding 16}
           [preview/customizer state descriptor theme]]
-         [quo.theme/provider :dark
+         [quo.theme/provider {:theme :dark}
           [rn/view
            {:background-color colors/neutral-90
             :flex-direction   :row

--- a/src/status_im/contexts/profile/backup_recovery_phrase/view.cljs
+++ b/src/status_im/contexts/profile/backup_recovery_phrase/view.cljs
@@ -3,7 +3,7 @@
     [clojure.string :as string]
     [native-module.core :as native-module]
     [quo.core :as quo]
-    [quo.theme :as quo.theme]
+    [quo.theme]
     [react-native.core :as rn]
     [reagent.core :as reagent]
     [status-im.contexts.profile.backup-recovery-phrase.style :as style]
@@ -52,7 +52,7 @@
                               :2 false
                               :3 false})
         {:keys [on-success masked-seed-phrase
-                revealed?]} (rf/sub [:get-screen-params])
+                revealed?]} (quo.theme/use-screen-params)
         revealed?           (reagent/atom revealed?)
         customization-color (rf/sub [:profile/customization-color])
         seed-phrase         (reagent/atom (if masked-seed-phrase

--- a/src/status_im/contexts/profile/edit/modal/view.cljs
+++ b/src/status_im/contexts/profile/edit/modal/view.cljs
@@ -4,6 +4,7 @@
     [oops.core :as oops]
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.hooks :as hooks]
     [react-native.platform :as platform]
@@ -188,7 +189,7 @@
 
 (defn view
   []
-  (let [{:keys [pending-event]}        (rf/sub [:get-screen-params])
+  (let [{:keys [pending-event]}        (quo.theme/use-screen-params)
         {initial-display-name :display-name
          initial-color        :customization-color
          [initial-image]      :images} (rf/sub [:profile/profile])

--- a/src/status_im/contexts/settings/privacy_and_security/share_usage/view.cljs
+++ b/src/status_im/contexts/settings/privacy_and_security/share_usage/view.cljs
@@ -50,7 +50,7 @@
   (rf/dispatch
    [:show-bottom-sheet
     {:content (fn []
-                [quo.theme/provider :dark
+                [quo.theme/provider {:theme :dark}
                  [privacy/privacy-statement]])
      :shell?  true}]))
 

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/missing_keypairs/encrypted_qr/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/missing_keypairs/encrypted_qr/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
+    [quo.theme]
     [react-native.clipboard :as clipboard]
     [react-native.core :as rn]
     [status-im.common.qr-codes.view :as qr-codes]
@@ -19,7 +20,7 @@
 
 (defn view
   []
-  (let [{:keys [key-uid]}             (rf/sub [:get-screen-params])
+  (let [{:keys [key-uid]}             (quo.theme/use-screen-params)
         {:keys [customization-color]} (rf/sub [:profile/profile-with-image])
         [code set-code]               (rn/use-state nil)
         valid-connection-string?      (rn/use-memo #(sync-utils/valid-connection-string? code) [code])

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/missing_keypairs/import_private_key/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/missing_keypairs/import_private_key/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [clojure.string :as string]
     [quo.core :as quo]
+    [quo.theme]
     [react-native.clipboard :as clipboard]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
@@ -21,7 +22,7 @@
 
 (defn view
   []
-  (let [keypair                       (rf/sub [:get-screen-params])
+  (let [keypair                       (quo.theme/use-screen-params)
         blur?                         true
         insets                        (safe-area/get-insets)
         customization-color           (rf/sub [:profile/customization-color])

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/missing_keypairs/import_seed_phrase/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/missing_keypairs/import_seed_phrase/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.settings.wallet.keypairs-and-accounts.missing-keypairs.import-seed-phrase.view
   (:require
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
@@ -16,7 +17,7 @@
            seed-phrase
            set-incorrect-seed-phrase
            focus-input]}]
-  (let [keypair             (rf/sub [:get-screen-params])
+  (let [keypair             (quo.theme/use-screen-params)
         customization-color (rf/sub [:profile/customization-color])
         show-errors         (rn/use-callback
                              (fn [_error]
@@ -56,7 +57,7 @@
 
 (defn view
   []
-  (let [keypair (rf/sub [:get-screen-params])]
+  (let [keypair (quo.theme/use-screen-params)]
     [quo/overlay {:type :shell}
      [enter-seed-phrase/screen
       {:keypair         keypair

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/missing_keypairs/scan_qr/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/missing_keypairs/scan_qr/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contexts.settings.wallet.keypairs-and-accounts.missing-keypairs.scan-qr.view
   (:require
+    [quo.theme]
     [react-native.core :as rn]
     [status-im.common.scan-qr-code.view :as scan-qr-code]
     [status-im.contexts.communities.events]
@@ -9,7 +10,7 @@
 
 (defn view
   []
-  (let [keypairs-key-uids (rf/sub [:get-screen-params])
+  (let [keypairs-key-uids (quo.theme/use-screen-params)
         on-success-scan   (rn/use-callback (fn [scanned-text]
                                              (rf/dispatch [:wallet/success-keypair-qr-scan
                                                            scanned-text

--- a/src/status_im/contexts/settings/wallet/keypairs_and_accounts/rename/view.cljs
+++ b/src/status_im/contexts/settings/wallet/keypairs_and_accounts/rename/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.settings.wallet.keypairs-and-accounts.rename.view
   (:require [clojure.string :as string]
             [quo.core :as quo]
+            [quo.theme]
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
             [status-im.common.floating-button-page.view :as floating-button-page]
@@ -16,8 +17,9 @@
 (defn view
   []
   (let [insets                                          (safe-area/get-insets)
+
         {existing-keypair-name :name
-         :keys                 [key-uid]}               (rf/sub [:get-screen-params])
+         :keys                 [key-uid]}               (quo.theme/use-screen-params)
         existing-keypair-names                          (rf/sub [:wallet/keypair-names])
         customization-color                             (rf/sub [:profile/customization-color])
         [unsaved-keypair-name set-unsaved-keypair-name] (rn/use-state existing-keypair-name)

--- a/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/add_address_to_save/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [clojure.string :as string]
     [quo.core :as quo]
+    [quo.theme]
     [react-native.clipboard :as clipboard]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
@@ -117,7 +118,7 @@
 
 (defn view
   []
-  (let [view-id                             (rf/sub [:view-id])
+  (let [screen-id                           (quo.theme/use-screen-id)
         profile-color                       (rf/sub [:profile/customization-color])
         accounts-addresses                  (rf/sub [:wallet/addresses])
         saved-addresses-addresses           (rf/sub [:wallet/saved-addresses-addresses])
@@ -182,7 +183,7 @@
                                        :on-press            navigate-back
                                        :margin-top          (safe-area/get-top)
                                        :accessibility-label :add-address-to-save-page-nav}]
-       :footer                       (when (= view-id :screen/settings.add-address-to-save)
+       :footer                       (when (= screen-id :screen/settings.add-address-to-save)
                                        [quo/button
                                         {:customization-color profile-color
                                          :disabled?           button-disabled?

--- a/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/save_address/view.cljs
@@ -18,7 +18,7 @@
 (defn view
   []
   (let [{:keys [address name customization-color ens
-                ens? edit?]}              (rf/sub [:get-screen-params])
+                ens? edit?]}              (quo.theme/use-screen-params)
         [address-label set-address-label] (rn/use-state (or name ""))
         [address-color set-address-color] (rn/use-state (or customization-color
                                                             (rand-nth colors/account-colors)))

--- a/src/status_im/contexts/settings/wallet/saved_addresses/share_address/view.cljs
+++ b/src/status_im/contexts/settings/wallet/saved_addresses/share_address/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.settings.wallet.saved-addresses.share-address.view
   (:require
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.platform :as platform]
     [status-im.contexts.settings.wallet.saved-addresses.share-address.style :as style]
@@ -31,7 +32,7 @@
 
 (defn view
   []
-  (let [{:keys [name address customization-color]} (rf/sub [:get-screen-params])
+  (let [{:keys [name address customization-color]} (quo.theme/use-screen-params)
         share-title                                (str name " " (i18n/label :t/address))
         qr-url                                     address
         qr-media-server-uri                        (rn/use-memo

--- a/src/status_im/contexts/shell/bottom_tabs/view.cljs
+++ b/src/status_im/contexts/shell/bottom_tabs/view.cljs
@@ -1,7 +1,7 @@
 (ns status-im.contexts.shell.bottom-tabs.view
   (:require
     [quo.core :as quo]
-    [quo.theme :as quo.theme]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
     [react-native.reanimated :as reanimated]
@@ -40,7 +40,7 @@
                                            (gesture/on-start
                                             (fn [_event]
                                               (rf/dispatch [:messages-home/select-tab :tab/recent]))))]
-    [quo.theme/provider :dark
+    [quo.theme/provider {:theme :dark}
      [reanimated/view
       {:style (style/bottom-tabs-container (:bottom-tabs-height shared-values))}
       [rn/view {:style (style/bottom-tabs)}

--- a/src/status_im/contexts/shell/home_stack/view.cljs
+++ b/src/status_im/contexts/shell/home_stack/view.cljs
@@ -1,7 +1,7 @@
 (ns status-im.contexts.shell.home-stack.view
   (:require
     [legacy.status-im.ui.screens.browser.stack :as browser.stack]
-    [quo.theme :as quo.theme]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.reanimated :as reanimated]
     [status-im.contexts.chat.home.view :as chat]
@@ -36,15 +36,16 @@
      [:<>])])
 
 (defn lazy-screen
-  [stack-id shared-values]
+  [stack-id shared-values theme]
   (when (load-stack? stack-id)
-    [f-stack-view stack-id shared-values]))
+    [quo.theme/provider {:theme theme :screen-id stack-id}
+     [f-stack-view stack-id shared-values]]))
 
 (defn view
   [shared-values]
   (let [theme (quo.theme/use-theme)]
     [rn/view {:style (style/home-stack theme)}
-     [lazy-screen :communities-stack shared-values]
-     [lazy-screen :chats-stack shared-values]
-     [lazy-screen :browser-stack shared-values]
-     [lazy-screen :wallet-stack shared-values]]))
+     [lazy-screen :communities-stack shared-values theme]
+     [lazy-screen :chats-stack shared-values theme]
+     [lazy-screen :browser-stack shared-values theme]
+     [lazy-screen :wallet-stack shared-values theme]]))

--- a/src/status_im/contexts/shell/share/view.cljs
+++ b/src/status_im/contexts/shell/share/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.shell.share.view
   (:require
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [status-im.contexts.shell.share.profile.view :as profile-view]
@@ -11,7 +12,7 @@
 
 (defn- header
   []
-  (let [{:keys [status]} (rf/sub [:get-screen-params])]
+  (let [{:keys [status]} (quo.theme/use-screen-params)]
     [:<>
      [rn/view {:style style/header-row}
       [quo/button
@@ -45,7 +46,7 @@
   []
   (let [{:keys [initial-tab hide-tab-selector?]
          :or   {initial-tab        :profile
-                hide-tab-selector? false}} (rf/sub [:get-screen-params])
+                hide-tab-selector? false}} (quo.theme/use-screen-params)
         [selected-tab set-selected-tab]    (rn/use-state initial-tab)]
     [rn/view {:style {:padding-top (safe-area/get-top)}}
      [header]

--- a/src/status_im/contexts/wallet/account/share_address/view.cljs
+++ b/src/status_im/contexts/wallet/account/share_address/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.wallet.account.share-address.view
   (:require
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.platform :as platform]
     [react-native.safe-area :as safe-area]
@@ -39,7 +40,8 @@
                                   :port        (rf/sub [:mediaserver/port])
                                   :qr-size     qr-size
                                   :error-level :highest})
-            {:keys [status]}    (rf/sub [:get-screen-params])
+
+            {:keys [status]}    (quo.theme/use-screen-params)
             title               (case status
                                   :share   (i18n/label :t/share-address)
                                   :receive (i18n/label :t/receive)

--- a/src/status_im/contexts/wallet/add_account/add_address_to_watch/confirm_address/component_spec.cljs
+++ b/src/status_im/contexts/wallet/add_account/add_address_to_watch/confirm_address/component_spec.cljs
@@ -9,9 +9,11 @@
   (h/test "Create Account button is disabled while no account name exists"
     (h/setup-subs {:wallet/watch-only-accounts        []
                    :alert-banners/top-margin          0
-                   :get-screen-params                 {:address "0xmock-address"}
                    :wallet/accounts-names             #{"My account 1" "My account 2"}
                    :wallet/accounts-emojis-and-colors #{["😊" :sky] ["😶" :army]}})
-    (h/render [confirm-address/view])
+    (h/render-with-context-provider
+     [confirm-address/view]
+     {:theme         :light
+      :screen-params {:address "0xmock-address"}})
     (h/is-truthy (h/get-by-text "0xmock-address"))
     (h/is-disabled (h/get-by-label-text :confirm-button-label))))

--- a/src/status_im/contexts/wallet/add_account/add_address_to_watch/confirm_address/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/add_address_to_watch/confirm_address/view.cljs
@@ -3,6 +3,7 @@
     [clojure.string :as string]
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
+    [quo.theme]
     [react-native.core :as rn]
     [reagent.core :as reagent]
     [status-im.common.emoji-picker.utils :as emoji-picker.utils]
@@ -15,7 +16,7 @@
 
 (defn view
   []
-  (let [{:keys [address]} (rf/sub [:get-screen-params])
+  (let [{:keys [address]} (quo.theme/use-screen-params)
         placeholder       (i18n/label :t/default-watched-address-placeholder)
         account-name      (reagent/atom "")
         account-color     (reagent/atom (rand-nth colors/account-colors))

--- a/src/status_im/contexts/wallet/add_account/create_account/edit_derivation_path/path_format_sheet/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/edit_derivation_path/path_format_sheet/view.cljs
@@ -1,13 +1,13 @@
 (ns status-im.contexts.wallet.add-account.create-account.edit-derivation-path.path-format-sheet.view
   (:require
     [quo.core :as quo]
+    [quo.theme]
     [status-im.constants :as constants]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+    [utils.i18n :as i18n]))
 
 (defn view
   []
-  (let [{:keys [customization-color]} (rf/sub [:get-screen-params])]
+  (let [{:keys [customization-color]} (quo.theme/use-screen-params)]
     [:<>
      [quo/drawer-top {:title (i18n/label :t/path-format)}]
      [quo/action-drawer

--- a/src/status_im/contexts/wallet/add_account/create_account/edit_derivation_path/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/edit_derivation_path/view.cljs
@@ -3,7 +3,7 @@
     [clojure.string :as string]
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
-    [quo.theme :as quo.theme]
+    [quo.theme]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
@@ -32,8 +32,9 @@
                              (on-reset)))]
     (fn []
       (let [theme                                      (quo.theme/use-theme)
+
             {:keys [public-key address]}               (rf/sub [:profile/profile])
-            {:keys [password current-derivation-path]} (rf/sub [:get-screen-params])
+            {:keys [password current-derivation-path]} (quo.theme/use-screen-params)
             primary-name                               (first (rf/sub
                                                                [:contacts/contact-two-names-by-identity
                                                                 public-key]))

--- a/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/key_pair_name/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [clojure.string :as string]
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [status-im.common.floating-button-page.view :as floating-button-page]
     [status-im.common.validation.general :as validators]
@@ -38,7 +39,7 @@
 
 (defn view
   []
-  (let [{:keys [workflow]}                (rf/sub [:get-screen-params])
+  (let [{:keys [workflow]}                (quo.theme/use-screen-params)
         customization-color               (rf/sub [:profile/customization-color])
         [key-pair-name set-key-pair-name] (rn/use-state "")
         [error set-error]                 (rn/use-state nil)

--- a/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/view.cljs
+++ b/src/status_im/contexts/wallet/add_account/create_account/new_keypair/confirm_backup/view.cljs
@@ -3,6 +3,7 @@
     [clojure.string :as string]
     [native-module.core :as native-module]
     [quo.core :as quo]
+    [quo.theme]
     [react-native.core :as rn]
     [reagent.core :as reagent]
     [status-im.contexts.wallet.add-account.create-account.new-keypair.confirm-backup.style :as style]
@@ -99,10 +100,11 @@
         quiz-index             (reagent/atom 0)
         incorrect-count        (reagent/atom 0)
         show-error?            (reagent/atom false)
+
         {:keys [on-success
                 on-try-again
                 masked-seed-phrase
-                theme shell?]} (rf/sub [:get-screen-params])
+                theme shell?]} (quo.theme/use-screen-params)
         unmasked-seed-phrase   (security/safe-unmask-data masked-seed-phrase)
         random-phrase          (reagent/atom [])]
     (fn []

--- a/src/status_im/contexts/wallet/common/scan_account/view.cljs
+++ b/src/status_im/contexts/wallet/common/scan_account/view.cljs
@@ -1,14 +1,14 @@
 (ns status-im.contexts.wallet.common.scan-account.view
   (:require
+    [quo.theme]
     [status-im.common.scan-qr-code.view :as scan-qr-code]
     [utils.address :as utils-address]
     [utils.debounce :as debounce]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+    [utils.i18n :as i18n]))
 
 (defn view
   []
-  (let [{:keys [on-result]} (rf/sub [:get-screen-params])]
+  (let [{:keys [on-result]} (quo.theme/use-screen-params)]
     [scan-qr-code/view
      {:title           (i18n/label :t/scan-qr)
       :subtitle        (i18n/label :t/scan-an-address-qr-code)

--- a/src/status_im/navigation/events.cljs
+++ b/src/status_im/navigation/events.cljs
@@ -50,10 +50,13 @@
 
 (rf/defn navigate-back
   {:events [:navigate-back]}
-  [{:keys [db]}]
+  [{:keys [db]} screen-id]
   {:fx [[:navigate-back nil]
-        ;; Required for navigating back using the Android hardware back button
-        (when (and platform/android? (= (:view-id db) :chat))
+        (when (or
+               ;; Closing chat using UI buttons in chat screen (screen-id is known)
+               (= screen-id :chat)
+               ;; Support chat closing using android hardware back button
+               (and platform/android? (= (:view-id db) :chat)))
           [:dispatch [:chat/close]])]})
 
 (rf/defn navigate-back-to

--- a/src/status_im/subs/general.cljs
+++ b/src/status_im/subs/general.cljs
@@ -82,9 +82,8 @@
 (re-frame/reg-sub
  :get-screen-params
  :<- [:screen-params]
- :<- [:view-id]
- (fn [[params view-id-db] [_ view-id]]
-   (get params (or view-id view-id-db))))
+ (fn [params [_ screen-id]]
+   (get params screen-id)))
 
 (defn- node-version
   [web3-node-version]

--- a/src/test_helpers/component.cljs
+++ b/src/test_helpers/component.cljs
@@ -4,7 +4,7 @@
   (:require ["@testing-library/react-native" :as rtl]
             [camel-snake-kebab.core :as camel-snake-kebab]
             [oops.core :as oops]
-            [quo.theme :as quo.theme]
+            [quo.theme]
             [re-frame.core :as re-frame]
             [reagent.core :as reagent]
             [utils.i18n :as i18n]))
@@ -56,7 +56,13 @@
   ([component]
    (render-with-theme-provider component :light))
   ([component theme]
-   (rtl/render (reagent/as-element [quo.theme/provider theme component]))))
+   (rtl/render (reagent/as-element [quo.theme/provider {:theme theme} component]))))
+
+(defn render-with-context-provider
+  ([component]
+   (render-with-theme-provider component :light))
+  ([component context]
+   (rtl/render (reagent/as-element [quo.theme/provider context component]))))
 
 (defn wait-for
   ([condition] (wait-for condition {}))


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/22340
also fixes https://github.com/status-im/status-mobile/pull/22336

### Summary

PR introduces screen-id, which is local and screen specific unlike view-id. (More details about PR in this comment - https://github.com/status-im/status-mobile/pull/22346#issuecomment-2743691582)

### Testing

Currently, we request data for the current screen using :view-id. In this PR it will be migrated to :screen-id, which affects many screens. The goal of this migration is to make the screens more stable, as :view-id is dynamic, while :screen-id is static and screen-specific.

- Please run full e2e test suite and also lightly test app. 
- Also test fix for https://github.com/status-im/status-mobile/issues/21660#issuecomment-2672028011 (IOS only navigation bug)

status: ready