### PR TITLE
feat_: support share logs on android

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/LogManager.kt
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/LogManager.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.AlertDialog
 import android.content.Context
 import android.content.DialogInterface
+import android.content.Intent
 import android.net.Uri
 import android.util.Log
 import androidx.core.content.FileProvider
@@ -201,6 +202,29 @@ class LogManager(private val reactContext: ReactApplicationContext) : ReactConte
             dbFile.delete()
             statusLogFile.delete()
             zipFile.deleteOnExit()
+        }
+    }
+
+    // workaround for android since react-native-share is not working for zip files, for iOS we use react-native-share
+    @ReactMethod
+    fun shareLogs(fileUri: String, callback: Callback) {
+        Log.d(TAG, "shareLogs: $fileUri")
+        
+        try {
+            val uri = Uri.parse(fileUri)
+            val intent = Intent(Intent.ACTION_SEND)
+            intent.type = "application/zip"
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            intent.putExtra(Intent.EXTRA_STREAM, uri)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            
+            val chooser = Intent.createChooser(intent, "Share Logs")
+            chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            reactContext.startActivity(chooser)
+            
+        } catch (e: Exception) {
+            Log.e(TAG, "Error sharing file: ${e.message}")
+            callback.invoke(e.message)
         }
     }
 

--- a/src/native_module/core.cljs
+++ b/src/native_module/core.cljs
@@ -313,6 +313,12 @@
   (log/debug "[native-module] send-logs")
   (.sendLogs ^js (log-manager) dbJson js-logs callback))
 
+;; workaround for android since react-native-share is not working for zip files
+(defn share-logs
+  [fileUri callback]
+  (log/debug "[native-module] share-logs")
+  (.shareLogs ^js (log-manager) fileUri callback))
+
 (defn close-application
   []
   (log/debug "[native-module] close-application")


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #22274 

## Testing notes
- iOS share log feature should remain the same as before
- added support for sharing log on android
- report bug through email should remain work as before

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Open Status
- Shake android device
- Press `Share Log` to see if you can share the logs through other apps


[comment]: # (Can be ready or wip)
status: ready

![image](https://github.com/user-attachments/assets/ea2c06ea-a93e-4d4e-8030-c5e77a604608)
![image](https://github.com/user-attachments/assets/4be84bd1-8bce-4bba-a98f-ce0dc2989600)

