### PR TITLE
fix: prevent adding more participants than the allowed group chat limit

### DIFF
--- a/src/status_im/contexts/chat/group/details/style.cljs
+++ b/src/status_im/contexts/chat/group/details/style.cljs
@@ -25,3 +25,17 @@
    :margin-bottom      bottom
    :background-color   (colors/theme-colors colors/white colors/neutral-95-opa-70 theme)
    :flex-direction     :row})
+
+(def manage-members-header
+  {:flex-direction    :row
+   :justify-content   :space-between
+   :align-items       :flex-end
+   :margin-horizontal 20
+   :margin-bottom     16})
+
+(defn counter
+  [theme error?]
+  {:margin-bottom 2
+   :color         (if error?
+                    (colors/theme-colors colors/danger-50 colors/danger-60 theme)
+                    (colors/theme-colors colors/neutral-40 colors/neutral-50 theme))})

--- a/src/status_im/contexts/chat/group/events.cljs
+++ b/src/status_im/contexts/chat/group/events.cljs
@@ -3,7 +3,9 @@
             [oops.core :as oops]
             [re-frame.core :as rf]
             [status-im.common.avatar-picture-picker.view :as avatar-picture-picker]
-            [taoensso.timbre :as log]))
+            [status-im.constants :as constants]
+            [taoensso.timbre :as log]
+            [utils.i18n :as i18n]))
 
 (rf/reg-event-fx :group-chat/create
  (fn [{:keys [db]} [{:keys [group-name group-color group-image]}]]
@@ -37,3 +39,16 @@
                      :on-success  (fn [response]
                                     (rf/dispatch [:chat-updated response true])
                                     (when on-success (on-success)))}]}))
+
+(rf/reg-event-fx :group-chat/set-manage-members-error
+ (fn [{:keys [db]} [{:keys [chat-id error?]}]]
+   {:db (assoc-in db
+         [:group-chat/manage-members-error chat-id]
+         error?)
+    :fx [(when error?
+           [:dispatch
+            [:toasts/upsert
+             {:type :negative
+              :text (i18n/label :t/new-group-limit
+                                {:max-contacts
+                                 constants/max-group-chat-participants})}]])]}))

--- a/src/status_im/subs/chats.cljs
+++ b/src/status_im/subs/chats.cljs
@@ -358,3 +358,37 @@
    (re-frame/subscribe [:chats/chat chat-id]))
  :->
  :image)
+
+(re-frame/reg-sub
+ :group-chat/selected-participants-count
+ :<- [:group-chat/selected-participants]
+ (fn [selected-participants]
+   (count selected-participants)))
+
+(re-frame/reg-sub
+ :group-chat/deselected-members-count
+ :<- [:group-chat/deselected-members]
+ (fn [deselected-members]
+   (count deselected-members)))
+
+(re-frame/reg-sub
+ :group-chat/member-count
+ (fn [[_ chat-id]]
+   (re-frame/subscribe [:chats/chat-by-id chat-id]))
+ (fn [{:keys [contacts]}]
+   (count contacts)))
+
+(re-frame/reg-sub
+ :group-chat/manage-members-count
+ (fn [[_ chat-id]]
+   [(re-frame/subscribe [:group-chat/member-count chat-id])
+    (re-frame/subscribe [:group-chat/selected-participants-count])
+    (re-frame/subscribe [:group-chat/deselected-members-count])])
+ (fn [[member-count selected-count deselected-count]]
+   (+ member-count selected-count (- deselected-count))))
+
+(re-frame/reg-sub
+ :group-chat/manage-members-error-by-chat-id
+ :<- [:group-chat/manage-members-error]
+ (fn [errors [_ chat-id]]
+   (get errors chat-id)))

--- a/src/status_im/subs/chats_test.cljs
+++ b/src/status_im/subs/chats_test.cljs
@@ -207,3 +207,15 @@
         :chats           chats
         :current-chat-id chat-id)
       (is (true? (rf/sub [sub-name]))))))
+
+(h/deftest-sub :group-chat/manage-members-count
+  [sub-name]
+  (testing "calculates the correct count of members in a group chat"
+    (let [contacts              [{:id "0x777"} {:id "0x789"}]
+          selected-participants ["0x123" "0x456"]
+          deselected-members    [{:id "Ox789"}]]
+      (swap! rf-db/app-db assoc
+        :chats                            {chat-id {:contacts contacts}}
+        :group-chat/selected-participants selected-participants
+        :group-chat/deselected-members    deselected-members)
+      (is (= 3 (rf/sub [sub-name chat-id]))))))

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -129,6 +129,7 @@
 ;;group chat
 (reg-root-key-sub :group-chat/selected-participants :group-chat/selected-participants)
 (reg-root-key-sub :group-chat/deselected-members :group-chat/deselected-members)
+(reg-root-key-sub :group-chat/manage-members-error :group-chat/manage-members-error)
 
 ;;messages
 (reg-root-key-sub :messages/messages :messages)


### PR DESCRIPTION
fixes #21590 

## Summary
This PR addresses an issue where users were able to add more participants to a group chat than the allowed maximum(20). The new logic ensures that participant additions are validated against the group size limit, preventing overflows.

This PR also adds member count in the right side of Manage members header.

### Screenshots


https://github.com/user-attachments/assets/9a47c6bb-f281-4e89-94ea-3b20333fbbea



### Platforms
- Android
- iOS

### Areas that may be impacted
#### Functional
- group chats

## Steps to test

- Open Status
- Create a group chat
- Open group chat
- Open group chat options -> Manage members
- Try adding more than 20 members

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

