### PR TITLE
fix: prevent login form errors from disappearing after login error occurs

### DIFF
--- a/src/status_im/common/standard_authentication/password_input/view.cljs
+++ b/src/status_im/common/standard_authentication/password_input/view.cljs
@@ -49,13 +49,14 @@
         theme                   (quo.context/use-theme)
         on-change-password      (rn/use-callback
                                  (fn [entered-password]
-                                   (reset! default-value entered-password)
-                                   (debounce/debounce-and-dispatch
-                                    [:profile/on-password-input-changed
-                                     {:password (security/mask-data
-                                                 entered-password)
-                                      :error    ""}]
-                                    100)))
+                                   (when (not= entered-password @default-value)
+                                     (reset! default-value entered-password)
+                                     (debounce/debounce-and-dispatch
+                                      [:profile/on-password-input-changed
+                                       {:password (security/mask-data
+                                                   entered-password)
+                                        :error    ""}]
+                                      100))))
         biometric-type          (rf/sub [:biometrics/supported-type])]
     [:<>
      [rn/view {:style {:flex-direction :row}}


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

## Summary
[comment]: # (Summarise the problem and how the pull request solves it)

* This PR attempts to resolve an issue with the login-form errors appearing and disappearing after submitting the incorrect password when trying to login to a profile.

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android
- iOS

### Areas that may be impacted
[comment]: # (Optional. Specify if some specific areas need to be tested, such as 1-1 chats)

#### Functional

- Login

## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Open Status
- Attempt to login to a profile using the incorrect password
- Observe if login error appears temporarily


## Screen captures

### Before changes


| Before changes | After Changes |
|---|---|
| <video src="https://github.com/user-attachments/assets/2e3a0794-708f-409a-ba55-c7a516a99cd2" /> | <video src="https://github.com/user-attachments/assets/62fcfa33-a105-4e72-a9d3-e751f3e06846" /> |



[comment]: # (Can be ready or wip)
status: ready