### PR TITLE
[#22548] fix: correct exchange rate order for swap

### DIFF
--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -356,7 +356,7 @@
    (when (and token-prices asset-to-pay)
      (let [exchange-rate (some->> asset-to-pay
                                   :decimals
-                                  (utils/token-exchange-rate receive-token-price pay-token-price))]
+                                  (utils/token-exchange-rate pay-token-price receive-token-price))]
        (or exchange-rate 0)))))
 
 (rf/reg-sub

--- a/src/status_im/subs/wallet/swap.cljs
+++ b/src/status_im/subs/wallet/swap.cljs
@@ -361,11 +361,11 @@
 
 (rf/reg-sub
  :wallet/swap-exchange-rate-fiat
- :<- [:wallet/swap-receive-token-price]
+ :<- [:wallet/swap-pay-token-price]
  :<- [:profile/currency-symbol]
- (fn [[receive-token-price currency-symbol]]
-   (when receive-token-price
-     (utils/fiat-formatted-for-ui currency-symbol receive-token-price))))
+ (fn [[pay-token-price currency-symbol]]
+   (when pay-token-price
+     (utils/fiat-formatted-for-ui currency-symbol pay-token-price))))
 
 (rf/reg-sub :wallet/max-swap-fee
  :<- [:wallet/swap-proposal-approval-required]

--- a/translations/en.json
+++ b/translations/en.json
@@ -2623,7 +2623,7 @@
   "sun": "Sun",
   "swap": "Swap",
   "swap-details": "Swap details",
-  "swap-exchange-rate-in-crypto": "1 {{receive-token-symbol}} ≈ {{exchange-rate}} {{pay-token-symbol}}",
+  "swap-exchange-rate-in-crypto": "1 {{pay-token-symbol}} ≈ {{exchange-rate}} {{receive-token-symbol}}",
   "swap-failed": "Swap failed",
   "swapped-to": "Swapped {{pay-amount}} {{pay-token-symbol}} to {{receive-amount}} {{receive-token-symbol}}",
   "swapping-to": "Swapping {{pay-amount}} {{pay-token-symbol}} to {{receive-amount}} {{receive-token-symbol}}",


### PR DESCRIPTION
fixes #22548

## Summary
Exchange rate on swap should show [asset to send] = [asset to receive] amount

### Areas that may be impacted

- Swap exchange rate


## Steps to test

1. Login to app
2. Go to swap 
3. Choose token to send and to receive
4. Look at the exchange rate below chosen tokens

## Result
<img src="https://github.com/user-attachments/assets/9c0254fe-c31f-45aa-ad34-e7e66b763c74" width="290px"/>
<img src="https://github.com/user-attachments/assets/4a5192cd-07a1-46ed-9e02-75c96a2e43b7" width="290px"/>


status: ready
