### PR TITLE
Remove unsupported notifications from ac notification data

### DIFF
--- a/src/status_im/contexts/shell/activity_center/view.cljs
+++ b/src/status_im/contexts/shell/activity_center/view.cljs
@@ -68,7 +68,7 @@
 
 (defn view
   []
-  (let [notifications    (rf/sub [:activity-center/notifications])
+  (let [notifications    (rf/sub [:activity-center/supported-notifications])
 
         ;; We globally control the active swipeable for all notifications
         ;; because when a swipe left/right gesture initiates, the previously

--- a/src/status_im/subs/activity_center.cljs
+++ b/src/status_im/subs/activity_center.cljs
@@ -9,12 +9,15 @@
  (fn [activity-center]
    (:notifications activity-center)))
 
+(defn supported-notification?
+  [notification]
+  (types/all-supported (:type notification)))
+
 (re-frame/reg-sub
  :activity-center/supported-notifications
  :<- [:activity-center/notifications]
  (fn [notifications]
-   (->> notifications
-        (filter #(types/all-supported (:type %))))))
+   (filter supported-notification? notifications)))
 
 (re-frame/reg-sub
  :activity-center/unread-counts-by-type

--- a/src/status_im/subs/activity_center.cljs
+++ b/src/status_im/subs/activity_center.cljs
@@ -10,6 +10,13 @@
    (:notifications activity-center)))
 
 (re-frame/reg-sub
+ :activity-center/supported-notifications
+ :<- [:activity-center/notifications]
+ (fn [notifications]
+   (->> notifications
+        (filter #(types/all-supported (:type %))))))
+
+(re-frame/reg-sub
  :activity-center/unread-counts-by-type
  :<- [:activity-center]
  (fn [activity-center]


### PR DESCRIPTION
fix #22418 

### Summary
There are several notification types that are not yet supported on mobile. When unsupported notifications are present in the notification data, this was causing a AC 'all' tab blank state.

This PR filters out unsupported notification types and renders only the supported ones to avoid this issue.
 
See [the issue](https://github.com/status-im/status-mobile/issues/22418) for the complete discussion.

### Risk

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.