### PR TITLE
Refactoring: removed duplications in send rf-db access paths

### DIFF
--- a/src/status_im/contexts/wallet/bridge/flow_config.cljs
+++ b/src/status_im/contexts/wallet/bridge/flow_config.cljs
@@ -1,10 +1,11 @@
-(ns status-im.contexts.wallet.bridge.flow-config)
+(ns status-im.contexts.wallet.bridge.flow-config
+  (:require [status-im.contexts.wallet.db-path :as db-path]))
 
 (def steps
   [{:screen-id  :screen/wallet.bridge-select-asset
-    :skip-step? (fn [db] (some? (get-in db [:wallet :ui :send :token])))}
+    :skip-step? (fn [db] (some? (get-in db (conj db-path/send :token))))}
    {:screen-id  :screen/wallet.bridge-to
-    :skip-step? (fn [db] (some? (get-in db [:wallet :ui :send :bridge-to-chain-id])))}
+    :skip-step? (fn [db] (some? (get-in db (conj db-path/send :bridge-to-chain-id))))}
    {:screen-id  :screen/wallet.bridge-input-amount
-    :skip-step? (fn [db] (some? (get-in db [:wallet :ui :send :amount])))}
+    :skip-step? (fn [db] (some? (get-in db (conj db-path/send :amount))))}
    {:screen-id :screen/wallet.transaction-confirmation}])

--- a/src/status_im/contexts/wallet/db.cljs
+++ b/src/status_im/contexts/wallet/db.cljs
@@ -1,4 +1,6 @@
-(ns status-im.contexts.wallet.db)
+(ns status-im.contexts.wallet.db
+  (:require
+    [status-im.contexts.wallet.db-path :as db-path]))
 
 (def defaults
   {:ui {;; Note: we set it to nil by default to differentiate when the user logs
@@ -6,3 +8,7 @@
         ;; tokens already exist in the app-db.
         :tokens-loading nil
         :active-tab     :assets}})
+
+(defn send
+  [db]
+  (get-in db db-path/send))

--- a/src/status_im/contexts/wallet/db_path.cljs
+++ b/src/status_im/contexts/wallet/db_path.cljs
@@ -1,3 +1,4 @@
 (ns status-im.contexts.wallet.db-path)
 
 (def swap [:wallet :ui :swap])
+(def send [:wallet :ui :send])

--- a/src/status_im/contexts/wallet/db_path.cljs
+++ b/src/status_im/contexts/wallet/db_path.cljs
@@ -1,4 +1,4 @@
 (ns status-im.contexts.wallet.db-path)
 
-(def swap [:wallet :ui :swap])
-(def send [:wallet :ui :send])
+(def ^:const swap [:wallet :ui :swap])
+(def ^:const send [:wallet :ui :send])

--- a/src/status_im/contexts/wallet/send/flow_config.cljs
+++ b/src/status_im/contexts/wallet/send/flow_config.cljs
@@ -1,28 +1,30 @@
 (ns status-im.contexts.wallet.send.flow-config
   (:require
+    [status-im.contexts.wallet.db :as db]
+    [status-im.contexts.wallet.db-path :as db-path]
     [status-im.contexts.wallet.send.utils :as send-utils]))
 
 (defn- collectible-selected?
   [db]
-  (let [collectible-stored (-> db :wallet :ui :send :collectible)
-        tx-type            (-> db :wallet :ui :send :tx-type)]
+  (let [{collectible-stored :collectible
+         tx-type            :tx-type} (db/send db)]
     (and (some? collectible-stored)
          (send-utils/tx-type-collectible? tx-type))))
 
 (defn- token-selected?
   [db]
-  (-> db :wallet :ui :send :token some?))
+  (-> db db/send :token some?))
 
 (def steps
   [{:screen-id  :screen/wallet.select-address
-    :skip-step? (fn [db] (some? (get-in db [:wallet :ui :send :recipient])))}
+    :skip-step? (fn [db] (some? (get-in db (conj db-path/send :recipient))))}
    {:screen-id  :screen/wallet.select-asset
     :skip-step? (fn [db] (or (token-selected? db) (collectible-selected? db)))}
    {:screen-id  :screen/wallet.send-input-amount
     :skip-step? (fn [db]
-                  (-> db :wallet :ui :send :tx-type send-utils/tx-type-collectible?))}
+                  (-> db db/send :tx-type send-utils/tx-type-collectible?))}
    {:screen-id  :screen/wallet.select-collectible-amount
     :skip-step? (fn [db]
                   (or (not (collectible-selected? db))
-                      (some? (get-in db [:wallet :ui :send :amount]))))}
+                      (some? (get-in db (conj db-path/send :amount)))))}
    {:screen-id :screen/wallet.transaction-confirmation}])

--- a/src/status_im/subs/wallet/networks_test.cljs
+++ b/src/status_im/subs/wallet/networks_test.cljs
@@ -2,6 +2,7 @@
   (:require
     [cljs.test :refer [is testing]]
     [re-frame.db :as rf-db]
+    [status-im.contexts.wallet.db-path :as db-path]
     [status-im.contexts.wallet.networks.config :as networks.config]
     status-im.subs.root
     status-im.subs.wallet.networks
@@ -95,7 +96,7 @@
     (swap! rf-db/app-db #(-> %
                              (assoc-in [:wallet :networks-by-id] network-data-by-id)
                              (assoc-in
-                              [:wallet :ui :send]
+                              db-path/send
                               {:from-values-by-chain {mainnet-chain-id 100}
                                :to-values-by-chain   {arbitrum-chain-id 100}
                                :token-display-name   "ETH"})))
@@ -106,7 +107,7 @@
     (swap! rf-db/app-db #(-> %
                              (assoc-in [:wallet :networks-by-id] network-data-by-id)
                              (assoc-in
-                              [:wallet :ui :send]
+                              db-path/send
                               {:from-values-by-chain {mainnet-chain-id 100}
                                :to-values-by-chain   {arbitrum-chain-id 100}
                                :token-display-name   "ARB1"})))

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -2,6 +2,7 @@
   (:require
     [cljs.test :refer [is testing use-fixtures]]
     [re-frame.db :as rf-db]
+    [status-im.contexts.wallet.db-path :as db-path]
     [status-im.contexts.wallet.networks.config :as networks.config]
     [status-im.subs.root]
     [test-helpers.unit :as h]
@@ -890,7 +891,7 @@
       #(-> %
            (assoc-in [:wallet :accounts] accounts-with-tokens)
            (assoc-in [:wallet :current-viewing-account-address] "0x1")
-           (assoc-in [:wallet :ui :send :route] route-data)
+           (update-in db-path/send assoc :route route-data)
            (assoc :currencies currencies)
            (assoc-in [:wallet :tokens :prices-per-token]
                      {:ETH {:usd 2000} :DAI {:usd 1}})


### PR DESCRIPTION
Continuation of #22314

## Summary
### Problem
We duplicate same `rf-db` path sections multiple times in our codebase. 

That means that any database refactoring will be a pain. In fact it is the same problem as sprinkling some magic constant around the code - tons of places will need to change if constants changed.

Lets check how things are with the send constants:
![Screenshot 2025-03-13 at 14 37 38](https://github.com/user-attachments/assets/1bdd8359-8a3c-416a-adb2-2b9394f9e642)
**124 occurences!**

### Decision
This PR reimplements suggestions proposed by @flexsurfer in #22288 - combining `update-in` with `assoc`/`dissoc` and proper destructuring to get rid of key sequence duplication. Plus It introduces constant `db/send` for `[:wallet :ui :send]` db path.


## Testing notes
Send/Bridge internals changed, they need testing

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

### Areas that may be impacted
[comment]: # (Optional. Specify if some specific areas need to be tested, such as 1-1 chats)

#### Functional

- wallet / transactions


## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Open Status
- Do some sends/bridges
- Make sure everything works


status: ready

