### PR TITLE
e2e: fixes according to new networks

### DIFF
--- a/test/appium/tests/activity_center/test_activity_center.py
+++ b/test/appium/tests/activity_center/test_activity_center.py
@@ -374,7 +374,7 @@ class TestActivityMultipleDevicePR(MultipleSharedDeviceTestCase):
         self.errors.verify_no_errors()
 
 
-@pytest.mark.xdist_group(name="new_six_2")
+@pytest.mark.xdist_group(name="six_2")
 @marks.nightly
 class TestActivityMultipleDevicePRTwo(MultipleSharedDeviceTestCase):
 

--- a/test/appium/tests/critical/wallet/test_wallet_mainnet.py
+++ b/test/appium/tests/critical/wallet/test_wallet_mainnet.py
@@ -349,6 +349,31 @@ class TestWalletOneDevice(MultipleSharedDeviceTestCase):
             self.wallet_view.click_system_back_button(times=5)
         self.errors.verify_no_errors()
 
+
+
+@pytest.mark.xdist_group(name="one_1")
+@marks.nightly
+@marks.secured
+@marks.smoke
+class TestWalletOneDeviceTwo(MultipleSharedDeviceTestCase):
+
+    def prepare_devices(self):
+        self.drivers, self.loop = create_shared_drivers(1)
+        self.sign_in_view = SignInView(self.drivers[0])
+        self.sender, self.receiver = transaction_senders['ETH_5'], transaction_senders['ETH_2']
+
+        self.sender['wallet_address'] = '0x' + self.sender['address']
+        self.receiver['wallet_address'] = '0x' + self.receiver['address']
+        self.sign_in_view.recover_access(passphrase=self.sender['passphrase'])
+
+        self.home_view = self.sign_in_view.get_home_view()
+        self.sender_username = self.home_view.get_username()
+        self.profile_view = self.home_view.profile_button.click()
+        self.profile_view.switch_network()
+        self.sign_in_view.sign_in(user_name=self.sender_username)
+        self.wallet_view = self.home_view.wallet_tab.click()
+        self.account_name = 'Account 1'
+
     @marks.testrail_id(727231)
     def test_wallet_add_remove_regular_account(self):
         self.sign_in_view.reopen_app(user_name=self.sender_username)

--- a/test/appium/tests/critical/wallet/test_wallet_testnet.py
+++ b/test/appium/tests/critical/wallet/test_wallet_testnet.py
@@ -31,8 +31,8 @@ class TestWalletMultipleDevice(MultipleSharedDeviceTestCase):
     @pytest.mark.parametrize(
         "network, amount",
         [
-            pytest.param("Arbitrum", 0.0001, marks=pytest.mark.testrail_id(742015)),
-            pytest.param("Status Network", 0.0002, marks=pytest.mark.testrail_id(727229)),
+            pytest.param("Arbitrum Sepolia", 0.0001, marks=pytest.mark.testrail_id(742015)),
+            pytest.param("Status Network Sepolia", 0.0002, marks=pytest.mark.testrail_id(727229)),
         ],
     )
     def test_send_eth(self, network, amount):
@@ -65,8 +65,8 @@ class TestWalletMultipleDevice(MultipleSharedDeviceTestCase):
     @pytest.mark.parametrize(
         "network, asset, asset_ticker, decimals, amount",
         [
-            pytest.param("Mainnet", 'USD Coin', 'USDC', 2, 0.01,  marks=pytest.mark.testrail_id(742016)),
-            pytest.param("Optimism", 'USD Coin', 'USDC', 2, 0.01,  marks=pytest.mark.testrail_id(727230)),
+            pytest.param("Sepolia", 'USD Coin', 'USDC', 2, 0.01,  marks=pytest.mark.testrail_id(742016)),
+            pytest.param("Optimism Sepolia", 'USD Coin', 'USDC', 2, 0.01,  marks=pytest.mark.testrail_id(727230)),
         ],
     )
     def test_wallet_send_erc20_from_drawer(self, network, asset, asset_ticker, decimals, amount):


### PR DESCRIPTION
This pull request introduces a new test class for shared device testing and updates some network parameters in existing tests. The most important changes include the addition of a new test class and modifications to the network names in parameterized tests.

New test class (to avoid imported account which is recovered from waku backup):

* [`test/appium/tests/critical/wallet/test_wallet_mainnet.py`](diffhunk://#diff-9397a6dff905b76d0e065c75ee85ca1b21dff6cc92c2b38d243dd7d8c77f9fc6R352-R376): Added `TestWalletOneDeviceTwo` class for shared device testing with multiple marks and a `prepare_devices` method to set up the test environment.

Updates to network parameters (to fix changes from https://github.com/status-im/status-mobile/pull/22353):

* [`test/appium/tests/critical/wallet/test_wallet_testnet.py`](diffhunk://#diff-2f765794c193e2a13ce0b0ca543b19ef3d0ac1907ad0eed4ef986e80da3b6fd6L34-R35): Updated network names to "Arbitrum Sepolia" and "Status Network Sepolia" in the `test_send_eth` method.
* [`test/appium/tests/critical/wallet/test_wallet_testnet.py`](diffhunk://#diff-2f765794c193e2a13ce0b0ca543b19ef3d0ac1907ad0eed4ef986e80da3b6fd6L68-R69): Updated network names to "Sepolia" and "Optimism Sepolia" in the `test_wallet_send_erc20_from_drawer` method.chats)

