### PR TITLE
feat(wallet)_: Add Polygon and Polygon Amoy Networks

### DIFF
--- a/src/status_im/contexts/wallet/networks/config.cljs
+++ b/src/status_im/contexts/wallet/networks/config.cljs
@@ -30,14 +30,17 @@
 (def ^:const bsc-chain-id 56)
 (def ^:const bsc-testnet-chain-id 97)
 
+(def ^:const polygon-chain-id 137)
+(def ^:const polygon-amoy-testnet-chain-id 80002)
+
 ;; NOTE: Add a chain to `new-networks` to:
-;;         1. highlight it as "new" in the UI
-;;         2. add a "new feature" dot to places where we show networks
+;;  1. highlight it as "new" in the UI
+;;  2. add a "new feature" dot to places where we show networks
 
 (def ^:const new-networks
   #{status-sepolia-chain-id
-    bsc-chain-id
-    bsc-testnet-chain-id})
+    polygon-chain-id
+    polygon-amoy-testnet-chain-id})
 
 (def ^:const chain-id-for-new-network-banner bsc-chain-id)
 
@@ -49,7 +52,8 @@
   #{ethereum-chain-id
     arbitrum-chain-id
     optimism-chain-id
-    base-chain-id})
+    base-chain-id
+    polygon-chain-id})
 
 ;; NOTE: add client-side chain details below for `mainnet` and `testnet`
 ;; respectively.
@@ -83,7 +87,13 @@
    {:network-name        :bsc
     :source              (resources/get-network :bsc)
     :abbreviated-name    "BSC"
-    :block-explorer-name "Bscscan"}})
+    :block-explorer-name "Bscscan"}
+
+   polygon-chain-id
+   {:network-name        :polygon
+    :source              (resources/get-network :polygon)
+    :abbreviated-name    "Polygon"
+    :block-explorer-name "PolygonScan"}})
 
 (def ^:const testnets
   {sepolia-chain-id
@@ -100,6 +110,9 @@
 
    bsc-testnet-chain-id
    (get mainnets bsc-chain-id)
+
+   polygon-amoy-testnet-chain-id
+   (get mainnets polygon-chain-id)
 
    status-sepolia-chain-id
    {:network-name        :status

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v10.27.0",
-    "commit-sha1": "f5fe88d8b31a287e66a48fe90ef613c7617279b6",
-    "src-sha256": "01cn2f9f3sq5dmygh4gqpip5zp9f61383xix7rfwxr2nazbqrka3"
+    "version": "feat/polygon",
+    "commit-sha1": "830d5f97bff86b18038411ee76451e78b6dc15c1",
+    "src-sha256": "0ypv71532vh9sszkp19lm0khpg1wwa2whz701yxa0i1dd57cv5lf"
 }


### PR DESCRIPTION
fixes #22432

Status-go PR: https://github.com/status-im/status-go/pull/6524

## Summary

This PR adds Polygon and Polygon Amoy (Testnet) Networks

## Review notes

This PR needs to be merged after the BSC chain integration (https://github.com/status-im/status-mobile/pull/22417) is merged

## Testing notes
- Link to [Polygon Amoy faucet](https://faucet.polygon.technology/) (Request for Bulk POL test token at the bottom)

### Platforms

- Android
- iOS

### Areas that may be impacted

#### Functional

- wallet / transactions
- dapps / app browsing
- networks


## Steps to test

- Open Status
- Verify token balances in Polygon are shown
- Verify Chain Explorer links are working
- Verify Send, Bridge and Swap transaction works as expected

status: WIP

