### PR TITLE
fix(nix/gradle): pad status messages to clear display properly

### DIFF
--- a/nix/deps/gradle/url2json.sh
+++ b/nix/deps/gradle/url2json.sh
@@ -115,7 +115,9 @@ PKG_URL_NO_EXT="${POM_URL%.pom}"
 # Name of package without extension.
 PKG_NAME="$(basename "${PKG_URL_NO_EXT}")"
 
-echo -en "${CLR} - Nix entry for: ${1##*/}\r" >&2
+# Append spaces to avoid overlapping package names.
+printf -v spaces '%*s' 60 ''
+echo -en "${CLR} - Nix entry for: ${1##*/}$spaces\r" >&2
 
 REPO_URL=$(match_repo_url "${PKG_URL_NO_EXT}")
 


### PR DESCRIPTION
## Summary

When running url2nix.sh the stderr status messages are not getting cleared properly.
e.g.

```
 - Nix entry for: httpclient-4.5.13.pommomdstate-2.2.0.pomom2.pom-with-guava.pomom
```

## Steps to test

- run url2json.sh

status: ready
