### PR TITLE
[#22567] fix: sign transactions from partially operable account

### DIFF
--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -117,9 +117,11 @@
 
 (defn partially-operable-accounts?
   [accounts]
-  (->> accounts
-       (some #(= :partially (:operable %)))
-       boolean))
+  (boolean
+   (some (fn [[_ account]]
+           (let [operable (:operable account)]
+             (= :partially operable)))
+         accounts)))
 
 (defn get-keypair-lowest-operability
   [{:keys [accounts]}]

--- a/src/status_im/contexts/wallet/data_store.cljs
+++ b/src/status_im/contexts/wallet/data_store.cljs
@@ -118,9 +118,8 @@
 (defn partially-operable-accounts?
   [accounts]
   (boolean
-   (some (fn [[_ account]]
-           (let [operable (:operable account)]
-             (= :partially operable)))
+   (some (fn [[_ {:keys [operable]}]]
+           (= :partially operable))
          accounts)))
 
 (defn get-keypair-lowest-operability


### PR DESCRIPTION
fixes #22567

## Summary

There is an issue with make partially operable account fully operable. and it throws error when user try to sign a transaction. 


### Areas that may be impacted

- Swap/Bridge/Send for restored account.


## Steps to test

1. Log in using the recovery phrase.
2. Enable Password authentication on the onboarding screen.
3. After restore, the following accounts should be displayed:
-  Account 1 (default keypair)
-  Account 2 (derived account from the default keypair)
4. Initiate a Send/Swap/Bridge transaction from Account 2.
5. Sign the transaction.

## Result 


https://github.com/user-attachments/assets/04d19299-befb-41cf-a8ca-b7a5d04dd750



status: ready