### PR TITLE
Login to keycard's profile with biometrics

### DIFF
--- a/src/status_im/common/biometric/events.cljs
+++ b/src/status_im/common/biometric/events.cljs
@@ -59,11 +59,21 @@
 
 (rf/reg-event-fx :biometric/enable enable-biometrics)
 
+(defn enable-biometrics-keycard
+  [{:keys [db]} [keycard-keys]]
+  {:db (assoc db :auth-method constants/auth-method-biometric)
+   :fx [[:dispatch [:keychain/save-keycard-keys-and-auth-method keycard-keys]]]})
+
+(rf/reg-event-fx :biometric/enable-keycard enable-biometrics-keycard)
+
 (defn disable-biometrics
   [{:keys [db]}]
-  (let [key-uid (get-in db [:profile/profile :key-uid])]
+  (let [key-uid          (get-in db [:profile/profile :key-uid])
+        keycard-profile? (not (nil? (get-in db [:profile/profile :keycard-pairing])))]
     {:db (assoc db :auth-method constants/auth-method-none)
-     :fx [[:keychain/clear-user-password key-uid]]}))
+     :fx [(if keycard-profile?
+            [:keychain/clear-keycard-keys key-uid]
+            [:keychain/clear-user-password key-uid])]}))
 
 (rf/reg-event-fx :biometric/disable disable-biometrics)
 

--- a/src/status_im/common/bottom_sheet/style.cljs
+++ b/src/status_im/common/bottom_sheet/style.cljs
@@ -50,3 +50,11 @@
    :border-radius     border-radius
    :margin-horizontal 8
    :background-color  (colors/theme-colors colors/white colors/neutral-90 theme)})
+
+(def drag-handle
+  {:height   50
+   :position :absolute
+   :top      0
+   :left     0
+   :right    0
+   :z-index  2})

--- a/src/status_im/common/bottom_sheet/view.cljs
+++ b/src/status_im/common/bottom_sheet/view.cljs
@@ -64,9 +64,10 @@
   [{:keys [hide? insets]}
    {:keys [content selected-item padding-bottom-override border-radius on-close shell?
            gradient-cover? customization-color hide-handle? blur-radius
-           hide-on-background-press?]
+           hide-on-background-press? drag-content?]
     :or   {border-radius             12
-           hide-on-background-press? true}}]
+           hide-on-background-press? true
+           drag-content?             true}}]
   (let [theme                             (quo.context/use-theme)
         {window-height :height}           (rn/get-window)
         [sheet-height set-sheet-height]   (rn/use-state 0)
@@ -129,7 +130,8 @@
                 {:flex             1
                  :background-color (if shell? colors/neutral-100-opa-60 colors/neutral-100-opa-70)})}]]
      ;; sheet
-     [gesture/gesture-detector {:gesture sheet-gesture}
+     [(if drag-content? gesture/gesture-detector :<>)
+      (when drag-content? {:gesture sheet-gesture})
       [reanimated/view
        {:style (reanimated/apply-animations-to-style
                 {:transform [{:translateY translate-y}]}
@@ -158,5 +160,9 @@
            {:customization-color customization-color
             :opacity             0.4}])
         (when-not hide-handle?
-          [quo/drawer-bar])
+          [:<>
+           [quo/drawer-bar]
+           (when-not drag-content?
+             [gesture/gesture-detector {:gesture sheet-gesture}
+              [rn/view {:style style/drag-handle}]])])
         [content]]]]]))

--- a/src/status_im/contexts/profile/settings/screens/password/view.cljs
+++ b/src/status_im/contexts/profile/settings/screens/password/view.cljs
@@ -10,9 +10,16 @@
   [button-label theme keycard-profile?]
   (fn []
     (if keycard-profile?
-      (rf/dispatch [:keycard/feature-unavailable-show
-                    {:theme        :dark
-                     :feature-name :settings.enable-biometrics}])
+      (rf/dispatch [:standard-auth/authorize-with-keycard-keys
+                    {:on-auth-success (fn [keycard-keys]
+                                        (rf/dispatch [:hide-bottom-sheet])
+                                        (rf/dispatch [:keycard/disconnect])
+                                        (rf/dispatch
+                                         [:biometric/authenticate
+                                          {:on-success #(rf/dispatch [:biometric/enable-keycard
+                                                                      keycard-keys])
+                                           :on-fail    #(rf/dispatch [:biometric/show-message
+                                                                      (ex-cause %)])}]))}])
       (rf/dispatch
        [:standard-auth/authorize-with-password
         {:blur?                   true


### PR DESCRIPTION
Problem: `The one thing I think is missing significantly is the ability to sign-in without keycard for those who want to (for a keycard based status account ofc, and by using biometrics). Currently the user must have his keycard all the time with him even to login and send a chat message for instance. Where can we log that in or feature upvote this `

Solution: Login to keycard's profile with biometrics without keycard. Can be enabled only in the profile settings , not supported during onboarding

there was also bad UX, when entering pin swipe happen often, so now it's possible to close sheet only with handle