### PR TITLE
ci: allow Nix cache collect step to fail

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 import groovy.json.JsonBuilder
 

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 import groovy.json.JsonBuilder
 

--- a/ci/Jenkinsfile.e2e-nightly
+++ b/ci/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.e2e-nightly
+++ b/ci/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 pipeline {
   agent { label params.AGENT_LABEL }
@@ -112,15 +112,23 @@ pipeline {
 
     stage('Collect') {
       steps { script {
-        nix.shell(
+        exitCode = nix.shell(
           """
             find /nix/store/ -mindepth 1 -maxdepth 1 \
               | grep -v -e '.*.links\$' -e '.*.lock\$' -e '.*.drv\$' -e '.*.drv\$' -e '.*-status-mobile-.*' \
-              | nix path-info --stdin --recursive \
+              | xargs nix path-info --recursive \
               > "${WORKSPACE_TMP}/store-paths.txt"
           """,
-          pure: false
+          pure: false,
+          returnStatus: true
         )
+        /* Some paths can throw 'path is not valid' errors, but it's not fatal. */
+        if (exitCode != 0) {
+          currentBuild.result = 'UNSTABLE'
+        }
+        if (lineCount("${WORKSPACE_TMP}/store-paths.txt") == 0) {
+          throw new Exception("No Nix store paths found to copy.")
+        }
       } }
     }
 
@@ -151,4 +159,11 @@ def nixSysOverride(os, arch, target='android') {
         arch == 'arm64' &&
         target =~ /.*android$/
     ) ? 'x86_64-darwin' : ''
+}
+
+def lineCount(filePath) {
+    return sh(
+        script: "wc -l ${filePath}",
+        returnStdout: true
+    ).trim()
 }

--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 pipeline {
   agent { label params.AGENT_LABEL }
@@ -14,6 +14,11 @@ pipeline {
       name: 'NIX_CACHE_USER',
       description: 'Username for Nix binary cache host.',
       defaultValue: params.NIX_CACHE_USER ?: 'nix-cache'
+    )
+    booleanParam(
+      name: 'BUILD_COMPONENTS',
+      description: 'Whether to build Mobile components first.',
+      defaultValue: params.BUILD_COMPONENTS ?: true,
     )
   }
 
@@ -48,6 +53,7 @@ pipeline {
     }
 
     stage('Build status-go') {
+      when { expression { params.BUILD_COMPONENTS } }
       steps { script {
         def platforms = ['mobile.android', 'mobile.ios', 'library']
         if (os != 'Darwin')  { platforms.removeAll { it == 'mobile.ios' } }
@@ -66,6 +72,7 @@ pipeline {
     }
 
     stage('Build android jsbundle') {
+      when { expression { params.BUILD_COMPONENTS } }
       steps { script {
         /* Build/fetch deps required for jsbundle build. */
         nix.build(
@@ -78,6 +85,7 @@ pipeline {
     }
 
     stage('Build android deps') {
+      when { expression { params.BUILD_COMPONENTS } }
       steps { script {
         /* Allow for Android builds on Apple ARM. */
         env.NIXPKGS_SYSTEM_OVERRIDE = nixSysOverride(os, arch, 'android')
@@ -92,6 +100,7 @@ pipeline {
     }
 
     stage('Build nix shell deps') {
+      when { expression { params.BUILD_COMPONENTS } }
       steps { script {
         def shells = ['android', 'ios', 'fastlane', 'keytool', 'clojure', 'gradle']
         if (os != 'Darwin') { shells.removeAll { it == 'ios' } }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.20'
+library 'status-jenkins-lib@nix/add-return-status'
 
 pipeline {
   agent {

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@nix/add-return-status'
+library 'status-jenkins-lib@v1.9.21'
 
 pipeline {
   agent {


### PR DESCRIPTION
Currently some paths in Nix store cause an error like this:
```
error: path '/nix/store/27fhcnb96303i45p78wmidnvdyklfr7s-qtbase-6c09620' is not valid
```
Which can have many causes. It's not fatal but it does stop the job.

We can still upload whatever did work and was saved to the store paths file even if that error is thrown.

Requires:
- https://github.com/status-im/status-jenkins-lib/pull/113