### PR TITLE
feat_: implement onLowMemory and onTrimMemory for android

### DIFF
--- a/android/app/src/main/java/im/status/ethereum/MainApplication.kt
+++ b/android/app/src/main/java/im/status/ethereum/MainApplication.kt
@@ -25,6 +25,10 @@ import im.status.ethereum.StatusOkHttpClientFactory
 import org.json.JSONObject
 import android.content.ComponentCallbacks2
 import android.util.Log
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import android.os.Process
 
 class MainApplication : NavigationApplication() {
 
@@ -54,6 +58,8 @@ class MainApplication : NavigationApplication() {
         if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
             DefaultNewArchitectureEntryPoint.load()
         }
+        
+        logHistoricalProcessExitReasons()
     }
 
     override fun onLowMemory() {
@@ -92,4 +98,40 @@ class MainApplication : NavigationApplication() {
 
     private fun getCurrentReactContext(): ReactContext? =
         reactNativeHost.reactInstanceManager.currentReactContext
+
+    private fun logHistoricalProcessExitReasons() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            try {
+                val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+                val exitReasons = activityManager.getHistoricalProcessExitReasons(packageName, 0, 5)
+                
+                if (exitReasons.isEmpty()) {
+                    Log.i("MainApplication", "No historical process exit reasons found")
+                    return
+                }
+                
+                Log.e("MainApplication", "Historical process exit reasons (last 5):")
+                exitReasons.forEachIndexed { index, reason ->
+                    Log.e("MainApplication", "Exit reason #${index + 1}:")
+                    Log.e("MainApplication", "  Process: ${reason.processName}")
+                    Log.e("MainApplication", "  Reason: ${reason.reason}")
+                    Log.e("MainApplication", "  Timestamp: ${reason.timestamp}")
+                    Log.e("MainApplication", "  Description: ${reason.description}")
+                    if (reason.importance > 0) {
+                        Log.e("MainApplication", "  Importance: ${reason.importance}")
+                    }
+                    if (reason.pss > 0) {
+                        Log.e("MainApplication", "  PSS: ${reason.pss} KB")
+                    }
+                    if (reason.rss > 0) {
+                        Log.e("MainApplication", "  RSS: ${reason.rss} KB")
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e("MainApplication", "Error getting historical process exit reasons", e)
+            }
+        } else {
+            Log.i("MainApplication", "Historical process exit reasons not available on this Android version")
+        }
+    }
 }

--- a/android/app/src/main/java/im/status/ethereum/MainApplication.kt
+++ b/android/app/src/main/java/im/status/ethereum/MainApplication.kt
@@ -24,6 +24,7 @@ import im.status.ethereum.pushnotifications.PushNotificationPackage
 import im.status.ethereum.StatusOkHttpClientFactory
 import org.json.JSONObject
 import android.content.ComponentCallbacks2
+import android.util.Log
 
 class MainApplication : NavigationApplication() {
 
@@ -57,12 +58,14 @@ class MainApplication : NavigationApplication() {
 
     override fun onLowMemory() {
         super.onLowMemory()
+        Log.i("MainApplication", "onLowMemory called")
         StatusPackage.switchToLowMemoryMode()
         emitEvent(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
     }
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
+        Log.i("MainApplication", "onTrimMemory called with level: $level")
         if (level !in arrayOf(
             ComponentCallbacks2.TRIM_MEMORY_BACKGROUND,
             ComponentCallbacks2.TRIM_MEMORY_MODERATE,

--- a/android/app/src/main/java/im/status/ethereum/MainApplication.kt
+++ b/android/app/src/main/java/im/status/ethereum/MainApplication.kt
@@ -65,7 +65,7 @@ class MainApplication : NavigationApplication() {
     override fun onLowMemory() {
         super.onLowMemory()
         Log.i("MainApplication", "onLowMemory called")
-        StatusPackage.switchToLowMemoryMode()
+        StatusPackage.releaseOSMemory()
         emitEvent(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
     }
 
@@ -79,7 +79,7 @@ class MainApplication : NavigationApplication() {
         )) {
             return
         }
-        StatusPackage.switchToLowMemoryMode()
+        StatusPackage.releaseOSMemory()
         emitEvent(level)
     }
 

--- a/android/app/src/main/java/im/status/ethereum/MainApplication.kt
+++ b/android/app/src/main/java/im/status/ethereum/MainApplication.kt
@@ -6,39 +6,41 @@ import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
-import com.facebook.react.bridge.JSIModulePackage
-import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.facebook.react.modules.network.OkHttpClientProvider
 import com.reactnativenavigation.NavigationApplication
 import com.reactnativenavigation.react.NavigationReactNativeHost
+import com.facebook.react.bridge.JSIModulePackage
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 import cl.json.RNSharePackage
 import com.reactnativecommunity.blurview.BlurViewPackage
 import im.status.ethereum.keycard.RNStatusKeycardPackage
+import im.status.ethereum.module.StatusBackendClient
 import im.status.ethereum.module.StatusPackage
 import im.status.ethereum.pushnotifications.PushNotificationPackage
 import im.status.ethereum.StatusOkHttpClientFactory
+import org.json.JSONObject
+import android.content.ComponentCallbacks2
 
 class MainApplication : NavigationApplication() {
 
     private val mReactNativeHost = object : NavigationReactNativeHost(this) {
-        override fun getUseDeveloperSupport(): Boolean {
-            return BuildConfig.DEBUG
-        }
+        override fun getUseDeveloperSupport() = BuildConfig.DEBUG
 
         override fun getPackages(): List<ReactPackage> =
             PackageList(this).packages.apply {
-          // Packages that cannot be autolinked yet can be added manually here
-          add(StatusPackage(RootUtil.isDeviceRooted()))
-          add(RNStatusKeycardPackage())
-          add(PushNotificationPackage())
-          add(BlurViewPackage())
-        }
+                add(StatusPackage(RootUtil.isDeviceRooted()))
+                add(RNStatusKeycardPackage())
+                add(PushNotificationPackage())
+                add(BlurViewPackage())
+            }
 
-        override fun getJSMainModuleName(): String = "index"
-
-        override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
-
-        override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+        override fun getJSMainModuleName() = "index"
+        override val isNewArchEnabled = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+        override val isHermesEnabled  = BuildConfig.IS_HERMES_ENABLED
     }
 
     override val reactNativeHost: ReactNativeHost
@@ -46,14 +48,45 @@ class MainApplication : NavigationApplication() {
 
     override fun onCreate() {
         super.onCreate()
-
         OkHttpClientProvider.setOkHttpClientFactory(StatusOkHttpClientFactory())
-
         WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG_WEBVIEW == "1")
-
         if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-            // If you opted-in for the New Architecture, we load the native entry point for this app.
             DefaultNewArchitectureEntryPoint.load()
         }
     }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        StatusPackage.switchToLowMemoryMode()
+        emitEvent(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
+    }
+
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        if (level !in arrayOf(
+            ComponentCallbacks2.TRIM_MEMORY_BACKGROUND,
+            ComponentCallbacks2.TRIM_MEMORY_MODERATE,
+            ComponentCallbacks2.TRIM_MEMORY_COMPLETE
+        )) {
+            return
+        }
+        StatusPackage.switchToLowMemoryMode()
+        emitEvent(level)
+    }
+
+    private fun emitEvent(level: Int) {
+        val data = Arguments.createMap().apply { putInt("level", level) }
+        // we can handle this event in src/status_im/common/signals/events.cljs with function process if we want to
+        val jsonEvent = JSONObject().apply {
+            put("type", "system.low-memory")
+            put("data", data)
+        }
+        val params = Arguments.createMap().apply { putString("jsonEvent", jsonEvent.toString()) }
+        getCurrentReactContext()
+            ?.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            ?.emit("gethEvent", params)
+    }
+
+    private fun getCurrentReactContext(): ReactContext? =
+        reactNativeHost.reactInstanceManager.currentReactContext
 }

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusPackage.kt
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusPackage.kt
@@ -15,6 +15,17 @@ class StatusPackage(private val rootedDevice: Boolean) : ReactPackage {
                 requestBody = "",
                 statusgoFunction = { Statusgo.imageServerTLSCert() }
             )
+            
+        fun switchToLowMemoryMode() {
+            // use pool to execute the request to avoid android.os.NetworkOnMainThreadException
+            StatusThreadPoolExecutor.getInstance().execute {
+                StatusBackendClient.executeStatusGoRequest(
+                    endpoint = "SwitchToLowMemoryMode",
+                    requestBody = "",
+                    statusgoFunction = { Statusgo.switchToLowMemoryMode() }
+                )
+            }
+        }
     }
 
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusPackage.kt
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusPackage.kt
@@ -16,13 +16,13 @@ class StatusPackage(private val rootedDevice: Boolean) : ReactPackage {
                 statusgoFunction = { Statusgo.imageServerTLSCert() }
             )
             
-        fun switchToLowMemoryMode() {
+        fun releaseOSMemory() {
             // use pool to execute the request to avoid android.os.NetworkOnMainThreadException
             StatusThreadPoolExecutor.getInstance().execute {
                 StatusBackendClient.executeStatusGoRequest(
-                    endpoint = "SwitchToLowMemoryMode",
+                    endpoint = "ReleaseOSMemory",
                     requestBody = "",
-                    statusgoFunction = { Statusgo.switchToLowMemoryMode() }
+                    statusgoFunction = { Statusgo.releaseOSMemory() }
                 )
             }
         }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v10.27.0",
-    "commit-sha1": "f5fe88d8b31a287e66a48fe90ef613c7617279b6",
-    "src-sha256": "01cn2f9f3sq5dmygh4gqpip5zp9f61383xix7rfwxr2nazbqrka3"
+    "version": "frank/chore/low-memory",
+    "commit-sha1": "1f7785067fff96c8d71e1eb1e6c572fc53ff0d4e",
+    "src-sha256": "1vi8bds8vb96vwc3wdv999q8jaq1vsn5bsmlmlk05f5v7qfjbr3s"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "frank/chore/low-memory",
-    "commit-sha1": "1f7785067fff96c8d71e1eb1e6c572fc53ff0d4e",
-    "src-sha256": "1vi8bds8vb96vwc3wdv999q8jaq1vsn5bsmlmlk05f5v7qfjbr3s"
+    "commit-sha1": "6f8401f5dd165a0fb0dbb544afd614d4313b0530",
+    "src-sha256": "1nq5345az2mkszz2agix8bmxgmh6ih0nb71amml6jmismxrkrpqd"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "frank/chore/low-memory",
-    "commit-sha1": "6f8401f5dd165a0fb0dbb544afd614d4313b0530",
-    "src-sha256": "1nq5345az2mkszz2agix8bmxgmh6ih0nb71amml6jmismxrkrpqd"
+    "commit-sha1": "e174de44cdda9edc5aa665321bfae0a2d0cd1b47",
+    "src-sha256": "1vdffn4pvk1mmf1kq1qlcxq03hw6n8367a02izskkpbhbiacv8rn"
 }


### PR DESCRIPTION
## Summary
this PR might help fixing issue #22463 
when switch Status App in background, `onLowMemory` / `onTrimMemory` might be invoked, we get a chance to release some memory back to OS and keep our App stay alive longer rather than being killed.
this PR also added [getHistoricalProcessExitReasons](https://developer.android.com/reference/kotlin/android/app/ActivityManager#gethistoricalprocessexitreasons)

relate [status-go PR](https://github.com/status-im/status-go/pull/6549)

logcat log that shows `getHistoricalProcessExitReasons` works:
```
2025-05-09 20:03:01.379 18950-18950/im.status.ethereum.debug I/MainApplication: Historical process exit reasons (last 5):
2025-05-09 20:03:01.379 18950-18950/im.status.ethereum.debug I/MainApplication: Exit reason #1:
2025-05-09 20:03:01.379 18950-18950/im.status.ethereum.debug I/MainApplication:   Process: com.google.android.webview:sandboxed_process0:org.chromium.content.app.SandboxedProcessService0:0
2025-05-09 20:03:01.379 18950-18950/im.status.ethereum.debug I/MainApplication:   Reason: 10
2025-05-09 20:03:01.379 18950-18950/im.status.ethereum.debug I/MainApplication:   Timestamp: 1746791035537
2025-05-09 20:03:01.379 18950-18950/im.status.ethereum.debug I/MainApplication:   Description: remove task
2025-05-09 20:03:01.379 18950-18950/im.status.ethereum.debug I/MainApplication:   Importance: 400
2025-05-09 20:03:01.379 18950-18950/im.status.ethereum.debug I/MainApplication:   PSS: 11132 KB
2025-05-09 20:03:01.379 18950-18950/im.status.ethereum.debug I/MainApplication:   RSS: 98092 KB
```

## Testing notes
see if PR build would keep our App stay alive longer in the background, if you can make Android system to trigger  `onLowMemory or onTrimMemory` without using `am` that would be great! I haven't be able to reproduce ): However, when Status is in the background, you can run `adb shell am send-trim-memory 22304 COMPLETE` to trigger `onLowMemory` / `onTrimMemory` manually. 22304 should be replaced with actual pid of Status.

### Platforms
[comment]: # (Optional. Specify which platforms should be tested)

- Android

## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

- Open Status and login
- Keep Status running in the background
- Wait for some time and try to switch Status back


[comment]: # (Can be ready or wip)
status: ready.
