### PR TITLE
fix: disable by default market tab feature with mocked data

### DIFF
--- a/src/status_im/feature_flags.cljs
+++ b/src/status_im/feature_flags.cljs
@@ -35,7 +35,7 @@
    ::wallet.wallet-connect              (enabled-in-env? :FLAG_WALLET_CONNECT_ENABLED)
    ::wallet.custom-network-amounts      (enabled-in-env? :FLAG_WALLET_CUSTOM_NETWORK_AMOUNTS_ENABLED)
    ::wallet.transaction-params          (enabled-in-env? :FLAG_WALLET_TRANSACTION_PARAMS_ENABLED)
-   ::market                             true})
+   ::market                             (enabled-in-env? :FLAG_MARKET_ENABLED)})
 
 (defonce ^:private feature-flags-config
   (reagent/atom initial-flags))


### PR DESCRIPTION
Fix https://github.com/status-im/status-mobile/issues/22610 