### PR TITLE
Changed the feature upvote feature request URL

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -260,7 +260,7 @@
 (def ^:const one-month (* one-day 31))
 
 (def ^:const create-account-link "https://status.app/help/wallet/create-wallet-accounts")
-(def ^:const mobile-upvote-link "https://status-mobile.featureupvote.com")
+(def ^:const mobile-upvote-link "https://discuss.status.app/c/features/51")
 (def ^:const status-help-link "https://status.app/help")
 
 (def ^:const visibility-status-unknown 0)


### PR DESCRIPTION
## Description

This PR updates the `mobile-upvote-link` in `constants.cljs`, replacing the deprecated Feature Upvote SaaS URL with a link to the [Features category on the Status community forum](https://discuss.status.app/c/features/51).

## Context

Feature Upvote is no longer suitable for our needs, it doesn’t align with our workflows and has now removed our old feature boards entirely. This has created confusion and left users with nowhere to submit or review feature requests.

As discussed in [this forum thread](https://discuss.status.app/t/we-need-to-talk-about-feature-upvote/4823/19) we’re moving feature discussions to the forum to ensure transparency, accessibility, and long-term sustainability.