### PR TITLE
Tokens aren't refetched on active networks disabling/enabling

### DIFF
--- a/src/status_im/contexts/wallet/common/utils/networks.cljs
+++ b/src/status_im/contexts/wallet/common/utils/networks.cljs
@@ -13,6 +13,7 @@
               (first (filter #(or (= (:chain-id %) chain-id)
                                   (= (:related-chain-id %) chain-id))
                              networks))))
+       (remove nil?)
        set))
 
 (defn balance-is-sufficient-to-use-chain

--- a/src/status_im/contexts/wallet/networks/events.cljs
+++ b/src/status_im/contexts/wallet/networks/events.cljs
@@ -73,8 +73,6 @@
    {:fx [[:dispatch [:wallet/reset-accounts-tokens]]
          [:dispatch [:wallet/reload-cached-balances]]
          [:dispatch [:wallet/reload-collectibles]]
-         [:dispatch [:wallet.tokens/reset-tokens]]
-         [:dispatch [:wallet.tokens/get-token-list]]
          [:dispatch [:wallet/check-new-networks-seen]]]}))
 
 (rf/reg-event-fx :wallet/update-network-active

--- a/src/status_im/contexts/wallet/networks/events.cljs
+++ b/src/status_im/contexts/wallet/networks/events.cljs
@@ -102,7 +102,9 @@
  (fn [{:keys [db]} [testnet?]]
    {:db (assoc-in db [:profile/profile :test-networks-enabled?] testnet?)
     :fx [[:dispatch [:profile/toggle-testnet-mode-banner]]
-         [:dispatch [:wallet/on-active-networks-change]]]}))
+         [:dispatch [:wallet/on-active-networks-change]]
+         [:dispatch [:wallet.tokens/reset-tokens]]
+         [:dispatch [:wallet.tokens/get-token-list]]]}))
 
 (rf/reg-event-fx
  :wallet/mark-new-networks-as-seen


### PR DESCRIPTION
## Summary
There was an issue:
After enabling/disabling active networks the price of assets that user had was displayed as 0 for a while.


## Review notes
The reason of problem was that we wiped out and refetched the full token list on every active network change. That resulted also in refetching tokens from our market proxy. All these took a long time and prices were shown as 0 while that happens. And when coingecko failed it never happened at all.
So as a fix I remove that token cleanup because our list of tokens is not related to active networks, so no reason to clear it.

