### PR TITLE
[#22010] fix: wrong selected account for bridging

### DIFF
--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -77,7 +77,11 @@
 
 (rf/reg-event-fx :wallet/switch-current-viewing-account
  (fn [{:keys [db]} [address]]
-   {:db (assoc-in db [:wallet :current-viewing-account-address] address)}))
+   (let [{:keys [tx-type]} (db/send db)
+         bridge-tx?        (= tx-type :tx/bridge)]
+     {:db (cond-> db
+            :always    (assoc-in [:wallet :current-viewing-account-address] address)
+            bridge-tx? (update-in db-path/send assoc :to-address address))})))
 
 (rf/reg-event-fx :wallet/clean-current-viewing-account
  (fn [{:keys [db]} [ignore-just-completed-transaction?]]


### PR DESCRIPTION
fixes #22010

## Summary
Assets received in the wrong account after bridging

### Areas that may be impacted

- Bridge flow

### Preconditions:
- Restore a profile where `Account 1` and `Account 2` are present.

### Steps to reproduce:
1. Go to the Bridge Setup page using `Account 1`.
2. Switch to `Account 2`
3. Perform the transaction.

status: ready