### PR TITLE
chore: update status-go to fix/resolving-next-nonce

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v10.12.0",
-    "commit-sha1": "f0884d2f51b549fc39226b74d190859485318a0c",
-    "src-sha256": "0qqabvvimmrs2iciq4ld5l9pyziclfjk8gdkp15v2rr5q0k0pgw3"
+    "version": "fix/resolving-next-nonce",
+    "commit-sha1": "95970ce3b57ea9eff9a65ab37d103e817c7e2b7d",
+    "src-sha256": "1wf9gg5riil2ccpg394gwzvrx7x75mj585s991bi0v5jvzq3gahy"
 }


### PR DESCRIPTION
Checking status-go changes https://github.com/status-im/status-go/pull/6441

should fix https://github.com/status-im/status-mobile/issues/22341

Testing notes:

How to verify the fix

- run the app without changes from [6441](https://github.com/status-im/status-go/pull/6441)
- check what's the last Nonce for the account you use, and let's say it's X
- when you're about to send a new tx from that account, go to the custom settings part and set the Nonce to something less than X
- then you can repeat the previous step
- at this point, when you're about to send a new tx, and go to the custom settings part, you will see that the Last Used Nonce is X+2 and suggested Nonce X+3. Sending this tx won't be executed.
- now use the same profile, but use the app version that points to changes done in [6441](https://github.com/status-im/status-go/pull/6441) and go to the custom settings part for sending a tx from the same account that was previously used, and now you will see that the Last Used Nonce is X and suggested Nonce is X+1 and sending this tx will succeed.

