### PR TITLE
[#22439] fix: open from page when multi operable account exist

### DIFF
--- a/src/status_im/contexts/wallet/home/view.cljs
+++ b/src/status_im/contexts/wallet/home/view.cljs
@@ -82,10 +82,10 @@
 
 (defn- call-to-actions
   []
-  (let [account-cards-data    (rf/sub [:wallet/account-cards-data])
+  (let [operable-accounts     (rf/sub [:wallet/operable-accounts])
         testnet-mode?         (rf/sub [:profile/test-networks-enabled?])
-        multiple-accounts?    (> (count account-cards-data) 1)
-        first-account-address (:address (first account-cards-data))
+        multiple-accounts?    (> (count operable-accounts) 1)
+        first-account-address (:address (first operable-accounts))
         on-send-press         (rn/use-callback
                                (fn []
                                  (rf/dispatch [:wallet/clean-send-data])


### PR DESCRIPTION
fixes #22439

## Summary
The From page is shown even though there is only one regular (default) account. So, the presence of a watch-only account triggers the From page unnecessarily.


### Areas that may be impacted

- Wallet home call to action buttons (swap/send/bridge)


## Steps to test

1. Restore an account with available assets (default account).
2. Add a watch-only account.
3. Open the wallet main page.
4. Tap Swap, Bridge, or Send button


## Result 


https://github.com/user-attachments/assets/de3c0b96-c3b6-4107-8558-bc9483fe241d



status: ready
