### PR TITLE
[#22347] fix: handle wc intent for android device

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -102,6 +102,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="status-app" />
                 <data android:scheme="ethereum" />
+                <data android:scheme="wc" />
             </intent-filter>
         </activity>
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>

--- a/src/status_im/common/router.cljs
+++ b/src/status_im/common/router.cljs
@@ -347,6 +347,10 @@
       (string/starts-with? uri constants/local-pairing-connection-string-identifier)
       (cb {:type :localpairing :data uri})
 
+      (string/starts-with? uri constants/wc-connection-string-identifier)
+      (cb {:type :wallet-connect
+           :uri  uri})
+
       :else
       (cb {:type :undefined
            :data uri}))))

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -203,7 +203,7 @@
          (str "wallet/" regx-string-any-ascii "+")])
        ")$"))
 (def regx-universal-link (re-pattern regx-string-universal-link))
-(def regx-deep-link #"((^ethereum:.*)|(^status-app://[\x00-\x7F]+$))")
+(def regx-deep-link #"((^ethereum:.*)|(^status-app://[\x00-\x7F]+)|(^wc://.*))")
 (def regx-ens #"^(?=.{5,255}$)([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$")
 (def regx-starts-with-uuid #"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
 

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -529,3 +529,5 @@
 (def ^:const go-waku-url "https://github.com/waku-org/go-waku")
 (def ^:const status-go-url "https://github.com/status-im/status-go")
 (def ^:const status-mobile-url "https://github.com/status-im/status-mobile")
+
+(def ^:const wc-connection-string-identifier "wc")


### PR DESCRIPTION
fixes #22347

## Summary
Status app does not appear in the list of apps available for connection via wallet connect deeplink (Android only)

Here is response from Reown team : 

> the issue is related on how our legacy sdk (the one used by Uniswap) detects wallets on Android.
>To appear on that list, you need to modify your android manifest file. You need to add an intent-filter with 
>scheme=‘wc’
>You can check an example here: https://github.com/reown-com/react-native->examples/blob/a3a9a2b760e7d96516b8bfceec992c5404b1bf4f/wallets/rn_cli_wallet/android/app/src/main/AndroidManifes>t.xml#L32C9-L37C25


### Platforms

- Android

### Areas that may be impacted

- It's just about make status app visible in explorer list


## Steps to test

1. Install Status app, login your profile
2. Open any Dapp in mobile browser
3. Proceed with wallet connect flow via deeplink
4. See if Status app is listed within the apps available for connection

status: ready