### PR TITLE
shell: fix clojure shell when system has yarn v4

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -38,6 +38,10 @@ in mkShell {
   LANG="en_US.UTF-8";
   LANGUAGE="en_US.UTF-8";
 
+  # Prevent Yarn from checking packageManager field in parent directories
+  # https://github.com/yarnpkg/yarn/blob/740c38c3a962c30ddb344a919bbfb7065620714b/src/cli/index.js#L292C21-L292C33
+  SKIP_YARN_COREPACK_CHECK="1";
+
   # Important to load our own Nix binary cache.
   NIX_CONFIG = builtins.readFile ./nix.conf;
 


### PR DESCRIPTION
`make run-clojure` used to break when system had yarn v4 because yarn 1.22.22 would check for `package.json` in parent directories, setting `SKIP_YARN_COREPACK_CHECK` prevents that.

fixes: https://github.com/status-im/status-mobile/issues/21887
