### PR TITLE
Chore: Lint warnings cleanup

### DIFF
--- a/src/legacy/status_im/subs/mailservers.cljs
+++ b/src/legacy/status_im/subs/mailservers.cljs
@@ -9,10 +9,3 @@
  :<- [:mailserver/mailservers]
  (fn [[current-mailserver-id current-fleet mailservers]]
    (get-in mailservers [current-fleet current-mailserver-id :name])))
-
-(re-frame/reg-sub
- :mailserver/fleet-mailservers
- :<- [:fleets/current-fleet]
- :<- [:mailserver/mailservers]
- (fn [[current-fleet mailservers]]
-   (current-fleet mailservers)))

--- a/src/quo/components/selectors/react/view.cljs
+++ b/src/quo/components/selectors/react/view.cljs
@@ -25,4 +25,4 @@
       {:on-press            on-press-add
        :state               :add-reaction
        :use-case            use-case
-       :accessibility-label (str "emoji-add-reaction")}])])
+       :accessibility-label "emoji-add-reaction"}])])

--- a/src/quo/components/share/share_qr_code/style.cljs
+++ b/src/quo/components/share/share_qr_code/style.cljs
@@ -16,15 +16,6 @@
    :padding-top        12
    :padding-bottom     8})
 
-;;; Header
-(def header-container
-  {:flex-direction :row
-   :margin-bottom  12})
-
-(def header-tab-active {:background-color colors/white-opa-20})
-(def header-tab-inactive {:background-color colors/white-opa-5})
-(def space-between-tabs {:width 8})
-
 ;;; QR code
 (defn qr-code-size
   [total-width]
@@ -60,10 +51,5 @@
   {:width (- total-width (* 2 padding-horizontal) share-button-size share-button-gap)})
 
 ;;; Wallet variants
-(def wallet-multichain-container
-  {:flex-direction  :row
-   :justify-content :space-between
-   :flex            1})
-
 (def watched-account-icon
   {:margin-left 4})

--- a/src/quo/components/wallet/account_card/view.cljs
+++ b/src/quo/components/wallet/account_card/view.cljs
@@ -123,7 +123,7 @@
                                    :pressed?            pressed?
                                    :metrics?            metrics?})
         :on-press     on-press}
-       (when (and customization-color (and (not watch-only?) (not missing-keypair?)))
+       (when (and customization-color (not watch-only?) (not missing-keypair?))
          [customization-colors/overlay
           {:customization-color customization-color
            :border-radius       16

--- a/src/react_native/keychain.cljs
+++ b/src/react_native/keychain.cljs
@@ -80,4 +80,4 @@
   [server]
   (when-not (empty? server)
     (-> (.resetInternetCredentials ^js react-native-keychain (string/lower-case server))
-        (.then #(when-not % (log/error (str "Error while clearing saved password.")))))))
+        (.then #(when-not % (log/error "Error while clearing saved password."))))))

--- a/src/status_im/common/pairing/events.cljs
+++ b/src/status_im/common/pairing/events.cljs
@@ -28,7 +28,8 @@
                                                    constants/local-pairing-event-received-account)
                                                 (= action
                                                    constants/local-pairing-action-pairing-account)
-                                                (and (some? account) (some? password)))
+                                                (some? account)
+                                                (some? password))
         multiaccount-data                  (when received-account?
                                              (merge account
                                                     {:password            password

--- a/src/status_im/contexts/communities/actions/accounts_selection/events_test.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/events_test.cljs
@@ -4,7 +4,6 @@
             [status-im.contexts.communities.actions.accounts-selection.events :as sut]))
 
 (def community-id "0x99")
-(def password "password")
 
 (def wallet-accounts
   {"0xA" {:address     "0xA"

--- a/src/status_im/contexts/keycard/manage/view.cljs
+++ b/src/status_im/contexts/keycard/manage/view.cljs
@@ -42,7 +42,6 @@
 
 (defn empty-backup-view
   []
-  []
   [:<>
    [quo/page-nav
     {:icon-name :i/close

--- a/src/status_im/contexts/preview/quo/settings/data_item.cljs
+++ b/src/status_im/contexts/preview/quo/settings/data_item.cljs
@@ -67,7 +67,7 @@
 
 (defn view
   []
-  (let [state (reagent/atom {:on-press            #(js/alert (str "pressed"))
+  (let [state (reagent/atom {:on-press            #(js/alert "pressed")
                              :blur?               false
                              :subtitle-type       :account
                              :card?               true

--- a/src/status_im/contexts/profile/edit/modal/view.cljs
+++ b/src/status_im/contexts/profile/edit/modal/view.cljs
@@ -221,7 +221,7 @@
                                                   (not= initial-display-name @display-name))
                                              (assoc :display-name @display-name)
 
-                                             (and (not= initial-image @profile-image))
+                                             (not= initial-image @profile-image)
                                              (assoc :picture @profile-image)
 
                                              (not= initial-color @custom-color)

--- a/src/status_im/contexts/settings/keycard/style.cljs
+++ b/src/status_im/contexts/settings/keycard/style.cljs
@@ -1,22 +1,10 @@
 (ns status-im.contexts.settings.keycard.style
-  (:require
-    [quo.foundations.colors :as colors]))
+  (:require [quo.foundations.colors :as colors]))
 
-(def registered-keycards-container
-  {:gap                12
-   :padding-horizontal 20})
+(def container {:padding-horizontal 28 :padding-top 20})
 
-(def keycard-row
-  {:gap              12
-   :padding          12
-   :border-radius    16
-   :flex-direction   :row
-   :background-color colors/white-opa-5})
+(def text-container {:margin-top 24})
 
-(def keycard-owner
-  {:gap            4
-   :flex-direction :row
-   :align-items    :center})
-
-(def keycard-owner-name
-  {:color colors/white-opa-40})
+(def text
+  {:margin-bottom 1
+   :color         colors/white-opa-70})

--- a/src/status_im/contexts/settings/keycard/view.cljs
+++ b/src/status_im/contexts/settings/keycard/view.cljs
@@ -1,10 +1,10 @@
 (ns status-im.contexts.settings.keycard.view
   (:require [quo.core :as quo]
-            [quo.foundations.colors :as colors]
             [react-native.core :as rn]
             [status-im.common.events-helper :as events-helper]
             [status-im.common.resources :as resources]
             [status-im.constants :as constants]
+            [status-im.contexts.settings.keycard.style :as style]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
@@ -18,7 +18,7 @@
      :on-press   events-helper/navigate-back}]
    [quo/page-top
     {:title (i18n/label :t/keycard)}]
-   [rn/view {:style {:padding-horizontal 28 :padding-top 20}}
+   [rn/view {:style style/container}
     [quo/small-option-card
      {:variant             :main
       :title               (i18n/label :t/get-keycard)
@@ -29,10 +29,9 @@
       :accessibility-label :get-keycard
       :image               (resources/get-image :keycard-buy)
       :on-press            #(rf/dispatch [:browser.ui/open-url constants/get-keycard-url])}]
-    [rn/view {:style {:margin-top 24}}
+    [rn/view {:style style/text-container}
      [quo/text
-      {:style  {:margin-bottom 1
-                :color         colors/white-opa-70}
+      {:style  style/text
        :size   :paragraph-2
        :weight :medium}
       (i18n/label :t/own-keycard)]]

--- a/src/status_im/contexts/wallet/collectible/tabs/about/view.cljs
+++ b/src/status_im/contexts/wallet/collectible/tabs/about/view.cljs
@@ -2,7 +2,6 @@
   (:require [quo.core :as quo]
             [react-native.core :as rn]
             [status-im.contexts.wallet.collectible.tabs.about.style :as style]
-            [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
 (def ^:private link-card-space 28)
@@ -24,9 +23,6 @@
        {:size :paragraph-2}
        (:description collectible-data)]]
      (when (count collectible-about)
-       [quo/section-label
-        {:container-style style/section-label
-         :section         (i18n/label :t/on-the-web)}]
        [rn/view {:style style/link-cards-container}
         (for [item (:cards collectible-about)]
           ^{:key (:title item)}

--- a/src/status_im/contexts/wallet/networks/db.cljs
+++ b/src/status_im/contexts/wallet/networks/db.cljs
@@ -38,10 +38,3 @@
   (-> db
       (get-network-details chain-id)
       (networks/get-block-explorer-address-url address)))
-
-(defn get-block-explorer-tx-url
-  "Returns the block-explorer transaction url for a chain"
-  [db chain-id tx-hash]
-  (-> db
-      (get-network-details chain-id)
-      (networks/get-block-explorer-tx-url tx-hash)))

--- a/src/status_im/contexts/wallet/rpc.cljs
+++ b/src/status_im/contexts/wallet/rpc.cljs
@@ -12,15 +12,6 @@
     {:message-to-sign (oops/oget res :messageToSign)
      :tx-args         (oops/oget res :txArgs)}))
 
-(defn build-raw-transaction
-  [chain-id tx-args signature]
-  (-> (rpc-events/call-async "wallet_buildRawTransaction"
-                             true
-                             chain-id
-                             (transforms/js-stringify tx-args 0)
-                             signature)
-      (promesa/then #(oops/oget % "rawTx"))))
-
 (defn hash-message-eip-191
   [message]
   (rpc-events/call-async "wallet_hashMessageEIP191" true message))

--- a/src/status_im/contexts/wallet/send/transaction_settings/core.cljs
+++ b/src/status_im/contexts/wallet/send/transaction_settings/core.cljs
@@ -2,8 +2,6 @@
   (:require
     [status-im.constants :as constants]))
 
-(def default-transaction-setting :tx-fee-mode/fast)
-
 (defn tx-fee-mode->gas-rate
   [tx-fee-mode]
   (case tx-fee-mode

--- a/src/status_im/contexts/wallet/wallet_connect/utils/data_store.cljs
+++ b/src/status_im/contexts/wallet/wallet_connect/utils/data_store.cljs
@@ -4,8 +4,7 @@
     [status-im.constants :as constants]
     [status-im.contexts.wallet.common.utils :as wallet-utils]
     [status-im.contexts.wallet.common.utils.networks :as network-utils]
-    utils.string
-    [utils.transforms :as transforms]))
+    utils.string))
 
 (defn compute-dapp-name
   "Sometimes dapps have no name or an empty name. Return url as name in that case"
@@ -32,10 +31,6 @@
    constants/wallet-connect-eth-sign-typed-method       :screen/wallet-connect.sign-message
    constants/wallet-connect-eth-sign-typed-v4-method    :screen/wallet-connect.sign-message
    constants/wallet-connect-eth-send-transaction-method :screen/wallet-connect.send-transaction})
-
-(defn extract-native-call-signature
-  [data]
-  (-> data transforms/json->clj :result))
 
 (defn get-request-method
   [event]

--- a/src/status_im/subs/bottom_sheet.cljs
+++ b/src/status_im/subs/bottom_sheet.cljs
@@ -1,8 +1,0 @@
-(ns status-im.subs.bottom-sheet
-  (:require
-    [re-frame.core :as re-frame]))
-
-(re-frame/reg-sub
- :bottom-sheet-sheets
- :<- [:bottom-sheet]
- :-> :sheets)

--- a/src/status_im/subs/communities.cljs
+++ b/src/status_im/subs/communities.cljs
@@ -237,16 +237,6 @@
    :community-icon        (:images community)})
 
 (re-frame/reg-sub
- :communities/home-item
- (fn [[_ community-id]]
-   [(re-frame/subscribe [:communities])
-    (re-frame/subscribe [:communities/unviewed-counts community-id])])
- (fn [[communities counts] [_ community-identity]]
-   (community->home-item
-    (get communities community-identity)
-    counts)))
-
-(re-frame/reg-sub
  :communities/my-pending-request-to-join
  :<- [:communities/my-pending-requests-to-join]
  (fn [requests [_ community-id]]

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -4,7 +4,6 @@
     status-im.subs.activity-center
     status-im.subs.alert-banner
     status-im.subs.biometrics
-    status-im.subs.bottom-sheet
     status-im.subs.chats
     status-im.subs.communities
     status-im.subs.community.account-selection

--- a/src/status_im/subs/wallet/dapps/requests.cljs
+++ b/src/status_im/subs/wallet/dapps/requests.cljs
@@ -1,6 +1,5 @@
 (ns status-im.subs.wallet.dapps.requests
   (:require [re-frame.core :as rf]
-            [status-im.contexts.keycard.utils :as keycard]
             [status-im.contexts.wallet.common.utils :as wallet-utils]
             [status-im.contexts.wallet.wallet-connect.utils.data-store :as
              data-store]
@@ -69,9 +68,3 @@
  :<- [:wallet-connect/current-request-method]
  typed-data/typed-data-request?)
 
-(rf/reg-sub
- :wallet-connect/sign-on-keycard?
- :<- [:wallet/keypairs]
- :<- [:wallet-connect/current-request-address]
- (fn [[keypairs address]]
-   (keycard/keycard-address? keypairs address)))

--- a/src/status_im/subs/wallet/saved_addresses.cljs
+++ b/src/status_im/subs/wallet/saved_addresses.cljs
@@ -4,11 +4,6 @@
     [re-frame.core :as rf]))
 
 (rf/reg-sub
- :wallet/saved-address
- :<- [:wallet/ui]
- :-> :saved-address)
-
-(rf/reg-sub
  :wallet/saved-addresses
  :<- [:wallet]
  :-> :saved-addresses)

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -154,11 +154,6 @@
  :-> :loading-swap-proposal-fee?)
 
 (rf/reg-sub
- :wallet/swap-transaction-for-signing
- :<- [:wallet/swap]
- :-> :transaction-for-signing)
-
-(rf/reg-sub
  :wallet/swap-proposal-amount-out
  :<- [:wallet/swap-proposal]
  :-> :amount-out)
@@ -291,15 +286,6 @@
                                                       0)
                                               (number/convert-to-whole-number pay-token-decimals))]
      pay-token-balance-selected-chain)))
-
-(rf/reg-sub
- :wallet/swap-asset-to-pay-balance-for-chain-ui
- :<- [:wallet/swap-asset-to-pay-balance-for-chain-data]
- (fn [asset-to-pay-with-current-account-balance [_ chain-id]]
-   (utils/token-balance-display-for-network
-    asset-to-pay-with-current-account-balance
-    chain-id
-    constants/min-token-decimals-to-display)))
 
 (rf/reg-sub
  :wallet/swap-asset-to-pay-amount-in-fiat

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -138,20 +138,9 @@
  :-> :selected-networks)
 
 (rf/reg-sub
- :wallet/network-filter-selector-state
- :<- [:wallet/network-filter]
- :-> :selector-state)
-
-(rf/reg-sub
  :wallet/current-viewing-account-address
  :<- [:wallet]
  :-> :current-viewing-account-address)
-
-(rf/reg-sub
- :wallet/viewing-account?
- :<- [:wallet/current-viewing-account-address]
- (fn [address]
-   (boolean address)))
 
 (rf/reg-sub
  :wallet/wallet-send-to-address
@@ -173,12 +162,6 @@
  :<- [:wallet/wallet-send-route]
  (fn [routes]
    (first routes)))
-
-(rf/reg-sub
- :wallet/gas-fees
- :<- [:wallet/wallet-send-route]
- (fn [route]
-   (:gas-fees (first route))))
 
 (rf/reg-sub
  :wallet/suggested-gas-fees-for-setting
@@ -232,11 +215,6 @@
  :wallet/wallet-send-loading-suggested-routes?
  :<- [:wallet/wallet-send]
  :-> :loading-suggested-routes?)
-
-(rf/reg-sub
- :wallet/wallet-send-transaction-for-signing
- :<- [:wallet/wallet-send]
- :-> :transaction-for-signing)
 
 (rf/reg-sub
  :wallet/wallet-send-suggested-routes
@@ -753,14 +731,6 @@
      (and (not-empty aggregated-tokens) zero-balance?))))
 
 (rf/reg-sub
- :wallet/network-preference-details
- :<- [:wallet/current-viewing-account]
- :<- [:wallet/network-details]
- (fn [[current-viewing-account network-details]]
-   (let [network-preferences-names (:network-preferences-names current-viewing-account)]
-     (filter #(contains? network-preferences-names (:network-name %)) network-details))))
-
-(rf/reg-sub
  :wallet/accounts-with-customization-color
  :<- [:wallet/accounts]
  (fn [accounts]
@@ -780,13 +750,6 @@
                                          (:prod-preferred-chain-ids %)))
                                     accounts)]
      (filter #(preferred-chains-ids (:chain-id %)) network-details))))
-
-(rf/reg-sub
- :wallet/preferred-chain-names-for-address
- (fn [[_ address]]
-   (rf/subscribe [:wallet/preferred-chains-for-address address]))
- (fn [preferred-chains-for-address _]
-   (map :network-name preferred-chains-for-address)))
 
 (rf/reg-sub
  :wallet/transactions
@@ -818,32 +781,6 @@
  :wallet/searching-address?
  :<- [:wallet/search-address]
  :-> :loading?)
-
-(rf/reg-sub
- :wallet/aggregated-fiat-balance-per-chain
- :<- [:wallet/aggregated-tokens]
- :<- [:profile/currency]
- :<- [:profile/currency-symbol]
- :<- [:wallet/prices-per-token]
- (fn [[aggregated-tokens currency currency-symbol prices-per-token]]
-   (utils/calculate-balances-per-chain
-    {:tokens           aggregated-tokens
-     :currency         currency
-     :currency-symbol  currency-symbol
-     :prices-per-token prices-per-token})))
-
-(rf/reg-sub
- :wallet/current-viewing-account-fiat-balance-per-chain
- :<- [:wallet/current-viewing-account]
- :<- [:profile/currency]
- :<- [:profile/currency-symbol]
- :<- [:wallet/prices-per-token]
- (fn [[{:keys [tokens]} currency currency-symbol prices-per-token]]
-   (utils/calculate-balances-per-chain
-    {:tokens           tokens
-     :currency         currency
-     :currency-symbol  currency-symbol
-     :prices-per-token prices-per-token})))
 
 (rf/reg-sub
  :wallet/import-private-key

--- a/src/status_im/subs/wallet/wallet_test.cljs
+++ b/src/status_im/subs/wallet/wallet_test.cljs
@@ -524,20 +524,6 @@
         :tokens                    tokens-0x2})
       (rf/sub [sub-name])))))
 
-(h/deftest-sub :wallet/network-preference-details
-  [sub-name]
-  (testing "returns newtork preference details"
-    (swap! rf-db/app-db
-      #(-> %
-           (assoc-in [:wallet :accounts] accounts)
-           (assoc-in [:wallet :current-viewing-account-address] "0x1")
-           (assoc-in [:wallet :tokens :prices-per-token]
-                     {:ETH {:usd 2000} :DAI {:usd 1}})
-           (assoc-in [:wallet :networks] network-data)))
-    (is
-     (match? (:prod network-data)
-             (rf/sub [sub-name])))))
-
 (h/deftest-sub :wallet/aggregated-tokens
   [sub-name]
   (testing "returns aggregated tokens from all accounts"
@@ -896,42 +882,6 @@
                      keys)]
       (is (match? (count chains) 1))
       (is (match? (first chains) optimism-chain-id)))))
-
-(h/deftest-sub :wallet/aggregated-fiat-balance-per-chain
-  [sub-name]
-  (testing "aggregated fiat balance per chain"
-    (swap! rf-db/app-db
-      #(-> %
-           (assoc-in [:wallet :accounts] accounts)
-           (assoc-in [:wallet :networks] network-data)
-           (assoc-in [:wallet :tokens :prices-per-token] {:ETH {:usd 2000} :DAI {:usd 1}})
-           (assoc :currencies currencies)
-           (assoc-in [:profile/profile :currency] :usd)))
-
-    (let [result (rf/sub [sub-name])
-          chains (keys result)]
-      (is (match? (count chains) 3))
-      (is (match? (get result mainnet-chain-id) "$9002.00"))
-      (is (match? (get result optimism-chain-id) "$8001.50")))))
-
-(h/deftest-sub :wallet/current-viewing-account-fiat-balance-per-chain
-  [sub-name]
-  (testing "current viewing account fiat balance per chain"
-    (swap! rf-db/app-db
-      #(-> %
-           (assoc-in [:wallet :accounts] accounts)
-           (assoc-in [:wallet :networks] network-data)
-           (assoc-in [:wallet :current-viewing-account-address] "0x2")
-           (assoc-in [:wallet :tokens :prices-per-token] {:ETH {:usd 2000} :DAI {:usd 1}})
-           (assoc :currencies currencies)
-           (assoc-in [:profile/profile :currency] :usd)))
-
-    (let [result (rf/sub [sub-name])
-          chains (keys result)]
-      (is (match? (count chains) 3))
-      (is (match? (get result mainnet-chain-id) "$5001.00"))
-      (is (match? (get result optimism-chain-id) "$6000.00"))
-      (is (match? (get result arbitrum-chain-id) "$0.00")))))
 
 (h/deftest-sub :wallet/wallet-send-fee-fiat-formatted
   [sub-name]

--- a/src/test_helpers/integration.cljs
+++ b/src/test_helpers/integration.cljs
@@ -74,7 +74,7 @@
 
 (defn logout
   []
-  (log/info (str "==== before dispatch logout ===="))
+  (log/info "==== before dispatch logout ====")
   (rf/dispatch [:profile/logout]))
 
 (defn log-headline
@@ -103,7 +103,7 @@
                                                           :timeout-ms  timeout-ms}
                                                          ::timeout)))
                                       timeout-ms)]
-          (log/info (str "==== inside wait-for after let block ===="))
+          (log/info "==== inside wait-for after let block ====")
           (rf/add-post-event-callback
            cb-id
            (fn [[event-id & _]]
@@ -237,9 +237,9 @@
         (setup-app)
         (setup-account)
         (logout)
-        (log/info (str "==== before wait-for logout ===="))
+        (log/info "==== before wait-for logout ====")
         (wait-for [:profile.logout/reset-state])
-        (log/info (str "==== after wait-for logout ===="))))))
+        (log/info "==== after wait-for logout ====")))))
 
 ;;;; Fixtures
 
@@ -265,9 +265,9 @@
     :after  (fn []
               (test/async done
                 (promesa/do (logout)
-                            (log/info (str "==== before wait-for logout ===="))
+                            (log/info "==== before wait-for logout ====")
                             (wait-for [:profile.logout/reset-state])
-                            (log/info (str "==== after wait-for logout ===="))
+                            (log/info "==== after wait-for logout ====")
                             (done))))})
   ([] (fixture-session [:new-account])))
 

--- a/src/utils/ethereum/chain_test.cljs
+++ b/src/utils/ethereum/chain_test.cljs
@@ -3,16 +3,6 @@
     [cljs.test :refer-macros [deftest is]]
     [utils.ethereum.chain :as chain]))
 
-(defn chain-ids-db
-  [test-networks-enabled?]
-  {:profile/profile {:test-networks-enabled? test-networks-enabled?}
-   :wallet          {:networks {:test [{:chain-id 11155111}
-                                       {:chain-id 421614}
-                                       {:chain-id 11155420}]
-                                :prod [{:chain-id 1}
-                                       {:chain-id 42161}
-                                       {:chain-id 10}]}}})
-
 (deftest chain-id->chain-keyword-test
   (is (= (chain/chain-id->chain-keyword 1) :mainnet))
   (is (= (chain/chain-id->chain-keyword 11155111) :sepolia))

--- a/src/utils/ethereum/eip/eip681.cljs
+++ b/src/utils/ethereum/eip/eip681.cljs
@@ -72,7 +72,8 @@
       (let [[_ authority-path query] (re-find uri-pattern s)]
         (when authority-path
           (let [[_ raw-address chain-id function-name] (re-find authority-path-pattern authority-path)]
-            (when (or (or (utils.ens/is-valid-eth-name? raw-address) (address? raw-address))
+            (when (or (utils.ens/is-valid-eth-name? raw-address)
+                      (address? raw-address)
                       (when (string/starts-with? raw-address "pay-")
                         (let [pay-address (string/replace-first raw-address "pay-" "")]
                           (or (utils.ens/is-valid-eth-name? pay-address)
@@ -83,8 +84,8 @@
                 (when-let [arguments (parse-arguments function-name query)]
                   (let [contract-address (get-in arguments [:function-arguments :address])]
                     (if-not (or (not contract-address)
-                                (or (utils.ens/is-valid-eth-name? contract-address)
-                                    (address? contract-address)))
+                                (utils.ens/is-valid-eth-name? contract-address)
+                                (address? contract-address))
                       nil
                       (merge {:address  address
                               :chain-id (if chain-id


### PR DESCRIPTION
## Summary

Just a bunch of small fixes found by linter:
- unused code
- unnecessarily nested `and`/`or` statements
- bunch of calls to `(str)` with one argument


## Review notes
Simple and easy-to-review online fixes


## Testing notes
I think e2e should be enough

### Platforms

- Android
- iOS

### Areas that may be impacted

#### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes


[comment]: # (Can be ready or wip)
status: ready

