### PR TITLE
e2e: new PR scope

### DIFF
--- a/test/appium/tests/critical/chats/test_1_1_public_chats.py
+++ b/test/appium/tests/critical/chats/test_1_1_public_chats.py
@@ -1,3 +1,4 @@
+from os import read
 import random
 
 import emoji
@@ -46,6 +47,8 @@ class TestOneToOneChatMultipleSharedDevicesNewUi(MultipleSharedDeviceTestCase):
         self.message_1, self.message_2, self.message_3, self.message_4 = \
             "Message 1", "Message 2", "Message 3", "Message 4"
 
+    @marks.smoke
+    @marks.xfail(reason="Might fail from time to time as reaction are set too slowly") # TODO: needs investigation
     @marks.testrail_id(702730)
     def test_1_1_chat_message_reaction(self):
         message_from_sender = "Message sender"
@@ -184,6 +187,7 @@ class TestOneToOneChatMultipleSharedDevicesNewUi(MultipleSharedDeviceTestCase):
 
         self.errors.verify_no_errors()
 
+    @marks.smoke
     @marks.testrail_id(702731)
     def test_1_1_chat_pin_messages(self):
         self.home_1.just_fyi("Check that Device1 can pin own message in 1-1 chat")
@@ -279,7 +283,6 @@ class TestOneToOneChatMultipleSharedDevicesNewUi(MultipleSharedDeviceTestCase):
         self.errors.verify_no_errors()
 
     @marks.testrail_id(702745)
-    @marks.smoke
     def test_1_1_chat_non_latin_messages_stack_update_profile_photo(self):
         self.home_1.navigate_back_to_home_view()
         self.home_1.profile_button.click()
@@ -412,6 +415,7 @@ class TestOneToOneChatMultipleSharedDevicesNewUi(MultipleSharedDeviceTestCase):
                 self.errors.append(self.chat_1, "Message reaction is not shown for the sender")
         self.errors.verify_no_errors()
 
+    @marks.smoke
     @marks.testrail_id(703391)
     def test_1_1_chat_send_image_save_and_share(self):
         if not self.chat_2.chat_message_input.is_element_displayed():

--- a/test/appium/tests/critical/chats/test_group_chat.py
+++ b/test/appium/tests/critical/chats/test_group_chat.py
@@ -81,6 +81,7 @@ class TestGroupChatMultipleDeviceMergedNewUI(MultipleSharedDeviceTestCase):
 
         self.chats[0].send_message(self.message_before_adding)
 
+    @marks.smoke
     @marks.testrail_id(702807)
     def test_group_chat_join_send_text_messages_push(self):
         message_to_admin = self.message_to_admin

--- a/test/appium/tests/critical/chats/test_public_chat_browsing.py
+++ b/test/appium/tests/critical/chats/test_public_chat_browsing.py
@@ -349,6 +349,7 @@ class TestCommunityMultipleDeviceMerged(MultipleSharedDeviceTestCase):
         self.channel_2 = self.community_2.get_channel(self.channel_name).click()
         self.channel_2.chat_message_input.wait_for_visibility_of_element(20)
 
+    @marks.smoke
     @marks.testrail_id(702838)
     def test_community_message_send_check_timestamps_sender_username(self):
         message = self.text_message
@@ -386,6 +387,7 @@ class TestCommunityMultipleDeviceMerged(MultipleSharedDeviceTestCase):
             self.errors.append(self.channel_1, "Message reaction is not shown for the sender")
         self.errors.verify_no_errors()
 
+    @marks.smoke
     @marks.testrail_id(702839)
     def test_community_message_delete(self):
         message_to_delete_everyone = 'delete for everyone'
@@ -460,8 +462,10 @@ class TestCommunityMultipleDeviceMerged(MultipleSharedDeviceTestCase):
                 self.errors.append(self.channel_1, 'Reply message was not received by the sender')
         self.errors.verify_no_errors()
 
+    @marks.smoke
+    @marks.xfail(reason="Might fail from time to time as reaction are set too slowly") # TODO: needs investigation
     @marks.testrail_id(702859)
-    def test_community_one_image_send_reply(self):
+    def test_community_one_image_send_reply_set_reaction(self):
         self.home_1.just_fyi('Send image in 1-1 chat from Gallery')
         image_description = 'description'
         self.channel_1.send_images_with_description(image_description)

--- a/test/appium/tests/critical/test_profile.py
+++ b/test/appium/tests/critical/test_profile.py
@@ -124,6 +124,7 @@ class TestProfileMultipleDevices(MultipleSharedDeviceTestCase):
         self.chat_1.send_message(self.message_1_1_from_1)
         self.new_username_1 = 'user 1'
 
+    @marks.smoke
     @marks.testrail_id(741968)
     def test_profile_change_username(self):
         self.home_1.navigate_back_to_home_view()
@@ -176,6 +177,7 @@ class TestProfileMultipleDevices(MultipleSharedDeviceTestCase):
 
         self.errors.verify_no_errors()
 
+    @marks.smoke
     @marks.testrail_id(741969)
     def test_profile_change_profile_photo(self):
         self.home_2.navigate_back_to_home_view()

--- a/test/appium/tests/critical/wallet/test_wallet_mainnet.py
+++ b/test/appium/tests/critical/wallet/test_wallet_mainnet.py
@@ -39,6 +39,7 @@ class TestWalletOneDevice(MultipleSharedDeviceTestCase):
         self.account_name = 'Account 1'
 
     @marks.testrail_id(740490)
+    @marks.xfail(reason="Might fail due to #22384")
     def test_wallet_balance_mainnet(self):
         self.wallet_view.just_fyi("Checking total balance")
         real_balance = {}
@@ -367,17 +368,11 @@ class TestWalletOneDeviceTwo(MultipleSharedDeviceTestCase):
         self.sign_in_view.recover_access(passphrase=self.sender['passphrase'])
 
         self.home_view = self.sign_in_view.get_home_view()
-        self.sender_username = self.home_view.get_username()
-        self.profile_view = self.home_view.profile_button.click()
-        self.profile_view.switch_network()
-        self.sign_in_view.sign_in(user_name=self.sender_username)
         self.wallet_view = self.home_view.wallet_tab.click()
         self.account_name = 'Account 1'
 
     @marks.testrail_id(727231)
     def test_wallet_add_remove_regular_account(self):
-        self.sign_in_view.reopen_app(user_name=self.sender_username)
-        self.home_view.wallet_tab.click()
         self.wallet_view.just_fyi("Adding new regular account")
         new_account_name = "New Account"
         self.wallet_view.add_regular_account(account_name=new_account_name)

--- a/test/appium/tests/critical/wallet/test_wallet_testnet.py
+++ b/test/appium/tests/critical/wallet/test_wallet_testnet.py
@@ -7,7 +7,7 @@ from users import transaction_senders
 from views.sign_in_view import SignInView
 
 
-@pytest.mark.xdist_group(name="five_2")
+@pytest.mark.xdist_group(name="four_2")
 @marks.nightly
 @marks.secured
 @marks.smoke


### PR DESCRIPTION
PR changes scope of e2e that we run in PR.



## Review notes
[comment]: # (Optional. Specify if something in particular should be looked at, or ignored, during review)
This pull request includes several changes to the test suite, specifically adding the `@marks.smoke` decorator to various test methods across multiple files. These changes help categorize and identify smoke tests within the test suite.

The most important changes include:

### Additions of `@marks.smoke` Decorator:
* [`test/appium/tests/critical/chats/test_1_1_public_chats.py`](diffhunk://#diff-559064e5d7dfb0ae68109b6674deb217b4093b8e4555bbd2ed9b71201f9c21fdR49): Added `@marks.smoke` to `test_1_1_chat_message_reaction`, `test_1_1_chat_emoji_send_reply_and_open_link`, and `test_1_1_chat_edit_message`. [[1]](diffhunk://#diff-559064e5d7dfb0ae68109b6674deb217b4093b8e4555bbd2ed9b71201f9c21fdR49) [[2]](diffhunk://#diff-559064e5d7dfb0ae68109b6674deb217b4093b8e4555bbd2ed9b71201f9c21fdR188) [[3]](diffhunk://#diff-559064e5d7dfb0ae68109b6674deb217b4093b8e4555bbd2ed9b71201f9c21fdR416)
* [`test/appium/tests/critical/chats/test_group_chat.py`](diffhunk://#diff-75d9a5f0c7f3dc9d33b0f6ff4babcf1d61f55a77ee5c718361dfef929792d92eR84): Added `@marks.smoke` to `test_group_chat_join_send_text_messages_push`.
* [`test/appium/tests/critical/chats/test_public_chat_browsing.py`](diffhunk://#diff-7c16da3034af9f03c4c8c457ed37ce5efd4fd3178217b10b06f09389d0a37d74R352): Added `@marks.smoke` to `test_community_message_send_check_timestamps_sender_username`, `test_community_message_delete`, and `test_community_one_image_send_reply`. [[1]](diffhunk://#diff-7c16da3034af9f03c4c8c457ed37ce5efd4fd3178217b10b06f09389d0a37d74R352) [[2]](diffhunk://#diff-7c16da3034af9f03c4c8c457ed37ce5efd4fd3178217b10b06f09389d0a37d74R390) [[3]](diffhunk://#diff-7c16da3034af9f03c4c8c457ed37ce5efd4fd3178217b10b06f09389d0a37d74R465)
* [`test/appium/tests/critical/test_profile.py`](diffhunk://#diff-ec2d136097510b9fbdb21a037ef1342ff7fa6c938747b7aa7c81f3ea6f0e20a8R127): Added `@marks.smoke` to `test_profile_change_username` and `test_profile_change_profile_photo`. [[1]](diffhunk://#diff-ec2d136097510b9fbdb21a037ef1342ff7fa6c938747b7aa7c81f3ea6f0e20a8R127) [[2]](diffhunk://#diff-ec2d136097510b9fbdb21a037ef1342ff7fa6c938747b7aa7c81f3ea6f0e20a8R180)

### Removal of `@marks.smoke` Decorator:
* [`test/appium/tests/critical/chats/test_1_1_public_chats.py`](diffhunk://#diff-559064e5d7dfb0ae68109b6674deb217b4093b8e4555bbd2ed9b71201f9c21fdL282): Removed `@marks.smoke` from `test_1_1_chat_non_latin_messages_stack_update_profile_photo`.


