### PR TITLE
[#22385] fix: tx setting current value as a range

### DIFF
--- a/src/status_im/contexts/wallet/common/transaction_settings/max_fee/view.cljs
+++ b/src/status_im/contexts/wallet/common/transaction_settings/max_fee/view.cljs
@@ -29,11 +29,11 @@
   []
   (let [network-base-fee (rf/sub [:wallet/tx-settings-network-base-fee-route])
         max-base-fee     (rf/sub [:wallet/tx-settings-max-base-fee])
-        priority-fee     (rf/sub [:wallet/tx-settings-priority-fee])
+        priority-fee     (rf/sub [:wallet/tx-settings-custom-priority-fee])
         conditions       (partial hint-and-status network-base-fee priority-fee)]
     [transaction-settings/custom-setting-screen
      {:screen-title  (i18n/label :t/max-base-fee)
-      :token-sybmol  :gwei
+      :token-symbol  :gwei
       :conditions-fn conditions
       :current       max-base-fee
       :info-title    (i18n/label :t/max-base-fee)

--- a/src/status_im/contexts/wallet/common/transaction_settings/priority_fee/view.cljs
+++ b/src/status_im/contexts/wallet/common/transaction_settings/priority_fee/view.cljs
@@ -6,7 +6,7 @@
     [utils.re-frame :as rf]))
 
 (defn hint-and-status
-  [priority-fee spectrum max-base-fee entered-value]
+  [spectrum max-base-fee entered-value]
   (let [upper-limit-exceeded? (> entered-value (:high spectrum))
         lower-limit-exceeded? (< entered-value (:low spectrum))]
     (cond
@@ -19,8 +19,7 @@
                                       :status    :warning}
       lower-limit-exceeded?          {:hint-text (i18n/label :t/priority-fee-lower spectrum)
                                       :status    :warning}
-      :else                          {:hint-text (i18n/label :t/priority-fee-current
-                                                             {:current priority-fee})
+      :else                          {:hint-text (i18n/label :t/priority-fee-current spectrum)
                                       :status    :default})))
 
 (defn view
@@ -29,7 +28,7 @@
         max-base-fee (rf/sub [:wallet/tx-settings-max-base-fee])
         spectrum     {:low  (rf/sub [:wallet/tx-settings-suggested-min-priority-fee])
                       :high (rf/sub [:wallet/tx-settings-suggested-max-priority-fee])}
-        conditions   (partial hint-and-status priority-fee spectrum max-base-fee)]
+        conditions   (partial hint-and-status spectrum max-base-fee)]
     [transaction-settings/custom-setting-screen
      {:screen-title  (i18n/label :t/priority-fee)
       :token-sybmol  :gwei

--- a/src/status_im/contexts/wallet/common/transaction_settings/priority_fee/view.cljs
+++ b/src/status_im/contexts/wallet/common/transaction_settings/priority_fee/view.cljs
@@ -24,14 +24,14 @@
 
 (defn view
   []
-  (let [priority-fee (rf/sub [:wallet/tx-settings-priority-fee])
+  (let [priority-fee (rf/sub [:wallet/tx-settings-custom-priority-fee])
         max-base-fee (rf/sub [:wallet/tx-settings-max-base-fee])
         spectrum     {:low  (rf/sub [:wallet/tx-settings-suggested-min-priority-fee])
                       :high (rf/sub [:wallet/tx-settings-suggested-max-priority-fee])}
         conditions   (partial hint-and-status spectrum max-base-fee)]
     [transaction-settings/custom-setting-screen
      {:screen-title  (i18n/label :t/priority-fee)
-      :token-sybmol  :gwei
+      :token-symbol  :gwei
       :conditions-fn conditions
       :current       priority-fee
       :info-title    (i18n/label :t/priority-fee)

--- a/src/status_im/contexts/wallet/common/transaction_settings/view.cljs
+++ b/src/status_im/contexts/wallet/common/transaction_settings/view.cljs
@@ -12,7 +12,7 @@
 (defn custom-settings-sheet
   [_]
   (let [max-base-fee   (rf/sub [:wallet/tx-settings-max-base-fee])
-        priority-fee   (rf/sub [:wallet/tx-settings-priority-fee])
+        priority-fee   (rf/sub [:wallet/tx-settings-custom-priority-fee])
         max-gas-amount (rf/sub [:wallet/tx-settings-gas-amount])
         nonce          (rf/sub [:wallet/tx-settings-nonce])
         account-color  (rf/sub [:wallet/current-viewing-account-color])

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -978,6 +978,18 @@
    (or value-set-by-user (:tx-priority-fee gas-fees))))
 
 (rf/reg-sub
+ :wallet/tx-settings-custom-priority-fee
+ :<- [:wallet/tx-settings-fee-mode]
+ :<- [:wallet/tx-settings-gas-fees]
+ :<- [:wallet/tx-settings-priority-fee-user]
+ :<- [:wallet/tx-settings-suggested-min-priority-fee]
+ (fn [[fee-mode gas-fees value-set-by-user min-priority-fee]]
+   (cond
+     value-set-by-user                value-set-by-user
+     (= :tx-fee-mode/custom fee-mode) (:tx-priority-fee gas-fees)
+     :else                            min-priority-fee)))
+
+(rf/reg-sub
  :wallet/tx-settings-gas-amount
  :<- [:wallet/tx-settings-gas-amount-route]
  :<- [:wallet/tx-settings-gas-amount-user]

--- a/src/status_im/subs/wallet/wallet.cljs
+++ b/src/status_im/subs/wallet/wallet.cljs
@@ -1012,9 +1012,8 @@
 (rf/reg-sub
  :wallet/tx-settings-suggested-max-priority-fee
  :<- [:wallet/tx-settings-gas-fees]
- :<- [:wallet/tx-settings-max-base-fee]
- (fn [[gas-fees max-base-fee]]
-   (min max-base-fee (:suggested-max-priority-fee gas-fees))))
+ (fn [gas-fees]
+   (:suggested-max-priority-fee gas-fees)))
 
 (rf/reg-sub
  :wallet/tx-settings-suggested-min-priority-fee

--- a/translations/en.json
+++ b/translations/en.json
@@ -2096,7 +2096,7 @@
   "principles": "Principles",
   "priority": "Priority",
   "priority-fee": "Priority fee",
-  "priority-fee-current": "Current: {{current}}",
+  "priority-fee-current": "Current: {{low}} - {{high}}",
   "priority-fee-higher": "Higher than necessary: {{low}} - {{high}}",
   "priority-fee-higher-max-base": "Higher than max base fee: {{max-base-fee}}",
   "priority-fee-lower": "Lower than suggested: {{low}} - {{high}}",


### PR DESCRIPTION
fixes #22385
fixes #22424

## Summary

According to the designs, current value should show the range (i.e 0 - 0.00001) but we show single value

## Testing notes

Regarding point 2: There’s no specific instruction on what the default should be. On mobile, we populate the input fields based on the last selected option (Normal, Fast, Urgent). So if the user selects “Fast” before switching to “Custom,” the custom inputs will be pre-filled with the “Fast” values.

### Areas that may be impacted

- Tx Setting

## Steps to test
[comment]: #  (Specify exact steps to test if there are such)

1. Open transaction Custom settings => Priority fee
2. Pay attention `current` value

## Result

https://github.com/user-attachments/assets/ae5a0cef-c1a4-4cbb-9a24-90f43ad3fd8f




status: ready